### PR TITLE
fix(ci): 将 macOS x64 Release runner 迁移至 macos-15-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
             rust_target: aarch64-unknown-linux-gnu
             package_target: linux-arm64
             builder: cross
-          - os: macos-13
+          - os: macos-15-intel
             rust_target: x86_64-apple-darwin
             package_target: macos-x64
             builder: cargo
@@ -154,7 +154,7 @@ jobs:
             platform: linux
             arch: arm64
             package_target: linux-arm64
-          - os: macos-13
+          - os: macos-15-intel
             platform: mac
             arch: x64
             package_target: macos-x64


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

Release 工作流中 macOS x64（CLI 与 Desktop）使用已弃用的 `macos-13` runner，任务无法排队，导致 CI 长时间卡住。macOS arm64 使用 `macos-14` 不受影响。

## 修改

将 `.github/workflows/release.yml` 中两处 `macos-13` 替换为 GitHub 官方为 Intel x64 提供的 `macos-15-intel`：

- `cli` job：`macos-x64` 矩阵项
- `desktop` job：`macos-x64` 矩阵项

参考：[actions/runner-images#13045](https://github.com/actions/runner-images/issues/13045)

## 说明

`macos-15-intel` 为 macOS 15 上的 Intel x86_64 镜像，可继续使用至 2027 年 8 月；之后 GitHub Actions 将不再提供 macOS x64 托管 runner。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4cbce50-4648-43aa-b0c2-4fcf5534fc91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4cbce50-4648-43aa-b0c2-4fcf5534fc91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

