### PR TITLE
fix(release): 修复 Release 上传目录导致发布失败

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.package_target }}
-          path: apps/desktop/release/*
+          # electron-builder leaves *-unpacked dirs when packaging Linux; exclude them.
+          path: |
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.deb
+            apps/desktop/release/*.dmg
+            apps/desktop/release/*.exe
+            apps/desktop/release/*.zip
           if-no-files-found: error
 
   publish:
@@ -240,8 +246,13 @@ jobs:
           Desktop artifacts are unsigned unless signing secrets are configured.
           EOF
           )"
+          mapfile -d '' -t assets < <(find release-assets -maxdepth 1 -type f -print0)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "No release assets found under release-assets" >&2
+            exit 1
+          fi
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" release-assets/* --clobber
+            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
           else
-            gh release create "$RELEASE_TAG" release-assets/* --title "$RELEASE_TAG" --notes "$notes"
+            gh release create "$RELEASE_TAG" "${assets[@]}" --title "$RELEASE_TAG" --notes "$notes"
           fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

`Publish GitHub Release` 使用 `gh release upload release-assets/*` 时，会把 electron-builder 在 Linux 打包留下的 `linux-arm64-unpacked` 等**目录**一并传给 GitHub API，导致：

```
read release-assets/linux-arm64-unpacked: is a directory
```

## 原因

构建 AppImage / deb 时，electron-builder 会先写出 `linux-<arch>-unpacked` 再打包；`apps/desktop/release/*` 与 `release-assets/*` 的 shell 通配符会把这些目录也算进去。

## 修改

1. **Desktop artifact**：只上传 `.AppImage`、`.deb`、`.dmg`、`.exe`、`.zip` 等安装包文件。
2. **Publish**：用 `find release-assets -maxdepth 1 -type f` 收集顶层文件再上传，避免目录或子目录内杂项文件进入 Release。

合并后需重新打 tag 或重跑 Release 工作流以完成 `v0.1.0` 发布。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4cbce50-4648-43aa-b0c2-4fcf5534fc91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4cbce50-4648-43aa-b0c2-4fcf5534fc91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

