### PR TITLE
refactor: Desktop host service decouple

### DIFF
--- a/apps/desktop/src/host/assistant-message-state.ts
+++ b/apps/desktop/src/host/assistant-message-state.ts
@@ -1,0 +1,604 @@
+import type {
+  ConversationMessageSnapshot,
+  MessageAuxSnapshot,
+  ToolBlockSnapshot,
+} from '../types.js';
+import {
+  describeAuxForDebug,
+  describeOptionalAuxForDebug,
+  hasStandaloneThinkingMessageInCurrentTurn,
+  indexForThinkingInsertAfterLastUser,
+  indexForThinkingInsertBeforeFirstToolAfterLastUser,
+  messageIndexIsInCurrentTurn,
+  messageOrderDebugLevel,
+  normalizeMessageAuxSnapshot,
+  stripPendingThinkingMatchingFinalized,
+  stripThinkingFromAux,
+  summarizeMessagesTailForOrderDebug,
+  truncateOneLineForDebug,
+} from './message-ordering.js';
+import {
+  pruneEmptyAssistantMessages as pruneEmptyAssistantMessagesFromSnapshots,
+  shiftStreamAssistantThinkingAnchorForInsertion as shiftThinkingAnchorForInsertion,
+  shiftStreamAssistantThinkingAnchorForRemoval as shiftThinkingAnchorForRemoval,
+} from './message-snapshots.js';
+
+export interface DesktopAssistantMessageStateMachineOptions {
+  messages: () => ConversationMessageSnapshot[];
+  setMessages: (messages: ConversationMessageSnapshot[]) => void;
+  allocateMessageId: () => number;
+  isRuntimeBusy: () => boolean;
+}
+
+export interface AssistantStandaloneAnchorState {
+  pendingAssistantMessageId?: number;
+  lastSettledAssistantMessageId?: number;
+}
+
+export interface AssistantPlacementState {
+  streamAssistantThinkingAnchor?: number;
+  streamAssistantAnchorSetInApplyBatchId: number;
+}
+
+export class DesktopAssistantMessageStateMachine {
+  private latestPendingAssistantAux: MessageAuxSnapshot | undefined;
+  private pendingAssistantMessageId: number | undefined;
+  private lastSettledAssistantMessageId: number | undefined;
+  private lastFinalizedThinkingSegment = '';
+  private streamAssistantThinkingAnchor: number | undefined;
+  private streamAssistantAnchorSetInApplyBatchId = 0;
+
+  constructor(private readonly options: DesktopAssistantMessageStateMachineOptions) {}
+
+  standaloneAnchorState(): AssistantStandaloneAnchorState {
+    return {
+      pendingAssistantMessageId: this.pendingAssistantMessageId,
+      lastSettledAssistantMessageId: this.lastSettledAssistantMessageId,
+    };
+  }
+
+  placementState(): AssistantPlacementState {
+    return {
+      streamAssistantThinkingAnchor: this.streamAssistantThinkingAnchor,
+      streamAssistantAnchorSetInApplyBatchId: this.streamAssistantAnchorSetInApplyBatchId,
+    };
+  }
+
+  beginAssistantResponse(insertAt: number, batchId: number): ConversationMessageSnapshot {
+    this.pendingAssistantMessageId = undefined;
+    this.latestPendingAssistantAux = undefined;
+    this.streamAssistantThinkingAnchor =
+      this.streamAssistantThinkingAnchor === undefined
+        ? insertAt
+        : Math.min(this.streamAssistantThinkingAnchor, insertAt);
+    this.streamAssistantAnchorSetInApplyBatchId = batchId;
+    return this.ensurePendingAssistantMessage();
+  }
+
+  upsertToolMessage(
+    toolCallId: string,
+    tool: ToolBlockSnapshot,
+    batchId: number,
+  ): ConversationMessageSnapshot {
+    const messages = this.messages();
+    const existing = messages.find(
+      (message) => message.tool?.toolCallId === toolCallId,
+    );
+
+    if (existing) {
+      const previousTool = existing.tool;
+      existing.tool = tool;
+      this.logToolMessageUpdate(existing.id, toolCallId, previousTool, tool, messages);
+      return existing;
+    }
+
+    if (this.streamAssistantThinkingAnchor === undefined) {
+      this.streamAssistantThinkingAnchor = messages.length;
+    }
+    this.streamAssistantAnchorSetInApplyBatchId = batchId;
+    const pushAt = messages.length;
+    const message: ConversationMessageSnapshot = {
+      id: this.options.allocateMessageId(),
+      role: 'assistant',
+      content: '',
+      tool,
+      pending: false,
+    };
+    messages.push(message);
+    this.logMessageOrderToolPreviewNew(tool.toolName, pushAt);
+    return message;
+  }
+
+  appendAssistantMessage(content: string, aux?: MessageAuxSnapshot): void {
+    const messages = this.messages();
+    const finalAux = this.normalizeCompletedAssistantAux(aux);
+    const message: ConversationMessageSnapshot = {
+      id: this.options.allocateMessageId(),
+      role: 'assistant',
+      content,
+      ...(finalAux ? { aux: finalAux } : {}),
+      pending: false,
+    };
+    messages.push(message);
+    this.logAssistantAuxDecision('append-assistant', {
+      messageId: message.id,
+      aux: message.aux,
+      content,
+    });
+  }
+
+  appendAssistantThinkingSegment(text: string): void {
+    this.lastFinalizedThinkingSegment = text.trim();
+    const messages = this.messages();
+    this.stripFinalizedThinkingFromAssistantAnchors(text);
+    const message: ConversationMessageSnapshot = {
+      id: this.options.allocateMessageId(),
+      role: 'assistant',
+      content: '',
+      aux: { thinking: text },
+      pending: false,
+    };
+    let insertAt = this.streamAssistantThinkingAnchor;
+    this.streamAssistantThinkingAnchor = undefined;
+    if (insertAt === undefined) {
+      insertAt = indexForThinkingInsertBeforeFirstToolAfterLastUser(messages);
+    }
+    if (insertAt === undefined) {
+      insertAt = indexForThinkingInsertAfterLastUser(messages);
+    }
+    const clamped = Math.max(0, Math.min(insertAt, messages.length));
+    messages.splice(clamped, 0, message);
+    const placed = `splice@${clamped}`;
+    this.logMessageOrderThinkingFinalized(placed, messages.length, text);
+    this.latestPendingAssistantAux = stripPendingThinkingMatchingFinalized(
+      this.latestPendingAssistantAux,
+      text,
+    );
+  }
+
+  updatePendingAssistantAux(
+    kind: 'thinking' | 'compressing',
+    text: string,
+  ): void {
+    const normalized = text.trim();
+    const existingIndex = this.findPendingAssistantMessageIndex();
+    const message =
+      existingIndex !== undefined
+        ? this.messages()[existingIndex]!
+        : normalized && this.options.isRuntimeBusy()
+          ? this.ensurePendingAssistantMessage()
+          : undefined;
+    const currentAux = message?.aux ?? this.latestPendingAssistantAux;
+    const nextAux = normalizeMessageAuxSnapshot({
+      ...(kind === 'thinking'
+        ? normalized
+          ? { thinking: text }
+          : {}
+        : currentAux?.thinking
+          ? { thinking: currentAux.thinking }
+          : {}),
+      ...(kind === 'compressing'
+        ? normalized
+          ? { compaction: text }
+          : {}
+        : currentAux?.compaction
+          ? { compaction: currentAux.compaction }
+          : {}),
+    });
+
+    if (message) {
+      if (nextAux) {
+        message.aux = nextAux;
+      } else {
+        delete message.aux;
+      }
+    }
+
+    if (nextAux) {
+      this.latestPendingAssistantAux = nextAux;
+    } else {
+      this.latestPendingAssistantAux = undefined;
+    }
+  }
+
+  appendPendingAssistantChunk(chunk: string): void {
+    const message = this.ensurePendingAssistantMessage();
+    message.content += chunk;
+  }
+
+  replacePendingAssistantText(text: string): void {
+    const message = this.ensurePendingAssistantMessage();
+    message.content = text;
+  }
+
+  completePendingAssistantMessage(): void {
+    const index = this.findPendingAssistantMessageIndex();
+    if (index === undefined) {
+      this.pendingAssistantMessageId = undefined;
+      return;
+    }
+    const message = this.messages()[index]!;
+    message.pending = false;
+    this.lastSettledAssistantMessageId = message.id;
+    this.pendingAssistantMessageId = undefined;
+    this.latestPendingAssistantAux = undefined;
+  }
+
+  removePendingAssistantMessage(): void {
+    const index = this.findPendingAssistantMessageIndex();
+    if (index === undefined) {
+      this.pendingAssistantMessageId = undefined;
+      this.latestPendingAssistantAux = undefined;
+      return;
+    }
+
+    const messages = this.messages();
+    const message = messages[index]!;
+    const aux = normalizeMessageAuxSnapshot(message.aux);
+    if (!message.content.trim() && !aux) {
+      this.handleMessageRemoved(index, message.id, 'remove-pending-assistant');
+      messages.splice(index, 1);
+    } else {
+      message.pending = false;
+      if (aux) {
+        message.aux = aux;
+      } else {
+        delete message.aux;
+      }
+      this.lastSettledAssistantMessageId = message.id;
+    }
+    this.pendingAssistantMessageId = undefined;
+    this.latestPendingAssistantAux = undefined;
+  }
+
+  materializeExistingCompletedAssistantMessage(
+    content: string,
+    aux?: MessageAuxSnapshot,
+  ): boolean {
+    const messages = this.messages();
+    const normalized = content.trim();
+    const finalAux = this.normalizeCompletedAssistantAux(aux);
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index]!;
+      if (message.role !== 'assistant' || message.tool) {
+        continue;
+      }
+      if (message.pending) {
+        continue;
+      }
+      if (message.content.trim() !== normalized) {
+        continue;
+      }
+      if (finalAux) {
+        message.aux = normalizeMessageAuxSnapshot({
+          ...(message.aux?.thinking ? { thinking: message.aux.thinking } : {}),
+          ...(message.aux?.compaction ? { compaction: message.aux.compaction } : {}),
+          ...(finalAux.thinking ? { thinking: finalAux.thinking } : {}),
+          ...(finalAux.compaction ? { compaction: finalAux.compaction } : {}),
+        });
+      }
+      if (hasStandaloneThinkingMessageInCurrentTurn(messages)) {
+        message.aux = stripThinkingFromAux(message.aux);
+        if (!message.aux) {
+          delete message.aux;
+        }
+      }
+      this.logAssistantAuxDecision('materialize-completed', {
+        messageId: message.id,
+        aux: message.aux,
+        content,
+      });
+      return true;
+    }
+    return false;
+  }
+
+  takeLatestPendingAux(): MessageAuxSnapshot | undefined {
+    const current = this.latestPendingAssistantAux;
+    this.latestPendingAssistantAux = undefined;
+    if (!current) {
+      this.logAssistantAuxDecision('take-pending-aux-none', {
+        finalizedThinking: this.lastFinalizedThinkingSegment,
+      });
+      this.lastFinalizedThinkingSegment = '';
+      return undefined;
+    }
+    if (
+      this.lastFinalizedThinkingSegment &&
+      current.thinking?.trim() === this.lastFinalizedThinkingSegment.trim()
+    ) {
+      const { thinking: _thinking, ...rest } = current;
+      this.logAssistantAuxDecision('take-pending-aux-strip-exact', {
+        aux: current,
+        finalizedThinking: this.lastFinalizedThinkingSegment,
+        extra: Object.keys(rest).length > 0 ? `kept=${describeAuxForDebug(rest)}` : 'kept=none',
+      });
+      this.lastFinalizedThinkingSegment = '';
+      return Object.keys(rest).length > 0 ? rest : undefined;
+    }
+    if (current.thinking && hasStandaloneThinkingMessageInCurrentTurn(this.messages())) {
+      const stripped = stripThinkingFromAux(current);
+      this.logAssistantAuxDecision('take-pending-aux-strip-standalone', {
+        aux: current,
+        finalizedThinking: this.lastFinalizedThinkingSegment,
+        extra: stripped ? `kept=${describeAuxForDebug(stripped)}` : 'kept=none',
+      });
+      this.lastFinalizedThinkingSegment = '';
+      return stripped;
+    }
+    this.logAssistantAuxDecision('take-pending-aux-carry', {
+      aux: current,
+      finalizedThinking: this.lastFinalizedThinkingSegment,
+    });
+    this.lastFinalizedThinkingSegment = '';
+    return current;
+  }
+
+  pruneEmptyAssistantMessages(reason: string): void {
+    const { messages, removed } = pruneEmptyAssistantMessagesFromSnapshots(this.messages());
+    this.options.setMessages(messages);
+    for (const removal of removed) {
+      this.handleMessageRemoved(removal.messageIndex, removal.messageId, `prune:${reason}`);
+    }
+    if (removed.length > 0) {
+      const removedIds = removed.map((removal) => removal.messageId);
+      console.warn(
+        `[desktop-host][messages] dropped ${removedIds.length} empty assistant message(s) during ${reason}: ${removedIds.join(', ')}`,
+      );
+    }
+  }
+
+  streamAssistantThinkingAnchorOr(defaultValue: number): number {
+    return this.streamAssistantThinkingAnchor ?? defaultValue;
+  }
+
+  shiftStreamAssistantThinkingAnchorForInsertion(insertAt: number): void {
+    this.streamAssistantThinkingAnchor = shiftThinkingAnchorForInsertion(
+      this.streamAssistantThinkingAnchor,
+      insertAt,
+    );
+  }
+
+  shiftStreamAssistantThinkingAnchorForRemoval(removeAt: number, removeCount = 1): void {
+    this.streamAssistantThinkingAnchor = shiftThinkingAnchorForRemoval(
+      this.streamAssistantThinkingAnchor,
+      removeAt,
+      removeCount,
+    );
+  }
+
+  handleMessageRemoved(messageIndex: number, messageId: number, reason: string): void {
+    this.shiftStreamAssistantThinkingAnchorForRemoval(messageIndex);
+    if (this.pendingAssistantMessageId === messageId) {
+      this.pendingAssistantMessageId = undefined;
+    }
+    if (this.lastSettledAssistantMessageId === messageId) {
+      this.lastSettledAssistantMessageId = undefined;
+    }
+    this.logAssistantAuxDecision('remove-message-anchor-shift', {
+      messageId,
+      extra: `reason=${reason} nextAnchor=${this.streamAssistantThinkingAnchor ?? '∅'}`,
+    });
+  }
+
+  resetStreamingPlacementState(full: boolean): void {
+    this.pendingAssistantMessageId = undefined;
+    this.lastSettledAssistantMessageId = undefined;
+    if (!full) {
+      this.streamAssistantThinkingAnchor = undefined;
+      return;
+    }
+    this.latestPendingAssistantAux = undefined;
+    this.lastFinalizedThinkingSegment = '';
+    this.streamAssistantThinkingAnchor = undefined;
+    this.streamAssistantAnchorSetInApplyBatchId = 0;
+  }
+
+  private messages(): ConversationMessageSnapshot[] {
+    return this.options.messages();
+  }
+
+  private ensurePendingAssistantMessage(): ConversationMessageSnapshot {
+    const messages = this.messages();
+    const existingIndex = this.findPendingAssistantMessageIndex();
+    if (existingIndex !== undefined) {
+      return messages[existingIndex]!;
+    }
+
+    const message: ConversationMessageSnapshot = {
+      id: this.options.allocateMessageId(),
+      role: 'assistant',
+      content: '',
+      ...(this.latestPendingAssistantAux ? { aux: { ...this.latestPendingAssistantAux } } : {}),
+      pending: true,
+    };
+    messages.push(message);
+    this.pendingAssistantMessageId = message.id;
+    return message;
+  }
+
+  private findPendingAssistantMessageIndex(): number | undefined {
+    const messages = this.messages();
+    if (this.pendingAssistantMessageId !== undefined) {
+      const index = messages.findIndex(
+        (message) =>
+          message.id === this.pendingAssistantMessageId &&
+          message.role === 'assistant' &&
+          message.pending &&
+          !message.tool,
+      );
+      if (index >= 0) {
+        return index;
+      }
+      this.pendingAssistantMessageId = undefined;
+    }
+
+    const fallbackIndex = messages.findIndex(
+      (message) => message.role === 'assistant' && message.pending && !message.tool,
+    );
+    if (fallbackIndex >= 0) {
+      this.pendingAssistantMessageId = messages[fallbackIndex]!.id;
+      return fallbackIndex;
+    }
+    return undefined;
+  }
+
+  private normalizeCompletedAssistantAux(aux?: MessageAuxSnapshot): MessageAuxSnapshot | undefined {
+    const normalized = normalizeMessageAuxSnapshot(aux);
+    if (!normalized?.thinking) {
+      return normalized;
+    }
+    const messages = this.messages();
+    if (!hasStandaloneThinkingMessageInCurrentTurn(messages)) {
+      return normalized;
+    }
+    const stripped = stripThinkingFromAux(normalized);
+    this.logAssistantAuxDecision('strip-completed-thinking-aux', {
+      aux: normalized,
+      extra: stripped ? `kept=${describeAuxForDebug(stripped)}` : 'kept=none',
+    });
+    return stripped;
+  }
+
+  private findLastSettledAssistantMessageIndex(): number | undefined {
+    if (this.lastSettledAssistantMessageId === undefined) {
+      return undefined;
+    }
+
+    const messages = this.messages();
+    const index = messages.findIndex(
+      (message) =>
+        message.id === this.lastSettledAssistantMessageId &&
+        message.role === 'assistant' &&
+        !message.tool &&
+        !message.pending,
+    );
+    if (index < 0 || !messageIndexIsInCurrentTurn(messages, index)) {
+      this.lastSettledAssistantMessageId = undefined;
+      return undefined;
+    }
+    return index;
+  }
+
+  private stripFinalizedThinkingFromAssistantAnchors(text: string): void {
+    const messages = this.messages();
+    const targets: Array<{ kind: 'pending' | 'settled'; index: number | undefined }> = [
+      { kind: 'pending', index: this.findPendingAssistantMessageIndex() },
+      { kind: 'settled', index: this.findLastSettledAssistantMessageIndex() },
+    ];
+
+    for (const target of targets) {
+      if (target.index === undefined) {
+        continue;
+      }
+      const message = messages[target.index];
+      if (!message) {
+        continue;
+      }
+      const beforeAux = normalizeMessageAuxSnapshot(message.aux);
+      const afterAux = stripPendingThinkingMatchingFinalized(beforeAux, text);
+      const changed = describeOptionalAuxForDebug(beforeAux) !== describeOptionalAuxForDebug(afterAux);
+      if (!changed) {
+        continue;
+      }
+      if (afterAux) {
+        message.aux = afterAux;
+      } else {
+        delete message.aux;
+      }
+      this.logAssistantAuxDecision('strip-finalized-thinking-anchor', {
+        messageId: message.id,
+        aux: beforeAux,
+        finalizedThinking: text,
+        extra: `target=${target.kind} next=${describeOptionalAuxForDebug(afterAux)}`,
+      });
+      return;
+    }
+
+    this.logAssistantAuxDecision('strip-finalized-thinking-miss', {
+      finalizedThinking: text,
+    });
+  }
+
+  private logToolMessageUpdate(
+    messageId: number,
+    toolCallId: string,
+    previousTool: ToolBlockSnapshot | undefined,
+    nextTool: ToolBlockSnapshot,
+    messages: ReadonlyArray<ConversationMessageSnapshot>,
+  ): void {
+    const mode = messageOrderDebugLevel();
+    if (mode === 'off') {
+      return;
+    }
+
+    const previousPhase = previousTool?.phase;
+    const nextPhase = nextTool.phase;
+    const previousHeadline = previousTool?.headline ?? '';
+    const nextHeadline = nextTool.headline;
+    const previousOutput = previousTool?.outputExcerpt ?? '';
+    const nextOutput = nextTool.outputExcerpt ?? '';
+    if (
+      previousPhase === nextPhase &&
+      previousHeadline === nextHeadline &&
+      previousOutput === nextOutput
+    ) {
+      return;
+    }
+
+    const tail = summarizeMessagesTailForOrderDebug([...messages], 8);
+    console.log(
+      `[desktop-host][tool] msg=${messageId} call=${toolCallId} name=${nextTool.toolName} phase=${previousPhase ?? '∅'}->${nextPhase} headline≈${truncateOneLineForDebug(nextHeadline, 42)} tail=${tail}`,
+    );
+  }
+
+  private logAssistantAuxDecision(
+    stage: string,
+    details: {
+      messageId?: number;
+      aux?: MessageAuxSnapshot;
+      content?: string;
+      finalizedThinking?: string;
+      extra?: string;
+    },
+  ): void {
+    if (messageOrderDebugLevel() === 'off') {
+      return;
+    }
+    const parts = [stage];
+    if (details.messageId !== undefined) {
+      parts.push(`msg=${details.messageId}`);
+    }
+    if (details.aux) {
+      parts.push(`aux=${describeAuxForDebug(details.aux)}`);
+    }
+    if (details.finalizedThinking?.trim()) {
+      parts.push(`final≈${truncateOneLineForDebug(details.finalizedThinking, 42)}`);
+    }
+    if (details.content?.trim()) {
+      parts.push(`content≈${truncateOneLineForDebug(details.content, 42)}`);
+    }
+    if (details.extra) {
+      parts.push(details.extra);
+    }
+    console.log(`[desktop-host][aux] ${parts.join(' ')}`);
+  }
+
+  private logMessageOrderThinkingFinalized(placed: string, lenAfter: number, text: string): void {
+    if (messageOrderDebugLevel() === 'off') {
+      return;
+    }
+    const oneLine = text.replace(/\s+/g, ' ').trim();
+    const clip = oneLine.slice(0, 72);
+    console.log(
+      `[desktop-host][msg-order] thinking-finalized ${placed} len=${lenAfter} text≈${clip}${oneLine.length > 72 ? '…' : ''}`,
+    );
+  }
+
+  private logMessageOrderToolPreviewNew(toolName: string, pushAt: number): void {
+    if (messageOrderDebugLevel() === 'off') {
+      return;
+    }
+    console.log(`[desktop-host][msg-order] tool-preview-new ${toolName} push@${pushAt}`);
+  }
+}

--- a/apps/desktop/src/host/conversation-snapshot.ts
+++ b/apps/desktop/src/host/conversation-snapshot.ts
@@ -1,0 +1,206 @@
+import type {
+  ConversationMessageSnapshot,
+  PendingAssistantAux,
+} from '../types.js';
+import {
+  buildVisibleMessageSnapshots,
+} from './message-snapshots.js';
+import {
+  isStandaloneSubagentStatusAux,
+  messageOrderDebugLevel,
+  parsePendingSubagentStatusText,
+  rewindStandalonePendingAuxInsertIndexForThinking,
+  shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse,
+  summarizeMessagesTailForOrderDebug,
+  truncateOneLineForDebug,
+} from './message-ordering.js';
+import type { StoredDesktopRewindMetadata } from './rewind.js';
+
+export interface BuildConversationMessagesInput {
+  messages: ConversationMessageSnapshot[];
+  livePendingAux?: PendingAssistantAux;
+  rewind: StoredDesktopRewindMetadata;
+}
+
+export interface SyncStandalonePendingAuxInput {
+  livePendingAux?: PendingAssistantAux;
+  pendingAssistantMessageId?: number;
+  lastSettledAssistantMessageId?: number;
+}
+
+interface StandalonePendingAuxSnapshot {
+  message: ConversationMessageSnapshot;
+  insertAt: number;
+  source: 'live' | 'persisted';
+  anchorMessageId?: number;
+  anchorResolvedIndex?: number;
+}
+
+export class DesktopConversationSnapshotView {
+  private persistedStandalonePendingAux: PendingAssistantAux | undefined;
+  private persistedStandalonePendingAuxAnchorMessageId: number | undefined;
+  private standalonePendingAuxMessageId: number | undefined;
+  private lastStandalonePendingAuxSnapshotLogSignature: string | undefined;
+
+  constructor(private readonly allocateMessageId: () => number) {}
+
+  buildMessagesWithPendingAssistant(input: BuildConversationMessagesInput): ConversationMessageSnapshot[] {
+    const snapshots = buildVisibleMessageSnapshots({
+      messages: input.messages,
+      livePendingAux: input.livePendingAux,
+      rewind: input.rewind,
+    });
+
+    const standalonePendingAux = this.standalonePendingAuxSnapshot(
+      input.livePendingAux,
+      snapshots,
+    );
+    if (!standalonePendingAux) {
+      this.lastStandalonePendingAuxSnapshotLogSignature = undefined;
+      return snapshots;
+    }
+
+    const insertAt = Math.max(0, Math.min(standalonePendingAux.insertAt, snapshots.length));
+    snapshots.splice(insertAt, 0, standalonePendingAux.message);
+    this.logSnapshotStandalonePendingAux(standalonePendingAux, snapshots);
+    return snapshots;
+  }
+
+  syncStandalonePendingAux(input: SyncStandalonePendingAuxInput): void {
+    const livePendingAux = input.livePendingAux;
+    if (livePendingAux && isStandaloneSubagentStatusAux(livePendingAux)) {
+      this.persistedStandalonePendingAux = {
+        kind: livePendingAux.kind,
+        statusText: livePendingAux.statusText,
+        ...(livePendingAux.detailText ? { detailText: livePendingAux.detailText } : {}),
+      };
+      if (this.standalonePendingAuxMessageId === undefined) {
+        this.standalonePendingAuxMessageId = this.allocateMessageId();
+      }
+      const anchorMessageId = input.pendingAssistantMessageId ?? input.lastSettledAssistantMessageId;
+      if (anchorMessageId !== undefined) {
+        this.persistedStandalonePendingAuxAnchorMessageId = anchorMessageId;
+      }
+      return;
+    }
+
+    if (!isStandaloneSubagentStatusAux(this.persistedStandalonePendingAux)) {
+      this.clearStandalonePendingAuxState();
+    }
+  }
+
+  shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
+    previousMessage: ConversationMessageSnapshot | undefined,
+  ): boolean {
+    return shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
+      previousMessage,
+      this.persistedStandalonePendingAux,
+    );
+  }
+
+  reanchorPersistedStandalonePendingAux(anchorMessageId: number): void {
+    this.persistedStandalonePendingAuxAnchorMessageId = anchorMessageId;
+  }
+
+  clearStandalonePendingAuxState(): void {
+    this.persistedStandalonePendingAux = undefined;
+    this.persistedStandalonePendingAuxAnchorMessageId = undefined;
+    this.standalonePendingAuxMessageId = undefined;
+    this.lastStandalonePendingAuxSnapshotLogSignature = undefined;
+  }
+
+  private standalonePendingAuxSnapshot(
+    livePendingAux: PendingAssistantAux | undefined,
+    snapshots: ConversationMessageSnapshot[],
+  ): StandalonePendingAuxSnapshot | undefined {
+    const liveStandalonePendingAux =
+      livePendingAux && isStandaloneSubagentStatusAux(livePendingAux)
+        ? livePendingAux
+        : undefined;
+    const liveStatusText = liveStandalonePendingAux
+      ? parsePendingSubagentStatusText(liveStandalonePendingAux.statusText)
+      : undefined;
+    if (liveStatusText) {
+      return {
+        source: 'live',
+        insertAt: snapshots.length,
+        message: this.standalonePendingAuxMessage(liveStatusText),
+      };
+    }
+
+    const persistedStandalonePendingAux =
+      this.persistedStandalonePendingAux && isStandaloneSubagentStatusAux(this.persistedStandalonePendingAux)
+        ? this.persistedStandalonePendingAux
+        : undefined;
+    const persistedStatusText = persistedStandalonePendingAux
+      ? parsePendingSubagentStatusText(persistedStandalonePendingAux.statusText)
+      : undefined;
+    if (!persistedStatusText) {
+      return undefined;
+    }
+
+    const anchorMessageId = this.persistedStandalonePendingAuxAnchorMessageId;
+    let anchorResolvedIndex: number | undefined;
+    let insertAt: number | undefined;
+    if (anchorMessageId !== undefined) {
+      const anchoredIndex = snapshots.findIndex((message) => message.id === anchorMessageId);
+      if (anchoredIndex >= 0) {
+        anchorResolvedIndex = anchoredIndex;
+        insertAt = rewindStandalonePendingAuxInsertIndexForThinking(snapshots, anchoredIndex);
+      }
+    }
+
+    if (insertAt === undefined) {
+      insertAt = snapshots.length > 0 ? Math.max(0, snapshots.length - 1) : 0;
+    }
+
+    return {
+      source: 'persisted',
+      anchorMessageId,
+      anchorResolvedIndex,
+      insertAt,
+      message: this.standalonePendingAuxMessage(persistedStatusText),
+    };
+  }
+
+  private standalonePendingAuxMessage(statusText: string): ConversationMessageSnapshot {
+    if (this.standalonePendingAuxMessageId === undefined) {
+      this.standalonePendingAuxMessageId = this.allocateMessageId();
+    }
+
+    return {
+      id: this.standalonePendingAuxMessageId,
+      role: 'assistant',
+      content: statusText,
+      pending: false,
+    };
+  }
+
+  private logSnapshotStandalonePendingAux(
+    standalonePendingAux: StandalonePendingAuxSnapshot,
+    snapshots: ConversationMessageSnapshot[],
+  ): void {
+    if (messageOrderDebugLevel() !== 'verbose') {
+      return;
+    }
+
+    const status = truncateOneLineForDebug(standalonePendingAux.message.content, 48);
+    const tail = summarizeMessagesTailForOrderDebug(snapshots, 6);
+    const signature = [
+      standalonePendingAux.source,
+      standalonePendingAux.message.id,
+      standalonePendingAux.insertAt,
+      standalonePendingAux.anchorMessageId ?? '∅',
+      standalonePendingAux.anchorResolvedIndex ?? '∅',
+      standalonePendingAux.message.content,
+      tail,
+    ].join('|');
+    if (signature === this.lastStandalonePendingAuxSnapshotLogSignature) {
+      return;
+    }
+    this.lastStandalonePendingAuxSnapshotLogSignature = signature;
+    console.log(
+      `[desktop-host][snapshot] standalone-subagent-status source=${standalonePendingAux.source} msg=${standalonePendingAux.message.id} insert=${standalonePendingAux.insertAt} anchorMsg=${standalonePendingAux.anchorMessageId ?? '∅'} anchorIdx=${standalonePendingAux.anchorResolvedIndex ?? '∅'} status≈${status}${standalonePendingAux.message.content.length > 48 ? '…' : ''} tail=${tail}`,
+    );
+  }
+}

--- a/apps/desktop/src/host/dreams.ts
+++ b/apps/desktop/src/host/dreams.ts
@@ -159,6 +159,7 @@ export async function runDesktopDreamCollectorOnce(
   let sourceContextMode: DreamCollectorSourceContextMode | undefined;
   let pendingCount = 0;
   let toolCalls: DesktopDreamCollectorRunLog['toolCalls'] = [];
+  let blockedToolName: string | undefined;
   let promptForDebug = '';
   let debugSessionPersisted = false;
   try {
@@ -222,6 +223,9 @@ export async function runDesktopDreamCollectorOnce(
       }));
       return;
     }
+    // Collector 目前仍复用完整的 DesktopToolExecutor；这里只额外挂载 dream scope，
+    // 不会把可见工具面裁成 dream-only。要真正收紧到特许可用工具，需要连同扩展/MCP
+    // 的暴露策略一起设计清楚，避免现在先做一层局部限制后再打破宿主边界。
     const toolExecutor = new DesktopToolExecutor(input.workspaceRoot, {
       dreamScope: scope,
       dreamSourceSession: {
@@ -246,7 +250,27 @@ export async function runDesktopDreamCollectorOnce(
       scope,
       sourceContext,
     });
-    const result = await runtime.submitUserTurn(promptForDebug);
+    let result = await runtime.submitUserTurn(promptForDebug);
+    for (let guard = 0; guard < 4; guard += 1) {
+      toolCalls = result.toolExecutions.map((execution) => ({
+        toolName: execution.toolName,
+        failed: execution.failed,
+      }));
+      if (result.kind === 'requires-approval') {
+        blockedToolName = result.approval.toolName;
+        result = await runtime.resumePendingApproval({
+          kind: 'deny',
+          resultText: `[dream collector policy] denied non-dream tool: ${result.approval.toolName}`,
+        });
+        continue;
+      }
+      if (result.kind === 'requires-questions') {
+        blockedToolName = result.questions.toolName;
+        result = await runtime.resumePendingQuestions({ status: 'skipped' });
+        continue;
+      }
+      break;
+    }
     toolCalls = result.toolExecutions.map((execution) => ({
       toolName: execution.toolName,
       failed: execution.failed,
@@ -297,6 +321,7 @@ export async function runDesktopDreamCollectorOnce(
       pendingCount,
       resultSummary: truncateText(result.assistantText, 1_000),
       toolCalls,
+      ...(blockedToolName ? { blockedToolName } : {}),
     });
   } catch (error) {
     if (input.config.dreams.debugMode && sourceSession && promptForDebug && !debugSessionPersisted) {
@@ -324,6 +349,7 @@ export async function runDesktopDreamCollectorOnce(
       pendingCount,
       error: error instanceof Error ? error.message : String(error),
       toolCalls,
+      ...(blockedToolName ? { blockedToolName } : {}),
     });
     throw error;
   }
@@ -524,6 +550,7 @@ interface DesktopDreamCollectorRunLog {
   pendingCount: number;
   resultSummary?: string;
   error?: string;
+  blockedToolName?: string;
   toolCalls: Array<{
     toolName: string;
     failed: boolean;

--- a/apps/desktop/src/host/dreams.ts
+++ b/apps/desktop/src/host/dreams.ts
@@ -1,0 +1,610 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+  AgentRuntime,
+  OpenAiPlanMetadata,
+  OpenAiToolAgentState,
+  OpenAiTransportConfig,
+} from '@spirit-agent/agent-core';
+import {
+  createHostDreamStore,
+  DREAM_RETENTION_MS as HOST_DREAM_RETENTION_MS,
+  dreamLogsDirPath,
+  type HostDreamSessionProgress,
+} from '@spirit-agent/host-internal';
+
+import type {
+  ConversationMessageSnapshot,
+  DesktopDreamCollectorSnapshot,
+  SessionListItem,
+} from '../types.js';
+import type { DesktopToolRequest, StoredDesktopSession } from './contracts.js';
+import {
+  chatsDirPath,
+  listStoredSessions,
+  loadStoredSession,
+  resolveApiKeyForModel,
+  saveStoredSession,
+  spiritAgentDataDir,
+  type DesktopConfigFile,
+} from './storage.js';
+import { DesktopToolExecutor } from './tool-executor.js';
+import {
+  currentApiBase,
+  sameWorkspaceRoot,
+} from './service-utils.js';
+
+export const DREAM_DEBUG_SESSION_FILE_PREFIX = 'dream-collector-';
+export const DREAM_COLLECTOR_TICK_INTERVAL_MS = 30_000;
+export const DREAM_COLLECTOR_MONITOR_INTERVAL_MS = 5_000;
+export const DREAM_COLLECTOR_BACKOFF_MS = 60_000;
+
+const DREAM_COLLECTOR_SOURCE_CONTEXT_MAX_CHARS = 16_000;
+const DREAM_COLLECTOR_INCREMENTAL_CONTEXT_MAX_CHARS = 8_000;
+const DREAM_COLLECTOR_ANCHOR_CONTEXT_MAX_CHARS = 4_000;
+const DREAM_COLLECTOR_ANCHOR_MESSAGE_COUNT = 4;
+const DREAM_COLLECTOR_SESSION_COOLDOWN_MS = 2 * 60 * 1000;
+const DREAM_COMMIT_CONTEXT_MAX_CHARS = 6_000;
+
+type DesktopRuntime = AgentRuntime<
+  OpenAiTransportConfig,
+  OpenAiToolAgentState,
+  DesktopToolRequest,
+  string
+>;
+
+export async function buildDreamCommitContext(input: {
+  workspaceRoot: string;
+  gitBranch?: string;
+}): Promise<string> {
+  const gitBranch = input.gitBranch?.trim();
+  if (!gitBranch) {
+    return '';
+  }
+
+  const dreamStore = createHostDreamStore({
+    spiritDataDir: spiritAgentDataDir(),
+    scope: {
+      workspaceRoot: input.workspaceRoot,
+      gitBranch,
+    },
+  });
+  await dreamStore.pruneExpired();
+  const dreams = await dreamStore.list({ includeDeleted: false, includeExpired: false });
+  if (dreams.length === 0) {
+    return '';
+  }
+
+  const rendered = dreams.map((dream, index) => {
+    const lines = [
+      `${index + 1}. ${dream.title}`,
+      `summary: ${dream.summary}`,
+      dream.details ? `details: ${dream.details}` : '',
+      dream.tags?.length ? `tags: ${dream.tags.join(', ')}` : '',
+      `updatedAtUnixMs: ${dream.updatedAtUnixMs}`,
+    ].filter(Boolean);
+    return lines.join('\n');
+  }).join('\n\n');
+  return truncateText(rendered, DREAM_COMMIT_CONTEXT_MAX_CHARS);
+}
+
+export function buildCommitMessageGenerationPrompt(input: {
+  workspaceRoot: string;
+  branch?: string;
+  dreamContextText?: string;
+  statusText: string;
+  diffStatText: string;
+  diffText: string;
+}): string {
+  const dreamSection = input.dreamContextText?.trim()
+    ? [
+        '',
+        '[dream summaries] 当前工作动向摘要',
+        input.dreamContextText.trim(),
+      ]
+    : [];
+  return [
+    '请为以下 Git 变更生成一条提交信息。',
+    '必须遵守仓库约定：type / 可选 scope 使用英文；subject 使用中文。',
+    '输出 JSON，由宿主解析。不要输出 Markdown、解释、代码块或额外字段。',
+    'message 应该是一条可直接执行 git commit 的提交信息。若需要正文，可使用换行。',
+    '如果提供了 dream summaries，请把它作为“为什么做这些变更”的语义背景；最终提交信息仍以 Git diff 为准。',
+    '',
+    `workspace: ${input.workspaceRoot}`,
+    `branch: ${input.branch ?? '(unknown)'}`,
+    ...dreamSection,
+    '',
+    '[git status --short --branch]',
+    input.statusText || '(empty)',
+    '',
+    '[git diff --stat HEAD]',
+    input.diffStatText || '(empty)',
+    '',
+    '[git diff HEAD]',
+    input.diffText || '(empty)',
+  ].join('\n');
+}
+
+export interface RunDesktopDreamCollectorOnceInput {
+  workspaceRoot: string;
+  gitBranch: string;
+  collectorModel: string;
+  config: DesktopConfigFile;
+  planMetadata: OpenAiPlanMetadata;
+}
+
+export interface RunDesktopDreamCollectorOnceDeps {
+  createRuntime(
+    transportConfig: OpenAiTransportConfig,
+    planMetadata: OpenAiPlanMetadata,
+    toolExecutor: DesktopToolExecutor,
+  ): DesktopRuntime;
+  getStatus(): DesktopDreamCollectorSnapshot;
+  setStatus(next: DesktopDreamCollectorSnapshot): void;
+}
+
+export async function runDesktopDreamCollectorOnce(
+  input: RunDesktopDreamCollectorOnceInput,
+  deps: RunDesktopDreamCollectorOnceDeps,
+): Promise<void> {
+  const runId = randomUUID();
+  const startedAtUnixMs = Date.now();
+  const scope = {
+    workspaceRoot: input.workspaceRoot,
+    gitBranch: input.gitBranch,
+  };
+  let sourceSession: SessionListItem | undefined;
+  let sourceContextMode: DreamCollectorSourceContextMode | undefined;
+  let pendingCount = 0;
+  let toolCalls: DesktopDreamCollectorRunLog['toolCalls'] = [];
+  let promptForDebug = '';
+  let debugSessionPersisted = false;
+  try {
+    const cutoffUnixMs = Date.now() - HOST_DREAM_RETENTION_MS;
+    const now = Date.now();
+    const storedSessions = (await listStoredSessions())
+      .filter((session) => sameWorkspaceRoot(session.workspaceRoot, input.workspaceRoot))
+      .filter((session) => session.gitBranch === input.gitBranch)
+      .filter((session) => !isDreamCollectorDebugSessionPath(session.path))
+      .filter((session) => session.modifiedAtUnixMs >= cutoffUnixMs)
+      .sort((left, right) => left.modifiedAtUnixMs - right.modifiedAtUnixMs);
+
+    const dreamStore = createHostDreamStore({ spiritDataDir: spiritAgentDataDir(), scope });
+    await dreamStore.pruneExpired(now);
+    const sessionProgressList = await dreamStore.listSessionProgress();
+    const sessionProgressMap = new Map(sessionProgressList.map((entry) => [entry.path, entry]));
+    const pendingSessions = storedSessions.filter((session) =>
+      shouldQueueDreamCollectorSession(session, sessionProgressMap.get(session.path), now),
+    );
+    pendingCount = pendingSessions.length;
+    if (pendingSessions.length === 0) {
+      deps.setStatus(clearDreamCollectorIssue({
+        ...deps.getStatus(),
+        state: 'idle',
+        pendingCount: 0,
+      }));
+      return;
+    }
+
+    sourceSession = pendingSessions[0]!;
+    deps.setStatus(clearDreamCollectorIssue({
+      ...deps.getStatus(),
+      state: 'running',
+      pendingCount: pendingSessions.length,
+    }));
+
+    const apiKey = await resolveApiKeyForModel(input.collectorModel);
+    if (!apiKey) {
+      throw new Error('梦境收集模型未配置 API Key。');
+    }
+
+    const activeProfile = input.config.models.find((model) => model.name === input.collectorModel);
+    const archive = await loadStoredSession(sourceSession.path);
+    const sessionProgress = sessionProgressMap.get(sourceSession.path);
+    const sourceContext = buildDreamCollectorSourceContext(archive, sessionProgress);
+    sourceContextMode = sourceContext.mode;
+    if (!sourceContext.shouldRunCollector) {
+      await dreamStore.upsertSessionProgress({
+        path: sourceSession.path,
+        ...(sourceSession.displayName ? { displayName: sourceSession.displayName } : {}),
+        lastProcessedSavedAtUnixMs: sourceSession.modifiedAtUnixMs,
+        lastProcessedMessageCount: sourceContext.processedMessageCount,
+        lastProcessedPrefixHash: sourceContext.prefixHash,
+        lastRunAtUnixMs: Date.now(),
+        cooldownUntilUnixMs: Date.now() + DREAM_COLLECTOR_SESSION_COOLDOWN_MS,
+      });
+      deps.setStatus(clearDreamCollectorIssue({
+        ...deps.getStatus(),
+        state: 'idle',
+        pendingCount: Math.max(0, pendingSessions.length - 1),
+      }));
+      return;
+    }
+    const toolExecutor = new DesktopToolExecutor(input.workspaceRoot, {
+      dreamScope: scope,
+      dreamSourceSession: {
+        path: sourceSession.path,
+        displayName: sourceSession.displayName,
+        savedAtUnixMs: sourceSession.modifiedAtUnixMs,
+      },
+    });
+    const runtime = deps.createRuntime(
+      {
+        apiKey,
+        model: input.collectorModel,
+        baseUrl: activeProfile?.apiBase ?? currentApiBase(input.config),
+        workspaceRoot: input.workspaceRoot,
+        ...(activeProfile?.provider ? { llmVendor: activeProfile.provider } : {}),
+      },
+      input.planMetadata,
+      toolExecutor,
+    );
+    promptForDebug = buildDreamCollectorPrompt({
+      sourceSession,
+      scope,
+      sourceContext,
+    });
+    const result = await runtime.submitUserTurn(promptForDebug);
+    toolCalls = result.toolExecutions.map((execution) => ({
+      toolName: execution.toolName,
+      failed: execution.failed,
+    }));
+    if (result.kind !== 'completed') {
+      throw new Error(result.kind === 'failed' ? result.error : `梦境收集未完成: ${result.kind}`);
+    }
+    if (input.config.dreams.debugMode) {
+      await persistDreamCollectorDebugSession({
+        runId,
+        workspaceRoot: input.workspaceRoot,
+        gitBranch: input.gitBranch,
+        collectorModel: input.collectorModel,
+        sourceSession,
+        prompt: promptForDebug,
+        assistantText: result.assistantText,
+        failed: false,
+      });
+      debugSessionPersisted = true;
+    }
+
+    await dreamStore.upsertSessionProgress({
+      path: sourceSession.path,
+      ...(sourceSession.displayName ? { displayName: sourceSession.displayName } : {}),
+      lastProcessedSavedAtUnixMs: sourceSession.modifiedAtUnixMs,
+      lastProcessedMessageCount: sourceContext.processedMessageCount,
+      lastProcessedPrefixHash: sourceContext.prefixHash,
+      lastRunAtUnixMs: Date.now(),
+      cooldownUntilUnixMs: Date.now() + DREAM_COLLECTOR_SESSION_COOLDOWN_MS,
+    });
+    deps.setStatus(clearDreamCollectorIssue({
+      ...deps.getStatus(),
+      state: 'idle',
+      lastSuccessAtUnixMs: Date.now(),
+      pendingCount: Math.max(0, pendingSessions.length - 1),
+      processedCount: deps.getStatus().processedCount + 1,
+    }));
+    await writeDreamCollectorRunLog({
+      runId,
+      startedAtUnixMs,
+      finishedAtUnixMs: Date.now(),
+      workspaceRoot: input.workspaceRoot,
+      gitBranch: input.gitBranch,
+      collectorModel: input.collectorModel,
+      sourceSessionPath: sourceSession.path,
+      decision: 'processed',
+      ...(sourceContextMode ? { sourceContextMode } : {}),
+      pendingCount,
+      resultSummary: truncateText(result.assistantText, 1_000),
+      toolCalls,
+    });
+  } catch (error) {
+    if (input.config.dreams.debugMode && sourceSession && promptForDebug && !debugSessionPersisted) {
+      await persistDreamCollectorDebugSession({
+        runId,
+        workspaceRoot: input.workspaceRoot,
+        gitBranch: input.gitBranch,
+        collectorModel: input.collectorModel,
+        sourceSession,
+        prompt: promptForDebug,
+        assistantText: error instanceof Error ? error.message : String(error),
+        failed: true,
+      });
+    }
+    await writeDreamCollectorRunLog({
+      runId,
+      startedAtUnixMs,
+      finishedAtUnixMs: Date.now(),
+      workspaceRoot: input.workspaceRoot,
+      gitBranch: input.gitBranch,
+      collectorModel: input.collectorModel,
+      ...(sourceSession ? { sourceSessionPath: sourceSession.path } : {}),
+      decision: 'failed',
+      ...(sourceContextMode ? { sourceContextMode } : {}),
+      pendingCount,
+      error: error instanceof Error ? error.message : String(error),
+      toolCalls,
+    });
+    throw error;
+  }
+}
+
+type DreamCollectorSourceContextMode = 'full' | 'incremental';
+
+interface DreamCollectorNormalizedMessage {
+  role: 'user' | 'assistant';
+  rendered: string;
+}
+
+interface DreamCollectorSourceContext {
+  mode: DreamCollectorSourceContextMode;
+  rendered: string;
+  prefixHash: string;
+  processedMessageCount: number;
+  shouldRunCollector: boolean;
+}
+
+function buildDreamCollectorSourceContext(
+  archive: StoredDesktopSession,
+  progress?: HostDreamSessionProgress,
+): DreamCollectorSourceContext {
+  const normalizedMessages = normalizeDreamCollectorMessages(archive);
+  const processedMessageCount = normalizedMessages.length;
+  const prefixHash = hashDreamCollectorMessages(normalizedMessages);
+  if (!progress) {
+    return {
+      mode: 'full',
+      rendered: renderDreamCollectorFullContext(normalizedMessages),
+      prefixHash,
+      processedMessageCount,
+      shouldRunCollector: true,
+    };
+  }
+
+  const needsFullRebuild =
+    progress.lastProcessedMessageCount > processedMessageCount ||
+    hashDreamCollectorMessages(
+      normalizedMessages.slice(0, Math.min(progress.lastProcessedMessageCount, processedMessageCount)),
+    ) !== progress.lastProcessedPrefixHash;
+  if (needsFullRebuild) {
+    return {
+      mode: 'full',
+      rendered: renderDreamCollectorFullContext(normalizedMessages),
+      prefixHash,
+      processedMessageCount,
+      shouldRunCollector: true,
+    };
+  }
+
+  const newMessages = normalizedMessages.slice(progress.lastProcessedMessageCount);
+  if (newMessages.length === 0) {
+    return {
+      mode: 'incremental',
+      rendered: '',
+      prefixHash,
+      processedMessageCount,
+      shouldRunCollector: false,
+    };
+  }
+
+  const anchorMessages = normalizedMessages.slice(
+    Math.max(0, progress.lastProcessedMessageCount - DREAM_COLLECTOR_ANCHOR_MESSAGE_COUNT),
+    progress.lastProcessedMessageCount,
+  );
+  return {
+    mode: 'incremental',
+    rendered: renderDreamCollectorIncrementalContext(anchorMessages, newMessages),
+    prefixHash,
+    processedMessageCount,
+    shouldRunCollector: true,
+  };
+}
+
+function normalizeDreamCollectorMessages(
+  archive: StoredDesktopSession,
+): DreamCollectorNormalizedMessage[] {
+  const source = archive.llmHistory.length > 0
+    ? archive.llmHistory
+    : archive.messages.map((message) => ({
+        role: message.role,
+        content: message.content,
+        imagePaths: [],
+      }));
+  return source
+    .filter(
+      (message): message is { role: 'user' | 'assistant'; content: string; imagePaths: string[] } =>
+        message.role === 'user' || message.role === 'assistant',
+    )
+    .filter((message) => message.content.trim().length > 0)
+    .map((message) => ({
+      role: message.role,
+      rendered: `${message.role.toUpperCase()}:\n${message.content.trim()}`,
+    }));
+}
+
+function hashDreamCollectorMessages(
+  messages: DreamCollectorNormalizedMessage[],
+): string {
+  return createHash('sha256')
+    .update(messages.map((message) => message.rendered).join('\n\n'), 'utf8')
+    .digest('hex')
+    .slice(0, 32);
+}
+
+function renderDreamCollectorFullContext(
+  messages: DreamCollectorNormalizedMessage[],
+): string {
+  return truncateText(
+    messages.map((message) => message.rendered).join('\n\n') || '(empty session)',
+    DREAM_COLLECTOR_SOURCE_CONTEXT_MAX_CHARS,
+  );
+}
+
+function renderDreamCollectorIncrementalContext(
+  anchorMessages: DreamCollectorNormalizedMessage[],
+  newMessages: DreamCollectorNormalizedMessage[],
+): string {
+  const anchorText = truncateText(
+    anchorMessages.map((message) => message.rendered).join('\n\n') || '(no prior anchor)',
+    DREAM_COLLECTOR_ANCHOR_CONTEXT_MAX_CHARS,
+  );
+  const deltaText = truncateText(
+    newMessages.map((message) => message.rendered).join('\n\n') || '(no delta)',
+    DREAM_COLLECTOR_INCREMENTAL_CONTEXT_MAX_CHARS,
+  );
+  return [
+    '[recent_anchor]',
+    anchorText,
+    '',
+    '[new_delta]',
+    deltaText,
+  ].join('\n');
+}
+
+function shouldQueueDreamCollectorSession(
+  session: SessionListItem,
+  progress: HostDreamSessionProgress | undefined,
+  nowUnixMs: number,
+): boolean {
+  if (!progress) {
+    return true;
+  }
+  if (session.modifiedAtUnixMs <= progress.lastProcessedSavedAtUnixMs) {
+    return false;
+  }
+  if (progress.cooldownUntilUnixMs !== undefined && nowUnixMs < progress.cooldownUntilUnixMs) {
+    return false;
+  }
+  return true;
+}
+
+function buildDreamCollectorPrompt(input: {
+  sourceSession: SessionListItem;
+  scope: { workspaceRoot: string; gitBranch: string };
+  sourceContext: DreamCollectorSourceContext;
+}): string {
+  const modeBlock = input.sourceContext.mode === 'incremental'
+    ? [
+        '这是同一会话在上次梦境收集后的新增内容。优先更新已有梦境，不要重复总结旧内容。',
+        '[source_session_incremental_context]',
+      ]
+    : [
+        '这是该会话当前可用的完整摘要上下文。',
+        '[source_session_full_context]',
+      ];
+  return [
+    '请收集这条源会话的梦境摘要。',
+    '你必须先调用 dream_list 查看当前 scope 的已有梦境。',
+    '如果源会话延续了已有动向，请调用 dream_update；如果是新动向，请调用 dream_record；如果已有梦境已经误导或过时，可调用 dream_delete。',
+    '如果写 tags，只保留最关键的 2 到 4 个短标签；优先使用简短 lowercase/kebab-case 词，不要把所有子话题都枚举进去。',
+    '如果源会话完全没有可沉淀的近期工作动向，可以不写入梦境，但不要执行任何非梦境维护操作。',
+    '',
+    `[scope] workspace=${input.scope.workspaceRoot}`,
+    `[scope] branch=${input.scope.gitBranch}`,
+    `[source_session] path=${input.sourceSession.path}`,
+    `[source_session] title=${input.sourceSession.displayName}`,
+    `[source_session] modifiedAtUnixMs=${input.sourceSession.modifiedAtUnixMs}`,
+    `[source_session] mode=${input.sourceContext.mode}`,
+    '',
+    ...modeBlock,
+    input.sourceContext.rendered,
+  ].join('\n');
+}
+
+interface DesktopDreamCollectorRunLog {
+  runId: string;
+  startedAtUnixMs: number;
+  finishedAtUnixMs: number;
+  workspaceRoot: string;
+  gitBranch: string;
+  collectorModel: string;
+  sourceSessionPath?: string;
+  decision: 'no-pending' | 'processed' | 'failed';
+  sourceContextMode?: DreamCollectorSourceContextMode;
+  pendingCount: number;
+  resultSummary?: string;
+  error?: string;
+  toolCalls: Array<{
+    toolName: string;
+    failed: boolean;
+  }>;
+}
+
+async function writeDreamCollectorRunLog(log: DesktopDreamCollectorRunLog): Promise<void> {
+  const logsDir = dreamLogsDirPath(spiritAgentDataDir());
+  await mkdir(logsDir, { recursive: true });
+  const fileName = `${log.startedAtUnixMs}-${log.runId}.json`;
+  await writeFile(path.join(logsDir, fileName), `${JSON.stringify(log, null, 2)}\n`, 'utf8');
+}
+
+async function persistDreamCollectorDebugSession(input: {
+  runId: string;
+  workspaceRoot: string;
+  gitBranch: string;
+  collectorModel: string;
+  sourceSession: SessionListItem;
+  prompt: string;
+  assistantText: string;
+  failed: boolean;
+}): Promise<void> {
+  const now = Date.now();
+  const messages: ConversationMessageSnapshot[] = [
+    {
+      id: 1,
+      role: 'user',
+      content: input.prompt,
+      pending: false,
+    },
+    {
+      id: 2,
+      role: 'assistant',
+      content: input.failed ? `生成失败：${input.assistantText}` : input.assistantText,
+      pending: false,
+    },
+  ];
+  const sessionFile = path.join(chatsDirPath(), `${DREAM_DEBUG_SESSION_FILE_PREFIX}${now}-${input.runId}.json`);
+  await saveStoredSession(sessionFile, {
+    messages,
+    assistantAux: [],
+    llmHistory: messages.map((message) => ({
+      role: message.role,
+      content: message.content,
+      imagePaths: [],
+    })),
+    subagentSessions: [],
+    savedAtUnixMs: now,
+    sessionDisplayName: `[梦境] ${input.sourceSession.displayName}`,
+    workspaceRoot: input.workspaceRoot,
+    gitBranch: input.gitBranch,
+    desktopMessages: messages,
+  });
+}
+
+export function isDreamCollectorDebugSessionPath(filePath: string): boolean {
+  return path.basename(filePath).startsWith(DREAM_DEBUG_SESSION_FILE_PREFIX);
+}
+
+export function emptyDreamCollectorSnapshot(
+  state: DesktopDreamCollectorSnapshot['state'],
+): DesktopDreamCollectorSnapshot {
+  return {
+    state,
+    pendingCount: 0,
+    processedCount: 0,
+  };
+}
+
+export function clearDreamCollectorIssue(
+  snapshot: DesktopDreamCollectorSnapshot,
+): DesktopDreamCollectorSnapshot {
+  const { lastError: _lastError, backoffUntilUnixMs: _backoffUntilUnixMs, ...clean } = snapshot;
+  return clean;
+}
+
+function truncateText(value: string, maxChars: number): string {
+  const chars = Array.from(value);
+  if (chars.length <= maxChars) {
+    return value;
+  }
+  return `${chars.slice(0, maxChars).join('')}...<truncated>`;
+}

--- a/apps/desktop/src/host/extensions.ts
+++ b/apps/desktop/src/host/extensions.ts
@@ -1,0 +1,323 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  buildContributedHostToolDefinitions,
+  type JsonObject,
+  type JsonValue,
+  type OpenAiExtensionSystemPrompt,
+} from '@spirit-agent/agent-core';
+import {
+  collectHostExtensionContributedTools,
+  type HostExtensionManager,
+  type HostInstalledExtension,
+} from '@spirit-agent/host-internal';
+
+import type {
+  DesktopExtensionCssLayer,
+  DesktopExtensionListItem,
+  DesktopMarketplaceCatalogItem,
+  DesktopMarketplaceDetail,
+  DesktopMarketplacePreparedInstall,
+} from '../types.js';
+
+export function buildDesktopExtensionToolDefinitions(
+  extensions: readonly HostInstalledExtension[],
+): JsonValue[] {
+  return buildContributedHostToolDefinitions(
+    collectHostExtensionContributedTools(extensions).map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema as JsonObject,
+    })),
+  );
+}
+
+export async function buildDesktopExtensionListItems(
+  manager: HostExtensionManager,
+  extensions: readonly HostInstalledExtension[],
+): Promise<DesktopExtensionListItem[]> {
+  return Promise.all(extensions.map(async (item) => ({
+    id: item.id,
+    displayName: item.manifest.name,
+    ...(item.manifest.icon ? { icon: item.manifest.icon } : {}),
+    version: item.manifest.version,
+    ...(item.manifest.description ? { description: item.manifest.description } : {}),
+    ...(item.manifest.author ? { author: item.manifest.author } : {}),
+    ...(item.manifest.homepage ? { homepage: item.manifest.homepage } : {}),
+    ...(item.manifest.main ? { main: item.manifest.main } : {}),
+    supportedHosts: [...item.manifest.supportedHosts],
+    ...(item.manifest.activationEvents?.length
+      ? { activationEvents: [...item.manifest.activationEvents] }
+      : {}),
+    ...(item.manifest.requestedCapabilities?.length
+      ? { requestedCapabilities: [...item.manifest.requestedCapabilities] }
+      : {}),
+    ...(item.manifest.contributes?.tools?.length
+      ? {
+          contributedTools: item.manifest.contributes.tools.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            ...(tool.approvalMode ? { approvalMode: tool.approvalMode } : {}),
+            ...(tool.executionMode ? { executionMode: tool.executionMode } : {}),
+          })),
+        }
+      : {}),
+    ...(item.manifest.contributes?.desktop?.css?.length
+      ? {
+          desktopCss: item.manifest.contributes.desktop.css.map((entry) => ({
+            path: entry.path,
+            ...(entry.media ? { media: entry.media } : {}),
+          })),
+        }
+      : {}),
+    ...(item.manifest.contributes?.cli?.hooks?.length
+      ? {
+          cliHooks: item.manifest.contributes.cli.hooks.map((hook) => ({
+            slot: hook.slot,
+            ...(hook.variant ? { variant: hook.variant } : {}),
+            ...(hook.tokens
+              ? {
+                  tokens: {
+                    ...(hook.tokens.foreground ? { foreground: hook.tokens.foreground } : {}),
+                    ...(hook.tokens.border ? { border: hook.tokens.border } : {}),
+                    ...(hook.tokens.accent ? { accent: hook.tokens.accent } : {}),
+                  },
+                }
+              : {}),
+            ...(hook.prefix ? { prefix: hook.prefix } : {}),
+            ...(hook.suffix ? { suffix: hook.suffix } : {}),
+          })),
+        }
+      : {}),
+    ...(item.manifest.settingsSchema?.length
+      ? {
+          settingsSchema: item.manifest.settingsSchema.map((setting) => ({
+            key: setting.key,
+            type: setting.type,
+            title: setting.title,
+            ...(setting.description ? { description: setting.description } : {}),
+            ...(setting.placeholder ? { placeholder: setting.placeholder } : {}),
+            ...(setting.required !== undefined ? { required: setting.required } : {}),
+            ...(setting.defaultValue !== undefined
+              ? { defaultValue: setting.defaultValue }
+              : {}),
+            ...(setting.options?.length
+              ? {
+                  options: setting.options.map((option) => ({
+                    value: option.value,
+                    label: option.label,
+                    ...(option.description ? { description: option.description } : {}),
+                  })),
+                }
+              : {}),
+          })),
+          settingsValues: await manager.getSettingsValues(item.id),
+        }
+      : {}),
+    ...(item.manifest.secretSlots?.length
+      ? {
+          secretSlots: item.manifest.secretSlots.map((slot) => ({
+            key: slot.key,
+            title: slot.title,
+            ...(slot.description ? { description: slot.description } : {}),
+            ...(slot.required !== undefined ? { required: slot.required } : {}),
+          })),
+          secretStatuses: Object.entries(
+            await manager.getSecretStatus(item.id),
+          ).map(([key, configured]) => ({
+            key,
+            configured,
+          })),
+        }
+      : {}),
+    ...(item.archiveFileName ? { archiveFileName: item.archiveFileName } : {}),
+    installedAtUnixMs: item.installedAtUnixMs,
+  })));
+}
+
+export async function collectDesktopExtensionCssLayers(
+  extensions: readonly HostInstalledExtension[],
+): Promise<DesktopExtensionCssLayer[]> {
+  const layers: DesktopExtensionCssLayer[] = [];
+
+  for (const item of extensions) {
+    const cssEntries = item.manifest.contributes?.desktop?.css ?? [];
+    for (const entry of cssEntries) {
+      const sourcePath = path.join(item.directoryPath, ...entry.path.split('/'));
+      try {
+        const cssText = await readFile(sourcePath, 'utf8');
+        if (!cssText.trim()) {
+          continue;
+        }
+        layers.push({
+          extensionId: item.id,
+          extensionName: item.manifest.name,
+          sourcePath: entry.path,
+          cssText,
+          ...(entry.media ? { media: entry.media } : {}),
+        });
+      } catch (error) {
+        console.warn(
+          `[desktop-host][extensions] read css failed: ${item.id}:${entry.path}`,
+          error,
+        );
+      }
+    }
+  }
+
+  return layers;
+}
+
+export async function collectExtensionSystemPrompts(
+  manager: HostExtensionManager,
+  host: unknown,
+): Promise<OpenAiExtensionSystemPrompt[]> {
+  const collected = await manager.collectSystemPromptContributions({
+    host,
+    logger: console,
+  });
+  return collected.map((entry) => ({
+    extensionId: entry.extensionId,
+    extensionName: entry.extensionName,
+    content: entry.content,
+  }));
+}
+
+export function toDesktopMarketplaceCatalogItem(item: {
+  extensionId: string;
+  packageName: string;
+  status: string;
+  featured: boolean;
+  defaultVersion: string;
+  defaultChannel: 'stable' | 'preview' | 'experimental';
+  defaultReviewStatus: 'unverified' | 'verified' | 'revoked';
+  detailPath: string;
+  displayName: string;
+  description: string;
+  author?: string;
+  homepageUrl?: string;
+  repositoryUrl?: string;
+  keywords: string[];
+  supportedHosts: Array<'cli' | 'desktop'>;
+  requestedCapabilities: string[];
+  iconUrl?: string;
+}): DesktopMarketplaceCatalogItem {
+  return {
+    extensionId: item.extensionId,
+    packageName: item.packageName,
+    status: item.status,
+    featured: item.featured,
+    defaultVersion: item.defaultVersion,
+    defaultChannel: item.defaultChannel,
+    defaultReviewStatus: item.defaultReviewStatus,
+    detailPath: item.detailPath,
+    displayName: item.displayName,
+    description: item.description,
+    ...(item.author ? { author: item.author } : {}),
+    ...(item.homepageUrl ? { homepageUrl: item.homepageUrl } : {}),
+    ...(item.repositoryUrl ? { repositoryUrl: item.repositoryUrl } : {}),
+    keywords: [...item.keywords],
+    supportedHosts: [...item.supportedHosts],
+    requestedCapabilities: [...item.requestedCapabilities],
+    ...(item.iconUrl ? { iconUrl: item.iconUrl } : {}),
+  };
+}
+
+export function toDesktopMarketplaceDetail(detail: {
+  extensionId: string;
+  packageName: string;
+  status: string;
+  featured: boolean;
+  defaultVersion: string;
+  readmePath: string;
+  versions: Array<{
+    version: string;
+    channel: 'stable' | 'preview' | 'experimental';
+    reviewStatus: 'unverified' | 'verified' | 'revoked';
+    displayName: string;
+    description: string;
+    author?: string;
+    homepageUrl?: string;
+    repositoryUrl?: string;
+    keywords: string[];
+    supportedHosts: Array<'cli' | 'desktop'>;
+    requestedCapabilities: string[];
+    iconUrl?: string;
+    publishedAt?: string;
+    tarballUrl?: string;
+    integrity?: string;
+    shasum?: string;
+    changelog?: {
+      summary: string;
+      body: string;
+    };
+  }>;
+}): DesktopMarketplaceDetail {
+  return {
+    extensionId: detail.extensionId,
+    packageName: detail.packageName,
+    status: detail.status,
+    featured: detail.featured,
+    defaultVersion: detail.defaultVersion,
+    readmePath: detail.readmePath,
+    versions: detail.versions.map((item) => ({
+      version: item.version,
+      channel: item.channel,
+      reviewStatus: item.reviewStatus,
+      displayName: item.displayName,
+      description: item.description,
+      ...(item.author ? { author: item.author } : {}),
+      ...(item.homepageUrl ? { homepageUrl: item.homepageUrl } : {}),
+      ...(item.repositoryUrl ? { repositoryUrl: item.repositoryUrl } : {}),
+      keywords: [...item.keywords],
+      supportedHosts: [...item.supportedHosts],
+      requestedCapabilities: [...item.requestedCapabilities],
+      ...(item.iconUrl ? { iconUrl: item.iconUrl } : {}),
+      ...(item.publishedAt ? { publishedAt: item.publishedAt } : {}),
+      ...(item.tarballUrl ? { tarballUrl: item.tarballUrl } : {}),
+      ...(item.integrity ? { integrity: item.integrity } : {}),
+      ...(item.shasum ? { shasum: item.shasum } : {}),
+      ...(item.changelog
+        ? {
+            changelog: {
+              summary: item.changelog.summary,
+              body: item.changelog.body,
+            },
+          }
+        : {}),
+    })),
+  };
+}
+
+export function toDesktopMarketplacePreparedInstall(prepared: {
+  extensionId: string;
+  packageName: string;
+  displayName: string;
+  description: string;
+  version: string;
+  channel: 'stable' | 'preview' | 'experimental';
+  reviewStatus: 'unverified' | 'verified' | 'revoked';
+  supportedHosts: Array<'cli' | 'desktop'>;
+  supportsCurrentHost: boolean;
+  tarballUrl?: string;
+  integrity?: string;
+  shasum?: string;
+  sourceFileName: string;
+}): DesktopMarketplacePreparedInstall {
+  return {
+    extensionId: prepared.extensionId,
+    packageName: prepared.packageName,
+    displayName: prepared.displayName,
+    description: prepared.description,
+    version: prepared.version,
+    channel: prepared.channel,
+    reviewStatus: prepared.reviewStatus,
+    supportedHosts: [...prepared.supportedHosts],
+    supportsCurrentHost: prepared.supportsCurrentHost,
+    ...(prepared.tarballUrl ? { tarballUrl: prepared.tarballUrl } : {}),
+    ...(prepared.integrity ? { integrity: prepared.integrity } : {}),
+    ...(prepared.shasum ? { shasum: prepared.shasum } : {}),
+    sourceFileName: prepared.sourceFileName,
+  };
+}

--- a/apps/desktop/src/host/mcp-config.ts
+++ b/apps/desktop/src/host/mcp-config.ts
@@ -1,0 +1,231 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  mcpUserConfigPath,
+  normalizeCapabilityToggles,
+  normalizeMcpServerConfig,
+  parseMcpConfigFile,
+  summarizeTransport,
+  type McpConfigFile,
+  type McpServerConfig,
+} from '@spirit-agent/agent-core';
+
+import type {
+  AddMcpServerRequest,
+  DesktopMcpServerListItem,
+  DesktopSnapshot,
+} from '../types.js';
+import { spiritAgentDataDir } from './storage.js';
+
+const MCP_DEFAULT_TIMEOUT_MS = 20_000;
+
+type DesktopMcpMetadataKind = 'env' | 'header';
+
+export function emptyMcpStatusSnapshot(): DesktopSnapshot['mcpStatus'] {
+  return {
+    revision: 0,
+    state: 'idle',
+    configuredServers: 0,
+    loadedServers: 0,
+    cachedTools: 0,
+  };
+}
+
+export function desktopMcpConfigPath(): string {
+  return mcpUserConfigPath(spiritAgentDataDir());
+}
+
+export function loadMcpConfigFileFromDisk(): McpConfigFile {
+  const configPath = desktopMcpConfigPath();
+  if (!existsSync(configPath)) {
+    return { servers: {} };
+  }
+
+  const content = readFileSync(configPath, 'utf8');
+  return parseMcpConfigFile(JSON.parse(content) as unknown);
+}
+
+export async function saveMcpConfigFileToDisk(config: McpConfigFile): Promise<void> {
+  const configPath = desktopMcpConfigPath();
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+export function listDesktopMcpServersFromDisk(): DesktopMcpServerListItem[] {
+  try {
+    const configFile = loadMcpConfigFileFromDisk();
+    return Object.entries(configFile.servers).map(([name, server]) => {
+      const normalized = normalizeMcpServerConfig(name, server);
+      switch (normalized.transport.type) {
+        case 'stdio':
+          return {
+            name: normalized.name,
+            displayName: normalized.displayName,
+            enabled: normalized.enabled,
+            capabilities: normalized.capabilities,
+            transport: {
+              type: 'stdio',
+              command: normalized.transport.command,
+              args: normalized.transport.args,
+              metadata: normalized.transport.env,
+              ...(normalized.transport.cwd ? { cwd: normalized.transport.cwd } : {}),
+              ...(normalized.transport.timeoutMs !== undefined
+                ? { timeoutMs: normalized.transport.timeoutMs }
+                : {}),
+              summary: summarizeTransport(normalized.transport),
+            },
+          };
+        case 'http':
+          return {
+            name: normalized.name,
+            displayName: normalized.displayName,
+            enabled: normalized.enabled,
+            capabilities: normalized.capabilities,
+            transport: {
+              type: 'http',
+              url: normalized.transport.url,
+              metadata: normalized.transport.headers,
+              ...(normalized.transport.timeoutMs !== undefined
+                ? { timeoutMs: normalized.transport.timeoutMs }
+                : {}),
+              summary: summarizeTransport(normalized.transport),
+            },
+          };
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function buildMcpServerConfigFromRequest(request: AddMcpServerRequest): McpServerConfig {
+  const name = request.name.trim();
+  const capabilities = normalizeCapabilityToggles(request.capabilities);
+  const metadata = parseDesktopMcpMetadata(
+    request.metadata ?? '',
+    request.transportType === 'http' ? 'header' : 'env',
+  );
+
+  if (request.transportType === 'http') {
+    return {
+      displayName: name,
+      enabled: true,
+      capabilities,
+      transport: {
+        type: 'http',
+        url: request.endpoint.trim(),
+        ...(Object.keys(metadata).length > 0 ? { headers: metadata } : {}),
+        timeoutMs: MCP_DEFAULT_TIMEOUT_MS,
+      },
+    };
+  }
+
+  const tokens = splitDesktopCommandLine(request.endpoint.trim());
+  const [command, ...args] = tokens;
+  if (!command) {
+    throw new Error('命令不能为空。');
+  }
+
+  return {
+    displayName: name,
+    enabled: true,
+    capabilities,
+    transport: {
+      type: 'stdio',
+      command,
+      ...(args.length > 0 ? { args } : {}),
+      ...(Object.keys(metadata).length > 0 ? { env: metadata } : {}),
+      timeoutMs: MCP_DEFAULT_TIMEOUT_MS,
+    },
+  };
+}
+
+function parseDesktopMcpMetadata(
+  input: string,
+  kind: DesktopMcpMetadataKind,
+): Record<string, string> {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  for (const item of trimmed.split(';')) {
+    const pair = item.trim();
+    if (!pair) {
+      continue;
+    }
+
+    const parsed = kind === 'env'
+      ? pair.split(/=(.*)/su, 2)
+      : pair.includes(':')
+        ? pair.split(/:(.*)/su, 2)
+        : pair.split(/=(.*)/su, 2);
+
+    if (parsed.length < 2) {
+      throw new Error(kind === 'env'
+        ? '环境变量格式应为 KEY=value；多个条目用分号分隔。'
+        : 'Header 格式应为 Key: Value；多个条目用分号分隔。');
+    }
+
+    const key = parsed[0]?.trim() ?? '';
+    if (!key) {
+      throw new Error(kind === 'env' ? '环境变量名不能为空。' : 'Header 名不能为空。');
+    }
+
+    result[key] = (parsed[1] ?? '').trim();
+  }
+
+  return result;
+}
+
+function splitDesktopCommandLine(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | undefined;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const ch = input[index]!;
+    if (quote) {
+      if (ch === quote) {
+        quote = undefined;
+        continue;
+      }
+      if (ch === '\\' && index + 1 < input.length) {
+        current += input[index + 1]!;
+        index += 1;
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (/\s/u.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    if (ch === '\\' && index + 1 < input.length) {
+      current += input[index + 1]!;
+      index += 1;
+      continue;
+    }
+    current += ch;
+  }
+
+  if (quote) {
+    throw new Error('命令格式错误：存在未闭合的引号。');
+  }
+  if (current) {
+    tokens.push(current);
+  }
+  return tokens;
+}

--- a/apps/desktop/src/host/mcp-config.ts
+++ b/apps/desktop/src/host/mcp-config.ts
@@ -109,13 +109,28 @@ export function buildMcpServerConfigFromRequest(request: AddMcpServerRequest): M
   );
 
   if (request.transportType === 'http') {
+    const endpoint = request.endpoint.trim();
+    if (!endpoint) {
+      throw new Error('HTTP endpoint 不能为空。');
+    }
+
+    let url: URL;
+    try {
+      url = new URL(endpoint);
+    } catch {
+      throw new Error('HTTP endpoint 必须是合法 URL。');
+    }
+    if (!url.protocol || !url.host) {
+      throw new Error('HTTP endpoint 必须包含 scheme 和 host。');
+    }
+
     return {
       displayName: name,
       enabled: true,
       capabilities,
       transport: {
         type: 'http',
-        url: request.endpoint.trim(),
+        url: url.toString(),
         ...(Object.keys(metadata).length > 0 ? { headers: metadata } : {}),
         timeoutMs: MCP_DEFAULT_TIMEOUT_MS,
       },

--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -1,0 +1,524 @@
+import type {
+  RuntimePendingApproval,
+  RuntimePendingQuestions,
+} from '@spirit-agent/agent-core';
+
+import type {
+  ConversationMessageSnapshot,
+  MessageAuxSnapshot,
+  PendingAssistantAux,
+  ToolBlockSnapshot,
+} from '../types.js';
+import type { DesktopToolRequest, StoredDesktopSession } from './contracts.js';
+
+/** 环境变量 `SPIRIT_DESKTOP_MESSAGE_ORDER_DEBUG`：不设为关；`1`/compact/on 紧凑；`2`/verbose 更详并节流纯 preview；`0`/off 显式关闭。 */
+export type MessageOrderDebugLevel = 'off' | 'compact' | 'verbose';
+
+export function messageOrderDebugLevel(): MessageOrderDebugLevel {
+  const raw = process.env.SPIRIT_DESKTOP_MESSAGE_ORDER_DEBUG?.trim().toLowerCase() ?? '';
+  if (raw === '') {
+    return 'off';
+  }
+  if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on' || raw === 'compact') {
+    return 'compact';
+  }
+  if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'no') {
+    return 'off';
+  }
+  if (raw === '2' || raw === 'verbose' || raw === 'debug' || raw === 'all') {
+    return 'verbose';
+  }
+  return 'off';
+}
+
+export function summarizeMessagesTailForOrderDebug(
+  messages: ConversationMessageSnapshot[],
+  max: number,
+): string {
+  if (messages.length === 0) {
+    return '∅';
+  }
+  const slice = messages.slice(Math.max(0, messages.length - max));
+  return slice.map(formatMessageOrderToken).join('«');
+}
+
+function formatMessageOrderToken(m: ConversationMessageSnapshot): string {
+  if (m.role === 'user') {
+    return 'U';
+  }
+  const toolName = m.tool?.toolName;
+  if (toolName) {
+    const phase = m.tool?.phase ?? '?';
+    const p =
+      phase === 'running' ? '~' : phase === 'succeeded' ? '=' : phase === 'failed' ? '!' : phase === 'pending-approval' ? '?' : '.';
+    return `${p}${truncateOneLineForDebug(toolName, 20)}`;
+  }
+  if (m.aux?.thinking && !m.content.trim()) {
+    return `H#${m.id}`;
+  }
+  if (m.aux?.compaction && !m.content.trim()) {
+    return `C#${m.id}`;
+  }
+  const c = m.content.trim();
+  if (!c) {
+    return 'Aε';
+  }
+  const hasThinking = Boolean(m.aux?.thinking?.trim());
+  const hasCompaction = Boolean(m.aux?.compaction?.trim());
+  const prefix = hasThinking ? (hasCompaction ? 'aTC' : 'aT') : hasCompaction ? 'aC' : 'a';
+  return `${prefix}#${m.id}:${truncateOneLineForDebug(c, 18)}`;
+}
+
+export function truncateOneLineForDebug(s: string, max: number): string {
+  const t = s.replace(/\s+/g, ' ').trim();
+  if (t.length <= max) {
+    return t;
+  }
+  return `${t.slice(0, max)}…`;
+}
+
+/** 自 history 尾部向前找**最后一条**非空 `assistant` 正文（OpenAI 路径下 `historyStore` 常无 `role: tool`，需用此作待审批时的兜底）。 */
+export function lastAssistantPlainTextInHistory(
+  hist: ReadonlyArray<{ role: string; content: string }>,
+): string | undefined {
+  for (let i = hist.length - 1; i >= 0; i -= 1) {
+    const m = hist[i];
+    if (m?.role === 'assistant' && m.content.trim()) {
+      return m.content.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * 自「最后一条 user」起至首条 `tool` 前，取**第一个**非空 assistant 正文。
+ * OpenAI 路径下 tool 结果通常不在 `history()` 的 LlmMessage 里，若仍用「最后一个」assistant
+ * 会误取工具执行后的终稿，从而覆盖/错配流式阶段已显示的前缀（如「好的，我来查看…」）。
+ */
+export function assistantPrefixBeforeFirstToolInCurrentTurn(
+  hist: ReadonlyArray<{ role: string; content: string }>,
+): string | undefined {
+  let lastUserIdx = -1;
+  for (let i = hist.length - 1; i >= 0; i -= 1) {
+    if (hist[i]?.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  let firstToolIdx = -1;
+  for (let i = lastUserIdx + 1; i < hist.length; i += 1) {
+    if (hist[i]?.role === 'tool') {
+      firstToolIdx = i;
+      break;
+    }
+  }
+
+  const end = firstToolIdx >= 0 ? firstToolIdx : hist.length;
+  for (let i = lastUserIdx + 1; i < end; i += 1) {
+    const m = hist[i];
+    if (!m) {
+      continue;
+    }
+    if (m.role === 'assistant' && m.content.trim()) {
+      return m.content.trim();
+    }
+  }
+
+  return undefined;
+}
+
+export function latestUnsyncedAssistantTextInCurrentTurn(
+  hist: ReadonlyArray<{ role: string; content: string }>,
+  messages: ReadonlyArray<ConversationMessageSnapshot>,
+): string | undefined {
+  const historyTexts = assistantPlainTextsInCurrentTurnHistory(hist);
+  if (historyTexts.length === 0) {
+    return undefined;
+  }
+
+  const existing = new Set(assistantPlainTextsInCurrentTurnMessages(messages));
+  for (let i = historyTexts.length - 1; i >= 0; i -= 1) {
+    const text = historyTexts[i]!;
+    if (!existing.has(text)) {
+      return text;
+    }
+  }
+
+  return undefined;
+}
+
+function assistantPlainTextsInCurrentTurnHistory(
+  hist: ReadonlyArray<{ role: string; content: string }>,
+): string[] {
+  let lastUserIdx = -1;
+  for (let i = hist.length - 1; i >= 0; i -= 1) {
+    if (hist[i]?.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  const texts: string[] = [];
+  for (let i = lastUserIdx + 1; i < hist.length; i += 1) {
+    const item = hist[i];
+    if (!item || item.role !== 'assistant') {
+      continue;
+    }
+    const text = item.content.trim();
+    if (text) {
+      texts.push(text);
+    }
+  }
+  return texts;
+}
+
+function assistantPlainTextsInCurrentTurnMessages(
+  messages: ReadonlyArray<ConversationMessageSnapshot>,
+): string[] {
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  const texts: string[] = [];
+  for (let i = lastUserIdx + 1; i < messages.length; i += 1) {
+    const item = messages[i];
+    if (!item || item.role !== 'assistant' || item.tool) {
+      continue;
+    }
+    const text = item.content.trim();
+    if (text) {
+      texts.push(text);
+    }
+  }
+  return texts;
+}
+
+export function stripPendingThinkingMatchingFinalized(
+  aux: MessageAuxSnapshot | undefined,
+  finalizedText: string,
+): MessageAuxSnapshot | undefined {
+  if (!aux?.thinking) {
+    return aux;
+  }
+  if (aux.thinking.trim() !== finalizedText.trim()) {
+    return aux;
+  }
+  const { thinking: _t, ...rest } = aux;
+  return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+export function stripThinkingFromAux(aux: MessageAuxSnapshot | undefined): MessageAuxSnapshot | undefined {
+  if (!aux?.thinking) {
+    return normalizeMessageAuxSnapshot(aux);
+  }
+  const { thinking: _thinking, ...rest } = aux;
+  return normalizeMessageAuxSnapshot(rest);
+}
+
+export function isStandaloneThinkingMessage(
+  message: ConversationMessageSnapshot | undefined,
+): boolean {
+  return Boolean(
+    message?.role === 'assistant' &&
+      !message.tool &&
+      !message.content.trim() &&
+      message.aux?.thinking?.trim(),
+  );
+}
+
+export function rewindStandalonePendingAuxInsertIndexForThinking(
+  messages: ReadonlyArray<ConversationMessageSnapshot>,
+  anchorIndex: number,
+): number {
+  let index = anchorIndex;
+  while (index > 0 && isStandaloneThinkingMessage(messages[index - 1])) {
+    index -= 1;
+  }
+  return index;
+}
+
+export function parsePendingSubagentStatusText(text: string | undefined): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+
+  const status = text
+    .trim()
+    .replace(/^[|/\\-]\s*/, '')
+    .trim();
+
+  if (!status || status === 'Thinking...' || status === 'Compressing...') {
+    return undefined;
+  }
+
+  return status;
+}
+
+export function isStandaloneSubagentStatusAux(
+  pendingAux: PendingAssistantAux | undefined,
+): boolean {
+  return Boolean(pendingAux && parsePendingSubagentStatusText(pendingAux.statusText));
+}
+
+export function shouldHidePendingAssistantThinkingForLiveStandaloneSubagentStatus(
+  message: ConversationMessageSnapshot,
+  livePendingAux: PendingAssistantAux | undefined,
+): boolean {
+  return Boolean(
+    isStandaloneSubagentStatusAux(livePendingAux) &&
+      message.role === 'assistant' &&
+      message.pending &&
+      !message.tool &&
+      !message.content.trim(),
+  );
+}
+
+export function shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
+  lastMessage: ConversationMessageSnapshot | undefined,
+  persistedStandalonePendingAux: PendingAssistantAux | undefined,
+): boolean {
+  return Boolean(
+    lastMessage?.role === 'assistant' &&
+      isStandaloneSubagentStatusAux(persistedStandalonePendingAux),
+  );
+}
+
+export function messageIndexIsInCurrentTurn(
+  messages: ReadonlyArray<ConversationMessageSnapshot>,
+  index: number,
+): boolean {
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+  return index > lastUserIdx;
+}
+
+export function hasStandaloneThinkingMessageInCurrentTurn(
+  messages: ReadonlyArray<ConversationMessageSnapshot>,
+): boolean {
+  let lastUserIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === 'user') {
+      lastUserIdx = i;
+      break;
+    }
+  }
+
+  for (let i = lastUserIdx + 1; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (
+      message?.role === 'assistant' &&
+      !message.tool &&
+      !message.content.trim() &&
+      Boolean(message.aux?.thinking?.trim())
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function describeAuxForDebug(aux: MessageAuxSnapshot): string {
+  const parts: string[] = [];
+  if (aux.thinking?.trim()) {
+    parts.push(`T≈${truncateOneLineForDebug(aux.thinking, 28)}`);
+  }
+  if (aux.compaction?.trim()) {
+    parts.push(`C≈${truncateOneLineForDebug(aux.compaction, 28)}`);
+  }
+  return parts.join('+') || 'none';
+}
+
+export function describeOptionalAuxForDebug(aux: MessageAuxSnapshot | undefined): string {
+  return aux ? describeAuxForDebug(aux) : 'none';
+}
+
+export function normalizeToolBlockSnapshot(
+  tool: ToolBlockSnapshot | undefined,
+): ToolBlockSnapshot | undefined {
+  if (!tool) {
+    return undefined;
+  }
+
+  const toolName = tool.toolName.trim() || 'unknown-tool';
+  const headline = tool.headline.trim() || defaultToolHeadline(tool.phase, toolName);
+  const detailLines = tool.detailLines.filter((line) => line.trim().length > 0);
+  const argsExcerpt = tool.argsExcerpt?.trim() ? tool.argsExcerpt : undefined;
+  const outputExcerpt = tool.outputExcerpt?.trim() ? tool.outputExcerpt : undefined;
+
+  return {
+    ...tool,
+    toolName,
+    headline,
+    detailLines,
+    ...(argsExcerpt ? { argsExcerpt } : {}),
+    ...(outputExcerpt ? { outputExcerpt } : {}),
+  };
+}
+
+export function normalizeMessageAuxSnapshot(
+  aux: MessageAuxSnapshot | undefined,
+): MessageAuxSnapshot | undefined {
+  if (!aux) {
+    return undefined;
+  }
+
+  const thinking = aux.thinking?.trim() ? aux.thinking : undefined;
+  const compaction = aux.compaction?.trim() ? aux.compaction : undefined;
+  if (!thinking && !compaction) {
+    return undefined;
+  }
+
+  return {
+    ...(thinking ? { thinking } : {}),
+    ...(compaction ? { compaction } : {}),
+  };
+}
+
+export function shouldDropEmptyAssistantMessage(
+  message: ConversationMessageSnapshot,
+  tool: ToolBlockSnapshot | undefined,
+  aux: MessageAuxSnapshot | undefined,
+): boolean {
+  return (
+    message.role === 'assistant' &&
+    !message.pending &&
+    !message.content.trim() &&
+    !tool &&
+    !aux
+  );
+}
+
+export function shouldHideEmptyPendingAssistantSnapshot(message: ConversationMessageSnapshot): boolean {
+  return (
+    message.role === 'assistant' &&
+    message.pending &&
+    !message.content.trim() &&
+    !message.tool &&
+    !normalizeMessageAuxSnapshot(message.aux)
+  );
+}
+
+function defaultToolHeadline(
+  phase: ToolBlockSnapshot['phase'],
+  toolName: string,
+): string {
+  switch (phase) {
+    case 'pending-approval':
+      return `等待确认: ${toolName}`;
+    case 'running':
+      return `调用中: ${toolName}`;
+    case 'failed':
+      return `工具执行失败: ${toolName}`;
+    case 'succeeded':
+    default:
+      return `工具执行完成: ${toolName}`;
+  }
+}
+
+/** 最后一条 user 之后、首条助手工具行之前；找不到则返回 `undefined`（由调用方改为插在「最后一条 user」之后）。 */
+export function indexForThinkingInsertBeforeFirstToolAfterLastUser(
+  messages: ConversationMessageSnapshot[],
+): number | undefined {
+  let lastUser = -1;
+  for (let i = 0; i < messages.length; i += 1) {
+    if (messages[i]?.role === 'user') {
+      lastUser = i;
+    }
+  }
+  for (let i = lastUser + 1; i < messages.length; i += 1) {
+    const m = messages[i];
+    if (m?.role === 'assistant' && m.tool) {
+      return i;
+    }
+  }
+  return undefined;
+}
+
+/** 与 `historyStore` 中最后一条 user 对齐：在其后插入思考，避免审批指导后尚无新工具行时误用 `push` 落到整段末尾。 */
+export function indexForThinkingInsertAfterLastUser(messages: ConversationMessageSnapshot[]): number {
+  let lastUser = -1;
+  for (let i = 0; i < messages.length; i += 1) {
+    if (messages[i]?.role === 'user') {
+      lastUser = i;
+    }
+  }
+  return lastUser < 0 ? 0 : lastUser + 1;
+}
+
+/** 末条 user 之后是否已有其它工具卡为「待审批」或「执行中」（不含当前 toolCallId）。 */
+function hasBlockingToolAheadOfSameTurnPreview(
+  messages: ConversationMessageSnapshot[],
+  thisToolCallId: string,
+): boolean {
+  let lastUser = -1;
+  for (let i = 0; i < messages.length; i += 1) {
+    if (messages[i]?.role === 'user') {
+      lastUser = i;
+    }
+  }
+  for (let i = lastUser + 1; i < messages.length; i += 1) {
+    const m = messages[i];
+    if (m?.role !== 'assistant' || !m.tool) {
+      continue;
+    }
+    if (m.tool.toolCallId === thisToolCallId) {
+      continue;
+    }
+    const p = m.tool.phase;
+    if (p === 'pending-approval' || p === 'running') {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function headlineForStreamingToolPreview(
+  messages: ConversationMessageSnapshot[],
+  toolCallId: string,
+  toolName: string,
+): string {
+  return hasBlockingToolAheadOfSameTurnPreview(messages, toolCallId)
+    ? `排队中: ${toolName}`
+    : `调用中: ${toolName}`;
+}
+
+export function restoreMessagesFromArchive(
+  archive: StoredDesktopSession,
+): ConversationMessageSnapshot[] {
+  const auxByIndex = new Map<number, MessageAuxSnapshot>();
+  for (const entry of archive.assistantAux) {
+    auxByIndex.set(entry.messageIndex, {
+      ...(entry.thinking ? { thinking: entry.thinking } : {}),
+      ...(entry.compaction ? { compaction: entry.compaction } : {}),
+    });
+  }
+
+  return archive.messages.map((message, index) => ({
+    id: index + 1,
+    role: message.role,
+    content: message.content,
+    ...(auxByIndex.get(index) ? { aux: auxByIndex.get(index) } : {}),
+    pending: false,
+  }));
+}
+
+export function toolMessageKey(
+  pending:
+    | RuntimePendingApproval<DesktopToolRequest, string>
+    | RuntimePendingQuestions<DesktopToolRequest>,
+): string {
+  return 'toolCallId' in pending && pending.toolCallId
+    ? pending.toolCallId
+    : `pending:${pending.toolName}`;
+}

--- a/apps/desktop/src/host/message-snapshots.ts
+++ b/apps/desktop/src/host/message-snapshots.ts
@@ -1,0 +1,112 @@
+import type {
+  ConversationMessageSnapshot,
+  PendingAssistantAux,
+} from '../types.js';
+import { canRewindMessage, type StoredDesktopRewindMetadata } from './rewind.js';
+import {
+  normalizeMessageAuxSnapshot,
+  normalizeToolBlockSnapshot,
+  shouldDropEmptyAssistantMessage,
+  shouldHideEmptyPendingAssistantSnapshot,
+  shouldHidePendingAssistantThinkingForLiveStandaloneSubagentStatus,
+  stripThinkingFromAux,
+} from './message-ordering.js';
+
+export interface PrunedAssistantMessage {
+  messageIndex: number;
+  messageId: number;
+}
+
+export function buildVisibleMessageSnapshots(input: {
+  messages: ConversationMessageSnapshot[];
+  livePendingAux?: PendingAssistantAux;
+  rewind: StoredDesktopRewindMetadata;
+}): ConversationMessageSnapshot[] {
+  return input.messages.flatMap((message) => {
+    const snapshot = buildVisibleMessageSnapshot({
+      message,
+      livePendingAux: input.livePendingAux,
+      rewind: input.rewind,
+    });
+    return snapshot && !shouldHideEmptyPendingAssistantSnapshot(snapshot) ? [snapshot] : [];
+  });
+}
+
+export function buildVisibleMessageSnapshot(input: {
+  message: ConversationMessageSnapshot;
+  livePendingAux?: PendingAssistantAux;
+  rewind: StoredDesktopRewindMetadata;
+}): ConversationMessageSnapshot | undefined {
+  const tool = normalizeToolBlockSnapshot(input.message.tool);
+  const aux = shouldHidePendingAssistantThinkingForLiveStandaloneSubagentStatus(
+    input.message,
+    input.livePendingAux,
+  )
+    ? stripThinkingFromAux(input.message.aux)
+    : normalizeMessageAuxSnapshot(input.message.aux);
+  if (shouldDropEmptyAssistantMessage(input.message, tool, aux)) {
+    return undefined;
+  }
+
+  const { canRewind: _canRewind, ...base } = input.message;
+  return {
+    ...base,
+    ...(tool ? { tool } : {}),
+    ...(aux ? { aux } : {}),
+    ...(canRewindMessage(input.rewind, input.message) ? { canRewind: true } : {}),
+  };
+}
+
+export function pruneEmptyAssistantMessages(
+  messages: ConversationMessageSnapshot[],
+): {
+  messages: ConversationMessageSnapshot[];
+  removed: PrunedAssistantMessage[];
+} {
+  const removed: PrunedAssistantMessage[] = [];
+  const nextMessages = messages.filter((message, index) => {
+    const drop = shouldDropEmptyAssistantMessage(
+      message,
+      normalizeToolBlockSnapshot(message.tool),
+      normalizeMessageAuxSnapshot(message.aux),
+    );
+    if (drop) {
+      removed.push({
+        messageIndex: index - removed.length,
+        messageId: message.id,
+      });
+    }
+    return !drop;
+  });
+  return { messages: nextMessages, removed };
+}
+
+export function shiftStreamAssistantThinkingAnchorForInsertion(
+  anchor: number | undefined,
+  insertAt: number,
+): number | undefined {
+  if (anchor !== undefined && insertAt <= anchor) {
+    return anchor + 1;
+  }
+  return anchor;
+}
+
+export function shiftStreamAssistantThinkingAnchorForRemoval(
+  anchor: number | undefined,
+  removeAt: number,
+  removeCount = 1,
+): number | undefined {
+  if (anchor === undefined || removeCount <= 0) {
+    return anchor;
+  }
+
+  if (removeAt + removeCount <= anchor) {
+    return anchor - removeCount;
+  }
+
+  if (removeAt < anchor) {
+    return removeAt;
+  }
+
+  return anchor;
+}

--- a/apps/desktop/src/host/rewind.ts
+++ b/apps/desktop/src/host/rewind.ts
@@ -113,6 +113,76 @@ export function createRewindCheckpointMetadata(
   };
 }
 
+export function upsertRewindCheckpointMetadata(
+  metadata: StoredDesktopRewindMetadata,
+  checkpoint: DesktopRewindCheckpointMetadata,
+): void {
+  const existing = metadata.checkpoints.findIndex(
+    (candidate) => candidate.messageId === checkpoint.messageId,
+  );
+  if (existing >= 0) {
+    metadata.checkpoints.splice(existing, 1, checkpoint);
+  } else {
+    metadata.checkpoints.push(checkpoint);
+  }
+  metadata.checkpoints.sort((left, right) => left.sequence - right.sequence);
+}
+
+export function pruneRewindMetadataAfterCheckpoint(
+  metadata: StoredDesktopRewindMetadata,
+  checkpointSequence: number,
+): void {
+  metadata.checkpoints = metadata.checkpoints.filter(
+    (checkpoint) => checkpoint.sequence < checkpointSequence,
+  );
+  metadata.fileChanges = metadata.fileChanges.filter(
+    (change) => change.sequence <= checkpointSequence,
+  );
+}
+
+export function canRewindMessage(
+  metadata: StoredDesktopRewindMetadata,
+  message: ConversationMessageSnapshot,
+): boolean {
+  if (message.pending || message.role !== 'user') {
+    return false;
+  }
+  return metadata.checkpoints.some((checkpoint) => checkpoint.messageId === message.id);
+}
+
+export function bindRewindFileChangesToToolMessage(
+  metadata: StoredDesktopRewindMetadata,
+  pendingUnboundFileChangeIds: string[],
+  execution: { toolCallId?: string; toolName: string },
+  messageId: number,
+): string[] {
+  const targetIds = new Set<string>();
+  const toolCallId = execution.toolCallId || `tool:${execution.toolName}`;
+  for (const change of metadata.fileChanges) {
+    if (change.messageId !== undefined) {
+      continue;
+    }
+    if (change.toolCallId === toolCallId) {
+      targetIds.add(change.id);
+    }
+  }
+  if (targetIds.size === 0) {
+    for (const id of pendingUnboundFileChangeIds) {
+      targetIds.add(id);
+    }
+  }
+  if (targetIds.size === 0) {
+    return pendingUnboundFileChangeIds;
+  }
+
+  for (const change of metadata.fileChanges) {
+    if (targetIds.has(change.id)) {
+      change.messageId = messageId;
+    }
+  }
+  return pendingUnboundFileChangeIds.filter((id) => !targetIds.has(id));
+}
+
 export function toDesktopFileChange(
   change: HostRecordedFileChange,
   sequence: number,

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -1,0 +1,495 @@
+import type {
+  JsonObject,
+  RuntimeEvent,
+  RuntimeToolExecution,
+} from '@spirit-agent/agent-core';
+import type { HostExtensionEvent } from '@spirit-agent/host-internal';
+
+import type { ConversationMessageSnapshot } from '../types.js';
+import type { DesktopToolRequest } from './contracts.js';
+import type { DesktopRuntime } from './runtime.js';
+import { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';
+import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
+import {
+  assistantPrefixBeforeFirstToolInCurrentTurn,
+  headlineForStreamingToolPreview,
+  indexForThinkingInsertBeforeFirstToolAfterLastUser,
+  lastAssistantPlainTextInHistory,
+  latestUnsyncedAssistantTextInCurrentTurn,
+  messageOrderDebugLevel,
+  summarizeMessagesTailForOrderDebug,
+  toolMessageKey,
+} from './message-ordering.js';
+
+export interface DesktopRuntimeEventOrchestratorOptions {
+  runtime: () => DesktopRuntime | undefined;
+  messages: () => ConversationMessageSnapshot[];
+  allocateMessageId: () => number;
+  assistantMessages: DesktopAssistantMessageStateMachine;
+  conversationSnapshotView: DesktopConversationSnapshotView;
+  clearCurrentTurnSkills: () => void;
+  setLastRuntimeError: (error: string) => void;
+  refreshArchiveFromRuntime: () => void;
+  dispatchExtensionEvent: (event: HostExtensionEvent) => void;
+  bindFileChangesToToolMessage: (
+    execution: RuntimeToolExecution<DesktopToolRequest>,
+    messageId: number,
+  ) => void;
+}
+
+export class DesktopRuntimeEventOrchestrator {
+  private lastApplyEventBatchId = 0;
+  private messageOrderDebugLastVerboseLogMs = 0;
+
+  constructor(private readonly options: DesktopRuntimeEventOrchestratorOptions) {}
+
+  reset(): void {
+    this.lastApplyEventBatchId = 0;
+    this.messageOrderDebugLastVerboseLogMs = 0;
+  }
+
+  consumeCompletedTurnResult(): void {
+    const runtime = this.options.runtime();
+    if (!runtime) {
+      return;
+    }
+
+    const result = runtime.takeCompletedTurnResult();
+    if (!result) {
+      return;
+    }
+
+    this.integrateToolExecutions(result.toolExecutions);
+    switch (result.kind) {
+      case 'completed':
+        this.options.clearCurrentTurnSkills();
+        if (result.assistantText.trim()) {
+          const aux = this.options.assistantMessages.takeLatestPendingAux();
+          if (!this.options.assistantMessages.materializeExistingCompletedAssistantMessage(result.assistantText, aux)) {
+            this.options.assistantMessages.appendAssistantMessage(result.assistantText, aux);
+          }
+        }
+        this.options.setLastRuntimeError('');
+        break;
+      case 'failed':
+        this.options.clearCurrentTurnSkills();
+        {
+          const aux = this.options.assistantMessages.takeLatestPendingAux();
+          if (!this.options.assistantMessages.materializeExistingCompletedAssistantMessage(result.error, aux)) {
+            this.options.assistantMessages.appendAssistantMessage(result.error, aux);
+          }
+        }
+        this.options.setLastRuntimeError(result.error);
+        break;
+      case 'requires-approval':
+      case 'requires-questions':
+        this.syncPendingToolStates();
+        this.syncAssistantPrefixFromHistoryBeforeToolRow();
+        this.options.setLastRuntimeError('');
+        break;
+      default:
+        break;
+    }
+
+    this.options.refreshArchiveFromRuntime();
+  }
+
+  applyRuntimeHostEvents(events: RuntimeEvent<DesktopToolRequest>[]): void {
+    const messages = this.options.messages();
+    const batchId =
+      events.length > 0 ? (this.lastApplyEventBatchId += 1) : this.lastApplyEventBatchId;
+    for (const event of events) {
+      if (event.kind === 'begin-assistant-response') {
+        const insertAt = messages.length;
+        const shouldReanchorStandalonePendingAux =
+          this.options.conversationSnapshotView.shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
+            messages[messages.length - 1],
+          );
+        const pendingAssistant = this.options.assistantMessages.beginAssistantResponse(insertAt, batchId);
+        if (shouldReanchorStandalonePendingAux) {
+          this.options.conversationSnapshotView.reanchorPersistedStandalonePendingAux(pendingAssistant.id);
+        }
+        continue;
+      }
+      if (event.kind === 'update-pending-assistant-thinking') {
+        this.options.assistantMessages.updatePendingAssistantAux('thinking', event.text);
+        continue;
+      }
+      if (event.kind === 'update-pending-assistant-compaction') {
+        this.options.assistantMessages.updatePendingAssistantAux('compressing', event.text);
+        continue;
+      }
+      if (event.kind === 'assistant-chunk') {
+        this.options.assistantMessages.appendPendingAssistantChunk(event.text);
+        continue;
+      }
+      if (event.kind === 'replace-pending-assistant') {
+        this.options.assistantMessages.replacePendingAssistantText(event.text);
+        continue;
+      }
+      if (event.kind === 'assistant-response-completed') {
+        this.options.assistantMessages.completePendingAssistantMessage();
+        continue;
+      }
+      if (event.kind === 'remove-pending-assistant') {
+        this.options.assistantMessages.removePendingAssistantMessage();
+        continue;
+      }
+      if (event.kind === 'assistant-thinking-segment-finalized') {
+        if (event.text.trim()) {
+          this.options.assistantMessages.appendAssistantThinkingSegment(event.text);
+        }
+        continue;
+      }
+      if (event.kind === 'tool-call-started') {
+        this.options.dispatchExtensionEvent({
+          type: 'onToolCall',
+          detail: {
+            toolCallId: event.toolCallId,
+            toolName: event.toolName,
+            request: event.request as JsonObject,
+          },
+        });
+        continue;
+      }
+      if (event.kind === 'approval-resolved') {
+        this.options.dispatchExtensionEvent({
+          type: 'onApprovalResolved',
+          detail: {
+            toolCallId: event.toolCallId,
+            toolName: event.toolName,
+            decisionKind: event.decisionKind,
+            request: event.request as JsonObject,
+          },
+        });
+        continue;
+      }
+      if (event.kind === 'tool-execution-finished') {
+        this.integrateToolExecutions([event.execution]);
+        this.options.dispatchExtensionEvent({
+          type: 'onToolResult',
+          detail: {
+            toolCallId: event.execution.toolCallId,
+            toolName: event.execution.toolName,
+            output: event.execution.output,
+            failed: event.execution.failed,
+            request: event.execution.request as JsonObject,
+          },
+        });
+        continue;
+      }
+      if (event.kind !== 'streaming-tool-preview') {
+        continue;
+      }
+      let argsExcerpt: string;
+      try {
+        argsExcerpt = truncateJson(JSON.parse(event.argumentsJson) as unknown);
+      } catch {
+        argsExcerpt = truncateText(event.argumentsJson, 4_000);
+      }
+      this.options.assistantMessages.upsertToolMessage(event.toolCallId, {
+        toolCallId: event.toolCallId,
+        toolName: event.toolName,
+        phase: 'running',
+        headline: headlineForStreamingToolPreview(messages, event.toolCallId, event.toolName),
+        detailLines: [],
+        argsExcerpt,
+      }, batchId);
+    }
+    const placement = this.options.assistantMessages.placementState();
+    this.logMessageOrderApplyBatch(
+      batchId,
+      events,
+      messages,
+      placement.streamAssistantThinkingAnchor,
+      placement.streamAssistantAnchorSetInApplyBatchId,
+    );
+  }
+
+  syncAssistantPrefixFromHistoryBeforeToolRow(): void {
+    const runtime = this.options.runtime();
+    if (!runtime) {
+      return;
+    }
+    const pendingTrim = runtime.pendingAssistantText().trim();
+    const awaitingInteractive =
+      Boolean(runtime.currentPendingApproval()) ||
+      Boolean(runtime.currentPendingQuestions());
+
+    if (pendingTrim && !awaitingInteractive) {
+      return;
+    }
+
+    const history = runtime.history();
+    const messages = this.options.messages();
+    const prefixFromUnsyncedLatest = latestUnsyncedAssistantTextInCurrentTurn(
+      history,
+      messages,
+    );
+    const prefixFromBeforeFirst = assistantPrefixBeforeFirstToolInCurrentTurn(history);
+    const prefixFromLastAssistant = lastAssistantPlainTextInHistory(history);
+    const prefix = (
+      awaitingInteractive && pendingTrim
+        ? pendingTrim
+        : awaitingInteractive
+          ? (prefixFromUnsyncedLatest ?? prefixFromLastAssistant ?? prefixFromBeforeFirst)
+          : (prefixFromUnsyncedLatest ?? prefixFromBeforeFirst)
+    )
+      ?.trim() ?? '';
+    const messageCount = messages.length;
+    const lastMessage = messageCount > 0 ? messages[messageCount - 1] : undefined;
+
+    if (!prefix || messageCount === 0) {
+      return;
+    }
+
+    const hasPlainPrefix = messages.some(
+      (message) => message.role === 'assistant' && message.content === prefix && !message.tool,
+    );
+    if (hasPlainPrefix) {
+      return;
+    }
+
+    const isLaterUnsyncedPrefix =
+      !awaitingInteractive &&
+      prefixFromUnsyncedLatest !== undefined &&
+      prefix === prefixFromUnsyncedLatest &&
+      prefixFromUnsyncedLatest !== prefixFromBeforeFirst;
+
+    if (isLaterUnsyncedPrefix) {
+      const anchor = this.options.assistantMessages.streamAssistantThinkingAnchorOr(messages.length);
+      const insertAt = Math.max(0, Math.min(anchor, messages.length));
+      const before = insertAt > 0 ? messages[insertAt - 1] : undefined;
+      if (
+        before?.role === 'assistant' &&
+        !before.tool &&
+        before.content.trim() === prefix
+      ) {
+        return;
+      }
+      this.insertAssistantPrefix(insertAt, prefix, `splice-at-anchor@${insertAt}`);
+      return;
+    }
+
+    if (awaitingInteractive) {
+      const approval = runtime.currentPendingApproval();
+      const questions = runtime.currentPendingQuestions();
+      const key = approval
+        ? toolMessageKey(approval)
+        : questions
+          ? toolMessageKey(questions)
+          : undefined;
+      if (key) {
+        const index = messages.findIndex(
+          (message) => message.role === 'assistant' && message.tool?.toolCallId === key,
+        );
+        if (index >= 0) {
+          const before = index > 0 ? messages[index - 1] : undefined;
+          if (
+            before?.role === 'assistant' &&
+            !before.tool &&
+            before.content.trim() === prefix
+          ) {
+            return;
+          }
+          this.insertAssistantPrefix(index, prefix, `splice-before-approval@${index}`);
+        }
+      }
+      return;
+    }
+
+    if (lastMessage!.role === 'user') {
+      messages.push({
+        id: this.options.allocateMessageId(),
+        role: 'assistant',
+        content: prefix,
+        pending: false,
+      });
+      this.logMessageOrderPrefixSync('push-after-user', messages);
+      return;
+    }
+
+    if (lastMessage!.role === 'assistant' && lastMessage!.tool) {
+      const firstToolIndex = indexForThinkingInsertBeforeFirstToolAfterLastUser(messages);
+      if (firstToolIndex === undefined) {
+        return;
+      }
+      const beforeFirst = firstToolIndex > 0 ? messages[firstToolIndex - 1] : undefined;
+      if (beforeFirst?.role === 'assistant' && beforeFirst.content === prefix && !beforeFirst.tool) {
+        return;
+      }
+      this.insertAssistantPrefix(firstToolIndex, prefix, `splice-before-first-tool@${firstToolIndex}`);
+      return;
+    }
+
+    if (lastMessage!.role === 'assistant' && !lastMessage!.tool && lastMessage!.content.trim() && lastMessage!.content !== prefix) {
+      const firstToolIndex = indexForThinkingInsertBeforeFirstToolAfterLastUser(messages);
+      if (firstToolIndex !== undefined) {
+        const beforeFirst = firstToolIndex > 0 ? messages[firstToolIndex - 1] : undefined;
+        if (beforeFirst?.role === 'assistant' && beforeFirst.content === prefix && !beforeFirst.tool) {
+          return;
+        }
+        this.insertAssistantPrefix(firstToolIndex, prefix, `splice-before-first-tool@${firstToolIndex}`);
+        return;
+      }
+      let toolIndex = -1;
+      for (let index = messageCount - 2; index >= 0; index -= 1) {
+        const message = messages[index];
+        if (message.role === 'assistant' && message.tool) {
+          toolIndex = index;
+          break;
+        }
+      }
+      if (toolIndex >= 0) {
+        const beforeTool = toolIndex > 0 ? messages[toolIndex - 1] : undefined;
+        if (beforeTool?.role === 'assistant' && beforeTool.content === prefix && !beforeTool.tool) {
+          return;
+        }
+        this.insertAssistantPrefix(toolIndex, prefix, `splice-before-tool@${toolIndex}`);
+        return;
+      }
+      if (!lastMessage!.content.startsWith(prefix)) {
+        this.insertAssistantPrefix(messageCount - 1, prefix, `splice-before-tail@${messageCount - 1}`);
+      }
+      return;
+    }
+  }
+
+  syncPendingToolStates(): void {
+    const runtime = this.options.runtime();
+    const approval = runtime?.currentPendingApproval();
+    if (approval) {
+      this.options.assistantMessages.upsertToolMessage(toolMessageKey(approval), {
+        toolCallId: toolMessageKey(approval),
+        toolName: approval.toolName,
+        phase: 'pending-approval',
+        headline: `等待确认: ${approval.toolName}`,
+        detailLines: [approval.prompt],
+        argsExcerpt: truncateJson(approval.request),
+      }, this.lastApplyEventBatchId);
+    }
+
+    const questions = runtime?.currentPendingQuestions();
+    if (questions) {
+      this.options.assistantMessages.upsertToolMessage(toolMessageKey(questions), {
+        toolCallId: toolMessageKey(questions),
+        toolName: questions.toolName,
+        phase: 'pending-approval',
+        headline: `等待补充信息: ${questions.toolName}`,
+        detailLines: [questions.questions.title ?? '请回答表单问题'],
+        argsExcerpt: truncateJson(questions.questions),
+      }, this.lastApplyEventBatchId);
+    }
+  }
+
+  private integrateToolExecutions(executions: RuntimeToolExecution<DesktopToolRequest>[]): void {
+    for (const execution of executions) {
+      const message = this.options.assistantMessages.upsertToolMessage(execution.toolCallId || `tool:${execution.toolName}`, {
+        toolCallId: execution.toolCallId || `tool:${execution.toolName}`,
+        toolName: execution.toolName,
+        phase: execution.failed ? 'failed' : 'succeeded',
+        headline: execution.failed
+          ? `工具执行失败: ${execution.toolName}`
+          : `工具执行完成: ${execution.toolName}`,
+        detailLines: [],
+        argsExcerpt: truncateJson(execution.request),
+        outputExcerpt: truncateText(execution.output, 4_000),
+      }, this.lastApplyEventBatchId);
+      this.options.bindFileChangesToToolMessage(execution, message.id);
+    }
+  }
+
+  private insertAssistantPrefix(insertAt: number, prefix: string, logLabel: string): void {
+    const messages = this.options.messages();
+    this.options.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(insertAt);
+    messages.splice(insertAt, 0, {
+      id: this.options.allocateMessageId(),
+      role: 'assistant',
+      content: prefix,
+      pending: false,
+    });
+    this.logMessageOrderPrefixSync(logLabel, messages);
+  }
+
+  private logMessageOrderApplyBatch(
+    batchId: number,
+    events: RuntimeEvent<DesktopToolRequest>[],
+    messages: ConversationMessageSnapshot[],
+    anchorEnd: number | undefined,
+    anchorSourceBatchEnd: number,
+  ): void {
+    const mode = messageOrderDebugLevel();
+    if (mode === 'off') return;
+
+    const tags: string[] = [];
+    let previewCount = 0;
+    for (const event of events) {
+      if (event.kind === 'begin-assistant-response') {
+        tags.push('begin');
+      } else if (event.kind === 'assistant-response-completed') {
+        tags.push('resp-done');
+      } else if (event.kind === 'remove-pending-assistant') {
+        tags.push('rm-pending');
+      } else if (event.kind === 'assistant-thinking-segment-finalized') {
+        tags.push(event.text.trim() ? 'finalize' : 'finalize-empty');
+      } else if (event.kind === 'tool-call-started') {
+        tags.push(`tool-start:${event.toolName}`);
+      } else if (event.kind === 'tool-execution-finished') {
+        tags.push(`tool-done:${event.execution.toolName}`);
+      } else if (event.kind === 'approval-resolved') {
+        tags.push(`approval-${event.decisionKind}`);
+      } else if (event.kind === 'approval-requested') {
+        tags.push(`approval:${event.approval.toolName}`);
+      } else if (event.kind === 'questions-requested') {
+        tags.push(`questions:${event.questions.toolName}`);
+      } else if (event.kind === 'streaming-tool-preview') {
+        previewCount += 1;
+      }
+    }
+
+    const hasOrderTags = tags.length > 0;
+    if (!hasOrderTags && previewCount === 0) {
+      return;
+    }
+
+    if (mode === 'compact' && !hasOrderTags) {
+      return;
+    }
+
+    if (!hasOrderTags && previewCount > 0 && mode === 'verbose') {
+      const now = Date.now();
+      if (now - this.messageOrderDebugLastVerboseLogMs < 1200) {
+        return;
+      }
+      this.messageOrderDebugLastVerboseLogMs = now;
+      tags.push(`preview×${previewCount}`);
+    } else if (hasOrderTags && previewCount > 0 && mode === 'verbose') {
+      tags.push(`pv×${previewCount}`);
+    }
+
+    const tail = summarizeMessagesTailForOrderDebug(messages, 12);
+    console.log(
+      `[desktop-host][msg-order] apply#${batchId} kinds=${tags.join(',')} anchor=${anchorEnd ?? '∅'} anchorBatch=${anchorSourceBatchEnd} len=${messages.length} tail=${tail}`,
+    );
+  }
+
+  private logMessageOrderPrefixSync(how: string, messages: ConversationMessageSnapshot[]): void {
+    if (messageOrderDebugLevel() === 'off') {
+      return;
+    }
+    const tail = summarizeMessagesTailForOrderDebug(messages, 10);
+    console.log(`[desktop-host][msg-order] prefix-sync ${how} len=${messages.length} tail=${tail}`);
+  }
+}
+
+function truncateJson(value: unknown): string {
+  return truncateText(JSON.stringify(value, null, 2), 4_000);
+}
+
+function truncateText(value: string, maxChars: number): string {
+  const chars = Array.from(value);
+  if (chars.length <= maxChars) {
+    return value;
+  }
+  return `${chars.slice(0, maxChars).join('')}...<truncated>`;
+}

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -8,8 +8,8 @@ import type { HostExtensionEvent } from '@spirit-agent/host-internal';
 import type { ConversationMessageSnapshot } from '../types.js';
 import type { DesktopToolRequest } from './contracts.js';
 import type { DesktopRuntime } from './runtime.js';
-import { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';
-import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
+import type { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';
+import type { DesktopConversationSnapshotView } from './conversation-snapshot.js';
 import {
   assistantPrefixBeforeFirstToolInCurrentTurn,
   headlineForStreamingToolPreview,

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -1,0 +1,92 @@
+import {
+  AgentRuntime,
+  appendOpenAiToolResultMessage,
+  appendOpenAiUserMessage,
+  extractLastOpenAiAssistantText,
+  pendingWorkspaceFilesFromInput,
+  rebuildOpenAiToolAgentStateAfterCompaction,
+  startOpenAiToolAgentState,
+  truncateOpenAiHistoryForCompaction,
+  truncateOpenAiToolAgentStateForContextRetry,
+  type ChatArchive,
+  type OpenAiActiveSkill,
+  type OpenAiEnabledRule,
+  type OpenAiEnabledSkillCatalogEntry,
+  type OpenAiExtensionSystemPrompt,
+  type OpenAiPlanMetadata,
+  type OpenAiToolAgentState,
+  type OpenAiTransport,
+  type OpenAiTransportConfig,
+} from '@spirit-agent/agent-core';
+
+import type { DesktopToolRequest } from './contracts.js';
+import type { DesktopToolExecutor } from './tool-executor.js';
+
+export type DesktopRuntime = AgentRuntime<
+  OpenAiTransportConfig,
+  OpenAiToolAgentState,
+  DesktopToolRequest,
+  string
+>;
+
+export function createDesktopRuntime(input: {
+  transportConfig: OpenAiTransportConfig;
+  history: ChatArchive['llmHistory'];
+  enabledRules: OpenAiEnabledRule[];
+  enabledSkillCatalog: OpenAiEnabledSkillCatalogEntry[];
+  planMetadata: OpenAiPlanMetadata;
+  extensionSystemPrompts: OpenAiExtensionSystemPrompt[];
+  toolExecutor: DesktopToolExecutor;
+  llmTransport: OpenAiTransport;
+  activeSkills: OpenAiActiveSkill[];
+  workspaceRoot: string;
+}): DesktopRuntime {
+  return new AgentRuntime({
+    config: input.transportConfig,
+    llmTransport: input.llmTransport,
+    toolExecutor: input.toolExecutor,
+    createToolAgentState: (messages, userInput) =>
+      startOpenAiToolAgentState(
+        messages,
+        userInput,
+        input.workspaceRoot,
+        input.enabledRules,
+        input.enabledSkillCatalog,
+        cloneActiveSkills(input.activeSkills),
+        input.transportConfig.model,
+        input.planMetadata,
+        input.extensionSystemPrompts,
+      ),
+    appendToolResultMessage: appendOpenAiToolResultMessage,
+    appendUserMessage: appendOpenAiUserMessage,
+    extractAssistantText: extractLastOpenAiAssistantText,
+    truncateStateForContextRetry: truncateOpenAiToolAgentStateForContextRetry,
+    truncateHistoryForCompaction: truncateOpenAiHistoryForCompaction,
+    rebuildRetryStateAfterCompaction: (messages, userInput, retryState) =>
+      rebuildOpenAiToolAgentStateAfterCompaction(
+        messages,
+        userInput,
+        retryState,
+        input.workspaceRoot,
+        input.enabledRules,
+        input.enabledSkillCatalog,
+        cloneActiveSkills(input.activeSkills),
+        input.transportConfig.model,
+        input.planMetadata,
+        input.extensionSystemPrompts,
+      ),
+    resolveWorkspaceFilesFromInput: (userInput) =>
+      pendingWorkspaceFilesFromInput(input.workspaceRoot, userInput),
+  }, input.history.map((message) => ({
+    role: message.role,
+    content: message.content,
+    imagePaths: [...message.imagePaths],
+  })));
+}
+
+export function cloneActiveSkills(skills: OpenAiActiveSkill[]): OpenAiActiveSkill[] {
+  return skills.map((skill) => ({
+    ...skill,
+    resources: skill.resources.map((resource) => ({ ...resource })),
+  }));
+}

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -1,0 +1,232 @@
+import type {
+  AskQuestionsResult as RuntimeAskQuestionsResult,
+  ChatArchive,
+  RuntimeApprovalDecision,
+  RuntimePendingQuestions,
+} from '@spirit-agent/agent-core';
+
+import type {
+  AskQuestionsResult,
+  DesktopDreamCollectorSnapshot,
+  DesktopModelProvider,
+  DesktopWebHostSnapshot,
+  PendingQuestionsSnapshot,
+} from '../types.js';
+import type { DesktopToolRequest } from './contracts.js';
+import {
+  type DesktopConfigFile,
+  type DesktopWebHostConfigFile,
+  mergeRecentWorkspaceRoots,
+} from './storage.js';
+import {
+  DESKTOP_WEB_HOST_POLICY,
+  getDesktopWebHostRuntimeStatus,
+} from './web-host-state.js';
+
+export function normalizeWorkspaceRootKey(workspaceRoot: string): string {
+  return workspaceRoot.replace(/\\/g, '/').replace(/\/+$/g, '').toLowerCase();
+}
+
+export function sameWorkspaceRoot(left: string, right: string): boolean {
+  return normalizeWorkspaceRootKey(left) === normalizeWorkspaceRootKey(right);
+}
+
+export function deriveWorkspaceLabel(workspaceRoot: string): string {
+  const normalized = workspaceRoot.replace(/\\/g, '/').replace(/\/+$/g, '');
+  const lastSlash = normalized.lastIndexOf('/');
+  return lastSlash >= 0 ? normalized.slice(lastSlash + 1) || normalized : normalized;
+}
+
+export function buildAvailableWorkspaces(currentWorkspaceRoot: string, recentWorkspaces?: string[]) {
+  return mergeRecentWorkspaceRoots(recentWorkspaces, currentWorkspaceRoot).map((workspaceRoot) => ({
+    path: workspaceRoot,
+    label: deriveWorkspaceLabel(workspaceRoot),
+  }));
+}
+
+export function cloneDesktopConfig(config: DesktopConfigFile): DesktopConfigFile {
+  return JSON.parse(JSON.stringify(config)) as DesktopConfigFile;
+}
+
+export function normalizeGeneratedCommitMessage(value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new Error('自动生成提交信息失败：模型未返回 message 字段。');
+  }
+
+  const normalized = value
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join('\n');
+
+  if (!normalized) {
+    throw new Error('自动生成提交信息失败：模型返回了空 message。');
+  }
+
+  return normalized;
+}
+
+export function sameDreamCollectorSnapshot(
+  left: DesktopDreamCollectorSnapshot,
+  right: DesktopDreamCollectorSnapshot,
+): boolean {
+  return left.state === right.state &&
+    left.lastRunAtUnixMs === right.lastRunAtUnixMs &&
+    left.lastSuccessAtUnixMs === right.lastSuccessAtUnixMs &&
+    left.lastError === right.lastError &&
+    left.pendingCount === right.pendingCount &&
+    left.processedCount === right.processedCount &&
+    left.backoffUntilUnixMs === right.backoffUntilUnixMs;
+}
+
+export function buildWebHostSnapshot(config: DesktopWebHostConfigFile): DesktopWebHostSnapshot {
+  const runtimeStatus = getDesktopWebHostRuntimeStatus();
+  const status = config.enabled
+    ? {
+        ...runtimeStatus,
+        host: runtimeStatus.host || config.host,
+        port: runtimeStatus.port || config.port,
+        ...(config.authTokenHash ? { pairingCode: undefined } : {}),
+      }
+    : {
+        state: 'disabled' as const,
+        host: config.host,
+        port: config.port,
+      };
+
+  return {
+    config: {
+      enabled: config.enabled,
+      host: config.host,
+      port: config.port,
+      paired: Boolean(config.authTokenHash),
+      authMode: 'pairing',
+    },
+    status,
+    policy: DESKTOP_WEB_HOST_POLICY,
+  };
+}
+
+export function currentApiBase(config: DesktopConfigFile): string {
+  return (
+    config.models.find((model) => model.name === config.activeModel)?.apiBase ||
+    config.models[0]?.apiBase ||
+    ''
+  );
+}
+
+export function cloneChatArchive(archive: ChatArchive): ChatArchive {
+  return {
+    messages: archive.messages.map((message) => ({ ...message })),
+    assistantAux: archive.assistantAux.map((entry) => ({ ...entry })),
+    llmHistory: archive.llmHistory.map((message) => ({
+      role: message.role,
+      content: message.content,
+      imagePaths: [...message.imagePaths],
+    })),
+    subagentSessions: (archive.subagentSessions ?? []).map((entry) => ({
+      summary: { ...entry.summary },
+      llmHistory: entry.llmHistory.map((message) => ({
+        role: message.role,
+        content: message.content,
+        imagePaths: [...message.imagePaths],
+      })),
+    })),
+  };
+}
+
+export function archiveBeforeLastUser(archive: ChatArchive): ChatArchive {
+  const cloned = cloneChatArchive(archive);
+  const messageIndex = findLastIndex(cloned.messages, (message) => message.role === 'user');
+  const historyIndex = findLastIndex(cloned.llmHistory, (message) => message.role === 'user');
+  return {
+    ...cloned,
+    messages: messageIndex >= 0 ? cloned.messages.slice(0, messageIndex) : cloned.messages,
+    assistantAux:
+      messageIndex >= 0
+        ? cloned.assistantAux.filter((entry) => entry.messageIndex < messageIndex)
+        : cloned.assistantAux,
+    llmHistory: historyIndex >= 0 ? cloned.llmHistory.slice(0, historyIndex) : cloned.llmHistory,
+  };
+}
+
+function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (predicate(items[index]!)) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+export function parseApprovalDecision(message: string): RuntimeApprovalDecision {
+  const trimmed = message.trim().toLowerCase();
+  if (!trimmed || trimmed === 'y' || trimmed === 'yes' || trimmed === 'approve') {
+    return { kind: 'allow' };
+  }
+  if (trimmed === 't' || trimmed === 'trust') {
+    return { kind: 'allow', persistTrust: true };
+  }
+  if (trimmed === 'n' || trimmed === 'no' || trimmed === 'deny') {
+    return { kind: 'deny' };
+  }
+  return {
+    kind: 'guidance',
+    userMessage: message,
+  };
+}
+
+export function toRuntimeAskQuestionsResult(
+  result: AskQuestionsResult,
+): RuntimeAskQuestionsResult {
+  if (result.status === 'skipped') {
+    return { status: 'skipped' };
+  }
+
+  return {
+    status: 'answered',
+    answers: result.answers ?? [],
+  };
+}
+
+export function mapPendingQuestions(
+  pending: RuntimePendingQuestions<DesktopToolRequest>,
+): PendingQuestionsSnapshot {
+  return {
+    toolCallId: pending.toolCallId,
+    toolName: pending.toolName,
+    request: {
+      ...(pending.questions.title ? { title: pending.questions.title } : {}),
+      questions: pending.questions.questions.map((question) => ({
+        id: question.id,
+        title: question.title,
+        kind: question.kind,
+        required: question.required === true,
+        options: (question.options ?? []).map((option) => ({
+          label: option.label,
+          ...(option.summary ? { summary: option.summary } : {}),
+        })),
+        allowCustomInput: question.allowCustomInput === true,
+        ...(question.customInputPlaceholder
+          ? { customInputPlaceholder: question.customInputPlaceholder }
+          : {}),
+        ...(question.customInputLabel
+          ? { customInputLabel: question.customInputLabel }
+          : {}),
+      })),
+    },
+  };
+}
+
+export function formatYamlScalarForSkillFrontmatter(value: string): string {
+  const flat = value.replace(/\r?\n/g, ' ').trim() || '说明';
+  return `"${flat.replace(/\\/gu, '\\\\').replace(/"/gu, '\\"')}"`;
+}
+
+export function parseAddModelProvider(value: unknown): DesktopModelProvider | undefined {
+  if (value === 'deepseek' || value === 'kimi' || value === 'minimax' || value === 'custom') {
+    return value;
+  }
+  return undefined;
+}

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -165,6 +165,7 @@ import {
   sameWorkspaceRoot,
   toRuntimeAskQuestionsResult,
 } from './service-utils.js';
+import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
 import { buildDesktopSnapshot } from './snapshot.js';
 import {
   assistantPrefixBeforeFirstToolInCurrentTurn,
@@ -174,7 +175,6 @@ import {
   hasStandaloneThinkingMessageInCurrentTurn,
   indexForThinkingInsertAfterLastUser,
   indexForThinkingInsertBeforeFirstToolAfterLastUser,
-  isStandaloneSubagentStatusAux,
   lastAssistantPlainTextInHistory,
   latestUnsyncedAssistantTextInCurrentTurn,
   messageIndexIsInCurrentTurn,
@@ -182,8 +182,6 @@ import {
   normalizeMessageAuxSnapshot,
   parsePendingSubagentStatusText,
   restoreMessagesFromArchive,
-  rewindStandalonePendingAuxInsertIndexForThinking,
-  shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse,
   stripPendingThinkingMatchingFinalized,
   stripThinkingFromAux,
   summarizeMessagesTailForOrderDebug,
@@ -191,7 +189,6 @@ import {
   toolMessageKey,
 } from './message-ordering.js';
 import {
-  buildVisibleMessageSnapshots,
   pruneEmptyAssistantMessages as pruneEmptyAssistantMessagesFromSnapshots,
   shiftStreamAssistantThinkingAnchorForInsertion as shiftThinkingAnchorForInsertion,
   shiftStreamAssistantThinkingAnchorForRemoval as shiftThinkingAnchorForRemoval,
@@ -332,11 +329,8 @@ class DesktopHostService {
   private lastRuntimeError = '';
   private activeApiKeyConfigured = false;
   private modelKeyPresence: Record<string, boolean> = {};
+  private readonly conversationSnapshotView = new DesktopConversationSnapshotView(() => this.allocateMessageId());
   private latestPendingAssistantAux: MessageAuxSnapshot | undefined;
-  private persistedStandalonePendingAux: PendingAssistantAux | undefined;
-  private persistedStandalonePendingAuxAnchorMessageId: number | undefined;
-  private standalonePendingAuxMessageId: number | undefined;
-  private lastStandalonePendingAuxSnapshotLogSignature: string | undefined;
   private pendingAssistantMessageId: number | undefined;
   private lastSettledAssistantMessageId: number | undefined;
   /** 思考段 finalize 去重、插入锚点与 apply 批次（见 `applyRuntimeHostEvents` / `appendAssistantThinkingSegment`）。 */
@@ -1891,7 +1885,11 @@ class DesktopHostService {
     const pendingApproval = this.runtime?.currentPendingApproval();
     const pendingQuestions = this.runtime?.currentPendingQuestions();
     const pendingAux = this.runtime?.pendingAuxState();
-    this.syncStandalonePendingAux(pendingAux);
+    this.conversationSnapshotView.syncStandalonePendingAux({
+      livePendingAux: pendingAux,
+      pendingAssistantMessageId: this.pendingAssistantMessageId,
+      lastSettledAssistantMessageId: this.lastSettledAssistantMessageId,
+    });
     if (pendingAux && !parsePendingSubagentStatusText(pendingAux.statusText)) {
       this.updatePendingAssistantAux(
         pendingAux.kind,
@@ -1915,7 +1913,11 @@ class DesktopHostService {
       mcpStatus: this.toolExecutor?.mcpStatusSnapshot() ?? emptyMcpStatusSnapshot(),
       mcpServers: listDesktopMcpServersFromDisk(),
       conversation: {
-        messages: this.messagesWithPendingAssistant(pendingAux),
+        messages: this.conversationSnapshotView.buildMessagesWithPendingAssistant({
+          messages: state.messages,
+          livePendingAux: pendingAux,
+          rewind: state.rewind,
+        }),
         ...(this.runtime?.pendingUserTurn()
           ? { pendingUserTurn: this.runtime.pendingUserTurn() }
           : {}),
@@ -2067,28 +2069,6 @@ class DesktopHostService {
       }));
       throw error;
     }
-  }
-
-  private messagesWithPendingAssistant(
-    livePendingAux?: PendingAssistantAux,
-  ): ConversationMessageSnapshot[] {
-    const state = this.requireState();
-    const snapshots = buildVisibleMessageSnapshots({
-      messages: state.messages,
-      livePendingAux,
-      rewind: state.rewind,
-    });
-
-    const standalonePendingAux = this.standalonePendingAuxSnapshot(livePendingAux, snapshots);
-    if (!standalonePendingAux) {
-      this.lastStandalonePendingAuxSnapshotLogSignature = undefined;
-      return snapshots;
-    }
-
-    const insertAt = Math.max(0, Math.min(standalonePendingAux.insertAt, snapshots.length));
-    snapshots.splice(insertAt, 0, standalonePendingAux.message);
-    this.logSnapshotStandalonePendingAux(standalonePendingAux, snapshots);
-    return snapshots;
   }
 
   private consumeCompletedTurnResult(): void {
@@ -2251,9 +2231,8 @@ class DesktopHostService {
       if (ev.kind === 'begin-assistant-response') {
         const at = state.messages.length;
         const shouldReanchorStandalonePendingAux =
-          shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
+          this.conversationSnapshotView.shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
             state.messages[state.messages.length - 1],
-            this.persistedStandalonePendingAux,
           );
         this.pendingAssistantMessageId = undefined;
         this.latestPendingAssistantAux = undefined;
@@ -2264,7 +2243,7 @@ class DesktopHostService {
         this.streamAssistantAnchorSetInApplyBatchId = batchId;
         const pendingAssistant = this.ensurePendingAssistantMessage();
         if (shouldReanchorStandalonePendingAux) {
-          this.persistedStandalonePendingAuxAnchorMessageId = pendingAssistant.id;
+          this.conversationSnapshotView.reanchorPersistedStandalonePendingAux(pendingAssistant.id);
         }
         continue;
       }
@@ -3200,150 +3179,12 @@ class DesktopHostService {
       this.streamAssistantThinkingAnchor = undefined;
       return;
     }
-    this.clearStandalonePendingAuxState();
+    this.conversationSnapshotView.clearStandalonePendingAuxState();
     this.lastFinalizedThinkingSegment = '';
     this.streamAssistantThinkingAnchor = undefined;
     this.streamAssistantAnchorSetInApplyBatchId = 0;
     this.lastApplyEventBatchId = 0;
     this.messageOrderDebugLastVerboseLogMs = 0;
-  }
-
-  private syncStandalonePendingAux(livePendingAux: PendingAssistantAux | undefined): void {
-    if (livePendingAux && isStandaloneSubagentStatusAux(livePendingAux)) {
-      this.persistedStandalonePendingAux = {
-        kind: livePendingAux.kind,
-        statusText: livePendingAux.statusText,
-        ...(livePendingAux.detailText ? { detailText: livePendingAux.detailText } : {}),
-      };
-      if (this.standalonePendingAuxMessageId === undefined) {
-        this.standalonePendingAuxMessageId = this.allocateMessageId();
-      }
-      const anchorMessageId = this.pendingAssistantMessageId ?? this.lastSettledAssistantMessageId;
-      if (anchorMessageId !== undefined) {
-        this.persistedStandalonePendingAuxAnchorMessageId = anchorMessageId;
-      }
-      return;
-    }
-
-    if (!isStandaloneSubagentStatusAux(this.persistedStandalonePendingAux)) {
-      this.clearStandalonePendingAuxState();
-    }
-  }
-
-  private standalonePendingAuxSnapshot(
-    livePendingAux: PendingAssistantAux | undefined,
-    snapshots: ConversationMessageSnapshot[],
-  ):
-    | {
-        message: ConversationMessageSnapshot;
-        insertAt: number;
-        source: 'live' | 'persisted';
-        anchorMessageId?: number;
-        anchorResolvedIndex?: number;
-      }
-    | undefined {
-    const liveStandalonePendingAux =
-      livePendingAux && isStandaloneSubagentStatusAux(livePendingAux)
-        ? livePendingAux
-        : undefined;
-    const liveStatusText = liveStandalonePendingAux
-      ? parsePendingSubagentStatusText(liveStandalonePendingAux.statusText)
-      : undefined;
-    if (liveStatusText) {
-      return {
-        source: 'live',
-        insertAt: snapshots.length,
-        message: this.standalonePendingAuxMessage(liveStatusText),
-      };
-    }
-
-    const persistedStandalonePendingAux =
-      this.persistedStandalonePendingAux && isStandaloneSubagentStatusAux(this.persistedStandalonePendingAux)
-        ? this.persistedStandalonePendingAux
-        : undefined;
-    const persistedStatusText = persistedStandalonePendingAux
-      ? parsePendingSubagentStatusText(persistedStandalonePendingAux.statusText)
-      : undefined;
-    if (!persistedStatusText) {
-      return undefined;
-    }
-
-    const anchorMessageId = this.persistedStandalonePendingAuxAnchorMessageId;
-    let anchorResolvedIndex: number | undefined;
-    let insertAt: number | undefined;
-    if (anchorMessageId !== undefined) {
-      const anchoredIndex = snapshots.findIndex((message) => message.id === anchorMessageId);
-      if (anchoredIndex >= 0) {
-        anchorResolvedIndex = anchoredIndex;
-        insertAt = rewindStandalonePendingAuxInsertIndexForThinking(snapshots, anchoredIndex);
-      }
-    }
-
-    if (insertAt === undefined) {
-      insertAt = snapshots.length > 0 ? Math.max(0, snapshots.length - 1) : 0;
-    }
-
-    return {
-      source: 'persisted',
-      anchorMessageId,
-      anchorResolvedIndex,
-      insertAt,
-      message: this.standalonePendingAuxMessage(persistedStatusText),
-    };
-  }
-
-  private standalonePendingAuxMessage(statusText: string): ConversationMessageSnapshot {
-    if (this.standalonePendingAuxMessageId === undefined) {
-      this.standalonePendingAuxMessageId = this.allocateMessageId();
-    }
-
-    return {
-      id: this.standalonePendingAuxMessageId,
-      role: 'assistant',
-      content: statusText,
-      pending: false,
-    };
-  }
-
-  private clearStandalonePendingAuxState(): void {
-    this.persistedStandalonePendingAux = undefined;
-    this.persistedStandalonePendingAuxAnchorMessageId = undefined;
-    this.standalonePendingAuxMessageId = undefined;
-    this.lastStandalonePendingAuxSnapshotLogSignature = undefined;
-  }
-
-  private logSnapshotStandalonePendingAux(
-    standalonePendingAux: {
-      message: ConversationMessageSnapshot;
-      insertAt: number;
-      source: 'live' | 'persisted';
-      anchorMessageId?: number;
-      anchorResolvedIndex?: number;
-    },
-    snapshots: ConversationMessageSnapshot[],
-  ): void {
-    if (messageOrderDebugLevel() !== 'verbose') {
-      return;
-    }
-
-    const status = truncateOneLineForDebug(standalonePendingAux.message.content, 48);
-    const tail = summarizeMessagesTailForOrderDebug(snapshots, 6);
-    const signature = [
-      standalonePendingAux.source,
-      standalonePendingAux.message.id,
-      standalonePendingAux.insertAt,
-      standalonePendingAux.anchorMessageId ?? '∅',
-      standalonePendingAux.anchorResolvedIndex ?? '∅',
-      standalonePendingAux.message.content,
-      tail,
-    ].join('|');
-    if (signature === this.lastStandalonePendingAuxSnapshotLogSignature) {
-      return;
-    }
-    this.lastStandalonePendingAuxSnapshotLogSignature = signature;
-    console.log(
-      `[desktop-host][snapshot] standalone-subagent-status source=${standalonePendingAux.source} msg=${standalonePendingAux.message.id} insert=${standalonePendingAux.insertAt} anchorMsg=${standalonePendingAux.anchorMessageId ?? '∅'} anchorIdx=${standalonePendingAux.anchorResolvedIndex ?? '∅'} status≈${status}${standalonePendingAux.message.content.length > 48 ? '…' : ''} tail=${tail}`,
-    );
   }
 
   private logToolMessageUpdate(

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 
 import {
-  AgentRuntime,
   buildDreamCollectorSystemMessage,
   buildExtensionsSystemMessage,
   buildPlanSystemMessage,
@@ -9,22 +8,13 @@ import {
   buildSkillsCatalogSystemMessage,
   type OpenAiActiveSkill,
   type OpenAiExtensionSystemPrompt,
-  appendOpenAiToolResultMessage,
-  appendOpenAiUserMessage,
-  extractLastOpenAiAssistantText,
   OpenAiTransport,
-  pendingWorkspaceFilesFromInput,
-  rebuildOpenAiToolAgentStateAfterCompaction,
-  startOpenAiToolAgentState,
-  truncateOpenAiHistoryForCompaction,
-  truncateOpenAiToolAgentStateForContextRetry,
   type AssistantAuxArchiveEntry,
   type ChatArchive,
   type JsonObject,
   type OpenAiEnabledRule,
   type OpenAiEnabledSkillCatalogEntry,
   type OpenAiPlanMetadata,
-  type OpenAiToolAgentState,
   type OpenAiTransportConfig,
   type RuntimeEvent,
   type RuntimeToolExecution,
@@ -133,6 +123,11 @@ import {
 } from './storage.js';
 import { DesktopToolExecutor } from './tool-executor.js';
 import {
+  cloneActiveSkills,
+  createDesktopRuntime,
+  type DesktopRuntime,
+} from './runtime.js';
+import {
   buildCommitMessageGenerationPrompt,
   buildDreamCommitContext,
   clearDreamCollectorIssue,
@@ -239,13 +234,6 @@ import {
   type DesktopRewindCheckpointSnapshot,
   type StoredDesktopRewindMetadata,
 } from './rewind.js';
-
-type DesktopRuntime = AgentRuntime<
-  OpenAiTransportConfig,
-  OpenAiToolAgentState,
-  DesktopToolRequest,
-  string
->;
 
 export interface DesktopExtensionMessageBoxRequest {
   title: string;
@@ -1887,47 +1875,18 @@ class DesktopHostService {
     toolExecutor: DesktopToolExecutor = this.requireToolExecutor(),
   ): DesktopRuntime {
     const workspaceRoot = transportConfig.workspaceRoot ?? this.requireState().workspaceRoot;
-    return new AgentRuntime({
-      config: transportConfig,
-      llmTransport: this.transport,
+    return createDesktopRuntime({
+      transportConfig,
+      history,
+      enabledRules,
+      enabledSkillCatalog,
+      planMetadata,
+      extensionSystemPrompts,
       toolExecutor,
-      createToolAgentState: (messages, userInput) =>
-        startOpenAiToolAgentState(
-          messages,
-          userInput,
-          workspaceRoot,
-          enabledRules,
-          enabledSkillCatalog,
-          cloneActiveSkills(this.currentTurnSkills),
-          transportConfig.model,
-          planMetadata,
-          extensionSystemPrompts,
-        ),
-      appendToolResultMessage: appendOpenAiToolResultMessage,
-      appendUserMessage: appendOpenAiUserMessage,
-      extractAssistantText: extractLastOpenAiAssistantText,
-      truncateStateForContextRetry: truncateOpenAiToolAgentStateForContextRetry,
-      truncateHistoryForCompaction: truncateOpenAiHistoryForCompaction,
-      rebuildRetryStateAfterCompaction: (messages, userInput, retryState) =>
-        rebuildOpenAiToolAgentStateAfterCompaction(
-          messages,
-          userInput,
-          retryState,
-          workspaceRoot,
-          enabledRules,
-          enabledSkillCatalog,
-          cloneActiveSkills(this.currentTurnSkills),
-          transportConfig.model,
-          planMetadata,
-          extensionSystemPrompts,
-        ),
-      resolveWorkspaceFilesFromInput: (input) =>
-        pendingWorkspaceFilesFromInput(workspaceRoot, input),
-    }, history.map((message) => ({
-      role: message.role,
-      content: message.content,
-      imagePaths: [...message.imagePaths],
-    })));
+      llmTransport: this.transport,
+      activeSkills: this.currentTurnSkills,
+      workspaceRoot,
+    });
   }
 
   private buildModelCatalogHints(state: HostState): DesktopModelCatalogHint[] {
@@ -3686,13 +3645,6 @@ class DesktopHostService {
     }
     return desktopExtensionHostAdapter;
   }
-}
-
-function cloneActiveSkills(skills: OpenAiActiveSkill[]): OpenAiActiveSkill[] {
-  return skills.map((skill) => ({
-    ...skill,
-    resources: skill.resources.map((resource) => ({ ...resource })),
-  }));
 }
 
 const desktopHostService = new DesktopHostService();

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -188,13 +188,9 @@ import {
   messageIndexIsInCurrentTurn,
   messageOrderDebugLevel,
   normalizeMessageAuxSnapshot,
-  normalizeToolBlockSnapshot,
   parsePendingSubagentStatusText,
   restoreMessagesFromArchive,
   rewindStandalonePendingAuxInsertIndexForThinking,
-  shouldDropEmptyAssistantMessage,
-  shouldHideEmptyPendingAssistantSnapshot,
-  shouldHidePendingAssistantThinkingForLiveStandaloneSubagentStatus,
   shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse,
   stripPendingThinkingMatchingFinalized,
   stripThinkingFromAux,
@@ -202,6 +198,12 @@ import {
   truncateOneLineForDebug,
   toolMessageKey,
 } from './message-ordering.js';
+import {
+  buildVisibleMessageSnapshots,
+  pruneEmptyAssistantMessages as pruneEmptyAssistantMessagesFromSnapshots,
+  shiftStreamAssistantThinkingAnchorForInsertion as shiftThinkingAnchorForInsertion,
+  shiftStreamAssistantThinkingAnchorForRemoval as shiftThinkingAnchorForRemoval,
+} from './message-snapshots.js';
 import {
   buildActiveSkillPayload,
   buildActivateSkillUserTurn,
@@ -223,7 +225,6 @@ import {
 } from './git.js';
 import {
   bindRewindFileChangesToToolMessage,
-  canRewindMessage,
   createDesktopRewindMetadata,
   createRewindCheckpointMetadata,
   fileChangeMetadata,
@@ -2181,9 +2182,10 @@ class DesktopHostService {
     livePendingAux?: PendingAssistantAux,
   ): ConversationMessageSnapshot[] {
     const state = this.requireState();
-    const snapshots = state.messages.flatMap((message) => {
-      const snapshot = this.messageSnapshot(message, livePendingAux);
-      return snapshot && !shouldHideEmptyPendingAssistantSnapshot(snapshot) ? [snapshot] : [];
+    const snapshots = buildVisibleMessageSnapshots({
+      messages: state.messages,
+      livePendingAux,
+      rewind: state.rewind,
     });
 
     const standalonePendingAux = this.standalonePendingAuxSnapshot(livePendingAux, snapshots);
@@ -3205,47 +3207,15 @@ class DesktopHostService {
     this.requireRuntime().replaceFromArchive(archive);
   }
 
-  private messageSnapshot(
-    message: ConversationMessageSnapshot,
-    livePendingAux?: PendingAssistantAux,
-  ): ConversationMessageSnapshot | undefined {
-    const tool = normalizeToolBlockSnapshot(message.tool);
-    const aux = shouldHidePendingAssistantThinkingForLiveStandaloneSubagentStatus(
-      message,
-      livePendingAux,
-    )
-      ? stripThinkingFromAux(message.aux)
-      : normalizeMessageAuxSnapshot(message.aux);
-    if (shouldDropEmptyAssistantMessage(message, tool, aux)) {
-      return undefined;
-    }
-
-    const { canRewind: _canRewind, ...base } = message;
-    return {
-      ...base,
-      ...(tool ? { tool } : {}),
-      ...(aux ? { aux } : {}),
-      ...(canRewindMessage(this.requireState().rewind, message) ? { canRewind: true } : {}),
-    };
-  }
-
   private pruneEmptyAssistantMessages(reason: string): void {
     const state = this.requireState();
-    const removedIds: number[] = [];
-    state.messages = state.messages.filter((message, index) => {
-      const drop = shouldDropEmptyAssistantMessage(
-        message,
-        normalizeToolBlockSnapshot(message.tool),
-        normalizeMessageAuxSnapshot(message.aux),
-      );
-      if (drop) {
-        const currentIndex = index - removedIds.length;
-        this.handleMessageRemoved(currentIndex, message.id, `prune:${reason}`);
-        removedIds.push(message.id);
-      }
-      return !drop;
-    });
-    if (removedIds.length > 0) {
+    const { messages, removed } = pruneEmptyAssistantMessagesFromSnapshots(state.messages);
+    state.messages = messages;
+    for (const removal of removed) {
+      this.handleMessageRemoved(removal.messageIndex, removal.messageId, `prune:${reason}`);
+    }
+    if (removed.length > 0) {
+      const removedIds = removed.map((removal) => removal.messageId);
       console.warn(
         `[desktop-host][messages] dropped ${removedIds.length} empty assistant message(s) during ${reason}: ${removedIds.join(', ')}`,
       );
@@ -3253,28 +3223,18 @@ class DesktopHostService {
   }
 
   private shiftStreamAssistantThinkingAnchorForInsertion(insertAt: number): void {
-    if (
-      this.streamAssistantThinkingAnchor !== undefined &&
-      insertAt <= this.streamAssistantThinkingAnchor
-    ) {
-      this.streamAssistantThinkingAnchor += 1;
-    }
+    this.streamAssistantThinkingAnchor = shiftThinkingAnchorForInsertion(
+      this.streamAssistantThinkingAnchor,
+      insertAt,
+    );
   }
 
   private shiftStreamAssistantThinkingAnchorForRemoval(removeAt: number, removeCount = 1): void {
-    if (this.streamAssistantThinkingAnchor === undefined || removeCount <= 0) {
-      return;
-    }
-
-    const anchor = this.streamAssistantThinkingAnchor;
-    if (removeAt + removeCount <= anchor) {
-      this.streamAssistantThinkingAnchor = anchor - removeCount;
-      return;
-    }
-
-    if (removeAt < anchor) {
-      this.streamAssistantThinkingAnchor = removeAt;
-    }
+    this.streamAssistantThinkingAnchor = shiftThinkingAnchorForRemoval(
+      this.streamAssistantThinkingAnchor,
+      removeAt,
+      removeCount,
+    );
   }
 
   private handleMessageRemoved(messageIndex: number, messageId: number, reason: string): void {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -1,7 +1,5 @@
-import { Buffer } from 'node:buffer';
 import { createHash, randomUUID } from 'node:crypto';
-import { existsSync, readFileSync } from 'node:fs';
-import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
@@ -13,7 +11,6 @@ import {
   buildSkillsCatalogSystemMessage,
   buildContributedHostToolDefinitions,
   type OpenAiActiveSkill,
-  type OpenAiActiveSkillResourceEntry,
   type OpenAiExtensionSystemPrompt,
   appendOpenAiToolResultMessage,
   appendOpenAiUserMessage,
@@ -25,7 +22,6 @@ import {
   truncateOpenAiHistoryForCompaction,
   truncateOpenAiToolAgentStateForContextRetry,
   type AssistantAuxArchiveEntry,
-  type AskQuestionsResult as RuntimeAskQuestionsResult,
   type ChatArchive,
   type JsonObject,
   type OpenAiEnabledRule,
@@ -33,17 +29,8 @@ import {
   type OpenAiPlanMetadata,
   type OpenAiToolAgentState,
   type OpenAiTransportConfig,
-  type RuntimePendingApproval,
-  type RuntimePendingQuestions,
   type RuntimeEvent,
   type RuntimeToolExecution,
-  mcpUserConfigPath,
-  normalizeCapabilityToggles,
-  normalizeMcpServerConfig,
-  parseMcpConfigFile,
-  summarizeTransport,
-  type McpConfigFile,
-  type McpServerConfig,
 } from '@spirit-agent/agent-core';
 import {
   collectHostExtensionContributedTools,
@@ -53,9 +40,6 @@ import {
   DREAM_RETENTION_MS as HOST_DREAM_RETENTION_MS,
   dreamLogsDirPath,
   listOpenAiCompatibleModelIds,
-  resolveInstructionPaths,
-  SKILL_FILE_NAME,
-  validateSkillName,
   restoreHostFileChanges,
   type HostExtensionMarketplaceManager,
   type HostDreamSessionProgress,
@@ -89,8 +73,6 @@ import type {
   DesktopDreamCollectorSnapshot,
   DesktopModelProvider,
   DeleteSkillRequest,
-  DesktopMcpServerListItem,
-  DesktopSkillRootKind,
   DesktopModelCatalogHint,
   DesktopSnapshot,
   FileRewindWarning,
@@ -110,7 +92,6 @@ import type {
   SubmitSkillSlashRequest,
   ToolBlockSnapshot,
   UpdateConfigRequest,
-  WorkspaceExplorerEntry,
   WorkspaceExplorerListResult,
   WorkspaceReadTextFileResult,
   WriteWorkspaceTextFileRequest,
@@ -148,13 +129,19 @@ import {
 } from './storage.js';
 import { DesktopToolExecutor } from './tool-executor.js';
 import {
+  buildMcpServerConfigFromRequest,
+  emptyMcpStatusSnapshot,
+  listDesktopMcpServersFromDisk,
+  loadMcpConfigFileFromDisk,
+  saveMcpConfigFileToDisk,
+} from './mcp-config.js';
+import {
   archiveBeforeLastUser,
   buildAvailableWorkspaces,
   buildWebHostSnapshot,
   cloneChatArchive,
   cloneDesktopConfig,
   currentApiBase,
-  formatYamlScalarForSkillFrontmatter,
   mapPendingQuestions,
   normalizeGeneratedCommitMessage,
   parseAddModelProvider,
@@ -191,6 +178,20 @@ import {
   truncateOneLineForDebug,
   toolMessageKey,
 } from './message-ordering.js';
+import {
+  buildActiveSkillPayload,
+  buildActivateSkillUserTurn,
+  buildCreateSkillUserTurn,
+  createSkillFile,
+  deleteSkillDir,
+  desktopInstructionPaths,
+  parseCreateSkillSlashPrompt,
+} from './skills.js';
+import {
+  listWorkspaceExplorerChildren as listWorkspaceExplorerChildrenFromDisk,
+  readWorkspaceTextFile as readWorkspaceTextFileFromDisk,
+  writeWorkspaceTextFile as writeWorkspaceTextFileToDisk,
+} from './workspace-files.js';
 import {
   buildWorkspaceGitCommitMessageContext,
   commitWorkspaceChanges,
@@ -686,34 +687,8 @@ class DesktopHostService {
       if (this.runtime?.isBusy()) {
         throw new Error('当前已有回复或审批在进行，请稍后再添加 Skill。');
       }
-
-      const rootKind = this.parseSkillRootKind(request.rootKind);
-      const name = request.name.trim().toLowerCase();
-      const nameIssue = validateSkillName(name);
-      if (nameIssue) {
-        throw new Error(nameIssue);
-      }
-
-      const description = (request.description ?? '').trim();
-      if (!description) {
-        throw new Error('描述不能为空。');
-      }
-      const skillDir = this.resolveSkillDir(name, rootKind);
-      if (existsSync(skillDir)) {
-        throw new Error(`该位置已存在同名 Skill：${name}`);
-      }
-
-      const frontmatterDescription = formatYamlScalarForSkillFrontmatter(description);
-      const fileContent = `---
-name: ${name}
-description: ${frontmatterDescription}
----
-
-在此编写技能正文：步骤、示例、边界条件与相对路径引用。
-`;
-
-      await mkdir(skillDir, { recursive: true });
-      await writeFile(path.join(skillDir, SKILL_FILE_NAME), fileContent, 'utf8');
+      const state = this.requireState();
+      await createSkillFile(state.workspaceRoot, request);
 
       await this.refreshRuntime();
       this.lastRuntimeError = '';
@@ -988,22 +963,8 @@ description: ${frontmatterDescription}
       if (this.runtime?.isBusy()) {
         throw new Error('当前已有回复或审批在进行，请稍后再删除 Skill。');
       }
-
-      const rootKind = this.parseSkillRootKind(request.rootKind);
-      const name = request.name.trim().toLowerCase();
-      const nameIssue = validateSkillName(name);
-      if (nameIssue) {
-        throw new Error(nameIssue);
-      }
-
-      const skillDir = this.resolveSkillDir(name, rootKind);
-      this.assertPathUnderSkillRoot(skillDir, rootKind);
-
-      if (!existsSync(skillDir)) {
-        throw new Error(`Skill 不存在：${name}`);
-      }
-
-      await rm(skillDir, { recursive: true, force: true });
+      const state = this.requireState();
+      await deleteSkillDir(state.workspaceRoot, request);
 
       await this.refreshRuntime();
       this.lastRuntimeError = '';
@@ -1058,7 +1019,11 @@ description: ${frontmatterDescription}
 
       const state = this.requireState();
       return this.submitUserTurnAfterInitialized(
-        buildCreateSkillUserTurn(state.workspaceRoot, this.instructionPaths(), prompt),
+        buildCreateSkillUserTurn(
+          state.workspaceRoot,
+          desktopInstructionPaths(state.workspaceRoot),
+          prompt,
+        ),
         {
           displayText: rawText,
         },
@@ -1379,59 +1344,15 @@ description: ${frontmatterDescription}
     return this.runSerialized(async () => {
       await this.ensureInitialized();
       const state = this.requireState();
-      const dir = this.resolveWorkspaceRelativePath(state, relativePath);
-      let st;
-      try {
-        st = await stat(dir);
-      } catch {
-        return { entries: [] };
-      }
-      if (!st.isDirectory()) {
-        return { entries: [] };
-      }
-      const dirents = await readdir(dir, { withFileTypes: true });
-      const entries: WorkspaceExplorerEntry[] = dirents
-        .filter((d) => d.name && d.name !== '.' && d.name !== '..')
-        .map((d) => ({
-          name: d.name,
-          kind: d.isDirectory() ? 'dir' : 'file',
-        }));
-      entries.sort((a, b) => {
-        if (a.kind !== b.kind) {
-          return a.kind === 'dir' ? -1 : 1;
-        }
-        return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
-      });
-      return { entries };
+      return listWorkspaceExplorerChildrenFromDisk(state.workspaceRoot, relativePath);
     });
   }
-
-  /** 单文件上限，避免大文件拖垮渲染进程。 */
-  private static readonly workspaceTextFileMaxBytes = 2 * 1024 * 1024;
 
   async readWorkspaceTextFile(relativePath: string): Promise<WorkspaceReadTextFileResult> {
     return this.runSerialized(async () => {
       await this.ensureInitialized();
       const state = this.requireState();
-      const posix = relativePath.replace(/\0/g, '').replace(/\\/g, '/').trim();
-      if (!posix) {
-        throw new Error('未指定文件路径');
-      }
-      const filePath = this.resolveWorkspaceRelativePath(state, relativePath);
-      let st;
-      try {
-        st = await stat(filePath);
-      } catch {
-        throw new Error('文件不存在或无法访问');
-      }
-      if (!st.isFile()) {
-        throw new Error('不是文件');
-      }
-      if (st.size > DesktopHostService.workspaceTextFileMaxBytes) {
-        throw new Error('文件过大，无法在侧栏打开');
-      }
-      const buf = await readFile(filePath);
-      return { text: buf.toString('utf8') };
+      return readWorkspaceTextFileFromDisk(state.workspaceRoot, relativePath);
     });
   }
 
@@ -1439,52 +1360,9 @@ description: ${frontmatterDescription}
     return this.runSerialized(async () => {
       await this.ensureInitialized();
       const state = this.requireState();
-      const posix = request.relativePath.replace(/\0/g, '').replace(/\\/g, '/').trim();
-      if (!posix) {
-        throw new Error('未指定文件路径');
-      }
-      const filePath = this.resolveWorkspaceRelativePath(state, request.relativePath);
-      let st;
-      try {
-        st = await stat(filePath);
-      } catch {
-        throw new Error('文件不存在或无法访问');
-      }
-      if (!st.isFile()) {
-        throw new Error('只能保存为普通文件');
-      }
-      const bytes = Buffer.byteLength(request.text, 'utf8');
-      if (bytes > DesktopHostService.workspaceTextFileMaxBytes) {
-        throw new Error('内容过大，无法保存');
-      }
-      await writeFile(filePath, request.text, 'utf8');
+      await writeWorkspaceTextFileToDisk(state.workspaceRoot, request);
       await this.refreshGitState();
     });
-  }
-
-  /**
-   * 将工作区相对路径解析为绝对路径；使用 `/` 分段，禁止 `..` 与绝对路径。
-   */
-  private resolveWorkspaceRelativePath(state: HostState, relativePath: string): string {
-    const root = path.resolve(state.workspaceRoot);
-    const cleaned = relativePath.replace(/\0/g, '');
-    const posix = cleaned.replace(/\\/g, '/').trim();
-    if (posix.startsWith('/') || /^[a-zA-Z]:/.test(posix)) {
-      throw new Error('无效路径');
-    }
-    const segments = posix.split('/').filter((s) => s.length > 0);
-    for (const seg of segments) {
-      if (seg === '..' || seg === '.') {
-        throw new Error('无效路径');
-      }
-    }
-    const target =
-      segments.length === 0 ? root : path.resolve(root, ...segments);
-    const rel = path.relative(root, target);
-    if (rel.startsWith('..') || path.isAbsolute(rel)) {
-      throw new Error('路径越出工作区');
-    }
-    return target;
   }
 
   async openSession(filePath: string): Promise<DesktopSnapshot> {
@@ -3860,49 +3738,6 @@ description: ${frontmatterDescription}
     state.activeSession.filePath = await saveStoredSession(state.activeSession.filePath, stored);
   }
 
-  private instructionPaths() {
-    const state = this.requireState();
-    return resolveInstructionPaths({
-      workspaceRoot: state.workspaceRoot,
-      spiritDataDir: spiritAgentDataDir(),
-    });
-  }
-
-  private parseSkillRootKind(value: unknown): DesktopSkillRootKind {
-    if (value === 'user' || value === 'workspaceSpirit' || value === 'workspaceAgents') {
-      return value;
-    }
-    throw new Error('无效的 Skill 根类型。');
-  }
-
-  private resolveSkillRootDir(rootKind: DesktopSkillRootKind): string {
-    const paths = this.instructionPaths();
-    switch (rootKind) {
-      case 'user':
-        return paths.userSkillsDir;
-      case 'workspaceSpirit':
-        return paths.workspaceSpiritSkillsDir;
-      case 'workspaceAgents':
-        return paths.workspaceAgentsSkillsDir;
-      default: {
-        const _exhaustive: never = rootKind;
-        return _exhaustive;
-      }
-    }
-  }
-
-  private resolveSkillDir(skillDirectoryName: string, rootKind: DesktopSkillRootKind): string {
-    return path.join(this.resolveSkillRootDir(rootKind), skillDirectoryName);
-  }
-
-  private assertPathUnderSkillRoot(targetDir: string, rootKind: DesktopSkillRootKind): void {
-    const root = path.resolve(this.resolveSkillRootDir(rootKind));
-    const resolved = path.resolve(targetDir);
-    if (resolved !== root && !resolved.startsWith(root + path.sep)) {
-      throw new Error('Skill 路径不在允许的根目录内。');
-    }
-  }
-
   private requireState(): HostState {
     if (!this.state) {
       throw new Error('宿主尚未初始化。');
@@ -4656,129 +4491,6 @@ function clearDreamCollectorIssue(
   return clean;
 }
 
-const MCP_DEFAULT_TIMEOUT_MS = 20_000;
-
-type DesktopMcpMetadataKind = 'env' | 'header';
-
-function emptyMcpStatusSnapshot(): DesktopSnapshot['mcpStatus'] {
-  return {
-    revision: 0,
-    state: 'idle',
-    configuredServers: 0,
-    loadedServers: 0,
-    cachedTools: 0,
-  };
-}
-
-function desktopMcpConfigPath(): string {
-  return mcpUserConfigPath(spiritAgentDataDir());
-}
-
-function loadMcpConfigFileFromDisk(): McpConfigFile {
-  const configPath = desktopMcpConfigPath();
-  if (!existsSync(configPath)) {
-    return { servers: {} };
-  }
-
-  const content = readFileSync(configPath, 'utf8');
-  return parseMcpConfigFile(JSON.parse(content) as unknown);
-}
-
-async function saveMcpConfigFileToDisk(config: McpConfigFile): Promise<void> {
-  const configPath = desktopMcpConfigPath();
-  await mkdir(path.dirname(configPath), { recursive: true });
-  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
-}
-
-function listDesktopMcpServersFromDisk(): DesktopMcpServerListItem[] {
-  try {
-    const configFile = loadMcpConfigFileFromDisk();
-    return Object.entries(configFile.servers).map(([name, server]) => {
-      const normalized = normalizeMcpServerConfig(name, server);
-      switch (normalized.transport.type) {
-        case 'stdio':
-          return {
-            name: normalized.name,
-            displayName: normalized.displayName,
-            enabled: normalized.enabled,
-            capabilities: normalized.capabilities,
-            transport: {
-              type: 'stdio',
-              command: normalized.transport.command,
-              args: normalized.transport.args,
-              metadata: normalized.transport.env,
-              ...(normalized.transport.cwd ? { cwd: normalized.transport.cwd } : {}),
-              ...(normalized.transport.timeoutMs !== undefined
-                ? { timeoutMs: normalized.transport.timeoutMs }
-                : {}),
-              summary: summarizeTransport(normalized.transport),
-            },
-          };
-        case 'http':
-          return {
-            name: normalized.name,
-            displayName: normalized.displayName,
-            enabled: normalized.enabled,
-            capabilities: normalized.capabilities,
-            transport: {
-              type: 'http',
-              url: normalized.transport.url,
-              metadata: normalized.transport.headers,
-              ...(normalized.transport.timeoutMs !== undefined
-                ? { timeoutMs: normalized.transport.timeoutMs }
-                : {}),
-              summary: summarizeTransport(normalized.transport),
-            },
-          };
-      }
-    });
-  } catch {
-    return [];
-  }
-}
-
-function buildMcpServerConfigFromRequest(request: AddMcpServerRequest): McpServerConfig {
-  const name = request.name.trim();
-  const capabilities = normalizeCapabilityToggles(request.capabilities);
-  const metadata = parseDesktopMcpMetadata(
-    request.metadata ?? '',
-    request.transportType === 'http' ? 'header' : 'env',
-  );
-
-  if (request.transportType === 'http') {
-    return {
-      displayName: name,
-      enabled: true,
-      capabilities,
-      transport: {
-        type: 'http',
-        url: request.endpoint.trim(),
-        ...(Object.keys(metadata).length > 0 ? { headers: metadata } : {}),
-        timeoutMs: MCP_DEFAULT_TIMEOUT_MS,
-      },
-    };
-  }
-
-  const tokens = splitDesktopCommandLine(request.endpoint.trim());
-  const [command, ...args] = tokens;
-  if (!command) {
-    throw new Error('命令不能为空。');
-  }
-
-  return {
-    displayName: name,
-    enabled: true,
-    capabilities,
-    transport: {
-      type: 'stdio',
-      command,
-      ...(args.length > 0 ? { args } : {}),
-      ...(Object.keys(metadata).length > 0 ? { env: metadata } : {}),
-      timeoutMs: MCP_DEFAULT_TIMEOUT_MS,
-    },
-  };
-}
-
 function toDesktopMarketplaceCatalogItem(item: {
   extensionId: string;
   packageName: string;
@@ -4915,254 +4627,6 @@ function toDesktopMarketplacePreparedInstall(prepared: {
     ...(prepared.shasum ? { shasum: prepared.shasum } : {}),
     sourceFileName: prepared.sourceFileName,
   };
-}
-
-function parseDesktopMcpMetadata(
-  input: string,
-  kind: DesktopMcpMetadataKind,
-): Record<string, string> {
-  const trimmed = input.trim();
-  if (!trimmed) {
-    return {};
-  }
-
-  const result: Record<string, string> = {};
-  for (const item of trimmed.split(';')) {
-    const pair = item.trim();
-    if (!pair) {
-      continue;
-    }
-
-    const parsed = kind === 'env'
-      ? pair.split(/=(.*)/su, 2)
-      : pair.includes(':')
-        ? pair.split(/:(.*)/su, 2)
-        : pair.split(/=(.*)/su, 2);
-
-    if (parsed.length < 2) {
-      throw new Error(kind === 'env'
-        ? '环境变量格式应为 KEY=value；多个条目用分号分隔。'
-        : 'Header 格式应为 Key: Value；多个条目用分号分隔。');
-    }
-
-    const key = parsed[0]?.trim() ?? '';
-    if (!key) {
-      throw new Error(kind === 'env' ? '环境变量名不能为空。' : 'Header 名不能为空。');
-    }
-
-    result[key] = (parsed[1] ?? '').trim();
-  }
-
-  return result;
-}
-
-function splitDesktopCommandLine(input: string): string[] {
-  const tokens: string[] = [];
-  let current = '';
-  let quote: '"' | "'" | undefined;
-
-  for (let index = 0; index < input.length; index += 1) {
-    const ch = input[index]!;
-    if (quote) {
-      if (ch === quote) {
-        quote = undefined;
-        continue;
-      }
-      if (ch === '\\' && index + 1 < input.length) {
-        current += input[index + 1]!;
-        index += 1;
-        continue;
-      }
-      current += ch;
-      continue;
-    }
-
-    if (ch === '"' || ch === "'") {
-      quote = ch;
-      continue;
-    }
-    if (/\s/u.test(ch)) {
-      if (current) {
-        tokens.push(current);
-        current = '';
-      }
-      continue;
-    }
-    if (ch === '\\' && index + 1 < input.length) {
-      current += input[index + 1]!;
-      index += 1;
-      continue;
-    }
-    current += ch;
-  }
-
-  if (quote) {
-    throw new Error('命令格式错误：存在未闭合的引号。');
-  }
-  if (current) {
-    tokens.push(current);
-  }
-  return tokens;
-}
-
-const ACTIVE_SKILL_CONTENT_MAX_CHARS = 12_000;
-const ACTIVE_SKILL_RESOURCE_MAX_ENTRIES = 24;
-const ACTIVE_SKILL_RESOURCE_DIRS: ReadonlyArray<{
-  kind: OpenAiActiveSkillResourceEntry['kind'];
-  dirname: string;
-}> = [
-  { kind: 'scripts', dirname: 'scripts' },
-  { kind: 'references', dirname: 'references' },
-  { kind: 'assets', dirname: 'assets' },
-];
-
-function buildActivateSkillUserTurn(skillName: string, extraNote: string): string {
-  const trimmed = extraNote.trim();
-  if (!trimmed) {
-    return `请按 skill "${skillName}" 处理当前任务。`;
-  }
-  return trimmed;
-}
-
-const CREATE_SKILL_PROMPT_HINT =
-  '请在 /create-skill 后描述你想生成或收紧的 Skill，例如：/create-skill 做一个用于排查 Electron 白屏的 Skill';
-
-function parseCreateSkillSlashPrompt(input: string): string | Error {
-  const trimmed = input.trim();
-  const prompt = trimmed.startsWith('/create-skill')
-    ? trimmed.slice('/create-skill'.length).trim()
-    : trimmed;
-  if (!prompt) {
-    return new Error(CREATE_SKILL_PROMPT_HINT);
-  }
-
-  return prompt;
-}
-
-function buildCreateSkillUserTurn(
-  workspaceRoot: string,
-  instructionPaths: ReturnType<typeof resolveInstructionPaths>,
-  prompt: string,
-): string {
-  const workspaceTargetRoot = instructionPaths.workspaceSpiritSkillsDir;
-  const userTargetRoot = instructionPaths.userSkillsDir;
-
-  return `你现在在处理一个 /create-skill 请求。
-
-目标:
-- default_scope: 工作区
-- workspace_skill_root: ${workspaceTargetRoot}
-- user_skill_root: ${userTargetRoot}
-- workspace_root: ${workspaceRoot}
-
-用户需求:
-${prompt}
-
-要求:
-- 先把它当成一次正常的 assistant 对话来处理，正常流式输出，不要伪装成后台静默生成器。
-- 默认创建到工作区 skill 根目录 ${workspaceTargetRoot}；只有在用户明确要求“用户级 / 全局 / 跨仓库复用 / 写到用户目录”这类语义时，才改为用户目录 ${userTargetRoot}。
-- 你需要先根据用户需求自行决定一个合适的 skill_name；名称必须是 1-64 个字符，只能使用小写字母、数字和连字符，不能以连字符开头或结尾，也不能包含连续连字符。
-- 最终目标目录名与 frontmatter \`name\` 必须完全等于你决定的 skill_name。
-- 最终文件路径必须是 \`<选定根目录>/<skill_name>/SKILL.md\`；不要写到其他位置。
-- 如果目标 Skill 已存在，先读取原有 \`SKILL.md\`，再基于现有内容压缩重写或收紧，不要在旧内容后面继续堆砌模板化废话。
-- \`SKILL.md\` 必须以 YAML frontmatter 开头，至少包含 \`name\` 和 \`description\`；正文使用 Markdown，重点写清“做什么、何时用、怎么做”。
-- \`description\` 要具体说明适用场景，便于 agent 在 catalog 中识别。
-- Skill 是给后续 agent/LLM 直接消费的能力说明，不是给人类流程管理看的。
-- 正文优先写步骤、输入输出示例、边界条件；避免空话、组织治理废话和泛泛 checklist。
-- 需要事实时先读取仓库内相关文件，不要臆造项目结构、技术栈、目录或既有工作流。
-- 如果技能需要引用其他文件，正文里使用相对路径表达，不要假设这些文件已经存在。
-- 如果你选择工作区 scope，优先提炼当前仓库内可复用的流程知识、约束和操作步骤，避免写成泛化的团队治理文档。
-- 如果你选择用户 scope，优先提炼跨仓库稳定复用的个人工作流、判断标准与执行步骤。
-- 写入仍会经过正常审批；不要假设自己已经拿到权限，也不要在工具成功前声称“已创建”或“已更新”。
-
-交付方式:
-- 如果你能直接在目标路径落盘，就在确认内容后使用文件工具写入。
-- 如果不能直接落盘，就把最终 \`SKILL.md\` 完整贴在回复里，并明确说明未写入。`;
-}
-
-async function buildActiveSkillPayload(
-  entry: HostMetadataSummary['skills']['entries'][number],
-): Promise<OpenAiActiveSkill> {
-  const skillRoot = path.dirname(entry.source.path);
-  const { content, truncated } = truncateActiveSkillContent(entry.content);
-  const { resources, truncated: resourcesTruncated } = await collectSkillResources(skillRoot);
-
-  return {
-    id: entry.source.id,
-    scope: entry.source.scope,
-    name: entry.source.name,
-    description: entry.source.description,
-    path: entry.source.path,
-    content,
-    truncated,
-    resources,
-    resourcesTruncated,
-  };
-}
-
-function truncateActiveSkillContent(content: string): {
-  content: string;
-  truncated: boolean;
-} {
-  const chars = [...content];
-  if (chars.length <= ACTIVE_SKILL_CONTENT_MAX_CHARS) {
-    return {
-      content: content.trim(),
-      truncated: false,
-    };
-  }
-
-  return {
-    content: `${chars.slice(0, ACTIVE_SKILL_CONTENT_MAX_CHARS).join('').trimEnd()}\n\n...<skill content truncated>`,
-    truncated: true,
-  };
-}
-
-async function collectSkillResources(skillRoot: string): Promise<{
-  resources: OpenAiActiveSkillResourceEntry[];
-  truncated: boolean;
-}> {
-  const resources: OpenAiActiveSkillResourceEntry[] = [];
-  let truncated = false;
-
-  for (const { kind, dirname } of ACTIVE_SKILL_RESOURCE_DIRS) {
-    const root = path.join(skillRoot, dirname);
-    if (!existsSync(root)) {
-      continue;
-    }
-
-    const stack = [root];
-    while (stack.length > 0) {
-      const current = stack.pop();
-      if (!current) {
-        continue;
-      }
-
-      const entries = await readdir(current, { withFileTypes: true });
-      entries.sort((left, right) => left.name.localeCompare(right.name));
-      for (const entry of entries) {
-        const fullPath = path.join(current, entry.name);
-        if (entry.isDirectory()) {
-          stack.push(fullPath);
-          continue;
-        }
-        if (!entry.isFile()) {
-          continue;
-        }
-        if (resources.length >= ACTIVE_SKILL_RESOURCE_MAX_ENTRIES) {
-          truncated = true;
-          return { resources, truncated };
-        }
-
-        resources.push({
-          kind,
-          path: path.relative(skillRoot, fullPath).replace(/\\/gu, '/'),
-        });
-      }
-    }
-  }
-
-  return { resources, truncated };
 }
 
 function cloneActiveSkills(skills: OpenAiActiveSkill[]): OpenAiActiveSkill[] {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
@@ -9,7 +9,6 @@ import {
   buildPlanSystemMessage,
   buildRulesSystemMessage,
   buildSkillsCatalogSystemMessage,
-  buildContributedHostToolDefinitions,
   type OpenAiActiveSkill,
   type OpenAiExtensionSystemPrompt,
   appendOpenAiToolResultMessage,
@@ -33,7 +32,6 @@ import {
   type RuntimeToolExecution,
 } from '@spirit-agent/agent-core';
 import {
-  collectHostExtensionContributedTools,
   createHostExtensionMarketplace,
   createHostExtensionManager,
   createHostDreamStore,
@@ -44,7 +42,6 @@ import {
   type HostExtensionMarketplaceManager,
   type HostDreamSessionProgress,
   type HostExtensionEvent,
-  type HostInstalledExtension,
   type HostRecordedFileChange,
 } from '@spirit-agent/host-internal';
 
@@ -128,6 +125,15 @@ import {
   type HostMetadataSummary,
 } from './storage.js';
 import { DesktopToolExecutor } from './tool-executor.js';
+import {
+  buildDesktopExtensionListItems,
+  buildDesktopExtensionToolDefinitions,
+  collectDesktopExtensionCssLayers,
+  collectExtensionSystemPrompts,
+  toDesktopMarketplaceCatalogItem,
+  toDesktopMarketplaceDetail,
+  toDesktopMarketplacePreparedInstall,
+} from './extensions.js';
 import {
   buildMcpServerConfigFromRequest,
   emptyMcpStatusSnapshot,
@@ -1693,13 +1699,7 @@ class DesktopHostService {
     );
     const extensions = await this.extensionManager().list();
     this.toolExecutor = new DesktopToolExecutor(state.workspaceRoot, {
-      extensionToolDefinitions: buildContributedHostToolDefinitions(
-        collectHostExtensionContributedTools(extensions).map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema as JsonObject,
-        })),
-      ),
+      extensionToolDefinitions: buildDesktopExtensionToolDefinitions(extensions),
       fileChangeObserver: {
         recordFileChange: (change) => this.recordHostFileChange(change),
       },
@@ -2503,137 +2503,8 @@ class DesktopHostService {
   private async refreshExtensionsList(): Promise<void> {
     const state = this.requireState();
     const extensions = await this.extensionManager().list();
-    state.extensionsList = await Promise.all(extensions.map(async (item) => ({
-      id: item.id,
-      displayName: item.manifest.name,
-      ...(item.manifest.icon ? { icon: item.manifest.icon } : {}),
-      version: item.manifest.version,
-      ...(item.manifest.description ? { description: item.manifest.description } : {}),
-      ...(item.manifest.author ? { author: item.manifest.author } : {}),
-      ...(item.manifest.homepage ? { homepage: item.manifest.homepage } : {}),
-      ...(item.manifest.main ? { main: item.manifest.main } : {}),
-      supportedHosts: [...item.manifest.supportedHosts],
-      ...(item.manifest.activationEvents?.length
-        ? { activationEvents: [...item.manifest.activationEvents] }
-        : {}),
-      ...(item.manifest.requestedCapabilities?.length
-        ? { requestedCapabilities: [...item.manifest.requestedCapabilities] }
-        : {}),
-      ...(item.manifest.contributes?.tools?.length
-        ? {
-            contributedTools: item.manifest.contributes.tools.map((tool) => ({
-              name: tool.name,
-              description: tool.description,
-              ...(tool.approvalMode ? { approvalMode: tool.approvalMode } : {}),
-              ...(tool.executionMode ? { executionMode: tool.executionMode } : {}),
-            })),
-          }
-        : {}),
-      ...(item.manifest.contributes?.desktop?.css?.length
-        ? {
-            desktopCss: item.manifest.contributes.desktop.css.map((entry) => ({
-              path: entry.path,
-              ...(entry.media ? { media: entry.media } : {}),
-            })),
-          }
-        : {}),
-      ...(item.manifest.contributes?.cli?.hooks?.length
-        ? {
-            cliHooks: item.manifest.contributes.cli.hooks.map((hook) => ({
-              slot: hook.slot,
-              ...(hook.variant ? { variant: hook.variant } : {}),
-              ...(hook.tokens
-                ? {
-                    tokens: {
-                      ...(hook.tokens.foreground ? { foreground: hook.tokens.foreground } : {}),
-                      ...(hook.tokens.border ? { border: hook.tokens.border } : {}),
-                      ...(hook.tokens.accent ? { accent: hook.tokens.accent } : {}),
-                    },
-                  }
-                : {}),
-              ...(hook.prefix ? { prefix: hook.prefix } : {}),
-              ...(hook.suffix ? { suffix: hook.suffix } : {}),
-            })),
-          }
-        : {}),
-      ...(item.manifest.settingsSchema?.length
-        ? {
-            settingsSchema: item.manifest.settingsSchema.map((setting) => ({
-              key: setting.key,
-              type: setting.type,
-              title: setting.title,
-              ...(setting.description ? { description: setting.description } : {}),
-              ...(setting.placeholder ? { placeholder: setting.placeholder } : {}),
-              ...(setting.required !== undefined ? { required: setting.required } : {}),
-              ...(setting.defaultValue !== undefined
-                ? { defaultValue: setting.defaultValue }
-                : {}),
-              ...(setting.options?.length
-                ? {
-                    options: setting.options.map((option) => ({
-                      value: option.value,
-                      label: option.label,
-                      ...(option.description ? { description: option.description } : {}),
-                    })),
-                  }
-                : {}),
-            })),
-            settingsValues: await this.extensionManager().getSettingsValues(item.id),
-          }
-        : {}),
-      ...(item.manifest.secretSlots?.length
-        ? {
-            secretSlots: item.manifest.secretSlots.map((slot) => ({
-              key: slot.key,
-              title: slot.title,
-              ...(slot.description ? { description: slot.description } : {}),
-              ...(slot.required !== undefined ? { required: slot.required } : {}),
-            })),
-            secretStatuses: Object.entries(
-              await this.extensionManager().getSecretStatus(item.id),
-            ).map(([key, configured]) => ({
-              key,
-              configured,
-            })),
-          }
-        : {}),
-      ...(item.archiveFileName ? { archiveFileName: item.archiveFileName } : {}),
-      installedAtUnixMs: item.installedAtUnixMs,
-    })));
-    state.extensionCss = await this.collectDesktopExtensionCssLayers(extensions);
-  }
-
-  private async collectDesktopExtensionCssLayers(
-    extensions: readonly HostInstalledExtension[],
-  ): Promise<DesktopExtensionCssLayer[]> {
-    const layers: DesktopExtensionCssLayer[] = [];
-
-    for (const item of extensions) {
-      const cssEntries = item.manifest.contributes?.desktop?.css ?? [];
-      for (const entry of cssEntries) {
-        const sourcePath = path.join(item.directoryPath, ...entry.path.split('/'));
-        try {
-          const cssText = await readFile(sourcePath, 'utf8');
-          if (!cssText.trim()) {
-            continue;
-          }
-          layers.push({
-            extensionId: item.id,
-            extensionName: item.manifest.name,
-            sourcePath: entry.path,
-            cssText,
-            ...(entry.media ? { media: entry.media } : {}),
-          });
-        } catch (error) {
-          console.warn(
-            `[desktop-host][extensions] read css failed: ${item.id}:${entry.path}`,
-            error,
-          );
-        }
-      }
-    }
-
-    return layers;
+    state.extensionsList = await buildDesktopExtensionListItems(this.extensionManager(), extensions);
+    state.extensionCss = await collectDesktopExtensionCssLayers(extensions);
   }
 
   private async refreshExtensionToolDefinitions(): Promise<void> {
@@ -2642,15 +2513,7 @@ class DesktopHostService {
     }
 
     const extensions = await this.extensionManager().list();
-    this.toolExecutor.setExtensionToolDefinitions(
-      buildContributedHostToolDefinitions(
-        collectHostExtensionContributedTools(extensions).map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema as JsonObject,
-        })),
-      ),
-    );
+    this.toolExecutor.setExtensionToolDefinitions(buildDesktopExtensionToolDefinitions(extensions));
   }
 
   private async collectExtensionSystemPrompts(): Promise<OpenAiExtensionSystemPrompt[]> {
@@ -2659,15 +2522,7 @@ class DesktopHostService {
       return [];
     }
 
-    const collected = await this.extensionManager().collectSystemPromptContributions({
-      host: adapter,
-      logger: console,
-    });
-    return collected.map((entry) => ({
-      extensionId: entry.extensionId,
-      extensionName: entry.extensionName,
-      content: entry.content,
-    }));
+    return collectExtensionSystemPrompts(this.extensionManager(), adapter);
   }
 
   private async refreshRuntimeAfterExtensionMutation(): Promise<void> {
@@ -4489,144 +4344,6 @@ function clearDreamCollectorIssue(
 ): DesktopDreamCollectorSnapshot {
   const { lastError: _lastError, backoffUntilUnixMs: _backoffUntilUnixMs, ...clean } = snapshot;
   return clean;
-}
-
-function toDesktopMarketplaceCatalogItem(item: {
-  extensionId: string;
-  packageName: string;
-  status: string;
-  featured: boolean;
-  defaultVersion: string;
-  defaultChannel: 'stable' | 'preview' | 'experimental';
-  defaultReviewStatus: 'unverified' | 'verified' | 'revoked';
-  detailPath: string;
-  displayName: string;
-  description: string;
-  author?: string;
-  homepageUrl?: string;
-  repositoryUrl?: string;
-  keywords: string[];
-  supportedHosts: Array<'cli' | 'desktop'>;
-  requestedCapabilities: string[];
-  iconUrl?: string;
-}): DesktopMarketplaceCatalogItem {
-  return {
-    extensionId: item.extensionId,
-    packageName: item.packageName,
-    status: item.status,
-    featured: item.featured,
-    defaultVersion: item.defaultVersion,
-    defaultChannel: item.defaultChannel,
-    defaultReviewStatus: item.defaultReviewStatus,
-    detailPath: item.detailPath,
-    displayName: item.displayName,
-    description: item.description,
-    ...(item.author ? { author: item.author } : {}),
-    ...(item.homepageUrl ? { homepageUrl: item.homepageUrl } : {}),
-    ...(item.repositoryUrl ? { repositoryUrl: item.repositoryUrl } : {}),
-    keywords: [...item.keywords],
-    supportedHosts: [...item.supportedHosts],
-    requestedCapabilities: [...item.requestedCapabilities],
-    ...(item.iconUrl ? { iconUrl: item.iconUrl } : {}),
-  };
-}
-
-function toDesktopMarketplaceDetail(detail: {
-  extensionId: string;
-  packageName: string;
-  status: string;
-  featured: boolean;
-  defaultVersion: string;
-  readmePath: string;
-  versions: Array<{
-    version: string;
-    channel: 'stable' | 'preview' | 'experimental';
-    reviewStatus: 'unverified' | 'verified' | 'revoked';
-    displayName: string;
-    description: string;
-    author?: string;
-    homepageUrl?: string;
-    repositoryUrl?: string;
-    keywords: string[];
-    supportedHosts: Array<'cli' | 'desktop'>;
-    requestedCapabilities: string[];
-    iconUrl?: string;
-    publishedAt?: string;
-    tarballUrl?: string;
-    integrity?: string;
-    shasum?: string;
-    changelog?: {
-      summary: string;
-      body: string;
-    };
-  }>;
-}): DesktopMarketplaceDetail {
-  return {
-    extensionId: detail.extensionId,
-    packageName: detail.packageName,
-    status: detail.status,
-    featured: detail.featured,
-    defaultVersion: detail.defaultVersion,
-    readmePath: detail.readmePath,
-    versions: detail.versions.map((item) => ({
-      version: item.version,
-      channel: item.channel,
-      reviewStatus: item.reviewStatus,
-      displayName: item.displayName,
-      description: item.description,
-      ...(item.author ? { author: item.author } : {}),
-      ...(item.homepageUrl ? { homepageUrl: item.homepageUrl } : {}),
-      ...(item.repositoryUrl ? { repositoryUrl: item.repositoryUrl } : {}),
-      keywords: [...item.keywords],
-      supportedHosts: [...item.supportedHosts],
-      requestedCapabilities: [...item.requestedCapabilities],
-      ...(item.iconUrl ? { iconUrl: item.iconUrl } : {}),
-      ...(item.publishedAt ? { publishedAt: item.publishedAt } : {}),
-      ...(item.tarballUrl ? { tarballUrl: item.tarballUrl } : {}),
-      ...(item.integrity ? { integrity: item.integrity } : {}),
-      ...(item.shasum ? { shasum: item.shasum } : {}),
-      ...(item.changelog
-        ? {
-            changelog: {
-              summary: item.changelog.summary,
-              body: item.changelog.body,
-            },
-          }
-        : {}),
-    })),
-  };
-}
-
-function toDesktopMarketplacePreparedInstall(prepared: {
-  extensionId: string;
-  packageName: string;
-  displayName: string;
-  description: string;
-  version: string;
-  channel: 'stable' | 'preview' | 'experimental';
-  reviewStatus: 'unverified' | 'verified' | 'revoked';
-  supportedHosts: Array<'cli' | 'desktop'>;
-  supportsCurrentHost: boolean;
-  tarballUrl?: string;
-  integrity?: string;
-  shasum?: string;
-  sourceFileName: string;
-}): DesktopMarketplacePreparedInstall {
-  return {
-    extensionId: prepared.extensionId,
-    packageName: prepared.packageName,
-    displayName: prepared.displayName,
-    description: prepared.description,
-    version: prepared.version,
-    channel: prepared.channel,
-    reviewStatus: prepared.reviewStatus,
-    supportedHosts: [...prepared.supportedHosts],
-    supportsCurrentHost: prepared.supportsCurrentHost,
-    ...(prepared.tarballUrl ? { tarballUrl: prepared.tarballUrl } : {}),
-    ...(prepared.integrity ? { integrity: prepared.integrity } : {}),
-    ...(prepared.shasum ? { shasum: prepared.shasum } : {}),
-    sourceFileName: prepared.sourceFileName,
-  };
 }
 
 function cloneActiveSkills(skills: OpenAiActiveSkill[]): OpenAiActiveSkill[] {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -55,7 +55,6 @@ import type {
   DesktopDreamCollectorSnapshot,
   DesktopModelProvider,
   DeleteSkillRequest,
-  DesktopModelCatalogHint,
   DesktopSnapshot,
   FileRewindWarning,
   RunExtensionRequest,
@@ -95,7 +94,6 @@ import {
 import {
   isModelCatalogCacheFresh,
   readModelCatalogCache,
-  readModelCatalogCacheSync,
   writeModelCatalogCache,
 } from './model-catalog-cache.js';
 import {
@@ -156,8 +154,6 @@ import {
 } from './mcp-config.js';
 import {
   archiveBeforeLastUser,
-  buildAvailableWorkspaces,
-  buildWebHostSnapshot,
   cloneChatArchive,
   cloneDesktopConfig,
   currentApiBase,
@@ -169,6 +165,7 @@ import {
   sameWorkspaceRoot,
   toRuntimeAskQuestionsResult,
 } from './service-utils.js';
+import { buildDesktopSnapshot } from './snapshot.js';
 import {
   assistantPrefixBeforeFirstToolInCurrentTurn,
   describeAuxForDebug,
@@ -1889,27 +1886,6 @@ class DesktopHostService {
     });
   }
 
-  private buildModelCatalogHints(state: HostState): DesktopModelCatalogHint[] {
-    const seen = new Set<string>();
-    const hints: DesktopModelCatalogHint[] = [];
-    for (const model of state.config.models) {
-      const base = model.apiBase.trim() || DEFAULT_API_BASE;
-      if (seen.has(base)) {
-        continue;
-      }
-      seen.add(base);
-      const hit = readModelCatalogCacheSync(base);
-      if (hit && hit.modelIds.length > 0) {
-        hints.push({
-          apiBase: hit.apiBase,
-          modelIds: hit.modelIds,
-          fetchedAtUnixMs: hit.fetchedAtUnixMs,
-        });
-      }
-    }
-    return hints;
-  }
-
   private buildSnapshot(): DesktopSnapshot {
     const state = this.requireState();
     const pendingApproval = this.runtime?.currentPendingApproval();
@@ -1924,62 +1900,18 @@ class DesktopHostService {
     }
     this.pruneEmptyAssistantMessages('buildSnapshot');
 
-    return {
+    return buildDesktopSnapshot({
       workspaceRoot: state.workspaceRoot,
-      availableWorkspaces: buildAvailableWorkspaces(
-        state.workspaceRoot,
-        state.config.recentWorkspaces,
-      ),
-      git: { ...state.git },
-      dreams: {
-        settings: {
-          enabled: state.config.dreams.enabled === true,
-          ...(state.config.dreams.collectorModel ? { collectorModel: state.config.dreams.collectorModel } : {}),
-          debugMode: state.config.dreams.debugMode === true,
-        },
-        collector: { ...this.dreamCollectorStatus },
-      },
+      config: state.config,
+      git: state.git,
+      metadata: state.metadata,
+      extensionsList: state.extensionsList,
+      extensionCss: state.extensionCss,
+      dreamCollectorStatus: this.dreamCollectorStatus,
       runtimeReady: this.runtime !== undefined,
-      ...(this.lastRuntimeError ? { runtimeError: this.lastRuntimeError } : {}),
-      config: {
-        models: state.config.models.map((model) => ({
-          name: model.name,
-          apiBase: model.apiBase,
-          ...(model.provider ? { provider: model.provider } : {}),
-          keyConfigured: this.modelKeyPresence[model.name] ?? false,
-        })),
-        activeModel: state.config.activeModel,
-        ...(state.config.uiLocale ? { uiLocale: state.config.uiLocale } : {}),
-        activeApiKeyConfigured: this.activeApiKeyConfigured,
-        windowsMica: state.config.windowsMica !== false,
-        planMode: state.config.planMode === true,
-        modelCatalogHints: this.buildModelCatalogHints(state),
-      },
-      webHost: buildWebHostSnapshot(state.config.webHost),
-      rules: {
-        discovered: state.metadata.rules.discovered,
-        enabled: state.metadata.rules.enabled,
-      },
-      skills: {
-        discovered: state.metadata.skills.discovered,
-        enabled: state.metadata.skills.enabled,
-      },
-      skillsList: state.metadata.skills.entries.map((entry) => ({
-        id: entry.source.id,
-        name: entry.source.name,
-        description: entry.source.description,
-        shortLabel: entry.source.shortLabel,
-        scope: entry.source.scope,
-        rootKind: entry.source.rootKind,
-        enabled: entry.enabled,
-      })),
-      // 须与 refreshExtensionsList 一致，否则设置页不显示工具/设置/密钥
-      extensionsList: state.extensionsList.map((item) => ({ ...item })),
-      extensionCss: state.extensionCss.map((entry) => ({ ...entry })),
-      plan: {
-        path: state.metadata.planMetadata.path,
-        exists: state.metadata.planMetadata.exists,
-      },
+      runtimeError: this.lastRuntimeError,
+      modelKeyPresence: this.modelKeyPresence,
+      activeApiKeyConfigured: this.activeApiKeyConfigured,
       mcpStatus: this.toolExecutor?.mcpStatusSnapshot() ?? emptyMcpStatusSnapshot(),
       mcpServers: listDesktopMcpServersFromDisk(),
       conversation: {
@@ -2021,8 +1953,8 @@ class DesktopHostService {
           ? { rewindWarnings: state.rewindWarnings.map((warning) => ({ ...warning })) }
           : {}),
       },
-      ...(state.activeSession ? { activeSession: { ...state.activeSession } } : {}),
-    };
+      ...(state.activeSession ? { activeSession: state.activeSession } : {}),
+    });
   }
 
   private findEphemeralSession(filePath: string): EphemeralSessionRecord | undefined {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -33,7 +33,6 @@ import {
   type OpenAiPlanMetadata,
   type OpenAiToolAgentState,
   type OpenAiTransportConfig,
-  type RuntimeApprovalDecision,
   type RuntimePendingApproval,
   type RuntimePendingQuestions,
   type RuntimeEvent,
@@ -94,14 +93,12 @@ import type {
   DesktopSkillRootKind,
   DesktopModelCatalogHint,
   DesktopSnapshot,
-  DesktopWebHostSnapshot,
   FileRewindWarning,
   RunExtensionRequest,
   UpdateExtensionSecretRequest,
   UpdateExtensionSettingsRequest,
   MessageAuxSnapshot,
   PendingAssistantAux,
-  PendingQuestionsSnapshot,
   RewindAndSubmitMessageRequest,
   RememberWorkspaceRequest,
   RemoveModelRequest,
@@ -151,14 +148,54 @@ import {
 } from './storage.js';
 import { DesktopToolExecutor } from './tool-executor.js';
 import {
+  archiveBeforeLastUser,
+  buildAvailableWorkspaces,
+  buildWebHostSnapshot,
+  cloneChatArchive,
+  cloneDesktopConfig,
+  currentApiBase,
+  formatYamlScalarForSkillFrontmatter,
+  mapPendingQuestions,
+  normalizeGeneratedCommitMessage,
+  parseAddModelProvider,
+  parseApprovalDecision,
+  sameDreamCollectorSnapshot,
+  sameWorkspaceRoot,
+  toRuntimeAskQuestionsResult,
+} from './service-utils.js';
+import {
+  assistantPrefixBeforeFirstToolInCurrentTurn,
+  describeAuxForDebug,
+  describeOptionalAuxForDebug,
+  headlineForStreamingToolPreview,
+  hasStandaloneThinkingMessageInCurrentTurn,
+  indexForThinkingInsertAfterLastUser,
+  indexForThinkingInsertBeforeFirstToolAfterLastUser,
+  isStandaloneSubagentStatusAux,
+  lastAssistantPlainTextInHistory,
+  latestUnsyncedAssistantTextInCurrentTurn,
+  messageIndexIsInCurrentTurn,
+  messageOrderDebugLevel,
+  normalizeMessageAuxSnapshot,
+  normalizeToolBlockSnapshot,
+  parsePendingSubagentStatusText,
+  restoreMessagesFromArchive,
+  rewindStandalonePendingAuxInsertIndexForThinking,
+  shouldDropEmptyAssistantMessage,
+  shouldHideEmptyPendingAssistantSnapshot,
+  shouldHidePendingAssistantThinkingForLiveStandaloneSubagentStatus,
+  shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse,
+  stripPendingThinkingMatchingFinalized,
+  stripThinkingFromAux,
+  summarizeMessagesTailForOrderDebug,
+  truncateOneLineForDebug,
+  toolMessageKey,
+} from './message-ordering.js';
+import {
   buildWorkspaceGitCommitMessageContext,
   commitWorkspaceChanges,
   readWorkspaceGitSnapshot,
 } from './git.js';
-import {
-  DESKTOP_WEB_HOST_POLICY,
-  getDesktopWebHostRuntimeStatus,
-} from './web-host-state.js';
 import {
   createDesktopRewindMetadata,
   createRewindCheckpointMetadata,
@@ -201,27 +238,6 @@ export function setDesktopExtensionHostAdapter(
   adapter: DesktopExtensionHostAdapter | undefined,
 ): void {
   desktopExtensionHostAdapter = adapter;
-}
-
-function normalizeWorkspaceRootKey(workspaceRoot: string): string {
-  return workspaceRoot.replace(/\\/g, '/').replace(/\/+$/g, '').toLowerCase();
-}
-
-function sameWorkspaceRoot(left: string, right: string): boolean {
-  return normalizeWorkspaceRootKey(left) === normalizeWorkspaceRootKey(right);
-}
-
-function deriveWorkspaceLabel(workspaceRoot: string): string {
-  const normalized = workspaceRoot.replace(/\\/g, '/').replace(/\/+$/g, '');
-  const lastSlash = normalized.lastIndexOf('/');
-  return lastSlash >= 0 ? normalized.slice(lastSlash + 1) || normalized : normalized;
-}
-
-function buildAvailableWorkspaces(currentWorkspaceRoot: string, recentWorkspaces?: string[]) {
-  return mergeRecentWorkspaceRoots(recentWorkspaces, currentWorkspaceRoot).map((workspaceRoot) => ({
-    path: workspaceRoot,
-    label: deriveWorkspaceLabel(workspaceRoot),
-  }));
 }
 
 const EPHEMERAL_COMMIT_SESSION_PREFIX = 'ephemeral://commit-message/';
@@ -4640,29 +4656,6 @@ function clearDreamCollectorIssue(
   return clean;
 }
 
-function cloneDesktopConfig(config: DesktopConfigFile): DesktopConfigFile {
-  return JSON.parse(JSON.stringify(config)) as DesktopConfigFile;
-}
-
-function normalizeGeneratedCommitMessage(value: unknown): string {
-  if (typeof value !== 'string') {
-    throw new Error('自动生成提交信息失败：模型未返回 message 字段。');
-  }
-
-  const normalized = value
-    .replace(/\r\n/g, '\n')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .join('\n');
-
-  if (!normalized) {
-    throw new Error('自动生成提交信息失败：模型返回了空 message。');
-  }
-
-  return normalized;
-}
-
 const MCP_DEFAULT_TIMEOUT_MS = 20_000;
 
 type DesktopMcpMetadataKind = 'env' | 'header';
@@ -5179,205 +5172,6 @@ function cloneActiveSkills(skills: OpenAiActiveSkill[]): OpenAiActiveSkill[] {
   }));
 }
 
-/** 环境变量 `SPIRIT_DESKTOP_MESSAGE_ORDER_DEBUG`：不设为关；`1`/compact/on 紧凑；`2`/verbose 更详并节流纯 preview；`0`/off 显式关闭。 */
-type MessageOrderDebugLevel = 'off' | 'compact' | 'verbose';
-
-function messageOrderDebugLevel(): MessageOrderDebugLevel {
-  const raw = process.env.SPIRIT_DESKTOP_MESSAGE_ORDER_DEBUG?.trim().toLowerCase() ?? '';
-  if (raw === '') {
-    return 'off';
-  }
-  if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on' || raw === 'compact') {
-    return 'compact';
-  }
-  if (raw === '0' || raw === 'false' || raw === 'off' || raw === 'no') {
-    return 'off';
-  }
-  if (raw === '2' || raw === 'verbose' || raw === 'debug' || raw === 'all') {
-    return 'verbose';
-  }
-  return 'off';
-}
-
-function summarizeMessagesTailForOrderDebug(
-  messages: ConversationMessageSnapshot[],
-  max: number,
-): string {
-  if (messages.length === 0) {
-    return '∅';
-  }
-  const slice = messages.slice(Math.max(0, messages.length - max));
-  return slice.map(formatMessageOrderToken).join('«');
-}
-
-function formatMessageOrderToken(m: ConversationMessageSnapshot): string {
-  if (m.role === 'user') {
-    return 'U';
-  }
-  const toolName = m.tool?.toolName;
-  if (toolName) {
-    const phase = m.tool?.phase ?? '?';
-    const p =
-      phase === 'running' ? '~' : phase === 'succeeded' ? '=' : phase === 'failed' ? '!' : phase === 'pending-approval' ? '?' : '.';
-    return `${p}${truncateOneLineForDebug(toolName, 20)}`;
-  }
-  if (m.aux?.thinking && !m.content.trim()) {
-    return `H#${m.id}`;
-  }
-  if (m.aux?.compaction && !m.content.trim()) {
-    return `C#${m.id}`;
-  }
-  const c = m.content.trim();
-  if (!c) {
-    return 'Aε';
-  }
-  const hasThinking = Boolean(m.aux?.thinking?.trim());
-  const hasCompaction = Boolean(m.aux?.compaction?.trim());
-  const prefix = hasThinking ? (hasCompaction ? 'aTC' : 'aT') : hasCompaction ? 'aC' : 'a';
-  return `${prefix}#${m.id}:${truncateOneLineForDebug(c, 18)}`;
-}
-
-function truncateOneLineForDebug(s: string, max: number): string {
-  const t = s.replace(/\s+/g, ' ').trim();
-  if (t.length <= max) {
-    return t;
-  }
-  return `${t.slice(0, max)}…`;
-}
-
-/** 自 history 尾部向前找**最后一条**非空 `assistant` 正文（OpenAI 路径下 `historyStore` 常无 `role: tool`，需用此作待审批时的兜底）。 */
-function lastAssistantPlainTextInHistory(
-  hist: ReadonlyArray<{ role: string; content: string }>,
-): string | undefined {
-  for (let i = hist.length - 1; i >= 0; i -= 1) {
-    const m = hist[i];
-    if (m?.role === 'assistant' && m.content.trim()) {
-      return m.content.trim();
-    }
-  }
-  return undefined;
-}
-
-/**
- * 自「最后一条 user」起至首条 `tool` 前，取**第一个**非空 assistant 正文。
- * OpenAI 路径下 tool 结果通常不在 `history()` 的 LlmMessage 里，若仍用「最后一个」assistant
- * 会误取工具执行后的终稿，从而覆盖/错配流式阶段已显示的前缀（如「好的，我来查看…」）。
- */
-function assistantPrefixBeforeFirstToolInCurrentTurn(
-  hist: ReadonlyArray<{ role: string; content: string }>,
-): string | undefined {
-  let lastUserIdx = -1;
-  for (let i = hist.length - 1; i >= 0; i -= 1) {
-    if (hist[i]?.role === 'user') {
-      lastUserIdx = i;
-      break;
-    }
-  }
-
-  let firstToolIdx = -1;
-  for (let i = lastUserIdx + 1; i < hist.length; i += 1) {
-    if (hist[i]?.role === 'tool') {
-      firstToolIdx = i;
-      break;
-    }
-  }
-
-  const end = firstToolIdx >= 0 ? firstToolIdx : hist.length;
-  for (let i = lastUserIdx + 1; i < end; i += 1) {
-    const m = hist[i];
-    if (!m) {
-      continue;
-    }
-    if (m.role === 'assistant' && m.content.trim()) {
-      return m.content.trim();
-    }
-  }
-
-  return undefined;
-}
-
-function latestUnsyncedAssistantTextInCurrentTurn(
-  hist: ReadonlyArray<{ role: string; content: string }>,
-  messages: ReadonlyArray<ConversationMessageSnapshot>,
-): string | undefined {
-  const historyTexts = assistantPlainTextsInCurrentTurnHistory(hist);
-  if (historyTexts.length === 0) {
-    return undefined;
-  }
-
-  const existing = new Set(assistantPlainTextsInCurrentTurnMessages(messages));
-  for (let i = historyTexts.length - 1; i >= 0; i -= 1) {
-    const text = historyTexts[i]!;
-    if (!existing.has(text)) {
-      return text;
-    }
-  }
-
-  return undefined;
-}
-
-function assistantPlainTextsInCurrentTurnHistory(
-  hist: ReadonlyArray<{ role: string; content: string }>,
-): string[] {
-  let lastUserIdx = -1;
-  for (let i = hist.length - 1; i >= 0; i -= 1) {
-    if (hist[i]?.role === 'user') {
-      lastUserIdx = i;
-      break;
-    }
-  }
-
-  const texts: string[] = [];
-  for (let i = lastUserIdx + 1; i < hist.length; i += 1) {
-    const item = hist[i];
-    if (!item || item.role !== 'assistant') {
-      continue;
-    }
-    const text = item.content.trim();
-    if (text) {
-      texts.push(text);
-    }
-  }
-  return texts;
-}
-
-function assistantPlainTextsInCurrentTurnMessages(
-  messages: ReadonlyArray<ConversationMessageSnapshot>,
-): string[] {
-  let lastUserIdx = -1;
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i]?.role === 'user') {
-      lastUserIdx = i;
-      break;
-    }
-  }
-
-  const texts: string[] = [];
-  for (let i = lastUserIdx + 1; i < messages.length; i += 1) {
-    const item = messages[i];
-    if (!item || item.role !== 'assistant' || item.tool) {
-      continue;
-    }
-    const text = item.content.trim();
-    if (text) {
-      texts.push(text);
-    }
-  }
-  return texts;
-}
-
-function formatYamlScalarForSkillFrontmatter(value: string): string {
-  const flat = value.replace(/\r?\n/g, ' ').trim() || '说明';
-  return `"${flat.replace(/\\/gu, '\\\\').replace(/"/gu, '\\"')}"`;
-}
-
-function parseAddModelProvider(value: unknown): DesktopModelProvider | undefined {
-  if (value === 'deepseek' || value === 'kimi' || value === 'minimax' || value === 'custom') {
-    return value;
-  }
-  return undefined;
-}
-
 const desktopHostService = new DesktopHostService();
 
 export function setDesktopMarketplaceFetchImplementation(
@@ -5397,473 +5191,6 @@ export function subscribeDesktopDreamUpdates(
   listener: (snapshot: DesktopSnapshot) => void,
 ): () => void {
   return desktopHostService.subscribeDreamUpdates(listener);
-}
-
-function sameDreamCollectorSnapshot(
-  left: DesktopDreamCollectorSnapshot,
-  right: DesktopDreamCollectorSnapshot,
-): boolean {
-  return left.state === right.state &&
-    left.lastRunAtUnixMs === right.lastRunAtUnixMs &&
-    left.lastSuccessAtUnixMs === right.lastSuccessAtUnixMs &&
-    left.lastError === right.lastError &&
-    left.pendingCount === right.pendingCount &&
-    left.processedCount === right.processedCount &&
-    left.backoffUntilUnixMs === right.backoffUntilUnixMs;
-}
-
-function buildWebHostSnapshot(config: DesktopWebHostConfigFile): DesktopWebHostSnapshot {
-  const runtimeStatus = getDesktopWebHostRuntimeStatus();
-  const status = config.enabled
-    ? {
-        ...runtimeStatus,
-        host: runtimeStatus.host || config.host,
-        port: runtimeStatus.port || config.port,
-        ...(config.authTokenHash ? { pairingCode: undefined } : {}),
-      }
-    : {
-        state: 'disabled' as const,
-        host: config.host,
-        port: config.port,
-      };
-
-  return {
-    config: {
-      enabled: config.enabled,
-      host: config.host,
-      port: config.port,
-      paired: Boolean(config.authTokenHash),
-      authMode: 'pairing',
-    },
-    status,
-    policy: DESKTOP_WEB_HOST_POLICY,
-  };
-}
-
-function currentApiBase(config: DesktopConfigFile): string {
-  return (
-    config.models.find((model) => model.name === config.activeModel)?.apiBase ||
-    config.models[0]?.apiBase ||
-    ''
-  );
-}
-
-function cloneChatArchive(archive: ChatArchive): ChatArchive {
-  return {
-    messages: archive.messages.map((message) => ({ ...message })),
-    assistantAux: archive.assistantAux.map((entry) => ({ ...entry })),
-    llmHistory: archive.llmHistory.map((message) => ({
-      role: message.role,
-      content: message.content,
-      imagePaths: [...message.imagePaths],
-    })),
-    subagentSessions: (archive.subagentSessions ?? []).map((entry) => ({
-      summary: { ...entry.summary },
-      llmHistory: entry.llmHistory.map((message) => ({
-        role: message.role,
-        content: message.content,
-        imagePaths: [...message.imagePaths],
-      })),
-    })),
-  };
-}
-
-function archiveBeforeLastUser(archive: ChatArchive): ChatArchive {
-  const cloned = cloneChatArchive(archive);
-  const messageIndex = findLastIndex(cloned.messages, (message) => message.role === 'user');
-  const historyIndex = findLastIndex(cloned.llmHistory, (message) => message.role === 'user');
-  return {
-    ...cloned,
-    messages: messageIndex >= 0 ? cloned.messages.slice(0, messageIndex) : cloned.messages,
-    assistantAux:
-      messageIndex >= 0
-        ? cloned.assistantAux.filter((entry) => entry.messageIndex < messageIndex)
-        : cloned.assistantAux,
-    llmHistory: historyIndex >= 0 ? cloned.llmHistory.slice(0, historyIndex) : cloned.llmHistory,
-  };
-}
-
-function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    if (predicate(items[index]!)) {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function parseApprovalDecision(message: string): RuntimeApprovalDecision {
-  const trimmed = message.trim().toLowerCase();
-  if (!trimmed || trimmed === 'y' || trimmed === 'yes' || trimmed === 'approve') {
-    return { kind: 'allow' };
-  }
-  if (trimmed === 't' || trimmed === 'trust') {
-    return { kind: 'allow', persistTrust: true };
-  }
-  if (trimmed === 'n' || trimmed === 'no' || trimmed === 'deny') {
-    return { kind: 'deny' };
-  }
-  return {
-    kind: 'guidance',
-    userMessage: message,
-  };
-}
-
-function toRuntimeAskQuestionsResult(
-  result: AskQuestionsResult,
-): RuntimeAskQuestionsResult {
-  if (result.status === 'skipped') {
-    return { status: 'skipped' };
-  }
-
-  return {
-    status: 'answered',
-    answers: result.answers ?? [],
-  };
-}
-
-function mapPendingQuestions(
-  pending: RuntimePendingQuestions<DesktopToolRequest>,
-): PendingQuestionsSnapshot {
-  return {
-    toolCallId: pending.toolCallId,
-    toolName: pending.toolName,
-    request: {
-      ...(pending.questions.title ? { title: pending.questions.title } : {}),
-      questions: pending.questions.questions.map((question) => ({
-        id: question.id,
-        title: question.title,
-        kind: question.kind,
-        required: question.required === true,
-        options: (question.options ?? []).map((option) => ({
-          label: option.label,
-          ...(option.summary ? { summary: option.summary } : {}),
-        })),
-        allowCustomInput: question.allowCustomInput === true,
-        ...(question.customInputPlaceholder
-          ? { customInputPlaceholder: question.customInputPlaceholder }
-          : {}),
-        ...(question.customInputLabel
-          ? { customInputLabel: question.customInputLabel }
-          : {}),
-      })),
-    },
-  };
-}
-
-function stripPendingThinkingMatchingFinalized(
-  aux: MessageAuxSnapshot | undefined,
-  finalizedText: string,
-): MessageAuxSnapshot | undefined {
-  if (!aux?.thinking) {
-    return aux;
-  }
-  if (aux.thinking.trim() !== finalizedText.trim()) {
-    return aux;
-  }
-  const { thinking: _t, ...rest } = aux;
-  return Object.keys(rest).length > 0 ? rest : undefined;
-}
-
-function stripThinkingFromAux(aux: MessageAuxSnapshot | undefined): MessageAuxSnapshot | undefined {
-  if (!aux?.thinking) {
-    return normalizeMessageAuxSnapshot(aux);
-  }
-  const { thinking: _thinking, ...rest } = aux;
-  return normalizeMessageAuxSnapshot(rest);
-}
-
-function isStandaloneThinkingMessage(
-  message: ConversationMessageSnapshot | undefined,
-): boolean {
-  return Boolean(
-    message?.role === 'assistant' &&
-      !message.tool &&
-      !message.content.trim() &&
-      message.aux?.thinking?.trim(),
-  );
-}
-
-function rewindStandalonePendingAuxInsertIndexForThinking(
-  messages: ReadonlyArray<ConversationMessageSnapshot>,
-  anchorIndex: number,
-): number {
-  let index = anchorIndex;
-  while (index > 0 && isStandaloneThinkingMessage(messages[index - 1])) {
-    index -= 1;
-  }
-  return index;
-}
-
-function parsePendingSubagentStatusText(text: string | undefined): string | undefined {
-  if (!text) {
-    return undefined;
-  }
-
-  const status = text
-    .trim()
-    .replace(/^[|/\\-]\s*/, '')
-    .trim();
-
-  if (!status || status === 'Thinking...' || status === 'Compressing...') {
-    return undefined;
-  }
-
-  return status;
-}
-
-function isStandaloneSubagentStatusAux(
-  pendingAux: PendingAssistantAux | undefined,
-): boolean {
-  return Boolean(pendingAux && parsePendingSubagentStatusText(pendingAux.statusText));
-}
-
-function shouldHidePendingAssistantThinkingForLiveStandaloneSubagentStatus(
-  message: ConversationMessageSnapshot,
-  livePendingAux: PendingAssistantAux | undefined,
-): boolean {
-  return Boolean(
-    isStandaloneSubagentStatusAux(livePendingAux) &&
-      message.role === 'assistant' &&
-      message.pending &&
-      !message.tool &&
-      !message.content.trim(),
-  );
-}
-
-function shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
-  lastMessage: ConversationMessageSnapshot | undefined,
-  persistedStandalonePendingAux: PendingAssistantAux | undefined,
-): boolean {
-  return Boolean(
-    lastMessage?.role === 'assistant' &&
-      isStandaloneSubagentStatusAux(persistedStandalonePendingAux),
-  );
-}
-
-function messageIndexIsInCurrentTurn(
-  messages: ReadonlyArray<ConversationMessageSnapshot>,
-  index: number,
-): boolean {
-  let lastUserIdx = -1;
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i]?.role === 'user') {
-      lastUserIdx = i;
-      break;
-    }
-  }
-  return index > lastUserIdx;
-}
-
-function hasStandaloneThinkingMessageInCurrentTurn(
-  messages: ReadonlyArray<ConversationMessageSnapshot>,
-): boolean {
-  let lastUserIdx = -1;
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (messages[i]?.role === 'user') {
-      lastUserIdx = i;
-      break;
-    }
-  }
-
-  for (let i = lastUserIdx + 1; i < messages.length; i += 1) {
-    const message = messages[i];
-    if (
-      message?.role === 'assistant' &&
-      !message.tool &&
-      !message.content.trim() &&
-      Boolean(message.aux?.thinking?.trim())
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function describeAuxForDebug(aux: MessageAuxSnapshot): string {
-  const parts: string[] = [];
-  if (aux.thinking?.trim()) {
-    parts.push(`T≈${truncateOneLineForDebug(aux.thinking, 28)}`);
-  }
-  if (aux.compaction?.trim()) {
-    parts.push(`C≈${truncateOneLineForDebug(aux.compaction, 28)}`);
-  }
-  return parts.join('+') || 'none';
-}
-
-function describeOptionalAuxForDebug(aux: MessageAuxSnapshot | undefined): string {
-  return aux ? describeAuxForDebug(aux) : 'none';
-}
-
-function normalizeToolBlockSnapshot(
-  tool: ToolBlockSnapshot | undefined,
-): ToolBlockSnapshot | undefined {
-  if (!tool) {
-    return undefined;
-  }
-
-  const toolName = tool.toolName.trim() || 'unknown-tool';
-  const headline = tool.headline.trim() || defaultToolHeadline(tool.phase, toolName);
-  const detailLines = tool.detailLines.filter((line) => line.trim().length > 0);
-  const argsExcerpt = tool.argsExcerpt?.trim() ? tool.argsExcerpt : undefined;
-  const outputExcerpt = tool.outputExcerpt?.trim() ? tool.outputExcerpt : undefined;
-
-  return {
-    ...tool,
-    toolName,
-    headline,
-    detailLines,
-    ...(argsExcerpt ? { argsExcerpt } : {}),
-    ...(outputExcerpt ? { outputExcerpt } : {}),
-  };
-}
-
-function normalizeMessageAuxSnapshot(
-  aux: MessageAuxSnapshot | undefined,
-): MessageAuxSnapshot | undefined {
-  if (!aux) {
-    return undefined;
-  }
-
-  const thinking = aux.thinking?.trim() ? aux.thinking : undefined;
-  const compaction = aux.compaction?.trim() ? aux.compaction : undefined;
-  if (!thinking && !compaction) {
-    return undefined;
-  }
-
-  return {
-    ...(thinking ? { thinking } : {}),
-    ...(compaction ? { compaction } : {}),
-  };
-}
-
-function shouldDropEmptyAssistantMessage(
-  message: ConversationMessageSnapshot,
-  tool: ToolBlockSnapshot | undefined,
-  aux: MessageAuxSnapshot | undefined,
-): boolean {
-  return (
-    message.role === 'assistant' &&
-    !message.pending &&
-    !message.content.trim() &&
-    !tool &&
-    !aux
-  );
-}
-
-function shouldHideEmptyPendingAssistantSnapshot(message: ConversationMessageSnapshot): boolean {
-  return (
-    message.role === 'assistant' &&
-    message.pending &&
-    !message.content.trim() &&
-    !message.tool &&
-    !normalizeMessageAuxSnapshot(message.aux)
-  );
-}
-
-function defaultToolHeadline(
-  phase: ToolBlockSnapshot['phase'],
-  toolName: string,
-): string {
-  switch (phase) {
-    case 'pending-approval':
-      return `等待确认: ${toolName}`;
-    case 'running':
-      return `调用中: ${toolName}`;
-    case 'failed':
-      return `工具执行失败: ${toolName}`;
-    case 'succeeded':
-    default:
-      return `工具执行完成: ${toolName}`;
-  }
-}
-
-/** 最后一条 user 之后、首条助手工具行之前；找不到则返回 `undefined`（由调用方改为插在「最后一条 user」之后）。 */
-function indexForThinkingInsertBeforeFirstToolAfterLastUser(
-  messages: ConversationMessageSnapshot[],
-): number | undefined {
-  let lastUser = -1;
-  for (let i = 0; i < messages.length; i += 1) {
-    if (messages[i]?.role === 'user') {
-      lastUser = i;
-    }
-  }
-  for (let i = lastUser + 1; i < messages.length; i += 1) {
-    const m = messages[i];
-    if (m?.role === 'assistant' && m.tool) {
-      return i;
-    }
-  }
-  return undefined;
-}
-
-/** 与 `historyStore` 中最后一条 user 对齐：在其后插入思考，避免审批指导后尚无新工具行时误用 `push` 落到整段末尾。 */
-function indexForThinkingInsertAfterLastUser(messages: ConversationMessageSnapshot[]): number {
-  let lastUser = -1;
-  for (let i = 0; i < messages.length; i += 1) {
-    if (messages[i]?.role === 'user') {
-      lastUser = i;
-    }
-  }
-  return lastUser < 0 ? 0 : lastUser + 1;
-}
-
-/** 末条 user 之后是否已有其它工具卡为「待审批」或「执行中」（不含当前 toolCallId）。 */
-function hasBlockingToolAheadOfSameTurnPreview(
-  messages: ConversationMessageSnapshot[],
-  thisToolCallId: string,
-): boolean {
-  let lastUser = -1;
-  for (let i = 0; i < messages.length; i += 1) {
-    if (messages[i]?.role === 'user') {
-      lastUser = i;
-    }
-  }
-  for (let i = lastUser + 1; i < messages.length; i += 1) {
-    const m = messages[i];
-    if (m?.role !== 'assistant' || !m.tool) {
-      continue;
-    }
-    if (m.tool.toolCallId === thisToolCallId) {
-      continue;
-    }
-    const p = m.tool.phase;
-    if (p === 'pending-approval' || p === 'running') {
-      return true;
-    }
-  }
-  return false;
-}
-
-function headlineForStreamingToolPreview(
-  messages: ConversationMessageSnapshot[],
-  toolCallId: string,
-  toolName: string,
-): string {
-  return hasBlockingToolAheadOfSameTurnPreview(messages, toolCallId)
-    ? `排队中: ${toolName}`
-    : `调用中: ${toolName}`;
-}
-
-function restoreMessagesFromArchive(
-  archive: StoredDesktopSession,
-): ConversationMessageSnapshot[] {
-  const auxByIndex = new Map<number, MessageAuxSnapshot>();
-  for (const entry of archive.assistantAux) {
-    auxByIndex.set(entry.messageIndex, {
-      ...(entry.thinking ? { thinking: entry.thinking } : {}),
-      ...(entry.compaction ? { compaction: entry.compaction } : {}),
-    });
-  }
-
-  return archive.messages.map((message, index) => ({
-    id: index + 1,
-    role: message.role,
-    content: message.content,
-    ...(auxByIndex.get(index) ? { aux: auxByIndex.get(index) } : {}),
-    pending: false,
-  }));
 }
 
 function truncateJson(value: unknown): string {
@@ -5891,14 +5218,4 @@ function deriveDisplayNameFromMessages(messages: ConversationMessageSnapshot[]):
     (message) => message.role === 'user' && message.content.trim().length > 0,
   );
   return deriveDisplayNameFromSeed(firstUser?.content ?? 'New conversation');
-}
-
-function toolMessageKey(
-  pending:
-    | RuntimePendingApproval<DesktopToolRequest, string>
-    | RuntimePendingQuestions<DesktopToolRequest>,
-): string {
-  return 'toolCallId' in pending && pending.toolCallId
-    ? pending.toolCallId
-    : `pending:${pending.toolName}`;
 }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -11,12 +11,10 @@ import {
   OpenAiTransport,
   type AssistantAuxArchiveEntry,
   type ChatArchive,
-  type JsonObject,
   type OpenAiEnabledRule,
   type OpenAiEnabledSkillCatalogEntry,
   type OpenAiPlanMetadata,
   type OpenAiTransportConfig,
-  type RuntimeEvent,
   type RuntimeToolExecution,
 } from '@spirit-agent/agent-core';
 import {
@@ -166,19 +164,11 @@ import {
 import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
 import { buildDesktopSnapshot } from './snapshot.js';
 import {
-  assistantPrefixBeforeFirstToolInCurrentTurn,
-  headlineForStreamingToolPreview,
-  indexForThinkingInsertBeforeFirstToolAfterLastUser,
-  lastAssistantPlainTextInHistory,
-  latestUnsyncedAssistantTextInCurrentTurn,
-  messageOrderDebugLevel,
   parsePendingSubagentStatusText,
   restoreMessagesFromArchive,
-  summarizeMessagesTailForOrderDebug,
-  truncateOneLineForDebug,
-  toolMessageKey,
 } from './message-ordering.js';
 import { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';
+import { DesktopRuntimeEventOrchestrator } from './runtime-event-orchestrator.js';
 import {
   buildActiveSkillPayload,
   buildActivateSkillUserTurn,
@@ -324,9 +314,26 @@ class DesktopHostService {
     allocateMessageId: () => this.allocateMessageId(),
     isRuntimeBusy: () => this.runtime?.isBusy() ?? false,
   });
-  /** 思考段 finalize 去重、插入锚点与 apply 批次（见 `applyRuntimeHostEvents` / `appendAssistantThinkingSegment`）。 */
-  private lastApplyEventBatchId = 0;
-  private messageOrderDebugLastVerboseLogMs = 0;
+  private readonly runtimeEvents = new DesktopRuntimeEventOrchestrator({
+    runtime: () => this.runtime,
+    messages: () => this.requireState().messages,
+    allocateMessageId: () => this.allocateMessageId(),
+    assistantMessages: this.assistantMessages,
+    conversationSnapshotView: this.conversationSnapshotView,
+    clearCurrentTurnSkills: () => {
+      this.currentTurnSkills = [];
+    },
+    setLastRuntimeError: (error) => {
+      this.lastRuntimeError = error;
+    },
+    refreshArchiveFromRuntime: () => this.refreshArchiveFromRuntime(),
+    dispatchExtensionEvent: (event) => {
+      void this.dispatchExtensionEvent(event);
+    },
+    bindFileChangesToToolMessage: (execution, messageId) => {
+      this.bindFileChangesToToolMessage(execution, messageId);
+    },
+  });
   private messageIdCounter = 1;
   private pendingUnboundFileChangeIds: string[] = [];
   private currentTurnSkills: OpenAiActiveSkill[] = [];
@@ -1122,7 +1129,7 @@ class DesktopHostService {
       this.refreshArchiveFromRuntime();
       await this.recordRewindCheckpoint(userMessage.id, beforeUserCheckpoint);
       await runtime.poll();
-      this.applyRuntimeHostEvents(runtime.drainEvents());
+      this.runtimeEvents.applyRuntimeHostEvents(runtime.drainEvents());
     } catch (error) {
       this.currentTurnSkills = [];
       this.assistantMessages.handleMessageRemoved(state.messages.length - 1, userMessage.id, 'send-user-rollback');
@@ -1130,9 +1137,9 @@ class DesktopHostService {
       throw error;
     }
 
-    this.consumeCompletedTurnResult();
-    this.syncPendingToolStates();
-    this.syncAssistantPrefixFromHistoryBeforeToolRow();
+    this.runtimeEvents.consumeCompletedTurnResult();
+    this.runtimeEvents.syncPendingToolStates();
+    this.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
     await this.flushDeferredRuntimeRefreshIfIdle();
     if (!runtime.isBusy()) {
       await this.refreshGitState();
@@ -1166,11 +1173,11 @@ class DesktopHostService {
       if (this.runtime) {
         this.runtime.tickThinkingSpinner();
         await this.runtime.poll();
-        this.applyRuntimeHostEvents(this.runtime.drainEvents());
+        this.runtimeEvents.applyRuntimeHostEvents(this.runtime.drainEvents());
       }
-      this.consumeCompletedTurnResult();
-      this.syncPendingToolStates();
-      this.syncAssistantPrefixFromHistoryBeforeToolRow();
+      this.runtimeEvents.consumeCompletedTurnResult();
+      this.runtimeEvents.syncPendingToolStates();
+      this.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
       await this.persistCurrentSessionIfNeeded();
       await this.flushDeferredRuntimeRefreshIfIdle();
       if (!this.runtime?.isBusy()) {
@@ -1198,10 +1205,10 @@ class DesktopHostService {
       }
       await runtime.continuePendingApproval(decision);
       await runtime.poll();
-      this.applyRuntimeHostEvents(runtime.drainEvents());
-      this.consumeCompletedTurnResult();
-      this.syncPendingToolStates();
-      this.syncAssistantPrefixFromHistoryBeforeToolRow();
+      this.runtimeEvents.applyRuntimeHostEvents(runtime.drainEvents());
+      this.runtimeEvents.consumeCompletedTurnResult();
+      this.runtimeEvents.syncPendingToolStates();
+      this.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
       await this.flushDeferredRuntimeRefreshIfIdle();
       if (!runtime.isBusy()) {
         await this.refreshGitState();
@@ -1216,10 +1223,10 @@ class DesktopHostService {
       const runtime = this.requireRuntime();
       await runtime.continuePendingQuestions(toRuntimeAskQuestionsResult(result));
       await runtime.poll();
-      this.applyRuntimeHostEvents(runtime.drainEvents());
-      this.consumeCompletedTurnResult();
-      this.syncPendingToolStates();
-      this.syncAssistantPrefixFromHistoryBeforeToolRow();
+      this.runtimeEvents.applyRuntimeHostEvents(runtime.drainEvents());
+      this.runtimeEvents.consumeCompletedTurnResult();
+      this.runtimeEvents.syncPendingToolStates();
+      this.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
       await this.persistCurrentSessionIfNeeded();
       await this.flushDeferredRuntimeRefreshIfIdle();
       if (!runtime.isBusy()) {
@@ -2056,51 +2063,6 @@ class DesktopHostService {
     }
   }
 
-  private consumeCompletedTurnResult(): void {
-    if (!this.runtime) {
-      return;
-    }
-
-    const result = this.runtime.takeCompletedTurnResult();
-    if (!result) {
-      return;
-    }
-
-    this.integrateToolExecutions(result.toolExecutions);
-    switch (result.kind) {
-      case 'completed':
-        this.currentTurnSkills = [];
-        if (result.assistantText.trim()) {
-          const aux = this.assistantMessages.takeLatestPendingAux();
-          if (!this.assistantMessages.materializeExistingCompletedAssistantMessage(result.assistantText, aux)) {
-            this.assistantMessages.appendAssistantMessage(result.assistantText, aux);
-          }
-        }
-        this.lastRuntimeError = '';
-        break;
-      case 'failed':
-        this.currentTurnSkills = [];
-        {
-          const aux = this.assistantMessages.takeLatestPendingAux();
-          if (!this.assistantMessages.materializeExistingCompletedAssistantMessage(result.error, aux)) {
-            this.assistantMessages.appendAssistantMessage(result.error, aux);
-          }
-        }
-        this.lastRuntimeError = result.error;
-        break;
-      case 'requires-approval':
-      case 'requires-questions':
-        this.syncPendingToolStates();
-        this.syncAssistantPrefixFromHistoryBeforeToolRow();
-        this.lastRuntimeError = '';
-        break;
-      default:
-        break;
-    }
-
-    this.refreshArchiveFromRuntime();
-  }
-
   private extensionManager() {
     return this.hostExtensionManager;
   }
@@ -2184,363 +2146,6 @@ class DesktopHostService {
       });
     } catch (error) {
       this.lastRuntimeError = error instanceof Error ? error.message : String(error);
-    }
-  }
-
-  private integrateToolExecutions(executions: RuntimeToolExecution<DesktopToolRequest>[]): void {
-    for (const execution of executions) {
-      const message = this.assistantMessages.upsertToolMessage(execution.toolCallId || `tool:${execution.toolName}`, {
-        toolCallId: execution.toolCallId || `tool:${execution.toolName}`,
-        toolName: execution.toolName,
-        phase: execution.failed ? 'failed' : 'succeeded',
-        headline: execution.failed
-          ? `工具执行失败: ${execution.toolName}`
-          : `工具执行完成: ${execution.toolName}`,
-        detailLines: [],
-        argsExcerpt: truncateJson(execution.request),
-        outputExcerpt: truncateText(execution.output, 4_000),
-      }, this.lastApplyEventBatchId);
-      this.bindFileChangesToToolMessage(execution, message.id);
-    }
-  }
-
-  private applyRuntimeHostEvents(events: RuntimeEvent<DesktopToolRequest>[]): void {
-    const state = this.requireState();
-    // 空 drain 不递增批次：否则同一 poll 里后续 consume→integrate 的 upsert 会误判批次并清空 preview 记下的锚点。
-    const batchId =
-      events.length > 0 ? (this.lastApplyEventBatchId += 1) : this.lastApplyEventBatchId;
-    // 严格按事件时序单遍处理；begin 一律 anchor := min(已有, messages.length)：
-    // - 同批内 preview 先于 begin：保留首条工具下标。
-    // - 同批内 finalize/tool-done 先于 begin 导致 at 已含新工具：保留先前跨 poll preview 写下的较小下标。
-    for (const ev of events) {
-      if (ev.kind === 'begin-assistant-response') {
-        const at = state.messages.length;
-        const shouldReanchorStandalonePendingAux =
-          this.conversationSnapshotView.shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
-            state.messages[state.messages.length - 1],
-          );
-        const pendingAssistant = this.assistantMessages.beginAssistantResponse(at, batchId);
-        if (shouldReanchorStandalonePendingAux) {
-          this.conversationSnapshotView.reanchorPersistedStandalonePendingAux(pendingAssistant.id);
-        }
-        continue;
-      }
-      if (ev.kind === 'update-pending-assistant-thinking') {
-        this.assistantMessages.updatePendingAssistantAux('thinking', ev.text);
-        continue;
-      }
-      if (ev.kind === 'update-pending-assistant-compaction') {
-        this.assistantMessages.updatePendingAssistantAux('compressing', ev.text);
-        continue;
-      }
-      if (ev.kind === 'assistant-chunk') {
-        this.assistantMessages.appendPendingAssistantChunk(ev.text);
-        continue;
-      }
-      if (ev.kind === 'replace-pending-assistant') {
-        this.assistantMessages.replacePendingAssistantText(ev.text);
-        continue;
-      }
-      if (ev.kind === 'assistant-response-completed') {
-        this.assistantMessages.completePendingAssistantMessage();
-        continue;
-      }
-      if (ev.kind === 'remove-pending-assistant') {
-        this.assistantMessages.removePendingAssistantMessage();
-        continue;
-      }
-      if (ev.kind === 'assistant-thinking-segment-finalized') {
-        if (ev.text.trim()) {
-          this.assistantMessages.appendAssistantThinkingSegment(ev.text);
-        }
-        continue;
-      }
-      if (ev.kind === 'tool-call-started') {
-        void this.dispatchExtensionEvent({
-          type: 'onToolCall',
-          detail: {
-            toolCallId: ev.toolCallId,
-            toolName: ev.toolName,
-            request: ev.request as JsonObject,
-          },
-        });
-        continue;
-      }
-      if (ev.kind === 'approval-resolved') {
-        void this.dispatchExtensionEvent({
-          type: 'onApprovalResolved',
-          detail: {
-            toolCallId: ev.toolCallId,
-            toolName: ev.toolName,
-            decisionKind: ev.decisionKind,
-            request: ev.request as JsonObject,
-          },
-        });
-        continue;
-      }
-      if (ev.kind === 'tool-execution-finished') {
-        this.integrateToolExecutions([ev.execution]);
-        void this.dispatchExtensionEvent({
-          type: 'onToolResult',
-          detail: {
-            toolCallId: ev.execution.toolCallId,
-            toolName: ev.execution.toolName,
-            output: ev.execution.output,
-            failed: ev.execution.failed,
-            request: ev.execution.request as JsonObject,
-          },
-        });
-        continue;
-      }
-      if (ev.kind !== 'streaming-tool-preview') {
-        continue;
-      }
-      let argsExcerpt: string;
-      try {
-        argsExcerpt = truncateJson(JSON.parse(ev.argumentsJson) as unknown);
-      } catch {
-        argsExcerpt = truncateText(ev.argumentsJson, 4_000);
-      }
-      this.assistantMessages.upsertToolMessage(ev.toolCallId, {
-        toolCallId: ev.toolCallId,
-        toolName: ev.toolName,
-        phase: 'running',
-        headline: headlineForStreamingToolPreview(state.messages, ev.toolCallId, ev.toolName),
-        detailLines: [],
-        argsExcerpt,
-      }, batchId);
-    }
-    const placement = this.assistantMessages.placementState();
-    this.logMessageOrderApplyBatch(
-      batchId,
-      events,
-      state,
-      placement.streamAssistantThinkingAnchor,
-      placement.streamAssistantAnchorSetInApplyBatchId,
-    );
-  }
-
-  /**
-   * 将 `runtime.history()` 中的助手正文同步到 `state.messages`（首轮：首条 tool 前前缀；待审批/问卷：
-   * 用 `lastAssistantPlainTextInHistory` 兜底，因 OpenAI 路径下 `history()` 常不含 `role: tool`）。
-   */
-  private syncAssistantPrefixFromHistoryBeforeToolRow(): void {
-    if (!this.runtime) {
-      return;
-    }
-    const pendingTrim = this.runtime.pendingAssistantText().trim();
-    const awaitingInteractive =
-      Boolean(this.runtime.currentPendingApproval()) ||
-      Boolean(this.runtime.currentPendingQuestions());
-
-    if (pendingTrim && !awaitingInteractive) {
-      return;
-    }
-
-    const hist = this.runtime.history();
-    const state = this.requireState();
-    const prefixFromUnsyncedLatest = latestUnsyncedAssistantTextInCurrentTurn(
-      hist,
-      state.messages,
-    );
-    const prefixFromBeforeFirst = assistantPrefixBeforeFirstToolInCurrentTurn(hist);
-    const prefixFromLastAssistant = lastAssistantPlainTextInHistory(hist);
-    const prefix = (
-      awaitingInteractive && pendingTrim
-        ? pendingTrim
-        : awaitingInteractive
-          ? (prefixFromUnsyncedLatest ?? prefixFromLastAssistant ?? prefixFromBeforeFirst)
-          : (prefixFromUnsyncedLatest ?? prefixFromBeforeFirst)
-    )
-      ?.trim() ?? '';
-    const n = state.messages.length;
-    const last = n > 0 ? state.messages[n - 1] : undefined;
-
-    if (!prefix) {
-      return;
-    }
-
-    if (n === 0) {
-      return;
-    }
-
-    const hasPlainPrefix = state.messages.some(
-      (m) => m.role === 'assistant' && m.content === prefix && !m.tool,
-    );
-    if (hasPlainPrefix) {
-      return;
-    }
-
-    const isLaterUnsyncedPrefix =
-      !awaitingInteractive &&
-      prefixFromUnsyncedLatest !== undefined &&
-      prefix === prefixFromUnsyncedLatest &&
-      prefixFromUnsyncedLatest !== prefixFromBeforeFirst;
-
-    if (isLaterUnsyncedPrefix) {
-      const anchor = this.assistantMessages.streamAssistantThinkingAnchorOr(state.messages.length);
-      const insertAt = Math.max(0, Math.min(anchor, state.messages.length));
-      const before = insertAt > 0 ? state.messages[insertAt - 1] : undefined;
-      if (
-        before?.role === 'assistant' &&
-        !before.tool &&
-        before.content.trim() === prefix
-      ) {
-        return;
-      }
-      this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(insertAt);
-      state.messages.splice(insertAt, 0, {
-        id: this.allocateMessageId(),
-        role: 'assistant',
-        content: prefix,
-        pending: false,
-      });
-      this.logMessageOrderPrefixSync(`splice-at-anchor@${insertAt}`, state);
-      return;
-    }
-
-    if (awaitingInteractive) {
-      const approval = this.runtime.currentPendingApproval();
-      const questions = this.runtime.currentPendingQuestions();
-      const key = approval
-        ? toolMessageKey(approval)
-        : questions
-          ? toolMessageKey(questions)
-          : undefined;
-      if (key) {
-        const idx = state.messages.findIndex(
-          (m) => m.role === 'assistant' && m.tool?.toolCallId === key,
-        );
-        if (idx >= 0) {
-          const before = idx > 0 ? state.messages[idx - 1] : undefined;
-          if (
-            before?.role === 'assistant' &&
-            !before.tool &&
-            before.content.trim() === prefix
-          ) {
-            return;
-          }
-          this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(idx);
-          state.messages.splice(idx, 0, {
-            id: this.allocateMessageId(),
-            role: 'assistant',
-            content: prefix,
-            pending: false,
-          });
-          this.logMessageOrderPrefixSync(`splice-before-approval@${idx}`, state);
-        }
-      }
-      return;
-    }
-
-    if (last!.role === 'user') {
-      state.messages.push({
-        id: this.allocateMessageId(),
-        role: 'assistant',
-        content: prefix,
-        pending: false,
-      });
-      this.logMessageOrderPrefixSync('push-after-user', state);
-      return;
-    }
-
-    if (last!.role === 'assistant' && last!.tool) {
-      const firstToolIdx = indexForThinkingInsertBeforeFirstToolAfterLastUser(state.messages);
-      if (firstToolIdx === undefined) {
-        return;
-      }
-      const beforeFirst = firstToolIdx > 0 ? state.messages[firstToolIdx - 1] : undefined;
-      if (beforeFirst?.role === 'assistant' && beforeFirst.content === prefix && !beforeFirst.tool) {
-        return;
-      }
-      this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(firstToolIdx);
-      state.messages.splice(firstToolIdx, 0, {
-        id: this.allocateMessageId(),
-        role: 'assistant',
-        content: prefix,
-        pending: false,
-      });
-      this.logMessageOrderPrefixSync(`splice-before-first-tool@${firstToolIdx}`, state);
-      return;
-    }
-
-    if (last!.role === 'assistant' && !last!.tool && last!.content.trim() && last!.content !== prefix) {
-      const firstToolIdx = indexForThinkingInsertBeforeFirstToolAfterLastUser(state.messages);
-      if (firstToolIdx !== undefined) {
-        const beforeFirst = firstToolIdx > 0 ? state.messages[firstToolIdx - 1] : undefined;
-        if (beforeFirst?.role === 'assistant' && beforeFirst.content === prefix && !beforeFirst.tool) {
-          return;
-        }
-        this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(firstToolIdx);
-        state.messages.splice(firstToolIdx, 0, {
-          id: this.allocateMessageId(),
-          role: 'assistant',
-          content: prefix,
-          pending: false,
-        });
-        this.logMessageOrderPrefixSync(`splice-before-first-tool@${firstToolIdx}`, state);
-        return;
-      }
-      let toolIdx = -1;
-      for (let i = n - 2; i >= 0; i -= 1) {
-        const m = state.messages[i];
-        if (m.role === 'assistant' && m.tool) {
-          toolIdx = i;
-          break;
-        }
-      }
-      if (toolIdx >= 0) {
-        const beforeTool = toolIdx > 0 ? state.messages[toolIdx - 1] : undefined;
-        if (beforeTool?.role === 'assistant' && beforeTool.content === prefix && !beforeTool.tool) {
-          return;
-        }
-        this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(toolIdx);
-        state.messages.splice(toolIdx, 0, {
-          id: this.allocateMessageId(),
-          role: 'assistant',
-          content: prefix,
-          pending: false,
-        });
-        this.logMessageOrderPrefixSync(`splice-before-tool@${toolIdx}`, state);
-        return;
-      }
-      if (!last!.content.startsWith(prefix)) {
-        this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(n - 1);
-        state.messages.splice(n - 1, 0, {
-          id: this.allocateMessageId(),
-          role: 'assistant',
-          content: prefix,
-          pending: false,
-        });
-        this.logMessageOrderPrefixSync(`splice-before-tail@${n - 1}`, state);
-      }
-      return;
-    }
-  }
-
-  private syncPendingToolStates(): void {
-    const approval = this.runtime?.currentPendingApproval();
-    if (approval) {
-      this.assistantMessages.upsertToolMessage(toolMessageKey(approval), {
-        toolCallId: toolMessageKey(approval),
-        toolName: approval.toolName,
-        phase: 'pending-approval',
-        headline: `等待确认: ${approval.toolName}`,
-        detailLines: [approval.prompt],
-        argsExcerpt: truncateJson(approval.request),
-      }, this.lastApplyEventBatchId);
-    }
-
-    const questions = this.runtime?.currentPendingQuestions();
-    if (questions) {
-      this.assistantMessages.upsertToolMessage(toolMessageKey(questions), {
-        toolCallId: toolMessageKey(questions),
-        toolName: questions.toolName,
-        phase: 'pending-approval',
-        headline: `等待补充信息: ${questions.toolName}`,
-        detailLines: [questions.questions.title ?? '请回答表单问题'],
-        argsExcerpt: truncateJson(questions.questions),
-      }, this.lastApplyEventBatchId);
     }
   }
 
@@ -2771,78 +2376,7 @@ class DesktopHostService {
       return;
     }
     this.conversationSnapshotView.clearStandalonePendingAuxState();
-    this.lastApplyEventBatchId = 0;
-    this.messageOrderDebugLastVerboseLogMs = 0;
-  }
-
-  private logMessageOrderApplyBatch(
-    batchId: number,
-    events: RuntimeEvent<DesktopToolRequest>[],
-    state: HostState,
-    anchorEnd: number | undefined,
-    anchorSourceBatchEnd: number,
-  ): void {
-    const mode = messageOrderDebugLevel();
-    if (mode === 'off') return;
-
-    const tags: string[] = [];
-    let previewCount = 0;
-    for (const ev of events) {
-      if (ev.kind === 'begin-assistant-response') {
-        tags.push('begin');
-      } else if (ev.kind === 'assistant-response-completed') {
-        tags.push('resp-done');
-      } else if (ev.kind === 'remove-pending-assistant') {
-        tags.push('rm-pending');
-      } else if (ev.kind === 'assistant-thinking-segment-finalized') {
-        tags.push(ev.text.trim() ? 'finalize' : 'finalize-empty');
-      } else if (ev.kind === 'tool-call-started') {
-        tags.push(`tool-start:${ev.toolName}`);
-      } else if (ev.kind === 'tool-execution-finished') {
-        tags.push(`tool-done:${ev.execution.toolName}`);
-      } else if (ev.kind === 'approval-resolved') {
-        tags.push(`approval-${ev.decisionKind}`);
-      } else if (ev.kind === 'approval-requested') {
-        tags.push(`approval:${ev.approval.toolName}`);
-      } else if (ev.kind === 'questions-requested') {
-        tags.push(`questions:${ev.questions.toolName}`);
-      } else if (ev.kind === 'streaming-tool-preview') {
-        previewCount += 1;
-      }
-    }
-
-    const hasOrderTags = tags.length > 0;
-    if (!hasOrderTags && previewCount === 0) {
-      return;
-    }
-
-    if (mode === 'compact' && !hasOrderTags) {
-      return;
-    }
-
-    if (!hasOrderTags && previewCount > 0 && mode === 'verbose') {
-      const now = Date.now();
-      if (now - this.messageOrderDebugLastVerboseLogMs < 1200) {
-        return;
-      }
-      this.messageOrderDebugLastVerboseLogMs = now;
-      tags.push(`preview×${previewCount}`);
-    } else if (hasOrderTags && previewCount > 0 && mode === 'verbose') {
-      tags.push(`pv×${previewCount}`);
-    }
-
-    const tail = summarizeMessagesTailForOrderDebug(state.messages, 12);
-    console.log(
-      `[desktop-host][msg-order] apply#${batchId} kinds=${tags.join(',')} anchor=${anchorEnd ?? '∅'} anchorBatch=${anchorSourceBatchEnd} len=${state.messages.length} tail=${tail}`,
-    );
-  }
-
-  private logMessageOrderPrefixSync(how: string, state: HostState): void {
-    if (messageOrderDebugLevel() === 'off') {
-      return;
-    }
-    const tail = summarizeMessagesTailForOrderDebug(state.messages, 10);
-    console.log(`[desktop-host][msg-order] prefix-sync ${how} len=${state.messages.length} tail=${tail}`);
+    this.runtimeEvents.reset();
   }
 
   private async runSerialized<T>(work: () => Promise<T>): Promise<T> {
@@ -2904,17 +2438,5 @@ export function subscribeDesktopDreamUpdates(
   listener: (snapshot: DesktopSnapshot) => void,
 ): () => void {
   return desktopHostService.subscribeDreamUpdates(listener);
-}
-
-function truncateJson(value: unknown): string {
-  return truncateText(JSON.stringify(value, null, 2), 4_000);
-}
-
-function truncateText(value: string, maxChars: number): string {
-  const chars = Array.from(value);
-  if (chars.length <= maxChars) {
-    return value;
-  }
-  return `${chars.slice(0, maxChars).join('')}...<truncated>`;
 }
 

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -1,5 +1,3 @@
-import { createHash, randomUUID } from 'node:crypto';
-import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import {
@@ -35,12 +33,9 @@ import {
   createHostExtensionMarketplace,
   createHostExtensionManager,
   createHostDreamStore,
-  DREAM_RETENTION_MS as HOST_DREAM_RETENTION_MS,
-  dreamLogsDirPath,
   listOpenAiCompatibleModelIds,
   restoreHostFileChanges,
   type HostExtensionMarketplaceManager,
-  type HostDreamSessionProgress,
   type HostExtensionEvent,
   type HostRecordedFileChange,
 } from '@spirit-agent/host-internal';
@@ -102,7 +97,6 @@ import {
 } from './model-catalog-cache.js';
 import {
   DEFAULT_API_BASE,
-  chatsDirPath,
   defaultNewSessionPath,
   discoverWorkspaceRoot,
   loadConfig,
@@ -125,6 +119,17 @@ import {
   type HostMetadataSummary,
 } from './storage.js';
 import { DesktopToolExecutor } from './tool-executor.js';
+import {
+  buildCommitMessageGenerationPrompt,
+  buildDreamCommitContext,
+  clearDreamCollectorIssue,
+  DREAM_COLLECTOR_BACKOFF_MS,
+  DREAM_COLLECTOR_MONITOR_INTERVAL_MS,
+  DREAM_COLLECTOR_TICK_INTERVAL_MS,
+  emptyDreamCollectorSnapshot,
+  isDreamCollectorDebugSessionPath,
+  runDesktopDreamCollectorOnce,
+} from './dreams.js';
 import {
   buildDesktopExtensionListItems,
   buildDesktopExtensionToolDefinitions,
@@ -249,16 +254,6 @@ export function setDesktopExtensionHostAdapter(
 
 const EPHEMERAL_COMMIT_SESSION_PREFIX = 'ephemeral://commit-message/';
 const MAX_EPHEMERAL_COMMIT_SESSIONS = 8;
-const DREAM_DEBUG_SESSION_FILE_PREFIX = 'dream-collector-';
-const DREAM_COLLECTOR_TICK_INTERVAL_MS = 30_000;
-const DREAM_COLLECTOR_MONITOR_INTERVAL_MS = 5_000;
-const DREAM_COLLECTOR_BACKOFF_MS = 60_000;
-const DREAM_COLLECTOR_SOURCE_CONTEXT_MAX_CHARS = 16_000;
-const DREAM_COLLECTOR_INCREMENTAL_CONTEXT_MAX_CHARS = 8_000;
-const DREAM_COLLECTOR_ANCHOR_CONTEXT_MAX_CHARS = 4_000;
-const DREAM_COLLECTOR_ANCHOR_MESSAGE_COUNT = 4;
-const DREAM_COLLECTOR_SESSION_COOLDOWN_MS = 2 * 60 * 1000;
-const DREAM_COMMIT_CONTEXT_MAX_CHARS = 6_000;
 
 interface EphemeralSessionRecord {
   path: string;
@@ -1820,7 +1815,25 @@ class DesktopHostService {
       planMetadata: { ...state.metadata.planMetadata },
     };
 
-    void this.runDreamCollectorOnce(collectorInput)
+    void runDesktopDreamCollectorOnce(collectorInput, {
+      createRuntime: (transportConfig, planMetadata, toolExecutor) => this.createRuntime(
+        transportConfig,
+        [],
+        [],
+        [],
+        planMetadata,
+        [
+          {
+            extensionId: 'dream-collector',
+            extensionName: '梦境收集器',
+            content: buildDreamCollectorSystemMessage(),
+          },
+        ],
+        toolExecutor,
+      ),
+      getStatus: () => this.dreamCollectorStatus,
+      setStatus: (next) => this.setDreamCollectorStatus(next),
+    })
       .catch((error) => {
         const backoffUntilUnixMs = Date.now() + DREAM_COLLECTOR_BACKOFF_MS;
         this.setDreamCollectorStatus({
@@ -1866,203 +1879,6 @@ class DesktopHostService {
     const snapshot = this.buildSnapshot();
     for (const listener of this.dreamUpdateListeners) {
       listener(snapshot);
-    }
-  }
-
-  private async runDreamCollectorOnce(input: {
-    workspaceRoot: string;
-    gitBranch: string;
-    collectorModel: string;
-    config: DesktopConfigFile;
-    planMetadata: OpenAiPlanMetadata;
-  }): Promise<void> {
-    const runId = randomUUID();
-    const startedAtUnixMs = Date.now();
-    const scope = {
-      workspaceRoot: input.workspaceRoot,
-      gitBranch: input.gitBranch,
-    };
-    let sourceSession: SessionListItem | undefined;
-    let sourceContextMode: DreamCollectorSourceContextMode | undefined;
-    let pendingCount = 0;
-    let toolCalls: DesktopDreamCollectorRunLog['toolCalls'] = [];
-    let promptForDebug = '';
-    let debugSessionPersisted = false;
-    try {
-      const cutoffUnixMs = Date.now() - HOST_DREAM_RETENTION_MS;
-      const now = Date.now();
-      const storedSessions = (await listStoredSessions())
-        .filter((session) => sameWorkspaceRoot(session.workspaceRoot, input.workspaceRoot))
-        .filter((session) => session.gitBranch === input.gitBranch)
-        .filter((session) => !isDreamCollectorDebugSessionPath(session.path))
-        .filter((session) => session.modifiedAtUnixMs >= cutoffUnixMs)
-        .sort((left, right) => left.modifiedAtUnixMs - right.modifiedAtUnixMs);
-
-      const dreamStore = createHostDreamStore({ spiritDataDir: spiritAgentDataDir(), scope });
-      await dreamStore.pruneExpired(now);
-      const sessionProgressList = await dreamStore.listSessionProgress();
-      const sessionProgressMap = new Map(sessionProgressList.map((entry) => [entry.path, entry]));
-      const pendingSessions = storedSessions.filter((session) =>
-        shouldQueueDreamCollectorSession(session, sessionProgressMap.get(session.path), now),
-      );
-      pendingCount = pendingSessions.length;
-      if (pendingSessions.length === 0) {
-        this.setDreamCollectorStatus(clearDreamCollectorIssue({
-          ...this.dreamCollectorStatus,
-          state: 'idle',
-          pendingCount: 0,
-        }));
-        return;
-      }
-
-      sourceSession = pendingSessions[0]!;
-      this.setDreamCollectorStatus(clearDreamCollectorIssue({
-        ...this.dreamCollectorStatus,
-        state: 'running',
-        pendingCount: pendingSessions.length,
-      }));
-
-      const apiKey = await resolveApiKeyForModel(input.collectorModel);
-      if (!apiKey) {
-        throw new Error('梦境收集模型未配置 API Key。');
-      }
-
-      const activeProfile = input.config.models.find((model) => model.name === input.collectorModel);
-      const archive = await loadStoredSession(sourceSession.path);
-      const sessionProgress = sessionProgressMap.get(sourceSession.path);
-      const sourceContext = buildDreamCollectorSourceContext(archive, sessionProgress);
-      sourceContextMode = sourceContext.mode;
-      if (!sourceContext.shouldRunCollector) {
-        await dreamStore.upsertSessionProgress({
-          path: sourceSession.path,
-          ...(sourceSession.displayName ? { displayName: sourceSession.displayName } : {}),
-          lastProcessedSavedAtUnixMs: sourceSession.modifiedAtUnixMs,
-          lastProcessedMessageCount: sourceContext.processedMessageCount,
-          lastProcessedPrefixHash: sourceContext.prefixHash,
-          lastRunAtUnixMs: Date.now(),
-          cooldownUntilUnixMs: Date.now() + DREAM_COLLECTOR_SESSION_COOLDOWN_MS,
-        });
-        this.setDreamCollectorStatus(clearDreamCollectorIssue({
-          ...this.dreamCollectorStatus,
-          state: 'idle',
-          pendingCount: Math.max(0, pendingSessions.length - 1),
-        }));
-        return;
-      }
-      const toolExecutor = new DesktopToolExecutor(input.workspaceRoot, {
-        dreamScope: scope,
-        dreamSourceSession: {
-          path: sourceSession.path,
-          displayName: sourceSession.displayName,
-          savedAtUnixMs: sourceSession.modifiedAtUnixMs,
-        },
-      });
-      const runtime = this.createRuntime(
-        {
-          apiKey,
-          model: input.collectorModel,
-          baseUrl: activeProfile?.apiBase ?? currentApiBase(input.config),
-          workspaceRoot: input.workspaceRoot,
-          ...(activeProfile?.provider ? { llmVendor: activeProfile.provider } : {}),
-        },
-        [],
-        [],
-        [],
-        input.planMetadata,
-        [
-          {
-            extensionId: 'dream-collector',
-            extensionName: '梦境收集器',
-            content: buildDreamCollectorSystemMessage(),
-          },
-        ],
-        toolExecutor,
-      );
-      promptForDebug = buildDreamCollectorPrompt({
-        sourceSession,
-        scope,
-        sourceContext,
-      });
-      const result = await runtime.submitUserTurn(promptForDebug);
-      toolCalls = result.toolExecutions.map((execution) => ({
-        toolName: execution.toolName,
-        failed: execution.failed,
-      }));
-      if (result.kind !== 'completed') {
-        throw new Error(result.kind === 'failed' ? result.error : `梦境收集未完成: ${result.kind}`);
-      }
-      if (input.config.dreams.debugMode) {
-        await persistDreamCollectorDebugSession({
-          runId,
-          workspaceRoot: input.workspaceRoot,
-          gitBranch: input.gitBranch,
-          collectorModel: input.collectorModel,
-          sourceSession,
-          prompt: promptForDebug,
-          assistantText: result.assistantText,
-          failed: false,
-        });
-        debugSessionPersisted = true;
-      }
-
-      await dreamStore.upsertSessionProgress({
-        path: sourceSession.path,
-        ...(sourceSession.displayName ? { displayName: sourceSession.displayName } : {}),
-        lastProcessedSavedAtUnixMs: sourceSession.modifiedAtUnixMs,
-        lastProcessedMessageCount: sourceContext.processedMessageCount,
-        lastProcessedPrefixHash: sourceContext.prefixHash,
-        lastRunAtUnixMs: Date.now(),
-        cooldownUntilUnixMs: Date.now() + DREAM_COLLECTOR_SESSION_COOLDOWN_MS,
-      });
-      this.setDreamCollectorStatus(clearDreamCollectorIssue({
-        ...this.dreamCollectorStatus,
-        state: 'idle',
-        lastSuccessAtUnixMs: Date.now(),
-        pendingCount: Math.max(0, pendingSessions.length - 1),
-        processedCount: this.dreamCollectorStatus.processedCount + 1,
-      }));
-      await writeDreamCollectorRunLog({
-        runId,
-        startedAtUnixMs,
-        finishedAtUnixMs: Date.now(),
-        workspaceRoot: input.workspaceRoot,
-        gitBranch: input.gitBranch,
-        collectorModel: input.collectorModel,
-        sourceSessionPath: sourceSession.path,
-        decision: 'processed',
-        ...(sourceContextMode ? { sourceContextMode } : {}),
-        pendingCount,
-        resultSummary: truncateText(result.assistantText, 1_000),
-        toolCalls,
-      });
-    } catch (error) {
-      if (input.config.dreams.debugMode && sourceSession && promptForDebug && !debugSessionPersisted) {
-        await persistDreamCollectorDebugSession({
-          runId,
-          workspaceRoot: input.workspaceRoot,
-          gitBranch: input.gitBranch,
-          collectorModel: input.collectorModel,
-          sourceSession,
-          prompt: promptForDebug,
-          assistantText: error instanceof Error ? error.message : String(error),
-          failed: true,
-        });
-      }
-      await writeDreamCollectorRunLog({
-        runId,
-        startedAtUnixMs,
-        finishedAtUnixMs: Date.now(),
-        workspaceRoot: input.workspaceRoot,
-        gitBranch: input.gitBranch,
-        collectorModel: input.collectorModel,
-        ...(sourceSession ? { sourceSessionPath: sourceSession.path } : {}),
-        decision: 'failed',
-        ...(sourceContextMode ? { sourceContextMode } : {}),
-        pendingCount,
-        error: error instanceof Error ? error.message : String(error),
-        toolCalls,
-      });
-      throw error;
     }
   }
 
@@ -4000,350 +3816,6 @@ class DesktopHostService {
     }
     return desktopExtensionHostAdapter;
   }
-}
-
-async function buildDreamCommitContext(input: {
-  workspaceRoot: string;
-  gitBranch?: string;
-}): Promise<string> {
-  const gitBranch = input.gitBranch?.trim();
-  if (!gitBranch) {
-    return '';
-  }
-
-  const dreamStore = createHostDreamStore({
-    spiritDataDir: spiritAgentDataDir(),
-    scope: {
-      workspaceRoot: input.workspaceRoot,
-      gitBranch,
-    },
-  });
-  await dreamStore.pruneExpired();
-  const dreams = await dreamStore.list({ includeDeleted: false, includeExpired: false });
-  if (dreams.length === 0) {
-    return '';
-  }
-
-  const rendered = dreams.map((dream, index) => {
-    const lines = [
-      `${index + 1}. ${dream.title}`,
-      `summary: ${dream.summary}`,
-      dream.details ? `details: ${dream.details}` : '',
-      dream.tags?.length ? `tags: ${dream.tags.join(', ')}` : '',
-      `updatedAtUnixMs: ${dream.updatedAtUnixMs}`,
-    ].filter(Boolean);
-    return lines.join('\n');
-  }).join('\n\n');
-  return truncateText(rendered, DREAM_COMMIT_CONTEXT_MAX_CHARS);
-}
-
-function buildCommitMessageGenerationPrompt(input: {
-  workspaceRoot: string;
-  branch?: string;
-  dreamContextText?: string;
-  statusText: string;
-  diffStatText: string;
-  diffText: string;
-}): string {
-  const dreamSection = input.dreamContextText?.trim()
-    ? [
-        '',
-        '[dream summaries] 当前工作动向摘要',
-        input.dreamContextText.trim(),
-      ]
-    : [];
-  return [
-    '请为以下 Git 变更生成一条提交信息。',
-    '必须遵守仓库约定：type / 可选 scope 使用英文；subject 使用中文。',
-    '输出 JSON，由宿主解析。不要输出 Markdown、解释、代码块或额外字段。',
-    'message 应该是一条可直接执行 git commit 的提交信息。若需要正文，可使用换行。',
-    '如果提供了 dream summaries，请把它作为“为什么做这些变更”的语义背景；最终提交信息仍以 Git diff 为准。',
-    '',
-    `workspace: ${input.workspaceRoot}`,
-    `branch: ${input.branch ?? '(unknown)'}`,
-    ...dreamSection,
-    '',
-    '[git status --short --branch]',
-    input.statusText || '(empty)',
-    '',
-    '[git diff --stat HEAD]',
-    input.diffStatText || '(empty)',
-    '',
-    '[git diff HEAD]',
-    input.diffText || '(empty)',
-  ].join('\n');
-}
-
-type DreamCollectorSourceContextMode = 'full' | 'incremental';
-
-interface DreamCollectorNormalizedMessage {
-  role: 'user' | 'assistant';
-  rendered: string;
-}
-
-interface DreamCollectorSourceContext {
-  mode: DreamCollectorSourceContextMode;
-  rendered: string;
-  prefixHash: string;
-  processedMessageCount: number;
-  shouldRunCollector: boolean;
-}
-
-function buildDreamCollectorSourceContext(
-  archive: StoredDesktopSession,
-  progress?: HostDreamSessionProgress,
-): DreamCollectorSourceContext {
-  const normalizedMessages = normalizeDreamCollectorMessages(archive);
-  const processedMessageCount = normalizedMessages.length;
-  const prefixHash = hashDreamCollectorMessages(normalizedMessages);
-  if (!progress) {
-    return {
-      mode: 'full',
-      rendered: renderDreamCollectorFullContext(normalizedMessages),
-      prefixHash,
-      processedMessageCount,
-      shouldRunCollector: true,
-    };
-  }
-
-  const needsFullRebuild =
-    progress.lastProcessedMessageCount > processedMessageCount ||
-    hashDreamCollectorMessages(
-      normalizedMessages.slice(0, Math.min(progress.lastProcessedMessageCount, processedMessageCount)),
-    ) !== progress.lastProcessedPrefixHash;
-  if (needsFullRebuild) {
-    return {
-      mode: 'full',
-      rendered: renderDreamCollectorFullContext(normalizedMessages),
-      prefixHash,
-      processedMessageCount,
-      shouldRunCollector: true,
-    };
-  }
-
-  const newMessages = normalizedMessages.slice(progress.lastProcessedMessageCount);
-  if (newMessages.length === 0) {
-    return {
-      mode: 'incremental',
-      rendered: '',
-      prefixHash,
-      processedMessageCount,
-      shouldRunCollector: false,
-    };
-  }
-
-  const anchorMessages = normalizedMessages.slice(
-    Math.max(0, progress.lastProcessedMessageCount - DREAM_COLLECTOR_ANCHOR_MESSAGE_COUNT),
-    progress.lastProcessedMessageCount,
-  );
-  return {
-    mode: 'incremental',
-    rendered: renderDreamCollectorIncrementalContext(anchorMessages, newMessages),
-    prefixHash,
-    processedMessageCount,
-    shouldRunCollector: true,
-  };
-}
-
-function normalizeDreamCollectorMessages(
-  archive: StoredDesktopSession,
-): DreamCollectorNormalizedMessage[] {
-  const source = archive.llmHistory.length > 0
-    ? archive.llmHistory
-    : archive.messages.map((message) => ({
-        role: message.role,
-        content: message.content,
-        imagePaths: [],
-      }));
-  return source
-    .filter(
-      (message): message is { role: 'user' | 'assistant'; content: string; imagePaths: string[] } =>
-        message.role === 'user' || message.role === 'assistant',
-    )
-    .filter((message) => message.content.trim().length > 0)
-    .map((message) => ({
-      role: message.role,
-      rendered: `${message.role.toUpperCase()}:\n${message.content.trim()}`,
-    }));
-}
-
-function hashDreamCollectorMessages(
-  messages: DreamCollectorNormalizedMessage[],
-): string {
-  return createHash('sha256')
-    .update(messages.map((message) => message.rendered).join('\n\n'), 'utf8')
-    .digest('hex')
-    .slice(0, 32);
-}
-
-function renderDreamCollectorFullContext(
-  messages: DreamCollectorNormalizedMessage[],
-): string {
-  return truncateText(
-    messages.map((message) => message.rendered).join('\n\n') || '(empty session)',
-    DREAM_COLLECTOR_SOURCE_CONTEXT_MAX_CHARS,
-  );
-}
-
-function renderDreamCollectorIncrementalContext(
-  anchorMessages: DreamCollectorNormalizedMessage[],
-  newMessages: DreamCollectorNormalizedMessage[],
-): string {
-  const anchorText = truncateText(
-    anchorMessages.map((message) => message.rendered).join('\n\n') || '(no prior anchor)',
-    DREAM_COLLECTOR_ANCHOR_CONTEXT_MAX_CHARS,
-  );
-  const deltaText = truncateText(
-    newMessages.map((message) => message.rendered).join('\n\n') || '(no delta)',
-    DREAM_COLLECTOR_INCREMENTAL_CONTEXT_MAX_CHARS,
-  );
-  return [
-    '[recent_anchor]',
-    anchorText,
-    '',
-    '[new_delta]',
-    deltaText,
-  ].join('\n');
-}
-
-function shouldQueueDreamCollectorSession(
-  session: SessionListItem,
-  progress: HostDreamSessionProgress | undefined,
-  nowUnixMs: number,
-): boolean {
-  if (!progress) {
-    return true;
-  }
-  if (session.modifiedAtUnixMs <= progress.lastProcessedSavedAtUnixMs) {
-    return false;
-  }
-  if (progress.cooldownUntilUnixMs !== undefined && nowUnixMs < progress.cooldownUntilUnixMs) {
-    return false;
-  }
-  return true;
-}
-
-function buildDreamCollectorPrompt(input: {
-  sourceSession: SessionListItem;
-  scope: { workspaceRoot: string; gitBranch: string };
-  sourceContext: DreamCollectorSourceContext;
-}): string {
-  const modeBlock = input.sourceContext.mode === 'incremental'
-    ? [
-        '这是同一会话在上次梦境收集后的新增内容。优先更新已有梦境，不要重复总结旧内容。',
-        '[source_session_incremental_context]',
-      ]
-    : [
-        '这是该会话当前可用的完整摘要上下文。',
-        '[source_session_full_context]',
-      ];
-  return [
-    '请收集这条源会话的梦境摘要。',
-    '你必须先调用 dream_list 查看当前 scope 的已有梦境。',
-    '如果源会话延续了已有动向，请调用 dream_update；如果是新动向，请调用 dream_record；如果已有梦境已经误导或过时，可调用 dream_delete。',
-    '如果写 tags，只保留最关键的 2 到 4 个短标签；优先使用简短 lowercase/kebab-case 词，不要把所有子话题都枚举进去。',
-    '如果源会话完全没有可沉淀的近期工作动向，可以不写入梦境，但不要执行任何非梦境维护操作。',
-    '',
-    `[scope] workspace=${input.scope.workspaceRoot}`,
-    `[scope] branch=${input.scope.gitBranch}`,
-    `[source_session] path=${input.sourceSession.path}`,
-    `[source_session] title=${input.sourceSession.displayName}`,
-    `[source_session] modifiedAtUnixMs=${input.sourceSession.modifiedAtUnixMs}`,
-    `[source_session] mode=${input.sourceContext.mode}`,
-    '',
-    ...modeBlock,
-    input.sourceContext.rendered,
-  ].join('\n');
-}
-
-interface DesktopDreamCollectorRunLog {
-  runId: string;
-  startedAtUnixMs: number;
-  finishedAtUnixMs: number;
-  workspaceRoot: string;
-  gitBranch: string;
-  collectorModel: string;
-  sourceSessionPath?: string;
-  decision: 'no-pending' | 'processed' | 'failed';
-  sourceContextMode?: DreamCollectorSourceContextMode;
-  pendingCount: number;
-  resultSummary?: string;
-  error?: string;
-  toolCalls: Array<{
-    toolName: string;
-    failed: boolean;
-  }>;
-}
-
-async function writeDreamCollectorRunLog(log: DesktopDreamCollectorRunLog): Promise<void> {
-  const logsDir = dreamLogsDirPath(spiritAgentDataDir());
-  await mkdir(logsDir, { recursive: true });
-  const fileName = `${log.startedAtUnixMs}-${log.runId}.json`;
-  await writeFile(path.join(logsDir, fileName), `${JSON.stringify(log, null, 2)}\n`, 'utf8');
-}
-
-async function persistDreamCollectorDebugSession(input: {
-  runId: string;
-  workspaceRoot: string;
-  gitBranch: string;
-  collectorModel: string;
-  sourceSession: SessionListItem;
-  prompt: string;
-  assistantText: string;
-  failed: boolean;
-}): Promise<void> {
-  const now = Date.now();
-  const messages: ConversationMessageSnapshot[] = [
-    {
-      id: 1,
-      role: 'user',
-      content: input.prompt,
-      pending: false,
-    },
-    {
-      id: 2,
-      role: 'assistant',
-      content: input.failed ? `生成失败：${input.assistantText}` : input.assistantText,
-      pending: false,
-    },
-  ];
-  const sessionFile = path.join(chatsDirPath(), `${DREAM_DEBUG_SESSION_FILE_PREFIX}${now}-${input.runId}.json`);
-  await saveStoredSession(sessionFile, {
-    messages,
-    assistantAux: [],
-    llmHistory: messages.map((message) => ({
-      role: message.role,
-      content: message.content,
-      imagePaths: [],
-    })),
-    subagentSessions: [],
-    savedAtUnixMs: now,
-    sessionDisplayName: `[梦境] ${input.sourceSession.displayName}`,
-    workspaceRoot: input.workspaceRoot,
-    gitBranch: input.gitBranch,
-    desktopMessages: messages,
-  });
-}
-
-function isDreamCollectorDebugSessionPath(filePath: string): boolean {
-  return path.basename(filePath).startsWith(DREAM_DEBUG_SESSION_FILE_PREFIX);
-}
-
-function emptyDreamCollectorSnapshot(
-  state: DesktopDreamCollectorSnapshot['state'],
-): DesktopDreamCollectorSnapshot {
-  return {
-    state,
-    pendingCount: 0,
-    processedCount: 0,
-  };
-}
-
-function clearDreamCollectorIssue(
-  snapshot: DesktopDreamCollectorSnapshot,
-): DesktopDreamCollectorSnapshot {
-  const { lastError: _lastError, backoffUntilUnixMs: _backoffUntilUnixMs, ...clean } = snapshot;
-  return clean;
 }
 
 function cloneActiveSkills(skills: OpenAiActiveSkill[]): OpenAiActiveSkill[] {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -60,7 +60,6 @@ import type {
   RunExtensionRequest,
   UpdateExtensionSecretRequest,
   UpdateExtensionSettingsRequest,
-  MessageAuxSnapshot,
   PendingAssistantAux,
   RewindAndSubmitMessageRequest,
   RememberWorkspaceRequest,
@@ -71,7 +70,6 @@ import type {
   PrepareMarketplaceExtensionInstallRequest,
   SubmitCreateSkillSlashRequest,
   SubmitSkillSlashRequest,
-  ToolBlockSnapshot,
   UpdateConfigRequest,
   WorkspaceExplorerListResult,
   WorkspaceReadTextFileResult,
@@ -169,30 +167,18 @@ import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
 import { buildDesktopSnapshot } from './snapshot.js';
 import {
   assistantPrefixBeforeFirstToolInCurrentTurn,
-  describeAuxForDebug,
-  describeOptionalAuxForDebug,
   headlineForStreamingToolPreview,
-  hasStandaloneThinkingMessageInCurrentTurn,
-  indexForThinkingInsertAfterLastUser,
   indexForThinkingInsertBeforeFirstToolAfterLastUser,
   lastAssistantPlainTextInHistory,
   latestUnsyncedAssistantTextInCurrentTurn,
-  messageIndexIsInCurrentTurn,
   messageOrderDebugLevel,
-  normalizeMessageAuxSnapshot,
   parsePendingSubagentStatusText,
   restoreMessagesFromArchive,
-  stripPendingThinkingMatchingFinalized,
-  stripThinkingFromAux,
   summarizeMessagesTailForOrderDebug,
   truncateOneLineForDebug,
   toolMessageKey,
 } from './message-ordering.js';
-import {
-  pruneEmptyAssistantMessages as pruneEmptyAssistantMessagesFromSnapshots,
-  shiftStreamAssistantThinkingAnchorForInsertion as shiftThinkingAnchorForInsertion,
-  shiftStreamAssistantThinkingAnchorForRemoval as shiftThinkingAnchorForRemoval,
-} from './message-snapshots.js';
+import { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';
 import {
   buildActiveSkillPayload,
   buildActivateSkillUserTurn,
@@ -330,13 +316,15 @@ class DesktopHostService {
   private activeApiKeyConfigured = false;
   private modelKeyPresence: Record<string, boolean> = {};
   private readonly conversationSnapshotView = new DesktopConversationSnapshotView(() => this.allocateMessageId());
-  private latestPendingAssistantAux: MessageAuxSnapshot | undefined;
-  private pendingAssistantMessageId: number | undefined;
-  private lastSettledAssistantMessageId: number | undefined;
+  private readonly assistantMessages = new DesktopAssistantMessageStateMachine({
+    messages: () => this.requireState().messages,
+    setMessages: (messages) => {
+      this.requireState().messages = messages;
+    },
+    allocateMessageId: () => this.allocateMessageId(),
+    isRuntimeBusy: () => this.runtime?.isBusy() ?? false,
+  });
   /** 思考段 finalize 去重、插入锚点与 apply 批次（见 `applyRuntimeHostEvents` / `appendAssistantThinkingSegment`）。 */
-  private lastFinalizedThinkingSegment = '';
-  private streamAssistantThinkingAnchor: number | undefined;
-  private streamAssistantAnchorSetInApplyBatchId = 0;
   private lastApplyEventBatchId = 0;
   private messageOrderDebugLastVerboseLogMs = 0;
   private messageIdCounter = 1;
@@ -1137,7 +1125,7 @@ class DesktopHostService {
       this.applyRuntimeHostEvents(runtime.drainEvents());
     } catch (error) {
       this.currentTurnSkills = [];
-      this.handleMessageRemoved(state.messages.length - 1, userMessage.id, 'send-user-rollback');
+      this.assistantMessages.handleMessageRemoved(state.messages.length - 1, userMessage.id, 'send-user-rollback');
       state.messages.pop();
       throw error;
     }
@@ -1166,7 +1154,7 @@ class DesktopHostService {
       pending: false,
     });
     this.resetStreamingPlacementState(false);
-    this.appendAssistantMessage(assistantText);
+    this.assistantMessages.appendAssistantMessage(assistantText);
     await this.persistCurrentSessionIfNeeded();
     await this.refreshGitState();
     return this.buildSnapshot();
@@ -1258,7 +1246,6 @@ class DesktopHostService {
       state.rewindWarnings = [];
       this.currentTurnSkills = [];
       this.pendingUnboundFileChangeIds = [];
-      this.latestPendingAssistantAux = undefined;
       this.resetStreamingPlacementState(true);
       this.messageIdCounter = 1;
       await this.refreshRuntime();
@@ -1359,7 +1346,6 @@ class DesktopHostService {
         this.currentTurnSkills = [];
         this.pendingUnboundFileChangeIds = [];
         this.messageIdCounter = nextMessageIdFromMessages(state.messages);
-        this.latestPendingAssistantAux = undefined;
         this.resetStreamingPlacementState(true);
         await this.refreshRuntime();
         this.lastRuntimeError = '';
@@ -1383,7 +1369,6 @@ class DesktopHostService {
       this.currentTurnSkills = [];
       this.pendingUnboundFileChangeIds = [];
       this.messageIdCounter = nextMessageIdFromMessages(state.messages);
-      this.latestPendingAssistantAux = undefined;
       this.resetStreamingPlacementState(true);
       await this.refreshRuntime();
       this.lastRuntimeError = '';
@@ -1603,7 +1588,6 @@ class DesktopHostService {
       this.deferredRuntimeRefreshWhileBusy = false;
       this.currentTurnSkills = [];
       this.pendingUnboundFileChangeIds = [];
-      this.latestPendingAssistantAux = undefined;
       this.resetStreamingPlacementState(true);
       this.messageIdCounter = 1;
       this.lastRuntimeError = '';
@@ -1885,18 +1869,19 @@ class DesktopHostService {
     const pendingApproval = this.runtime?.currentPendingApproval();
     const pendingQuestions = this.runtime?.currentPendingQuestions();
     const pendingAux = this.runtime?.pendingAuxState();
+    const standaloneAnchorState = this.assistantMessages.standaloneAnchorState();
     this.conversationSnapshotView.syncStandalonePendingAux({
       livePendingAux: pendingAux,
-      pendingAssistantMessageId: this.pendingAssistantMessageId,
-      lastSettledAssistantMessageId: this.lastSettledAssistantMessageId,
+      pendingAssistantMessageId: standaloneAnchorState.pendingAssistantMessageId,
+      lastSettledAssistantMessageId: standaloneAnchorState.lastSettledAssistantMessageId,
     });
     if (pendingAux && !parsePendingSubagentStatusText(pendingAux.statusText)) {
-      this.updatePendingAssistantAux(
+      this.assistantMessages.updatePendingAssistantAux(
         pendingAux.kind,
         pendingAux.detailText ?? pendingAux.statusText,
       );
     }
-    this.pruneEmptyAssistantMessages('buildSnapshot');
+    this.assistantMessages.pruneEmptyAssistantMessages('buildSnapshot');
 
     return buildDesktopSnapshot({
       workspaceRoot: state.workspaceRoot,
@@ -2086,9 +2071,9 @@ class DesktopHostService {
       case 'completed':
         this.currentTurnSkills = [];
         if (result.assistantText.trim()) {
-          const aux = this.takeLatestPendingAux();
-          if (!this.materializeExistingCompletedAssistantMessage(result.assistantText, aux)) {
-            this.appendAssistantMessage(result.assistantText, aux);
+          const aux = this.assistantMessages.takeLatestPendingAux();
+          if (!this.assistantMessages.materializeExistingCompletedAssistantMessage(result.assistantText, aux)) {
+            this.assistantMessages.appendAssistantMessage(result.assistantText, aux);
           }
         }
         this.lastRuntimeError = '';
@@ -2096,9 +2081,9 @@ class DesktopHostService {
       case 'failed':
         this.currentTurnSkills = [];
         {
-          const aux = this.takeLatestPendingAux();
-          if (!this.materializeExistingCompletedAssistantMessage(result.error, aux)) {
-            this.appendAssistantMessage(result.error, aux);
+          const aux = this.assistantMessages.takeLatestPendingAux();
+          if (!this.assistantMessages.materializeExistingCompletedAssistantMessage(result.error, aux)) {
+            this.assistantMessages.appendAssistantMessage(result.error, aux);
           }
         }
         this.lastRuntimeError = result.error;
@@ -2204,7 +2189,7 @@ class DesktopHostService {
 
   private integrateToolExecutions(executions: RuntimeToolExecution<DesktopToolRequest>[]): void {
     for (const execution of executions) {
-      const message = this.upsertToolMessage(execution.toolCallId || `tool:${execution.toolName}`, {
+      const message = this.assistantMessages.upsertToolMessage(execution.toolCallId || `tool:${execution.toolName}`, {
         toolCallId: execution.toolCallId || `tool:${execution.toolName}`,
         toolName: execution.toolName,
         phase: execution.failed ? 'failed' : 'succeeded',
@@ -2214,7 +2199,7 @@ class DesktopHostService {
         detailLines: [],
         argsExcerpt: truncateJson(execution.request),
         outputExcerpt: truncateText(execution.output, 4_000),
-      });
+      }, this.lastApplyEventBatchId);
       this.bindFileChangesToToolMessage(execution, message.id);
     }
   }
@@ -2234,46 +2219,39 @@ class DesktopHostService {
           this.conversationSnapshotView.shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
             state.messages[state.messages.length - 1],
           );
-        this.pendingAssistantMessageId = undefined;
-        this.latestPendingAssistantAux = undefined;
-        this.streamAssistantThinkingAnchor =
-          this.streamAssistantThinkingAnchor === undefined
-            ? at
-            : Math.min(this.streamAssistantThinkingAnchor, at);
-        this.streamAssistantAnchorSetInApplyBatchId = batchId;
-        const pendingAssistant = this.ensurePendingAssistantMessage();
+        const pendingAssistant = this.assistantMessages.beginAssistantResponse(at, batchId);
         if (shouldReanchorStandalonePendingAux) {
           this.conversationSnapshotView.reanchorPersistedStandalonePendingAux(pendingAssistant.id);
         }
         continue;
       }
       if (ev.kind === 'update-pending-assistant-thinking') {
-        this.updatePendingAssistantAux('thinking', ev.text);
+        this.assistantMessages.updatePendingAssistantAux('thinking', ev.text);
         continue;
       }
       if (ev.kind === 'update-pending-assistant-compaction') {
-        this.updatePendingAssistantAux('compressing', ev.text);
+        this.assistantMessages.updatePendingAssistantAux('compressing', ev.text);
         continue;
       }
       if (ev.kind === 'assistant-chunk') {
-        this.appendPendingAssistantChunk(ev.text);
+        this.assistantMessages.appendPendingAssistantChunk(ev.text);
         continue;
       }
       if (ev.kind === 'replace-pending-assistant') {
-        this.replacePendingAssistantText(ev.text);
+        this.assistantMessages.replacePendingAssistantText(ev.text);
         continue;
       }
       if (ev.kind === 'assistant-response-completed') {
-        this.completePendingAssistantMessage();
+        this.assistantMessages.completePendingAssistantMessage();
         continue;
       }
       if (ev.kind === 'remove-pending-assistant') {
-        this.removePendingAssistantMessage();
+        this.assistantMessages.removePendingAssistantMessage();
         continue;
       }
       if (ev.kind === 'assistant-thinking-segment-finalized') {
         if (ev.text.trim()) {
-          this.appendAssistantThinkingSegment(ev.text);
+          this.assistantMessages.appendAssistantThinkingSegment(ev.text);
         }
         continue;
       }
@@ -2323,21 +2301,22 @@ class DesktopHostService {
       } catch {
         argsExcerpt = truncateText(ev.argumentsJson, 4_000);
       }
-      this.upsertToolMessage(ev.toolCallId, {
+      this.assistantMessages.upsertToolMessage(ev.toolCallId, {
         toolCallId: ev.toolCallId,
         toolName: ev.toolName,
         phase: 'running',
         headline: headlineForStreamingToolPreview(state.messages, ev.toolCallId, ev.toolName),
         detailLines: [],
         argsExcerpt,
-      });
+      }, batchId);
     }
+    const placement = this.assistantMessages.placementState();
     this.logMessageOrderApplyBatch(
       batchId,
       events,
       state,
-      this.streamAssistantThinkingAnchor,
-      this.streamAssistantAnchorSetInApplyBatchId,
+      placement.streamAssistantThinkingAnchor,
+      placement.streamAssistantAnchorSetInApplyBatchId,
     );
   }
 
@@ -2399,7 +2378,7 @@ class DesktopHostService {
       prefixFromUnsyncedLatest !== prefixFromBeforeFirst;
 
     if (isLaterUnsyncedPrefix) {
-      const anchor = this.streamAssistantThinkingAnchor ?? state.messages.length;
+      const anchor = this.assistantMessages.streamAssistantThinkingAnchorOr(state.messages.length);
       const insertAt = Math.max(0, Math.min(anchor, state.messages.length));
       const before = insertAt > 0 ? state.messages[insertAt - 1] : undefined;
       if (
@@ -2409,7 +2388,7 @@ class DesktopHostService {
       ) {
         return;
       }
-      this.shiftStreamAssistantThinkingAnchorForInsertion(insertAt);
+      this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(insertAt);
       state.messages.splice(insertAt, 0, {
         id: this.allocateMessageId(),
         role: 'assistant',
@@ -2441,7 +2420,7 @@ class DesktopHostService {
           ) {
             return;
           }
-          this.shiftStreamAssistantThinkingAnchorForInsertion(idx);
+          this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(idx);
           state.messages.splice(idx, 0, {
             id: this.allocateMessageId(),
             role: 'assistant',
@@ -2474,7 +2453,7 @@ class DesktopHostService {
       if (beforeFirst?.role === 'assistant' && beforeFirst.content === prefix && !beforeFirst.tool) {
         return;
       }
-      this.shiftStreamAssistantThinkingAnchorForInsertion(firstToolIdx);
+      this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(firstToolIdx);
       state.messages.splice(firstToolIdx, 0, {
         id: this.allocateMessageId(),
         role: 'assistant',
@@ -2492,7 +2471,7 @@ class DesktopHostService {
         if (beforeFirst?.role === 'assistant' && beforeFirst.content === prefix && !beforeFirst.tool) {
           return;
         }
-        this.shiftStreamAssistantThinkingAnchorForInsertion(firstToolIdx);
+        this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(firstToolIdx);
         state.messages.splice(firstToolIdx, 0, {
           id: this.allocateMessageId(),
           role: 'assistant',
@@ -2515,7 +2494,7 @@ class DesktopHostService {
         if (beforeTool?.role === 'assistant' && beforeTool.content === prefix && !beforeTool.tool) {
           return;
         }
-        this.shiftStreamAssistantThinkingAnchorForInsertion(toolIdx);
+        this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(toolIdx);
         state.messages.splice(toolIdx, 0, {
           id: this.allocateMessageId(),
           role: 'assistant',
@@ -2526,7 +2505,7 @@ class DesktopHostService {
         return;
       }
       if (!last!.content.startsWith(prefix)) {
-        this.shiftStreamAssistantThinkingAnchorForInsertion(n - 1);
+        this.assistantMessages.shiftStreamAssistantThinkingAnchorForInsertion(n - 1);
         state.messages.splice(n - 1, 0, {
           id: this.allocateMessageId(),
           role: 'assistant',
@@ -2542,368 +2521,27 @@ class DesktopHostService {
   private syncPendingToolStates(): void {
     const approval = this.runtime?.currentPendingApproval();
     if (approval) {
-      this.upsertToolMessage(toolMessageKey(approval), {
+      this.assistantMessages.upsertToolMessage(toolMessageKey(approval), {
         toolCallId: toolMessageKey(approval),
         toolName: approval.toolName,
         phase: 'pending-approval',
         headline: `等待确认: ${approval.toolName}`,
         detailLines: [approval.prompt],
         argsExcerpt: truncateJson(approval.request),
-      });
+      }, this.lastApplyEventBatchId);
     }
 
     const questions = this.runtime?.currentPendingQuestions();
     if (questions) {
-      this.upsertToolMessage(toolMessageKey(questions), {
+      this.assistantMessages.upsertToolMessage(toolMessageKey(questions), {
         toolCallId: toolMessageKey(questions),
         toolName: questions.toolName,
         phase: 'pending-approval',
         headline: `等待补充信息: ${questions.toolName}`,
         detailLines: [questions.questions.title ?? '请回答表单问题'],
         argsExcerpt: truncateJson(questions.questions),
-      });
+      }, this.lastApplyEventBatchId);
     }
-  }
-
-  private upsertToolMessage(
-    toolCallId: string,
-    tool: ToolBlockSnapshot,
-  ): ConversationMessageSnapshot {
-    const state = this.requireState();
-    const existing = state.messages.find(
-      (message) => message.tool?.toolCallId === toolCallId,
-    );
-
-    if (existing) {
-      const previousTool = existing.tool;
-      existing.tool = tool;
-      this.logToolMessageUpdate(existing.id, toolCallId, previousTool, tool, state.messages);
-      return existing;
-    }
-
-    const batchId = this.lastApplyEventBatchId;
-    if (this.streamAssistantThinkingAnchor === undefined) {
-      this.streamAssistantThinkingAnchor = state.messages.length;
-    }
-    this.streamAssistantAnchorSetInApplyBatchId = batchId;
-    const pushAt = state.messages.length;
-    const message: ConversationMessageSnapshot = {
-      id: this.allocateMessageId(),
-      role: 'assistant',
-      content: '',
-      tool,
-      pending: false,
-    };
-    state.messages.push(message);
-    this.logMessageOrderToolPreviewNew(tool.toolName, pushAt);
-    return message;
-  }
-
-  private appendAssistantMessage(content: string, aux?: MessageAuxSnapshot): void {
-    const state = this.requireState();
-    const finalAux = this.normalizeCompletedAssistantAux(aux);
-    const message: ConversationMessageSnapshot = {
-      id: this.allocateMessageId(),
-      role: 'assistant',
-      content,
-      ...(finalAux ? { aux: finalAux } : {}),
-      pending: false,
-    };
-    state.messages.push(message);
-    this.logAssistantAuxDecision('append-assistant', {
-      messageId: message.id,
-      aux: message.aux,
-      content,
-    });
-  }
-
-  /** 将本段模型思考固化为独立消息，并从挂起 aux 中剥离同文以避免与终稿重复。 */
-  private appendAssistantThinkingSegment(text: string): void {
-    this.lastFinalizedThinkingSegment = text.trim();
-    const state = this.requireState();
-    this.stripFinalizedThinkingFromAssistantAnchors(text);
-    const msg: ConversationMessageSnapshot = {
-      id: this.allocateMessageId(),
-      role: 'assistant',
-      content: '',
-      aux: { thinking: text },
-      pending: false,
-    };
-    let insertAt = this.streamAssistantThinkingAnchor;
-    this.streamAssistantThinkingAnchor = undefined;
-    if (insertAt === undefined) {
-      insertAt = indexForThinkingInsertBeforeFirstToolAfterLastUser(state.messages);
-    }
-    if (insertAt === undefined) {
-      insertAt = indexForThinkingInsertAfterLastUser(state.messages);
-    }
-    const clamped = Math.max(0, Math.min(insertAt, state.messages.length));
-    state.messages.splice(clamped, 0, msg);
-    const placed = `splice@${clamped}`;
-    this.logMessageOrderThinkingFinalized(placed, state.messages.length, text);
-    this.latestPendingAssistantAux = stripPendingThinkingMatchingFinalized(
-      this.latestPendingAssistantAux,
-      text,
-    );
-  }
-
-  private findPendingAssistantMessageIndex(): number | undefined {
-    const state = this.requireState();
-    if (this.pendingAssistantMessageId !== undefined) {
-      const index = state.messages.findIndex(
-        (message) =>
-          message.id === this.pendingAssistantMessageId &&
-          message.role === 'assistant' &&
-          message.pending &&
-          !message.tool,
-      );
-      if (index >= 0) {
-        return index;
-      }
-      this.pendingAssistantMessageId = undefined;
-    }
-
-    const fallbackIndex = state.messages.findIndex(
-      (message) => message.role === 'assistant' && message.pending && !message.tool,
-    );
-    if (fallbackIndex >= 0) {
-      this.pendingAssistantMessageId = state.messages[fallbackIndex]!.id;
-      return fallbackIndex;
-    }
-    return undefined;
-  }
-
-  private ensurePendingAssistantMessage(): ConversationMessageSnapshot {
-    const state = this.requireState();
-    const existingIndex = this.findPendingAssistantMessageIndex();
-    if (existingIndex !== undefined) {
-      return state.messages[existingIndex]!;
-    }
-
-    const message: ConversationMessageSnapshot = {
-      id: this.allocateMessageId(),
-      role: 'assistant',
-      content: '',
-      ...(this.latestPendingAssistantAux ? { aux: { ...this.latestPendingAssistantAux } } : {}),
-      pending: true,
-    };
-    state.messages.push(message);
-    this.pendingAssistantMessageId = message.id;
-    return message;
-  }
-
-  private updatePendingAssistantAux(
-    kind: 'thinking' | 'compressing',
-    text: string,
-  ): void {
-    const normalized = text.trim();
-    const existingIndex = this.findPendingAssistantMessageIndex();
-    const message =
-      existingIndex !== undefined
-        ? this.requireState().messages[existingIndex]!
-        : normalized && this.runtime?.isBusy()
-          ? this.ensurePendingAssistantMessage()
-          : undefined;
-    const currentAux = message?.aux ?? this.latestPendingAssistantAux;
-    const nextAux = normalizeMessageAuxSnapshot({
-      ...(kind === 'thinking'
-        ? normalized
-          ? { thinking: text }
-          : {}
-        : currentAux?.thinking
-          ? { thinking: currentAux.thinking }
-          : {}),
-      ...(kind === 'compressing'
-        ? normalized
-          ? { compaction: text }
-          : {}
-        : currentAux?.compaction
-          ? { compaction: currentAux.compaction }
-          : {}),
-    });
-
-    if (message) {
-      if (nextAux) {
-        message.aux = nextAux;
-      } else {
-        delete message.aux;
-      }
-    }
-
-    if (nextAux) {
-      this.latestPendingAssistantAux = nextAux;
-    } else {
-      this.latestPendingAssistantAux = undefined;
-    }
-  }
-
-  private appendPendingAssistantChunk(chunk: string): void {
-    const message = this.ensurePendingAssistantMessage();
-    message.content += chunk;
-  }
-
-  private replacePendingAssistantText(text: string): void {
-    const message = this.ensurePendingAssistantMessage();
-    message.content = text;
-  }
-
-  private completePendingAssistantMessage(): void {
-    const index = this.findPendingAssistantMessageIndex();
-    if (index === undefined) {
-      this.pendingAssistantMessageId = undefined;
-      return;
-    }
-    const message = this.requireState().messages[index]!;
-    message.pending = false;
-    this.lastSettledAssistantMessageId = message.id;
-    this.pendingAssistantMessageId = undefined;
-    this.latestPendingAssistantAux = undefined;
-  }
-
-  private removePendingAssistantMessage(): void {
-    const index = this.findPendingAssistantMessageIndex();
-    if (index === undefined) {
-      this.pendingAssistantMessageId = undefined;
-      this.latestPendingAssistantAux = undefined;
-      return;
-    }
-
-    const state = this.requireState();
-    const message = state.messages[index]!;
-    const aux = normalizeMessageAuxSnapshot(message.aux);
-    if (!message.content.trim() && !aux) {
-      this.handleMessageRemoved(index, message.id, 'remove-pending-assistant');
-      state.messages.splice(index, 1);
-    } else {
-      message.pending = false;
-      if (aux) {
-        message.aux = aux;
-      } else {
-        delete message.aux;
-      }
-      this.lastSettledAssistantMessageId = message.id;
-    }
-    this.pendingAssistantMessageId = undefined;
-    this.latestPendingAssistantAux = undefined;
-  }
-
-  private materializeExistingCompletedAssistantMessage(
-    content: string,
-    aux?: MessageAuxSnapshot,
-  ): boolean {
-    const state = this.requireState();
-    const normalized = content.trim();
-    const finalAux = this.normalizeCompletedAssistantAux(aux);
-    for (let index = state.messages.length - 1; index >= 0; index -= 1) {
-      const message = state.messages[index]!;
-      if (message.role !== 'assistant' || message.tool) {
-        continue;
-      }
-      if (message.pending) {
-        continue;
-      }
-      if (message.content.trim() !== normalized) {
-        continue;
-      }
-      if (finalAux) {
-        message.aux = normalizeMessageAuxSnapshot({
-          ...(message.aux?.thinking ? { thinking: message.aux.thinking } : {}),
-          ...(message.aux?.compaction ? { compaction: message.aux.compaction } : {}),
-          ...(finalAux.thinking ? { thinking: finalAux.thinking } : {}),
-          ...(finalAux.compaction ? { compaction: finalAux.compaction } : {}),
-        });
-      }
-      if (hasStandaloneThinkingMessageInCurrentTurn(state.messages)) {
-        message.aux = stripThinkingFromAux(message.aux);
-        if (!message.aux) {
-          delete message.aux;
-        }
-      }
-      this.logAssistantAuxDecision('materialize-completed', {
-        messageId: message.id,
-        aux: message.aux,
-        content,
-      });
-      return true;
-    }
-    return false;
-  }
-
-  private normalizeCompletedAssistantAux(aux?: MessageAuxSnapshot): MessageAuxSnapshot | undefined {
-    const normalized = normalizeMessageAuxSnapshot(aux);
-    if (!normalized?.thinking) {
-      return normalized;
-    }
-    const state = this.requireState();
-    if (!hasStandaloneThinkingMessageInCurrentTurn(state.messages)) {
-      return normalized;
-    }
-    const stripped = stripThinkingFromAux(normalized);
-    this.logAssistantAuxDecision('strip-completed-thinking-aux', {
-      aux: normalized,
-      extra: stripped ? `kept=${describeAuxForDebug(stripped)}` : 'kept=none',
-    });
-    return stripped;
-  }
-
-  private findLastSettledAssistantMessageIndex(): number | undefined {
-    if (this.lastSettledAssistantMessageId === undefined) {
-      return undefined;
-    }
-
-    const state = this.requireState();
-    const index = state.messages.findIndex(
-      (message) =>
-        message.id === this.lastSettledAssistantMessageId &&
-        message.role === 'assistant' &&
-        !message.tool &&
-        !message.pending,
-    );
-    if (index < 0 || !messageIndexIsInCurrentTurn(state.messages, index)) {
-      this.lastSettledAssistantMessageId = undefined;
-      return undefined;
-    }
-    return index;
-  }
-
-  private stripFinalizedThinkingFromAssistantAnchors(text: string): void {
-    const state = this.requireState();
-    const targets: Array<{ kind: 'pending' | 'settled'; index: number | undefined }> = [
-      { kind: 'pending', index: this.findPendingAssistantMessageIndex() },
-      { kind: 'settled', index: this.findLastSettledAssistantMessageIndex() },
-    ];
-
-    for (const target of targets) {
-      if (target.index === undefined) {
-        continue;
-      }
-      const message = state.messages[target.index];
-      if (!message) {
-        continue;
-      }
-      const beforeAux = normalizeMessageAuxSnapshot(message.aux);
-      const afterAux = stripPendingThinkingMatchingFinalized(beforeAux, text);
-      const changed = describeOptionalAuxForDebug(beforeAux) !== describeOptionalAuxForDebug(afterAux);
-      if (!changed) {
-        continue;
-      }
-      if (afterAux) {
-        message.aux = afterAux;
-      } else {
-        delete message.aux;
-      }
-      this.logAssistantAuxDecision('strip-finalized-thinking-anchor', {
-        messageId: message.id,
-        aux: beforeAux,
-        finalizedThinking: text,
-        extra: `target=${target.kind} next=${describeOptionalAuxForDebug(afterAux)}`,
-      });
-      return;
-    }
-
-    this.logAssistantAuxDecision('strip-finalized-thinking-miss', {
-      finalizedThinking: text,
-    });
   }
 
   private ensureActiveSession(seedText: string): void {
@@ -2987,7 +2625,7 @@ class DesktopHostService {
     messageId: number,
     beforeUserCheckpoint?: DesktopRewindCheckpointSnapshot,
   ): Promise<void> {
-    this.pruneEmptyAssistantMessages('recordRewindCheckpoint');
+    this.assistantMessages.pruneEmptyAssistantMessages('recordRewindCheckpoint');
     const state = this.requireState();
     if (!state.activeSession) {
       return;
@@ -3030,7 +2668,7 @@ class DesktopHostService {
   }
 
   private buildRewindCheckpointSnapshot(): DesktopRewindCheckpointSnapshot {
-    this.pruneEmptyAssistantMessages('buildRewindCheckpointSnapshot');
+    this.assistantMessages.pruneEmptyAssistantMessages('buildRewindCheckpointSnapshot');
     const state = this.requireState();
     const archive = this.runtime
       ? this.runtime.toArchive(this.archiveMessages(), this.archiveAssistantAux())
@@ -3070,55 +2708,10 @@ class DesktopHostService {
     }));
     pruneRewindMetadataAfterCheckpoint(state.rewind, checkpointSequence);
     this.pendingUnboundFileChangeIds = [];
-    this.latestPendingAssistantAux = undefined;
     this.messageIdCounter = nextMessageIdFromMessages(state.messages);
     this.resetStreamingPlacementState(true);
-    this.pruneEmptyAssistantMessages('restoreBeforeRewindCheckpoint');
+    this.assistantMessages.pruneEmptyAssistantMessages('restoreBeforeRewindCheckpoint');
     this.requireRuntime().replaceFromArchive(archive);
-  }
-
-  private pruneEmptyAssistantMessages(reason: string): void {
-    const state = this.requireState();
-    const { messages, removed } = pruneEmptyAssistantMessagesFromSnapshots(state.messages);
-    state.messages = messages;
-    for (const removal of removed) {
-      this.handleMessageRemoved(removal.messageIndex, removal.messageId, `prune:${reason}`);
-    }
-    if (removed.length > 0) {
-      const removedIds = removed.map((removal) => removal.messageId);
-      console.warn(
-        `[desktop-host][messages] dropped ${removedIds.length} empty assistant message(s) during ${reason}: ${removedIds.join(', ')}`,
-      );
-    }
-  }
-
-  private shiftStreamAssistantThinkingAnchorForInsertion(insertAt: number): void {
-    this.streamAssistantThinkingAnchor = shiftThinkingAnchorForInsertion(
-      this.streamAssistantThinkingAnchor,
-      insertAt,
-    );
-  }
-
-  private shiftStreamAssistantThinkingAnchorForRemoval(removeAt: number, removeCount = 1): void {
-    this.streamAssistantThinkingAnchor = shiftThinkingAnchorForRemoval(
-      this.streamAssistantThinkingAnchor,
-      removeAt,
-      removeCount,
-    );
-  }
-
-  private handleMessageRemoved(messageIndex: number, messageId: number, reason: string): void {
-    this.shiftStreamAssistantThinkingAnchorForRemoval(messageIndex);
-    if (this.pendingAssistantMessageId === messageId) {
-      this.pendingAssistantMessageId = undefined;
-    }
-    if (this.lastSettledAssistantMessageId === messageId) {
-      this.lastSettledAssistantMessageId = undefined;
-    }
-    this.logAssistantAuxDecision('remove-message-anchor-shift', {
-      messageId,
-      extra: `reason=${reason} nextAnchor=${this.streamAssistantThinkingAnchor ?? '∅'}`,
-    });
   }
 
   private async persistCurrentSessionIfNeeded(): Promise<void> {
@@ -3127,7 +2720,7 @@ class DesktopHostService {
       return;
     }
 
-    this.pruneEmptyAssistantMessages('persistCurrentSessionIfNeeded');
+    this.assistantMessages.pruneEmptyAssistantMessages('persistCurrentSessionIfNeeded');
 
     const archive = this.runtime
       ? this.runtime.toArchive(this.archiveMessages(), this.archiveAssistantAux())
@@ -3173,123 +2766,13 @@ class DesktopHostService {
    * @param full `false`：仅清思考插入锚点（新用户轮次，避免误插旧工具链）。`true`：另清 finalize 去重与 apply 批次计数（重置会话 / 打开存档）。
    */
   private resetStreamingPlacementState(full: boolean): void {
-    this.pendingAssistantMessageId = undefined;
-    this.lastSettledAssistantMessageId = undefined;
+    this.assistantMessages.resetStreamingPlacementState(full);
     if (!full) {
-      this.streamAssistantThinkingAnchor = undefined;
       return;
     }
     this.conversationSnapshotView.clearStandalonePendingAuxState();
-    this.lastFinalizedThinkingSegment = '';
-    this.streamAssistantThinkingAnchor = undefined;
-    this.streamAssistantAnchorSetInApplyBatchId = 0;
     this.lastApplyEventBatchId = 0;
     this.messageOrderDebugLastVerboseLogMs = 0;
-  }
-
-  private logToolMessageUpdate(
-    messageId: number,
-    toolCallId: string,
-    previousTool: ToolBlockSnapshot | undefined,
-    nextTool: ToolBlockSnapshot,
-    messages: ReadonlyArray<ConversationMessageSnapshot>,
-  ): void {
-    const mode = messageOrderDebugLevel();
-    if (mode === 'off') {
-      return;
-    }
-
-    const previousPhase = previousTool?.phase;
-    const nextPhase = nextTool.phase;
-    const previousHeadline = previousTool?.headline ?? '';
-    const nextHeadline = nextTool.headline;
-    const previousOutput = previousTool?.outputExcerpt ?? '';
-    const nextOutput = nextTool.outputExcerpt ?? '';
-    if (
-      previousPhase === nextPhase &&
-      previousHeadline === nextHeadline &&
-      previousOutput === nextOutput
-    ) {
-      return;
-    }
-
-    const tail = summarizeMessagesTailForOrderDebug([...messages], 8);
-    console.log(
-      `[desktop-host][tool] msg=${messageId} call=${toolCallId} name=${nextTool.toolName} phase=${previousPhase ?? '∅'}->${nextPhase} headline≈${truncateOneLineForDebug(nextHeadline, 42)} tail=${tail}`,
-    );
-  }
-
-  private takeLatestPendingAux(): MessageAuxSnapshot | undefined {
-    const current = this.latestPendingAssistantAux;
-    this.latestPendingAssistantAux = undefined;
-    if (!current) {
-      this.logAssistantAuxDecision('take-pending-aux-none', {
-        finalizedThinking: this.lastFinalizedThinkingSegment,
-      });
-      this.lastFinalizedThinkingSegment = '';
-      return undefined;
-    }
-    if (
-      this.lastFinalizedThinkingSegment &&
-      current.thinking?.trim() === this.lastFinalizedThinkingSegment.trim()
-    ) {
-      const { thinking: _thinking, ...rest } = current;
-      this.logAssistantAuxDecision('take-pending-aux-strip-exact', {
-        aux: current,
-        finalizedThinking: this.lastFinalizedThinkingSegment,
-        extra: Object.keys(rest).length > 0 ? `kept=${describeAuxForDebug(rest)}` : 'kept=none',
-      });
-      this.lastFinalizedThinkingSegment = '';
-      return Object.keys(rest).length > 0 ? rest : undefined;
-    }
-    if (current.thinking && hasStandaloneThinkingMessageInCurrentTurn(this.requireState().messages)) {
-      const stripped = stripThinkingFromAux(current);
-      this.logAssistantAuxDecision('take-pending-aux-strip-standalone', {
-        aux: current,
-        finalizedThinking: this.lastFinalizedThinkingSegment,
-        extra: stripped ? `kept=${describeAuxForDebug(stripped)}` : 'kept=none',
-      });
-      this.lastFinalizedThinkingSegment = '';
-      return stripped;
-    }
-    this.logAssistantAuxDecision('take-pending-aux-carry', {
-      aux: current,
-      finalizedThinking: this.lastFinalizedThinkingSegment,
-    });
-    this.lastFinalizedThinkingSegment = '';
-    return current;
-  }
-
-  private logAssistantAuxDecision(
-    stage: string,
-    details: {
-      messageId?: number;
-      aux?: MessageAuxSnapshot;
-      content?: string;
-      finalizedThinking?: string;
-      extra?: string;
-    },
-  ): void {
-    if (messageOrderDebugLevel() === 'off') {
-      return;
-    }
-    const parts = [stage];
-    if (details.messageId !== undefined) {
-      parts.push(`msg=${details.messageId}`);
-    }
-    if (details.aux) {
-      parts.push(`aux=${describeAuxForDebug(details.aux)}`);
-    }
-    if (details.finalizedThinking?.trim()) {
-      parts.push(`final≈${truncateOneLineForDebug(details.finalizedThinking, 42)}`);
-    }
-    if (details.content?.trim()) {
-      parts.push(`content≈${truncateOneLineForDebug(details.content, 42)}`);
-    }
-    if (details.extra) {
-      parts.push(details.extra);
-    }
-    console.log(`[desktop-host][aux] ${parts.join(' ')}`);
   }
 
   private logMessageOrderApplyBatch(
@@ -3354,30 +2837,12 @@ class DesktopHostService {
     );
   }
 
-  private logMessageOrderThinkingFinalized(placed: string, lenAfter: number, text: string): void {
-    if (messageOrderDebugLevel() === 'off') {
-      return;
-    }
-    const one = text.replace(/\s+/g, ' ').trim();
-    const clip = one.slice(0, 72);
-    console.log(
-      `[desktop-host][msg-order] thinking-finalized ${placed} len=${lenAfter} text≈${clip}${one.length > 72 ? '…' : ''}`,
-    );
-  }
-
   private logMessageOrderPrefixSync(how: string, state: HostState): void {
     if (messageOrderDebugLevel() === 'off') {
       return;
     }
     const tail = summarizeMessagesTailForOrderDebug(state.messages, 10);
     console.log(`[desktop-host][msg-order] prefix-sync ${how} len=${state.messages.length} tail=${tail}`);
-  }
-
-  private logMessageOrderToolPreviewNew(toolName: string, pushAt: number): void {
-    if (messageOrderDebugLevel() === 'off') {
-      return;
-    }
-    console.log(`[desktop-host][msg-order] tool-preview-new ${toolName} push@${pushAt}`);
   }
 
   private async runSerialized<T>(work: () => Promise<T>): Promise<T> {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -88,7 +88,20 @@ import type {
   WorkspaceReadTextFileResult,
   WriteWorkspaceTextFileRequest,
 } from '../types.js';
-import type { DesktopToolRequest, HostCommandName, StoredDesktopSession } from './contracts.js';
+import type { DesktopToolRequest, HostCommandName } from './contracts.js';
+import {
+  buildCommitEphemeralSessionRecord,
+  buildStoredDesktopSession,
+  createEphemeralCommitSessionPath,
+  deriveDisplayNameFromSeed,
+  ephemeralSessionsToListItems,
+  type EphemeralSessionRecord,
+  isEphemeralCommitSessionPath,
+  nextMessageIdFromMessages,
+  rememberEphemeralSessionRecord,
+  restoreEphemeralSessionState,
+  restoreStoredSessionState,
+} from './sessions.js';
 import {
   isModelCatalogCacheFresh,
   readModelCatalogCache,
@@ -209,15 +222,19 @@ import {
   readWorkspaceGitSnapshot,
 } from './git.js';
 import {
+  bindRewindFileChangesToToolMessage,
+  canRewindMessage,
   createDesktopRewindMetadata,
   createRewindCheckpointMetadata,
   fileChangeMetadata,
   loadRewindCheckpointSnapshot,
   loadRewindFileChange,
   nextDesktopRewindSequence,
+  pruneRewindMetadataAfterCheckpoint,
   saveRewindCheckpointSnapshot,
   saveRewindFileChange,
   toDesktopFileChange,
+  upsertRewindCheckpointMetadata,
   type DesktopRewindCheckpointSnapshot,
   type StoredDesktopRewindMetadata,
 } from './rewind.js';
@@ -250,23 +267,6 @@ export function setDesktopExtensionHostAdapter(
   adapter: DesktopExtensionHostAdapter | undefined,
 ): void {
   desktopExtensionHostAdapter = adapter;
-}
-
-const EPHEMERAL_COMMIT_SESSION_PREFIX = 'ephemeral://commit-message/';
-const MAX_EPHEMERAL_COMMIT_SESSIONS = 8;
-
-interface EphemeralSessionRecord {
-  path: string;
-  displayName: string;
-  workspaceRoot: string;
-  modifiedAtUnixMs: number;
-  messages: ConversationMessageSnapshot[];
-  llmHistory: ChatArchive['llmHistory'];
-  readOnly: true;
-}
-
-function isEphemeralCommitSessionPath(filePath: string): boolean {
-  return filePath.startsWith(EPHEMERAL_COMMIT_SESSION_PREFIX);
 }
 
 type CommandPayloads = {
@@ -1298,14 +1298,7 @@ class DesktopHostService {
       await this.ensureInitialized();
       const state = this.requireState();
       const stored = await listStoredSessions();
-      const ephemeral: SessionListItem[] = state.ephemeralSessions.map((session) => ({
-        path: session.path,
-        displayName: session.displayName,
-        modifiedAtUnixMs: session.modifiedAtUnixMs,
-        workspaceRoot: session.workspaceRoot,
-        kind: 'ephemeral',
-        readOnly: true,
-      }));
+      const ephemeral: SessionListItem[] = ephemeralSessionsToListItems(state.ephemeralSessions);
       return [...stored, ...ephemeral].sort((left, right) => right.modifiedAtUnixMs - left.modifiedAtUnixMs);
     });
   }
@@ -1376,24 +1369,16 @@ class DesktopHostService {
         }
         await this.ensureInitialized(ephemeral.workspaceRoot);
         const state = this.requireState();
-        state.messages = ephemeral.messages.map((message) => ({ ...message }));
-        state.activeSession = {
-          filePath: ephemeral.path,
-          displayName: ephemeral.displayName,
-          kind: 'ephemeral',
-          readOnly: true,
-        };
-        state.archiveHistory = ephemeral.llmHistory.map((message) => ({
-          role: message.role,
-          content: message.content,
-          imagePaths: [...message.imagePaths],
-        }));
-        state.archiveSubagentSessions = [];
-        state.rewind = createDesktopRewindMetadata();
+        const restored = restoreEphemeralSessionState(ephemeral);
+        state.messages = restored.messages;
+        state.activeSession = restored.activeSession;
+        state.archiveHistory = restored.archiveHistory;
+        state.archiveSubagentSessions = restored.archiveSubagentSessions;
+        state.rewind = restored.rewind;
         state.rewindWarnings = [];
         this.currentTurnSkills = [];
         this.pendingUnboundFileChangeIds = [];
-        this.messageIdCounter = Math.max(0, ...state.messages.map((message) => message.id)) + 1;
+        this.messageIdCounter = nextMessageIdFromMessages(state.messages);
         this.latestPendingAssistantAux = undefined;
         this.resetStreamingPlacementState(true);
         await this.refreshRuntime();
@@ -1404,34 +1389,20 @@ class DesktopHostService {
       const loaded = await loadStoredSession(filePath);
       await this.ensureInitialized(loaded.workspaceRoot);
       const state = this.requireState();
-      state.messages = loaded.desktopMessages
-        ? loaded.desktopMessages.map((message) => ({ ...message }))
-        : restoreMessagesFromArchive(loaded);
-      state.activeSession = {
-        filePath: path.resolve(filePath),
-        displayName:
-          loaded.sessionDisplayName ?? deriveDisplayNameFromMessages(state.messages),
-        kind: 'stored',
-      };
-      state.archiveHistory = loaded.llmHistory.map((message) => ({
-        role: message.role,
-        content: message.content,
-        imagePaths: [...message.imagePaths],
-      }));
-      state.archiveSubagentSessions = (loaded.subagentSessions ?? []).map((entry) => ({
-        summary: { ...entry.summary },
-        llmHistory: entry.llmHistory.map((message) => ({
-          role: message.role,
-          content: message.content,
-          imagePaths: [...message.imagePaths],
-        })),
-      }));
-      state.rewind = loaded.rewind ?? createDesktopRewindMetadata();
+      const restored = restoreStoredSessionState({
+        filePath,
+        loaded,
+        fallbackMessages: restoreMessagesFromArchive(loaded),
+      });
+      state.messages = restored.messages;
+      state.activeSession = restored.activeSession;
+      state.archiveHistory = restored.archiveHistory;
+      state.archiveSubagentSessions = restored.archiveSubagentSessions;
+      state.rewind = restored.rewind;
       state.rewindWarnings = [];
       this.currentTurnSkills = [];
       this.pendingUnboundFileChangeIds = [];
-      this.messageIdCounter =
-        Math.max(0, ...state.messages.map((message) => message.id)) + 1;
+      this.messageIdCounter = nextMessageIdFromMessages(state.messages);
       this.latestPendingAssistantAux = undefined;
       this.resetStreamingPlacementState(true);
       await this.refreshRuntime();
@@ -2100,10 +2071,7 @@ class DesktopHostService {
 
   private rememberEphemeralSession(record: EphemeralSessionRecord): void {
     const state = this.requireState();
-    state.ephemeralSessions = [
-      record,
-      ...state.ephemeralSessions.filter((session) => session.path !== record.path),
-    ].slice(0, MAX_EPHEMERAL_COMMIT_SESSIONS);
+    state.ephemeralSessions = rememberEphemeralSessionRecord(state.ephemeralSessions, record);
   }
 
   private async generateCommitMessageFromModel(): Promise<string> {
@@ -2128,7 +2096,7 @@ class DesktopHostService {
       diffStatText: commitContext.diffStatText,
       diffText: commitContext.diffText,
     });
-    const sessionPath = `${EPHEMERAL_COMMIT_SESSION_PREFIX}${Date.now()}`;
+    const sessionPath = createEphemeralCommitSessionPath();
     const baseMessages: ConversationMessageSnapshot[] = [
       {
         id: 1,
@@ -2181,19 +2149,12 @@ class DesktopHostService {
           pending: false,
         },
       ];
-      this.rememberEphemeralSession({
+      this.rememberEphemeralSession(buildCommitEphemeralSessionRecord({
         path: sessionPath,
         displayName: `[Commit] ${deriveDisplayNameFromSeed(message)}`,
         workspaceRoot: state.workspaceRoot,
-        modifiedAtUnixMs: Date.now(),
         messages: finalMessages,
-        llmHistory: finalMessages.map((entry) => ({
-          role: entry.role,
-          content: entry.content,
-          imagePaths: [],
-        })),
-        readOnly: true,
-      });
+      }));
       return message;
     } catch (error) {
       const failureMessage = `生成失败：${error instanceof Error ? error.message : String(error)}`;
@@ -2206,19 +2167,12 @@ class DesktopHostService {
           pending: false,
         },
       ];
-      this.rememberEphemeralSession({
+      this.rememberEphemeralSession(buildCommitEphemeralSessionRecord({
         path: sessionPath,
         displayName: '[Commit] 自动生成失败',
         workspaceRoot: state.workspaceRoot,
-        modifiedAtUnixMs: Date.now(),
         messages: finalMessages,
-        llmHistory: finalMessages.map((entry) => ({
-          role: entry.role,
-          content: entry.content,
-          imagePaths: [],
-        })),
-        readOnly: true,
-      });
+      }));
       throw error;
     }
   }
@@ -3149,32 +3103,11 @@ class DesktopHostService {
     messageId: number,
   ): void {
     const state = this.requireState();
-    const targetIds = new Set<string>();
-    const toolCallId = execution.toolCallId || `tool:${execution.toolName}`;
-    for (const change of state.rewind.fileChanges) {
-      if (change.messageId !== undefined) {
-        continue;
-      }
-      if (change.toolCallId === toolCallId) {
-        targetIds.add(change.id);
-      }
-    }
-    if (targetIds.size === 0) {
-      for (const id of this.pendingUnboundFileChangeIds) {
-        targetIds.add(id);
-      }
-    }
-    if (targetIds.size === 0) {
-      return;
-    }
-
-    for (const change of state.rewind.fileChanges) {
-      if (targetIds.has(change.id)) {
-        change.messageId = messageId;
-      }
-    }
-    this.pendingUnboundFileChangeIds = this.pendingUnboundFileChangeIds.filter(
-      (id) => !targetIds.has(id),
+    this.pendingUnboundFileChangeIds = bindRewindFileChangesToToolMessage(
+      state.rewind,
+      this.pendingUnboundFileChangeIds,
+      execution,
+      messageId,
     );
   }
 
@@ -3221,15 +3154,7 @@ class DesktopHostService {
       },
     );
 
-    const existing = state.rewind.checkpoints.findIndex(
-      (candidate) => candidate.messageId === messageId,
-    );
-    if (existing >= 0) {
-      state.rewind.checkpoints.splice(existing, 1, checkpoint);
-    } else {
-      state.rewind.checkpoints.push(checkpoint);
-    }
-    state.rewind.checkpoints.sort((left, right) => left.sequence - right.sequence);
+    upsertRewindCheckpointMetadata(state.rewind, checkpoint);
   }
 
   private buildRewindCheckpointSnapshot(): DesktopRewindCheckpointSnapshot {
@@ -3271,15 +3196,10 @@ class DesktopHostService {
         imagePaths: [...message.imagePaths],
       })),
     }));
-    state.rewind.checkpoints = state.rewind.checkpoints.filter(
-      (checkpoint) => checkpoint.sequence < checkpointSequence,
-    );
-    state.rewind.fileChanges = state.rewind.fileChanges.filter(
-      (change) => change.sequence <= checkpointSequence,
-    );
+    pruneRewindMetadataAfterCheckpoint(state.rewind, checkpointSequence);
     this.pendingUnboundFileChangeIds = [];
     this.latestPendingAssistantAux = undefined;
-    this.messageIdCounter = Math.max(0, ...state.messages.map((message) => message.id)) + 1;
+    this.messageIdCounter = nextMessageIdFromMessages(state.messages);
     this.resetStreamingPlacementState(true);
     this.pruneEmptyAssistantMessages('restoreBeforeRewindCheckpoint');
     this.requireRuntime().replaceFromArchive(archive);
@@ -3305,7 +3225,7 @@ class DesktopHostService {
       ...base,
       ...(tool ? { tool } : {}),
       ...(aux ? { aux } : {}),
-      ...(this.canRewindMessage(message) ? { canRewind: true } : {}),
+      ...(canRewindMessage(this.requireState().rewind, message) ? { canRewind: true } : {}),
     };
   }
 
@@ -3371,15 +3291,6 @@ class DesktopHostService {
     });
   }
 
-  private canRewindMessage(message: ConversationMessageSnapshot): boolean {
-    if (message.pending || message.role !== 'user') {
-      return false;
-    }
-    return this.requireState().rewind.checkpoints.some(
-      (checkpoint) => checkpoint.messageId === message.id,
-    );
-  }
-
   private async persistCurrentSessionIfNeeded(): Promise<void> {
     const state = this.requireState();
     if (!state.activeSession || state.activeSession.kind === 'ephemeral' || this.runtime?.isBusy()) {
@@ -3397,15 +3308,14 @@ class DesktopHostService {
           subagentSessions: state.archiveSubagentSessions ?? [],
         } satisfies ChatArchive;
 
-    const stored: StoredDesktopSession = {
-      ...archive,
-      savedAtUnixMs: Date.now(),
+    const stored = buildStoredDesktopSession({
+      archive,
       sessionDisplayName: state.activeSession.displayName,
       workspaceRoot: state.workspaceRoot,
-      ...(state.git.branch ? { gitBranch: state.git.branch } : {}),
-      desktopMessages: state.messages.map((message) => ({ ...message })),
+      gitBranch: state.git.branch,
+      desktopMessages: state.messages,
       rewind: state.rewind,
-    };
+    });
     state.activeSession.filePath = await saveStoredSession(state.activeSession.filePath, stored);
   }
 
@@ -3858,17 +3768,3 @@ function truncateText(value: string, maxChars: number): string {
   return `${chars.slice(0, maxChars).join('')}...<truncated>`;
 }
 
-function deriveDisplayNameFromSeed(seed: string): string {
-  const trimmed = seed.trim();
-  if (!trimmed) {
-    return 'New conversation';
-  }
-  return trimmed.length > 28 ? `${trimmed.slice(0, 28)}…` : trimmed;
-}
-
-function deriveDisplayNameFromMessages(messages: ConversationMessageSnapshot[]): string {
-  const firstUser = messages.find(
-    (message) => message.role === 'user' && message.content.trim().length > 0,
-  );
-  return deriveDisplayNameFromSeed(firstUser?.content ?? 'New conversation');
-}

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -1,0 +1,183 @@
+import path from 'node:path';
+
+import type { ChatArchive } from '@spirit-agent/agent-core';
+
+import type {
+  ActiveSessionSnapshot,
+  ConversationMessageSnapshot,
+  SessionListItem,
+} from '../types.js';
+import type { StoredDesktopSession } from './contracts.js';
+import { createDesktopRewindMetadata, type StoredDesktopRewindMetadata } from './rewind.js';
+
+export const EPHEMERAL_COMMIT_SESSION_PREFIX = 'ephemeral://commit-message/';
+const MAX_EPHEMERAL_COMMIT_SESSIONS = 8;
+
+export interface EphemeralSessionRecord {
+  path: string;
+  displayName: string;
+  workspaceRoot: string;
+  modifiedAtUnixMs: number;
+  messages: ConversationMessageSnapshot[];
+  llmHistory: ChatArchive['llmHistory'];
+  readOnly: true;
+}
+
+export interface RestoredSessionState {
+  messages: ConversationMessageSnapshot[];
+  activeSession: ActiveSessionSnapshot;
+  archiveHistory: ChatArchive['llmHistory'];
+  archiveSubagentSessions: NonNullable<ChatArchive['subagentSessions']>;
+  rewind: StoredDesktopRewindMetadata;
+}
+
+export function isEphemeralCommitSessionPath(filePath: string): boolean {
+  return filePath.startsWith(EPHEMERAL_COMMIT_SESSION_PREFIX);
+}
+
+export function createEphemeralCommitSessionPath(now = Date.now()): string {
+  return `${EPHEMERAL_COMMIT_SESSION_PREFIX}${now}`;
+}
+
+export function rememberEphemeralSessionRecord(
+  sessions: EphemeralSessionRecord[],
+  record: EphemeralSessionRecord,
+): EphemeralSessionRecord[] {
+  return [
+    record,
+    ...sessions.filter((session) => session.path !== record.path),
+  ].slice(0, MAX_EPHEMERAL_COMMIT_SESSIONS);
+}
+
+export function ephemeralSessionsToListItems(
+  sessions: EphemeralSessionRecord[],
+): SessionListItem[] {
+  return sessions.map((session) => ({
+    path: session.path,
+    displayName: session.displayName,
+    modifiedAtUnixMs: session.modifiedAtUnixMs,
+    workspaceRoot: session.workspaceRoot,
+    kind: 'ephemeral',
+    readOnly: true,
+  }));
+}
+
+export function buildCommitEphemeralSessionRecord(input: {
+  path: string;
+  displayName: string;
+  workspaceRoot: string;
+  messages: ConversationMessageSnapshot[];
+  modifiedAtUnixMs?: number;
+}): EphemeralSessionRecord {
+  return {
+    path: input.path,
+    displayName: input.displayName,
+    workspaceRoot: input.workspaceRoot,
+    modifiedAtUnixMs: input.modifiedAtUnixMs ?? Date.now(),
+    messages: cloneConversationMessages(input.messages),
+    llmHistory: input.messages.map((entry) => ({
+      role: entry.role,
+      content: entry.content,
+      imagePaths: [],
+    })),
+    readOnly: true,
+  };
+}
+
+export function restoreEphemeralSessionState(record: EphemeralSessionRecord): RestoredSessionState {
+  return {
+    messages: cloneConversationMessages(record.messages),
+    activeSession: {
+      filePath: record.path,
+      displayName: record.displayName,
+      kind: 'ephemeral',
+      readOnly: true,
+    },
+    archiveHistory: cloneArchiveHistory(record.llmHistory),
+    archiveSubagentSessions: [],
+    rewind: createDesktopRewindMetadata(),
+  };
+}
+
+export function restoreStoredSessionState(input: {
+  filePath: string;
+  loaded: StoredDesktopSession;
+  fallbackMessages: ConversationMessageSnapshot[];
+}): RestoredSessionState {
+  const messages = input.loaded.desktopMessages
+    ? cloneConversationMessages(input.loaded.desktopMessages)
+    : cloneConversationMessages(input.fallbackMessages);
+  return {
+    messages,
+    activeSession: {
+      filePath: path.resolve(input.filePath),
+      displayName: input.loaded.sessionDisplayName ?? deriveDisplayNameFromMessages(messages),
+      kind: 'stored',
+    },
+    archiveHistory: cloneArchiveHistory(input.loaded.llmHistory),
+    archiveSubagentSessions: cloneSubagentSessions(input.loaded.subagentSessions ?? []),
+    rewind: input.loaded.rewind ?? createDesktopRewindMetadata(),
+  };
+}
+
+export function buildStoredDesktopSession(input: {
+  archive: ChatArchive;
+  savedAtUnixMs?: number;
+  sessionDisplayName: string;
+  workspaceRoot: string;
+  gitBranch?: string;
+  desktopMessages: ConversationMessageSnapshot[];
+  rewind: StoredDesktopRewindMetadata;
+}): StoredDesktopSession {
+  return {
+    ...input.archive,
+    savedAtUnixMs: input.savedAtUnixMs ?? Date.now(),
+    sessionDisplayName: input.sessionDisplayName,
+    workspaceRoot: input.workspaceRoot,
+    ...(input.gitBranch ? { gitBranch: input.gitBranch } : {}),
+    desktopMessages: cloneConversationMessages(input.desktopMessages),
+    rewind: input.rewind,
+  };
+}
+
+export function nextMessageIdFromMessages(messages: ConversationMessageSnapshot[]): number {
+  return Math.max(0, ...messages.map((message) => message.id)) + 1;
+}
+
+export function deriveDisplayNameFromSeed(seed: string): string {
+  const trimmed = seed.trim();
+  if (!trimmed) {
+    return 'New conversation';
+  }
+  return trimmed.length > 28 ? `${trimmed.slice(0, 28)}…` : trimmed;
+}
+
+export function deriveDisplayNameFromMessages(messages: ConversationMessageSnapshot[]): string {
+  const firstUser = messages.find(
+    (message) => message.role === 'user' && message.content.trim().length > 0,
+  );
+  return deriveDisplayNameFromSeed(firstUser?.content ?? 'New conversation');
+}
+
+function cloneConversationMessages(
+  messages: ConversationMessageSnapshot[],
+): ConversationMessageSnapshot[] {
+  return messages.map((message) => ({ ...message }));
+}
+
+function cloneArchiveHistory(history: ChatArchive['llmHistory']): ChatArchive['llmHistory'] {
+  return history.map((message) => ({
+    role: message.role,
+    content: message.content,
+    imagePaths: [...message.imagePaths],
+  }));
+}
+
+function cloneSubagentSessions(
+  sessions: NonNullable<ChatArchive['subagentSessions']>,
+): NonNullable<ChatArchive['subagentSessions']> {
+  return sessions.map((entry) => ({
+    summary: { ...entry.summary },
+    llmHistory: cloneArchiveHistory(entry.llmHistory),
+  }));
+}

--- a/apps/desktop/src/host/skills.ts
+++ b/apps/desktop/src/host/skills.ts
@@ -1,0 +1,292 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+  OpenAiActiveSkill,
+  OpenAiActiveSkillResourceEntry,
+} from '@spirit-agent/agent-core';
+import {
+  resolveInstructionPaths,
+  SKILL_FILE_NAME,
+  validateSkillName,
+} from '@spirit-agent/host-internal';
+
+import type {
+  CreateSkillRequest,
+  DeleteSkillRequest,
+  DesktopSkillRootKind,
+} from '../types.js';
+import {
+  type HostMetadataSummary,
+  spiritAgentDataDir,
+} from './storage.js';
+import { formatYamlScalarForSkillFrontmatter } from './service-utils.js';
+
+const ACTIVE_SKILL_CONTENT_MAX_CHARS = 12_000;
+const ACTIVE_SKILL_RESOURCE_MAX_ENTRIES = 24;
+const ACTIVE_SKILL_RESOURCE_DIRS: ReadonlyArray<{
+  kind: OpenAiActiveSkillResourceEntry['kind'];
+  dirname: string;
+}> = [
+  { kind: 'scripts', dirname: 'scripts' },
+  { kind: 'references', dirname: 'references' },
+  { kind: 'assets', dirname: 'assets' },
+];
+
+export function desktopInstructionPaths(workspaceRoot: string) {
+  return resolveInstructionPaths({
+    workspaceRoot,
+    spiritDataDir: spiritAgentDataDir(),
+  });
+}
+
+export function parseSkillRootKind(value: unknown): DesktopSkillRootKind {
+  if (value === 'user' || value === 'workspaceSpirit' || value === 'workspaceAgents') {
+    return value;
+  }
+  throw new Error('无效的 Skill 根类型。');
+}
+
+export function resolveSkillRootDir(
+  instructionPaths: ReturnType<typeof resolveInstructionPaths>,
+  rootKind: DesktopSkillRootKind,
+): string {
+  switch (rootKind) {
+    case 'user':
+      return instructionPaths.userSkillsDir;
+    case 'workspaceSpirit':
+      return instructionPaths.workspaceSpiritSkillsDir;
+    case 'workspaceAgents':
+      return instructionPaths.workspaceAgentsSkillsDir;
+    default: {
+      const _exhaustive: never = rootKind;
+      return _exhaustive;
+    }
+  }
+}
+
+export function resolveSkillDir(
+  instructionPaths: ReturnType<typeof resolveInstructionPaths>,
+  skillDirectoryName: string,
+  rootKind: DesktopSkillRootKind,
+): string {
+  return path.join(resolveSkillRootDir(instructionPaths, rootKind), skillDirectoryName);
+}
+
+export function assertPathUnderSkillRoot(
+  instructionPaths: ReturnType<typeof resolveInstructionPaths>,
+  targetDir: string,
+  rootKind: DesktopSkillRootKind,
+): void {
+  const root = path.resolve(resolveSkillRootDir(instructionPaths, rootKind));
+  const resolved = path.resolve(targetDir);
+  if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+    throw new Error('Skill 路径不在允许的根目录内。');
+  }
+}
+
+export async function createSkillFile(
+  workspaceRoot: string,
+  request: CreateSkillRequest,
+): Promise<void> {
+  const instructionPaths = desktopInstructionPaths(workspaceRoot);
+  const rootKind = parseSkillRootKind(request.rootKind);
+  const name = request.name.trim().toLowerCase();
+  const nameIssue = validateSkillName(name);
+  if (nameIssue) {
+    throw new Error(nameIssue);
+  }
+
+  const description = (request.description ?? '').trim();
+  if (!description) {
+    throw new Error('描述不能为空。');
+  }
+  const skillDir = resolveSkillDir(instructionPaths, name, rootKind);
+  if (existsSync(skillDir)) {
+    throw new Error(`该位置已存在同名 Skill：${name}`);
+  }
+
+  const frontmatterDescription = formatYamlScalarForSkillFrontmatter(description);
+  const fileContent = `---
+name: ${name}
+description: ${frontmatterDescription}
+---
+
+在此编写技能正文：步骤、示例、边界条件与相对路径引用。
+`;
+
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(path.join(skillDir, SKILL_FILE_NAME), fileContent, 'utf8');
+}
+
+export async function deleteSkillDir(
+  workspaceRoot: string,
+  request: DeleteSkillRequest,
+): Promise<void> {
+  const instructionPaths = desktopInstructionPaths(workspaceRoot);
+  const rootKind = parseSkillRootKind(request.rootKind);
+  const name = request.name.trim().toLowerCase();
+  const nameIssue = validateSkillName(name);
+  if (nameIssue) {
+    throw new Error(nameIssue);
+  }
+
+  const skillDir = resolveSkillDir(instructionPaths, name, rootKind);
+  assertPathUnderSkillRoot(instructionPaths, skillDir, rootKind);
+
+  if (!existsSync(skillDir)) {
+    throw new Error(`Skill 不存在：${name}`);
+  }
+
+  await rm(skillDir, { recursive: true, force: true });
+}
+
+export function buildActivateSkillUserTurn(skillName: string, extraNote: string): string {
+  const trimmed = extraNote.trim();
+  if (!trimmed) {
+    return `请按 skill "${skillName}" 处理当前任务。`;
+  }
+  return trimmed;
+}
+
+const CREATE_SKILL_PROMPT_HINT =
+  '请在 /create-skill 后描述你想生成或收紧的 Skill，例如：/create-skill 做一个用于排查 Electron 白屏的 Skill';
+
+export function parseCreateSkillSlashPrompt(input: string): string | Error {
+  const trimmed = input.trim();
+  const prompt = trimmed.startsWith('/create-skill')
+    ? trimmed.slice('/create-skill'.length).trim()
+    : trimmed;
+  if (!prompt) {
+    return new Error(CREATE_SKILL_PROMPT_HINT);
+  }
+
+  return prompt;
+}
+
+export function buildCreateSkillUserTurn(
+  workspaceRoot: string,
+  instructionPaths: ReturnType<typeof resolveInstructionPaths>,
+  prompt: string,
+): string {
+  const workspaceTargetRoot = instructionPaths.workspaceSpiritSkillsDir;
+  const userTargetRoot = instructionPaths.userSkillsDir;
+
+  return `你现在在处理一个 /create-skill 请求。
+
+目标:
+- default_scope: 工作区
+- workspace_skill_root: ${workspaceTargetRoot}
+- user_skill_root: ${userTargetRoot}
+- workspace_root: ${workspaceRoot}
+
+用户需求:
+${prompt}
+
+要求:
+- 先把它当成一次正常的 assistant 对话来处理，正常流式输出，不要伪装成后台静默生成器。
+- 默认创建到工作区 skill 根目录 ${workspaceTargetRoot}；只有在用户明确要求“用户级 / 全局 / 跨仓库复用 / 写到用户目录”这类语义时，才改为用户目录 ${userTargetRoot}。
+- 你需要先根据用户需求自行决定一个合适的 skill_name；名称必须是 1-64 个字符，只能使用小写字母、数字和连字符，不能以连字符开头或结尾，也不能包含连续连字符。
+- 最终目标目录名与 frontmatter \`name\` 必须完全等于你决定的 skill_name。
+- 最终文件路径必须是 \`<选定根目录>/<skill_name>/SKILL.md\`；不要写到其他位置。
+- 如果目标 Skill 已存在，先读取原有 \`SKILL.md\`，再基于现有内容压缩重写或收紧，不要在旧内容后面继续堆砌模板化废话。
+- \`SKILL.md\` 必须以 YAML frontmatter 开头，至少包含 \`name\` 和 \`description\`；正文使用 Markdown，重点写清“做什么、何时用、怎么做”。
+- \`description\` 要具体说明适用场景，便于 agent 在 catalog 中识别。
+- Skill 是给后续 agent/LLM 直接消费的能力说明，不是给人类流程管理看的。
+- 正文优先写步骤、输入输出示例、边界条件；避免空话、组织治理废话和泛泛 checklist。
+- 需要事实时先读取仓库内相关文件，不要臆造项目结构、技术栈、目录或既有工作流。
+- 如果技能需要引用其他文件，正文里使用相对路径表达，不要假设这些文件已经存在。
+- 如果你选择工作区 scope，优先提炼当前仓库内可复用的流程知识、约束和操作步骤，避免写成泛化的团队治理文档。
+- 如果你选择用户 scope，优先提炼跨仓库稳定复用的个人工作流、判断标准与执行步骤。
+- 写入仍会经过正常审批；不要假设自己已经拿到权限，也不要在工具成功前声称“已创建”或“已更新”。
+
+交付方式:
+- 如果你能直接在目标路径落盘，就在确认内容后使用文件工具写入。
+- 如果不能直接落盘，就把最终 \`SKILL.md\` 完整贴在回复里，并明确说明未写入。`;
+}
+
+export async function buildActiveSkillPayload(
+  entry: HostMetadataSummary['skills']['entries'][number],
+): Promise<OpenAiActiveSkill> {
+  const skillRoot = path.dirname(entry.source.path);
+  const { content, truncated } = truncateActiveSkillContent(entry.content);
+  const { resources, truncated: resourcesTruncated } = await collectSkillResources(skillRoot);
+
+  return {
+    id: entry.source.id,
+    scope: entry.source.scope,
+    name: entry.source.name,
+    description: entry.source.description,
+    path: entry.source.path,
+    content,
+    truncated,
+    resources,
+    resourcesTruncated,
+  };
+}
+
+function truncateActiveSkillContent(content: string): {
+  content: string;
+  truncated: boolean;
+} {
+  const chars = [...content];
+  if (chars.length <= ACTIVE_SKILL_CONTENT_MAX_CHARS) {
+    return {
+      content: content.trim(),
+      truncated: false,
+    };
+  }
+
+  return {
+    content: `${chars.slice(0, ACTIVE_SKILL_CONTENT_MAX_CHARS).join('').trimEnd()}\n\n...<skill content truncated>`,
+    truncated: true,
+  };
+}
+
+async function collectSkillResources(skillRoot: string): Promise<{
+  resources: OpenAiActiveSkillResourceEntry[];
+  truncated: boolean;
+}> {
+  const resources: OpenAiActiveSkillResourceEntry[] = [];
+  let truncated = false;
+
+  for (const { kind, dirname } of ACTIVE_SKILL_RESOURCE_DIRS) {
+    const root = path.join(skillRoot, dirname);
+    if (!existsSync(root)) {
+      continue;
+    }
+
+    const stack = [root];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) {
+        continue;
+      }
+
+      const entries = await readdir(current, { withFileTypes: true });
+      entries.sort((left, right) => left.name.localeCompare(right.name));
+      for (const entry of entries) {
+        const fullPath = path.join(current, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(fullPath);
+          continue;
+        }
+        if (!entry.isFile()) {
+          continue;
+        }
+        if (resources.length >= ACTIVE_SKILL_RESOURCE_MAX_ENTRIES) {
+          truncated = true;
+          return { resources, truncated };
+        }
+
+        resources.push({
+          kind,
+          path: path.relative(skillRoot, fullPath).replace(/\\/gu, '/'),
+        });
+      }
+    }
+  }
+
+  return { resources, truncated };
+}

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -1,0 +1,124 @@
+import type {
+  ActiveSessionSnapshot,
+  ConversationSnapshot,
+  DesktopDreamCollectorSnapshot,
+  DesktopExtensionCssLayer,
+  DesktopExtensionListItem,
+  DesktopGitSnapshot,
+  DesktopMcpServerListItem,
+  DesktopModelCatalogHint,
+  DesktopSnapshot,
+  McpStatusSnapshot,
+} from '../types.js';
+import { readModelCatalogCacheSync } from './model-catalog-cache.js';
+import {
+  DEFAULT_API_BASE,
+  type DesktopConfigFile,
+  type HostMetadataSummary,
+} from './storage.js';
+import {
+  buildAvailableWorkspaces,
+  buildWebHostSnapshot,
+} from './service-utils.js';
+
+export interface BuildDesktopSnapshotInput {
+  workspaceRoot: string;
+  config: DesktopConfigFile;
+  git: DesktopGitSnapshot;
+  metadata: HostMetadataSummary;
+  extensionsList: DesktopExtensionListItem[];
+  extensionCss: DesktopExtensionCssLayer[];
+  dreamCollectorStatus: DesktopDreamCollectorSnapshot;
+  runtimeReady: boolean;
+  runtimeError: string;
+  modelKeyPresence: Record<string, boolean>;
+  activeApiKeyConfigured: boolean;
+  mcpStatus: McpStatusSnapshot;
+  mcpServers: DesktopMcpServerListItem[];
+  conversation: ConversationSnapshot;
+  activeSession?: ActiveSessionSnapshot;
+}
+
+export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopSnapshot {
+  return {
+    workspaceRoot: input.workspaceRoot,
+    availableWorkspaces: buildAvailableWorkspaces(
+      input.workspaceRoot,
+      input.config.recentWorkspaces,
+    ),
+    git: { ...input.git },
+    dreams: {
+      settings: {
+        enabled: input.config.dreams.enabled === true,
+        ...(input.config.dreams.collectorModel ? { collectorModel: input.config.dreams.collectorModel } : {}),
+        debugMode: input.config.dreams.debugMode === true,
+      },
+      collector: { ...input.dreamCollectorStatus },
+    },
+    runtimeReady: input.runtimeReady,
+    ...(input.runtimeError ? { runtimeError: input.runtimeError } : {}),
+    config: {
+      models: input.config.models.map((model) => ({
+        name: model.name,
+        apiBase: model.apiBase,
+        ...(model.provider ? { provider: model.provider } : {}),
+        keyConfigured: input.modelKeyPresence[model.name] ?? false,
+      })),
+      activeModel: input.config.activeModel,
+      ...(input.config.uiLocale ? { uiLocale: input.config.uiLocale } : {}),
+      activeApiKeyConfigured: input.activeApiKeyConfigured,
+      windowsMica: input.config.windowsMica !== false,
+      planMode: input.config.planMode === true,
+      modelCatalogHints: buildModelCatalogHints(input.config),
+    },
+    webHost: buildWebHostSnapshot(input.config.webHost),
+    rules: {
+      discovered: input.metadata.rules.discovered,
+      enabled: input.metadata.rules.enabled,
+    },
+    skills: {
+      discovered: input.metadata.skills.discovered,
+      enabled: input.metadata.skills.enabled,
+    },
+    skillsList: input.metadata.skills.entries.map((entry) => ({
+      id: entry.source.id,
+      name: entry.source.name,
+      description: entry.source.description,
+      shortLabel: entry.source.shortLabel,
+      scope: entry.source.scope,
+      rootKind: entry.source.rootKind,
+      enabled: entry.enabled,
+    })),
+    extensionsList: input.extensionsList.map((item) => ({ ...item })),
+    extensionCss: input.extensionCss.map((entry) => ({ ...entry })),
+    plan: {
+      path: input.metadata.planMetadata.path,
+      exists: input.metadata.planMetadata.exists,
+    },
+    mcpStatus: input.mcpStatus,
+    mcpServers: input.mcpServers,
+    conversation: input.conversation,
+    ...(input.activeSession ? { activeSession: { ...input.activeSession } } : {}),
+  };
+}
+
+export function buildModelCatalogHints(config: DesktopConfigFile): DesktopModelCatalogHint[] {
+  const seen = new Set<string>();
+  const hints: DesktopModelCatalogHint[] = [];
+  for (const model of config.models) {
+    const base = model.apiBase.trim() || DEFAULT_API_BASE;
+    if (seen.has(base)) {
+      continue;
+    }
+    seen.add(base);
+    const hit = readModelCatalogCacheSync(base);
+    if (hit && hit.modelIds.length > 0) {
+      hints.push({
+        apiBase: hit.apiBase,
+        modelIds: hit.modelIds,
+        fetchedAtUnixMs: hit.fetchedAtUnixMs,
+      });
+    }
+  }
+  return hints;
+}

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -30,7 +30,7 @@ export interface BuildDesktopSnapshotInput {
   extensionCss: DesktopExtensionCssLayer[];
   dreamCollectorStatus: DesktopDreamCollectorSnapshot;
   runtimeReady: boolean;
-  runtimeError: string;
+  runtimeError?: string;
   modelKeyPresence: Record<string, boolean>;
   activeApiKeyConfigured: boolean;
   mcpStatus: McpStatusSnapshot;

--- a/apps/desktop/src/host/workspace-files.ts
+++ b/apps/desktop/src/host/workspace-files.ts
@@ -1,0 +1,117 @@
+import { Buffer } from 'node:buffer';
+import { readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+  WorkspaceExplorerEntry,
+  WorkspaceExplorerListResult,
+  WorkspaceReadTextFileResult,
+  WriteWorkspaceTextFileRequest,
+} from '../types.js';
+
+/** 单文件上限，避免大文件拖垮渲染进程。 */
+const WORKSPACE_TEXT_FILE_MAX_BYTES = 2 * 1024 * 1024;
+
+/**
+ * 将工作区相对路径解析为绝对路径；使用 `/` 分段，禁止 `..` 与绝对路径。
+ */
+export function resolveWorkspaceRelativePath(workspaceRoot: string, relativePath: string): string {
+  const root = path.resolve(workspaceRoot);
+  const cleaned = relativePath.replace(/\0/g, '');
+  const posix = cleaned.replace(/\\/g, '/').trim();
+  if (posix.startsWith('/') || /^[a-zA-Z]:/.test(posix)) {
+    throw new Error('无效路径');
+  }
+  const segments = posix.split('/').filter((segment) => segment.length > 0);
+  for (const segment of segments) {
+    if (segment === '..' || segment === '.') {
+      throw new Error('无效路径');
+    }
+  }
+  const target = segments.length === 0 ? root : path.resolve(root, ...segments);
+  const rel = path.relative(root, target);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error('路径越出工作区');
+  }
+  return target;
+}
+
+export async function listWorkspaceExplorerChildren(
+  workspaceRoot: string,
+  relativePath: string,
+): Promise<WorkspaceExplorerListResult> {
+  const dir = resolveWorkspaceRelativePath(workspaceRoot, relativePath);
+  let fileStat;
+  try {
+    fileStat = await stat(dir);
+  } catch {
+    return { entries: [] };
+  }
+  if (!fileStat.isDirectory()) {
+    return { entries: [] };
+  }
+  const dirents = await readdir(dir, { withFileTypes: true });
+  const entries: WorkspaceExplorerEntry[] = dirents
+    .filter((dirent) => dirent.name && dirent.name !== '.' && dirent.name !== '..')
+    .map((dirent) => ({
+      name: dirent.name,
+      kind: dirent.isDirectory() ? 'dir' : 'file',
+    }));
+  entries.sort((left, right) => {
+    if (left.kind !== right.kind) {
+      return left.kind === 'dir' ? -1 : 1;
+    }
+    return left.name.localeCompare(right.name, undefined, { sensitivity: 'base' });
+  });
+  return { entries };
+}
+
+export async function readWorkspaceTextFile(
+  workspaceRoot: string,
+  relativePath: string,
+): Promise<WorkspaceReadTextFileResult> {
+  const posix = relativePath.replace(/\0/g, '').replace(/\\/g, '/').trim();
+  if (!posix) {
+    throw new Error('未指定文件路径');
+  }
+  const filePath = resolveWorkspaceRelativePath(workspaceRoot, relativePath);
+  let fileStat;
+  try {
+    fileStat = await stat(filePath);
+  } catch {
+    throw new Error('文件不存在或无法访问');
+  }
+  if (!fileStat.isFile()) {
+    throw new Error('不是文件');
+  }
+  if (fileStat.size > WORKSPACE_TEXT_FILE_MAX_BYTES) {
+    throw new Error('文件过大，无法在侧栏打开');
+  }
+  const buffer = await readFile(filePath);
+  return { text: buffer.toString('utf8') };
+}
+
+export async function writeWorkspaceTextFile(
+  workspaceRoot: string,
+  request: WriteWorkspaceTextFileRequest,
+): Promise<void> {
+  const posix = request.relativePath.replace(/\0/g, '').replace(/\\/g, '/').trim();
+  if (!posix) {
+    throw new Error('未指定文件路径');
+  }
+  const filePath = resolveWorkspaceRelativePath(workspaceRoot, request.relativePath);
+  let fileStat;
+  try {
+    fileStat = await stat(filePath);
+  } catch {
+    throw new Error('文件不存在或无法访问');
+  }
+  if (!fileStat.isFile()) {
+    throw new Error('只能保存为普通文件');
+  }
+  const bytes = Buffer.byteLength(request.text, 'utf8');
+  if (bytes > WORKSPACE_TEXT_FILE_MAX_BYTES) {
+    throw new Error('内容过大，无法保存');
+  }
+  await writeFile(filePath, request.text, 'utf8');
+}

--- a/apps/desktop/src/host/workspace-files.ts
+++ b/apps/desktop/src/host/workspace-files.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { readFile, readdir, stat, writeFile } from 'node:fs/promises';
+import { lstat, readFile, readdir, realpath, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type {
@@ -15,8 +15,12 @@ const WORKSPACE_TEXT_FILE_MAX_BYTES = 2 * 1024 * 1024;
 /**
  * 将工作区相对路径解析为绝对路径；使用 `/` 分段，禁止 `..` 与绝对路径。
  */
-export function resolveWorkspaceRelativePath(workspaceRoot: string, relativePath: string): string {
+export async function resolveWorkspaceRelativePath(
+  workspaceRoot: string,
+  relativePath: string,
+): Promise<string> {
   const root = path.resolve(workspaceRoot);
+  const canonicalRoot = await realpath(root);
   const cleaned = relativePath.replace(/\0/g, '');
   const posix = cleaned.replace(/\\/g, '/').trim();
   if (posix.startsWith('/') || /^[a-zA-Z]:/.test(posix)) {
@@ -28,11 +32,41 @@ export function resolveWorkspaceRelativePath(workspaceRoot: string, relativePath
       throw new Error('无效路径');
     }
   }
+
   const target = segments.length === 0 ? root : path.resolve(root, ...segments);
   const rel = path.relative(root, target);
   if (rel.startsWith('..') || path.isAbsolute(rel)) {
     throw new Error('路径越出工作区');
   }
+
+  let current = root;
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    try {
+      const entry = await lstat(current);
+      if (entry.isSymbolicLink()) {
+        throw new Error('路径包含符号链接');
+      }
+    } catch (error) {
+      if (error instanceof Error && error.message === '路径包含符号链接') {
+        throw error;
+      }
+      break;
+    }
+  }
+
+  try {
+    const canonicalTarget = await realpath(target);
+    const canonicalRel = path.relative(canonicalRoot, canonicalTarget);
+    if (canonicalRel.startsWith('..') || path.isAbsolute(canonicalRel)) {
+      throw new Error('路径越出工作区');
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message === '路径越出工作区') {
+      throw error;
+    }
+  }
+
   return target;
 }
 
@@ -40,7 +74,7 @@ export async function listWorkspaceExplorerChildren(
   workspaceRoot: string,
   relativePath: string,
 ): Promise<WorkspaceExplorerListResult> {
-  const dir = resolveWorkspaceRelativePath(workspaceRoot, relativePath);
+  const dir = await resolveWorkspaceRelativePath(workspaceRoot, relativePath);
   let fileStat;
   try {
     fileStat = await stat(dir);
@@ -74,7 +108,7 @@ export async function readWorkspaceTextFile(
   if (!posix) {
     throw new Error('未指定文件路径');
   }
-  const filePath = resolveWorkspaceRelativePath(workspaceRoot, relativePath);
+  const filePath = await resolveWorkspaceRelativePath(workspaceRoot, relativePath);
   let fileStat;
   try {
     fileStat = await stat(filePath);
@@ -99,7 +133,7 @@ export async function writeWorkspaceTextFile(
   if (!posix) {
     throw new Error('未指定文件路径');
   }
-  const filePath = resolveWorkspaceRelativePath(workspaceRoot, request.relativePath);
+  const filePath = await resolveWorkspaceRelativePath(workspaceRoot, request.relativePath);
   let fileStat;
   try {
     fileStat = await stat(filePath);


### PR DESCRIPTION
- **refactor(desktop): 提取 host service 纯工具与内部上下文**
- **refactor(desktop): 提取 workspace mcp 与 skill 命令**
- **refactor(desktop): 提取扩展与市场协调逻辑**
- **refactor(desktop): 提取 dream collector 与提交信息编排**
- **refactor(desktop): 提取会话状态与 rewind 绑定逻辑**
- **refactor(desktop): 提取消息快照流水线**
- **refactor(desktop): 提取桌面 runtime 工厂**
- **fix(desktop): 避免梦境收集器因审批退避**
- **chore(desktop): 建立消息流解耦基线**
- **refactor(desktop): 提取桌面宿主快照装配器**
- **refactor(desktop): 提取会话快照与子代理状态视图**
- **refactor(desktop): 提取 assistant 消息状态机**
- **refactor(desktop): 提取 runtime 事件编排**
- **chore(desktop): 完成消息流解耦验收**
- **fix(desktop): 解决 Reivew 问题**
