### PR TITLE
feat(desktop): Desktop 系统通知与 Windows 审批 Toast

### DIFF
--- a/apps/desktop/electron/desktop-attention.ts
+++ b/apps/desktop/electron/desktop-attention.ts
@@ -1,0 +1,53 @@
+import { BrowserWindow } from 'electron';
+
+let mainWindowRef: BrowserWindow | undefined;
+let pendingApproval = false;
+let pendingQuestions = false;
+let pendingTaskComplete = false;
+let flashFrameActive = false;
+
+function shouldRequestAttention(away: boolean): boolean {
+  return away && (pendingApproval || pendingQuestions || pendingTaskComplete);
+}
+
+export function registerDesktopAttention(mainWindow: BrowserWindow): void {
+  mainWindowRef = mainWindow;
+}
+
+export function setDesktopAttentionPending(flags: {
+  needsApproval?: boolean;
+  needsQuestions?: boolean;
+  needsTaskComplete?: boolean;
+}): void {
+  if (typeof flags.needsApproval === 'boolean') {
+    pendingApproval = flags.needsApproval;
+  }
+  if (typeof flags.needsQuestions === 'boolean') {
+    pendingQuestions = flags.needsQuestions;
+  }
+  if (typeof flags.needsTaskComplete === 'boolean') {
+    pendingTaskComplete = flags.needsTaskComplete;
+  }
+}
+
+/** Sync taskbar flash when user is away and something needs attention. */
+export function refreshDesktopAttention(away: boolean): void {
+  if (!away) {
+    pendingTaskComplete = false;
+  }
+
+  const active = shouldRequestAttention(away);
+  if (active === flashFrameActive) {
+    return;
+  }
+
+  flashFrameActive = active;
+  const window = mainWindowRef;
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+
+  if (process.platform === 'win32' || process.platform === 'linux') {
+    window.flashFrame(active);
+  }
+}

--- a/apps/desktop/electron/desktop-notifications.ts
+++ b/apps/desktop/electron/desktop-notifications.ts
@@ -1,5 +1,12 @@
 import { app, BrowserWindow, Notification } from 'electron';
 
+import {
+  buildWindowsToastXml,
+  parseWindowsToastActivation,
+  resolveNotificationActionIndex,
+  shouldUseWindowsToastXml,
+} from '../src/lib/windows-toast-xml.js';
+
 const DESKTOP_APP_USER_MODEL_ID = 'ai.spiritagent.desktop';
 
 export type DesktopNotificationAction = {
@@ -24,6 +31,8 @@ export type ApprovalNotificationHandler = (
 let mainWindowRef: BrowserWindow | undefined;
 let approvalHandler: ApprovalNotificationHandler | undefined;
 let permissionRequested = false;
+let windowsActivationHandlerRegistered = false;
+let approvalActionInFlight = false;
 
 const activeTags = new Map<string, Notification>();
 
@@ -37,6 +46,72 @@ function focusMainWindow(): void {
   }
   window.show();
   window.focus();
+}
+
+function handleApprovalActionIndex(index: number | undefined): void {
+  if (index !== 0 && index !== 1) {
+    focusMainWindow();
+    return;
+  }
+  void (async () => {
+    if (approvalActionInFlight) {
+      return;
+    }
+    approvalActionInFlight = true;
+    try {
+      if (index === 0) {
+        await approvalHandler?.('allow');
+      } else {
+        await approvalHandler?.('deny');
+      }
+    } finally {
+      approvalActionInFlight = false;
+      focusMainWindow();
+    }
+  })();
+}
+
+function handleWindowsToastActivation(details: {
+  type?: string;
+  actionIndex?: number;
+  arguments?: string;
+}): void {
+  const parsed = parseWindowsToastActivation(details);
+  if (parsed.kind === 'action') {
+    handleApprovalActionIndex(parsed.actionIndex);
+    return;
+  }
+  focusMainWindow();
+}
+
+function registerWindowsNotificationActivationHandler(): void {
+  if (windowsActivationHandlerRegistered || process.platform !== 'win32') {
+    return;
+  }
+  const notificationWithActivation = Notification as typeof Notification & {
+    handleActivation?: (
+      callback: (details: {
+        type?: string;
+        actionIndex?: number;
+        arguments?: string;
+      }) => void,
+    ) => void;
+  };
+  if (typeof notificationWithActivation.handleActivation !== 'function') {
+    return;
+  }
+  windowsActivationHandlerRegistered = true;
+  notificationWithActivation.handleActivation((details) => {
+    handleWindowsToastActivation(details);
+  });
+}
+
+/** Register early in `app.whenReady()` so toast button clicks are not missed. */
+export function registerWindowsToastActivationHandler(): void {
+  if (process.platform === 'win32') {
+    app.setAppUserModelId(DESKTOP_APP_USER_MODEL_ID);
+    registerWindowsNotificationActivationHandler();
+  }
 }
 
 async function ensureNotificationPermission(): Promise<boolean> {
@@ -66,10 +141,7 @@ export function registerDesktopNotifications(
 ): void {
   mainWindowRef = mainWindow;
   approvalHandler = options?.onApprovalAction;
-
-  if (process.platform === 'win32') {
-    app.setAppUserModelId(DESKTOP_APP_USER_MODEL_ID);
-  }
+  registerWindowsToastActivationHandler();
 }
 
 export function setApprovalNotificationHandler(handler: ApprovalNotificationHandler | undefined): void {
@@ -90,30 +162,32 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
     }
   }
 
-  const notification = new Notification({
-    title: payload.title,
-    body: payload.body,
-    silent: payload.silent === true,
-    ...(tag ? { tag } : {}),
-    ...(payload.actions && payload.actions.length > 0
-      ? { actions: payload.actions }
-      : {}),
-  });
+  const useWindowsToastXml =
+    process.platform === 'win32' && shouldUseWindowsToastXml(payload);
+
+  const notification = useWindowsToastXml
+    ? new Notification({
+        toastXml: buildWindowsToastXml(payload),
+        silent: payload.silent === true,
+        ...(tag ? { tag } : {}),
+      })
+    : new Notification({
+        title: payload.title,
+        body: payload.body,
+        silent: payload.silent === true,
+        ...(tag ? { tag } : {}),
+        ...(payload.actions && payload.actions.length > 0
+          ? { actions: payload.actions }
+          : {}),
+      });
 
   notification.on('click', () => {
     focusMainWindow();
   });
 
   if (payload.kind === 'approval' && payload.actions && payload.actions.length > 0) {
-    notification.on('action', (_event, index) => {
-      void (async () => {
-        if (index === 0) {
-          await approvalHandler?.('allow');
-        } else if (index === 1) {
-          await approvalHandler?.('deny');
-        }
-        focusMainWindow();
-      })();
+    notification.on('action', (event, legacyIndex) => {
+      handleApprovalActionIndex(resolveNotificationActionIndex(event, legacyIndex));
     });
   }
 

--- a/apps/desktop/electron/desktop-notifications.ts
+++ b/apps/desktop/electron/desktop-notifications.ts
@@ -1,0 +1,131 @@
+import { app, BrowserWindow, Notification } from 'electron';
+
+const DESKTOP_APP_USER_MODEL_ID = 'ai.spiritagent.desktop';
+
+export type DesktopNotificationAction = {
+  type: 'button';
+  text: string;
+};
+
+export type DesktopNotificationPayload = {
+  title: string;
+  body?: string;
+  tag?: string;
+  silent?: boolean;
+  actions?: DesktopNotificationAction[];
+  /** When set, action index 0/1 map to allow/deny approval. */
+  kind?: 'task-complete' | 'approval' | 'ask-questions' | 'generic';
+};
+
+export type ApprovalNotificationHandler = (
+  decision: 'allow' | 'deny',
+) => Promise<void>;
+
+let mainWindowRef: BrowserWindow | undefined;
+let approvalHandler: ApprovalNotificationHandler | undefined;
+let permissionRequested = false;
+
+const activeTags = new Map<string, Notification>();
+
+function focusMainWindow(): void {
+  const window = mainWindowRef;
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+  if (window.isMinimized()) {
+    window.restore();
+  }
+  window.show();
+  window.focus();
+}
+
+async function ensureNotificationPermission(): Promise<boolean> {
+  if (!Notification.isSupported()) {
+    return false;
+  }
+  if (process.platform !== 'darwin') {
+    return true;
+  }
+  const notificationWithPermission = Notification as typeof Notification & {
+    requestPermission?: () => Promise<'granted' | 'denied' | 'default'>;
+  };
+  if (!permissionRequested && typeof notificationWithPermission.requestPermission === 'function') {
+    permissionRequested = true;
+    try {
+      await notificationWithPermission.requestPermission();
+    } catch {
+      // ignore permission errors
+    }
+  }
+  return true;
+}
+
+export function registerDesktopNotifications(
+  mainWindow: BrowserWindow,
+  options?: { onApprovalAction?: ApprovalNotificationHandler },
+): void {
+  mainWindowRef = mainWindow;
+  approvalHandler = options?.onApprovalAction;
+
+  if (process.platform === 'win32') {
+    app.setAppUserModelId(DESKTOP_APP_USER_MODEL_ID);
+  }
+}
+
+export function setApprovalNotificationHandler(handler: ApprovalNotificationHandler | undefined): void {
+  approvalHandler = handler;
+}
+
+export async function showDesktopNotification(payload: DesktopNotificationPayload): Promise<boolean> {
+  if (!(await ensureNotificationPermission())) {
+    return false;
+  }
+
+  const tag = payload.tag?.trim() || undefined;
+  if (tag) {
+    const previous = activeTags.get(tag);
+    if (previous) {
+      previous.close();
+      activeTags.delete(tag);
+    }
+  }
+
+  const notification = new Notification({
+    title: payload.title,
+    body: payload.body,
+    silent: payload.silent === true,
+    ...(tag ? { tag } : {}),
+    ...(payload.actions && payload.actions.length > 0
+      ? { actions: payload.actions }
+      : {}),
+  });
+
+  notification.on('click', () => {
+    focusMainWindow();
+  });
+
+  if (payload.kind === 'approval' && payload.actions && payload.actions.length > 0) {
+    notification.on('action', (_event, index) => {
+      void (async () => {
+        if (index === 0) {
+          await approvalHandler?.('allow');
+        } else if (index === 1) {
+          await approvalHandler?.('deny');
+        }
+        focusMainWindow();
+      })();
+    });
+  }
+
+  notification.on('close', () => {
+    if (tag) {
+      activeTags.delete(tag);
+    }
+  });
+
+  notification.show();
+  if (tag) {
+    activeTags.set(tag, notification);
+  }
+  return true;
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -613,11 +613,11 @@ async function createMainWindow(): Promise<BrowserWindow> {
 
 if (gotSpiritSingleInstanceLock) {
   app.whenReady().then(async () => {
-  handleSpiritNotificationProtocolArgv(process.argv);
   bindSpiritNotificationProtocolHandlers({
     onApproval: handleApprovalNotificationAction,
     onFocus: focusSpiritDesktopWindows,
   });
+  handleSpiritNotificationProtocolArgv(process.argv);
   registerWindowsToastActivationHandler();
   if (process.platform === 'win32') {
     Menu.setApplicationMenu(null);

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -18,6 +18,16 @@ import {
   type WebContents,
 } from 'electron';
 
+import {
+  registerDesktopNotifications,
+  showDesktopNotification,
+  type DesktopNotificationPayload,
+} from './desktop-notifications.js';
+import {
+  getAppAwayFromUser,
+  registerWindowPresence,
+  setRendererVisibility,
+} from './window-presence.js';
 import { openSystemTerminalInDirectory } from './open-system-terminal.js';
 import { WorkspacePtyManager } from './workspace-pty.js';
 import { isAllowedExternalUrl, getCachedLocalListeningEndpoints, getScanningPromise, startLocalListenersScan } from './local-listeners.js';
@@ -199,6 +209,25 @@ async function stopDesktopWebHostIfRunning(): Promise<void> {
     return;
   }
   await desktopWebHost.stop();
+}
+
+async function handleApprovalNotificationAction(decision: 'allow' | 'deny'): Promise<void> {
+  try {
+    const polled = await invokeMainDesktopHostCommand('poll');
+    if (!isDesktopSnapshot(polled) || !polled.conversation.pendingToolApproval) {
+      return;
+    }
+    await invokeMainDesktopHostCommand('replyPendingApproval', {
+      decision: { kind: decision },
+    });
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send('desktop:notify-refresh');
+      }
+    }
+  } catch (error) {
+    console.error('[spirit-desktop] approval notification action failed:', error);
+  }
 }
 
 async function invokeMainDesktopHostCommand(
@@ -526,6 +555,11 @@ async function createMainWindow(): Promise<BrowserWindow> {
     workspacePtyManager.disposeAllForWebContents(webContentsId);
   });
 
+  registerDesktopNotifications(window, {
+    onApprovalAction: handleApprovalNotificationAction,
+  });
+  registerWindowPresence(window);
+
   return window;
 }
 
@@ -782,6 +816,23 @@ app.whenReady().then(async () => {
         sender.send('desktop:local-listeners-done');
       }
     });
+  });
+
+  ipcMain.handle('desktop:show-notification', async (_event, payload: DesktopNotificationPayload) => {
+    if (!getAppAwayFromUser()) {
+      return false;
+    }
+    if (!payload || typeof payload.title !== 'string' || !payload.title.trim()) {
+      return false;
+    }
+    return showDesktopNotification(payload);
+  });
+
+  ipcMain.handle('desktop:get-app-away', () => getAppAwayFromUser());
+
+  ipcMain.handle('desktop:report-renderer-visibility', (_event, payload: { hidden?: boolean }) => {
+    setRendererVisibility(payload?.hidden === true);
+    return getAppAwayFromUser();
   });
 
   await syncInitialDesktopWebHost();

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   registerDesktopNotifications,
+  registerWindowsToastActivationHandler,
   showDesktopNotification,
   type DesktopNotificationPayload,
 } from './desktop-notifications.js';
@@ -28,6 +29,12 @@ import {
   setDesktopAttentionPending,
   refreshDesktopAttention,
 } from './desktop-attention.js';
+import {
+  bindSpiritNotificationProtocolHandlers,
+  handleSpiritNotificationProtocolArgv,
+  installSpiritNotificationProtocolRouting,
+  registerSpiritNotificationProtocolClient,
+} from './notification-protocol.js';
 import {
   getAppAwayFromUser,
   registerWindowPresence,
@@ -40,6 +47,31 @@ import { isAllowedExternalUrl, getCachedLocalListeningEndpoints, getScanningProm
 import type { DesktopSnapshot } from '../src/types.js';
 
 const spiritWebviewHooksAttached = new WeakSet<WebContents>();
+
+registerSpiritNotificationProtocolClient();
+installSpiritNotificationProtocolRouting();
+
+const gotSpiritSingleInstanceLock = app.requestSingleInstanceLock();
+if (!gotSpiritSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', (_event, argv) => {
+    handleSpiritNotificationProtocolArgv(argv);
+  });
+}
+
+function focusSpiritDesktopWindows(): void {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (window.isDestroyed()) {
+      continue;
+    }
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
+  }
+}
 
 function sendBrowserOpenUrlToHost(guestContents: WebContents, url: string): void {
   if (!isAllowedExternalUrl(url)) {
@@ -217,17 +249,27 @@ async function stopDesktopWebHostIfRunning(): Promise<void> {
 }
 
 async function handleApprovalNotificationAction(decision: 'allow' | 'deny'): Promise<void> {
-  try {
-    const polled = await invokeMainDesktopHostCommand('poll');
-    if (!isDesktopSnapshot(polled) || !polled.conversation.pendingToolApproval) {
-      return;
+  let deliveredToRenderer = false;
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (window.isDestroyed() || window.webContents.isDestroyed()) {
+      continue;
     }
-    await invokeMainDesktopHostCommand('replyPendingApproval', {
+    window.webContents.send('desktop:approval-from-notification', { decision });
+    deliveredToRenderer = true;
+  }
+  if (deliveredToRenderer) {
+    return;
+  }
+
+  try {
+    const next = await invokeMainDesktopHostCommand('replyPendingApproval', {
       decision: { kind: decision },
     });
-    for (const window of BrowserWindow.getAllWindows()) {
-      if (!window.isDestroyed()) {
-        window.webContents.send('desktop:notify-refresh');
+    if (isDesktopSnapshot(next)) {
+      for (const window of BrowserWindow.getAllWindows()) {
+        if (!window.isDestroyed()) {
+          window.webContents.send('desktop:notify-refresh');
+        }
       }
     }
   } catch (error) {
@@ -569,7 +611,14 @@ async function createMainWindow(): Promise<BrowserWindow> {
   return window;
 }
 
-app.whenReady().then(async () => {
+if (gotSpiritSingleInstanceLock) {
+  app.whenReady().then(async () => {
+  handleSpiritNotificationProtocolArgv(process.argv);
+  bindSpiritNotificationProtocolHandlers({
+    onApproval: handleApprovalNotificationAction,
+    onFocus: focusSpiritDesktopWindows,
+  });
+  registerWindowsToastActivationHandler();
   if (process.platform === 'win32') {
     Menu.setApplicationMenu(null);
   }
@@ -864,7 +913,8 @@ app.whenReady().then(async () => {
       await createMainWindow();
     }
   });
-});
+  });
+}
 
 app.on('before-quit', (event) => {
   unsubscribeDesktopDreamUpdates?.();

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -24,6 +24,11 @@ import {
   type DesktopNotificationPayload,
 } from './desktop-notifications.js';
 import {
+  registerDesktopAttention,
+  setDesktopAttentionPending,
+  refreshDesktopAttention,
+} from './desktop-attention.js';
+import {
   getAppAwayFromUser,
   registerWindowPresence,
   setRendererVisibility,
@@ -558,6 +563,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
   registerDesktopNotifications(window, {
     onApprovalAction: handleApprovalNotificationAction,
   });
+  registerDesktopAttention(window);
   registerWindowPresence(window);
 
   return window;
@@ -834,6 +840,21 @@ app.whenReady().then(async () => {
     setRendererVisibility(payload?.hidden === true);
     return getAppAwayFromUser();
   });
+
+  ipcMain.handle(
+    'desktop:sync-attention-pending',
+    (
+      _event,
+      payload: { needsApproval?: boolean; needsQuestions?: boolean; needsTaskComplete?: boolean },
+    ) => {
+      setDesktopAttentionPending({
+        needsApproval: payload?.needsApproval === true,
+        needsQuestions: payload?.needsQuestions === true,
+        needsTaskComplete: payload?.needsTaskComplete === true,
+      });
+      refreshDesktopAttention(getAppAwayFromUser());
+    },
+  );
 
   await syncInitialDesktopWebHost();
   await createMainWindow();

--- a/apps/desktop/electron/notification-protocol.ts
+++ b/apps/desktop/electron/notification-protocol.ts
@@ -1,0 +1,66 @@
+import path from 'node:path';
+
+import { app } from 'electron';
+
+import {
+  SPIRIT_NOTIFICATION_PROTOCOL,
+  findSpiritNotificationProtocolUrl,
+  parseSpiritNotificationProtocolUrl,
+} from '../src/lib/spirit-notification-protocol.js';
+
+export type SpiritNotificationProtocolHandlers = {
+  onApproval: (decision: 'allow' | 'deny') => void | Promise<void>;
+  onFocus?: () => void;
+};
+
+let handlers: SpiritNotificationProtocolHandlers | undefined;
+
+export function registerSpiritNotificationProtocolClient(): void {
+  if (process.platform !== 'win32') {
+    return;
+  }
+  if (process.defaultApp) {
+    if (process.argv.length >= 2) {
+      app.setAsDefaultProtocolClient(SPIRIT_NOTIFICATION_PROTOCOL, process.execPath, [
+        path.resolve(process.argv[1]),
+      ]);
+    }
+  } else {
+    app.setAsDefaultProtocolClient(SPIRIT_NOTIFICATION_PROTOCOL);
+  }
+}
+
+export function bindSpiritNotificationProtocolHandlers(
+  next: SpiritNotificationProtocolHandlers,
+): void {
+  handlers = next;
+}
+
+export function handleSpiritNotificationProtocolArgv(argv: readonly string[]): void {
+  const rawUrl = findSpiritNotificationProtocolUrl(argv);
+  if (!rawUrl) {
+    return;
+  }
+  dispatchSpiritNotificationProtocolUrl(rawUrl);
+}
+
+function dispatchSpiritNotificationProtocolUrl(rawUrl: string): void {
+  const parsed = parseSpiritNotificationProtocolUrl(rawUrl);
+  if (!parsed || !handlers) {
+    return;
+  }
+  if (parsed.kind === 'approval') {
+    void handlers.onApproval(parsed.decision);
+    return;
+  }
+  handlers.onFocus?.();
+}
+
+export function installSpiritNotificationProtocolRouting(): void {
+  if (process.platform === 'darwin') {
+    app.on('open-url', (event, url) => {
+      event.preventDefault();
+      dispatchSpiritNotificationProtocolUrl(url);
+    });
+  }
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,6 +1,7 @@
 import { clipboard, contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('spiritDesktop', {
+  platform: process.platform,
   bootstrap(request?: unknown) {
     return ipcRenderer.invoke('desktop:invoke', 'bootstrap', { request });
   },
@@ -287,6 +288,40 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
     return () => {
       ipcRenderer.removeListener('desktop:pty-data', onData);
       ipcRenderer.removeListener('desktop:pty-exit', onExit);
+    };
+  },
+  showNotification(request: {
+    title: string;
+    body?: string;
+    tag?: string;
+    silent?: boolean;
+    actions?: Array<{ type: 'button'; text: string }>;
+    kind?: 'task-complete' | 'approval' | 'ask-questions' | 'generic';
+  }) {
+    return ipcRenderer.invoke('desktop:show-notification', request);
+  },
+  getAppAwayFromUser() {
+    return ipcRenderer.invoke('desktop:get-app-away') as Promise<boolean>;
+  },
+  reportRendererVisibility(hidden: boolean) {
+    return ipcRenderer.invoke('desktop:report-renderer-visibility', { hidden }) as Promise<boolean>;
+  },
+  subscribeAppAwayChanged(callback: (away: boolean) => void) {
+    const onAway = (_event: Electron.IpcRendererEvent, payload: { away?: boolean }) => {
+      callback(payload?.away === true);
+    };
+    ipcRenderer.on('desktop:app-away-changed', onAway);
+    return () => {
+      ipcRenderer.removeListener('desktop:app-away-changed', onAway);
+    };
+  },
+  subscribeNotifyRefresh(callback: () => void) {
+    const onRefresh = () => {
+      callback();
+    };
+    ipcRenderer.on('desktop:notify-refresh', onRefresh);
+    return () => {
+      ipcRenderer.removeListener('desktop:notify-refresh', onRefresh);
     };
   },
 });

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -331,4 +331,18 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
       ipcRenderer.removeListener('desktop:notify-refresh', onRefresh);
     };
   },
+  subscribeApprovalFromNotification(callback: (payload: { decision: 'allow' | 'deny' }) => void) {
+    const onApproval = (
+      _event: Electron.IpcRendererEvent,
+      payload: { decision?: string },
+    ) => {
+      if (payload?.decision === 'allow' || payload?.decision === 'deny') {
+        callback({ decision: payload.decision });
+      }
+    };
+    ipcRenderer.on('desktop:approval-from-notification', onApproval);
+    return () => {
+      ipcRenderer.removeListener('desktop:approval-from-notification', onApproval);
+    };
+  },
 });

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -306,6 +306,13 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   reportRendererVisibility(hidden: boolean) {
     return ipcRenderer.invoke('desktop:report-renderer-visibility', { hidden }) as Promise<boolean>;
   },
+  syncAttentionPending(flags: {
+    needsApproval: boolean;
+    needsQuestions: boolean;
+    needsTaskComplete: boolean;
+  }) {
+    return ipcRenderer.invoke('desktop:sync-attention-pending', flags) as Promise<void>;
+  },
   subscribeAppAwayChanged(callback: (away: boolean) => void) {
     const onAway = (_event: Electron.IpcRendererEvent, payload: { away?: boolean }) => {
       callback(payload?.away === true);

--- a/apps/desktop/electron/window-presence.ts
+++ b/apps/desktop/electron/window-presence.ts
@@ -1,0 +1,55 @@
+import { BrowserWindow } from 'electron';
+
+let mainWindowRef: BrowserWindow | undefined;
+let rendererHidden = false;
+
+function broadcastAwayChanged(away: boolean): void {
+  const window = mainWindowRef;
+  if (!window || window.isDestroyed()) {
+    return;
+  }
+  window.webContents.send('desktop:app-away-changed', { away });
+}
+
+function recomputeAway(): boolean {
+  const away = isAppAwayFromUser();
+  broadcastAwayChanged(away);
+  return away;
+}
+
+export function registerWindowPresence(mainWindow: BrowserWindow): void {
+  mainWindowRef = mainWindow;
+  const update = () => {
+    recomputeAway();
+  };
+  mainWindow.on('blur', update);
+  mainWindow.on('focus', update);
+  mainWindow.on('minimize', update);
+  mainWindow.on('restore', update);
+  mainWindow.on('hide', update);
+  mainWindow.on('show', update);
+  recomputeAway();
+}
+
+export function setRendererVisibility(hidden: boolean): void {
+  rendererHidden = hidden;
+  recomputeAway();
+}
+
+export function isAppAwayFromUser(): boolean {
+  const window = mainWindowRef;
+  if (!window || window.isDestroyed()) {
+    return false;
+  }
+  if (rendererHidden) {
+    return true;
+  }
+  if (window.isMinimized()) {
+    return true;
+  }
+  return !window.isFocused();
+}
+
+export function getAppAwayFromUser(): boolean {
+  return isAppAwayFromUser();
+}

--- a/apps/desktop/electron/window-presence.ts
+++ b/apps/desktop/electron/window-presence.ts
@@ -1,5 +1,7 @@
 import { BrowserWindow } from 'electron';
 
+import { refreshDesktopAttention } from './desktop-attention.js';
+
 let mainWindowRef: BrowserWindow | undefined;
 let rendererHidden = false;
 
@@ -14,6 +16,7 @@ function broadcastAwayChanged(away: boolean): void {
 function recomputeAway(): boolean {
   const away = isAppAwayFromUser();
   broadcastAwayChanged(away);
+  refreshDesktopAttention(away);
   return away;
 }
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
     "dist": "npm run build && electron-builder --config electron-builder.yml",
     "dist:dir": "npm run build && electron-builder --config electron-builder.yml --dir",
     "test:host": "npm run build:electron && node --test test/host/*.test.mjs",
-    "test:lib": "node --experimental-strip-types --test test/workspace-tool-tabs.test.mjs test/browser-url.test.mjs test/browser-element-picker.test.mjs test/local-listeners-parse.test.mjs test/lib/tool-call-display.test.mjs test/lib/conversation-continue-ui.test.mjs test/lib/desktop-notification-copy.test.mjs test/lib/edit-file-line-delta.test.mjs && npx --yes tsx --test test/composer-segments.test.mjs test/skill-slash.test.mjs && npm run build:electron && node --test test/conversation-thinking-ui.test.mjs",
+    "test:lib": "node --experimental-strip-types --test test/workspace-tool-tabs.test.mjs test/browser-url.test.mjs test/browser-element-picker.test.mjs test/local-listeners-parse.test.mjs test/lib/tool-call-display.test.mjs test/lib/conversation-continue-ui.test.mjs test/lib/desktop-notification-copy.test.mjs test/lib/windows-toast-xml.test.mjs test/lib/spirit-notification-protocol.test.mjs test/lib/edit-file-line-delta.test.mjs && npx --yes tsx --test test/composer-segments.test.mjs test/skill-slash.test.mjs && npm run build:electron && node --test test/conversation-thinking-ui.test.mjs",
     "preview": "vite preview --host 127.0.0.1 --port 4173",
     "start": "electron dist-electron/electron/main.js",
     "gen:icons": "node scripts/gen-app-icons.mjs",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
     "dist": "npm run build && electron-builder --config electron-builder.yml",
     "dist:dir": "npm run build && electron-builder --config electron-builder.yml --dir",
     "test:host": "npm run build:electron && node --test test/host/*.test.mjs",
-    "test:lib": "node --experimental-strip-types --test test/workspace-tool-tabs.test.mjs test/browser-url.test.mjs test/browser-element-picker.test.mjs test/local-listeners-parse.test.mjs test/lib/tool-call-display.test.mjs test/lib/conversation-continue-ui.test.mjs && npx --yes tsx --test test/composer-segments.test.mjs test/skill-slash.test.mjs && npm run build:electron && node --test test/conversation-thinking-ui.test.mjs",
+    "test:lib": "node --experimental-strip-types --test test/workspace-tool-tabs.test.mjs test/browser-url.test.mjs test/browser-element-picker.test.mjs test/local-listeners-parse.test.mjs test/lib/tool-call-display.test.mjs test/lib/conversation-continue-ui.test.mjs test/lib/desktop-notification-copy.test.mjs test/lib/edit-file-line-delta.test.mjs && npx --yes tsx --test test/composer-segments.test.mjs test/skill-slash.test.mjs && npm run build:electron && node --test test/conversation-thinking-ui.test.mjs",
     "preview": "vite preview --host 127.0.0.1 --port 4173",
     "start": "electron dist-electron/electron/main.js",
     "gen:icons": "node scripts/gen-app-icons.mjs",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
     "dist": "npm run build && electron-builder --config electron-builder.yml",
     "dist:dir": "npm run build && electron-builder --config electron-builder.yml --dir",
     "test:host": "npm run build:electron && node --test test/host/*.test.mjs",
-    "test:lib": "node --experimental-strip-types --test test/workspace-tool-tabs.test.mjs test/browser-url.test.mjs test/browser-element-picker.test.mjs test/local-listeners-parse.test.mjs test/lib/tool-call-display.test.mjs test/lib/conversation-continue-ui.test.mjs test/lib/desktop-notification-copy.test.mjs test/lib/windows-toast-xml.test.mjs test/lib/spirit-notification-protocol.test.mjs test/lib/edit-file-line-delta.test.mjs && npx --yes tsx --test test/composer-segments.test.mjs test/skill-slash.test.mjs && npm run build:electron && node --test test/conversation-thinking-ui.test.mjs",
+    "test:lib": "node --experimental-strip-types --test test/workspace-tool-tabs.test.mjs test/browser-url.test.mjs test/browser-element-picker.test.mjs test/local-listeners-parse.test.mjs test/lib/tool-call-display.test.mjs test/lib/conversation-continue-ui.test.mjs test/lib/desktop-notification-copy.test.mjs test/lib/spirit-notification-protocol.test.mjs test/lib/edit-file-line-delta.test.mjs && npx --yes tsx --test test/composer-segments.test.mjs test/skill-slash.test.mjs test/lib/windows-toast-xml.test.mjs && npm run build:electron && node --test test/conversation-thinking-ui.test.mjs",
     "preview": "vite preview --host 127.0.0.1 --port 4173",
     "start": "electron dist-electron/electron/main.js",
     "gen:icons": "node scripts/gen-app-icons.mjs",

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -156,6 +156,9 @@ declare global {
     }): Promise<void>;
     subscribeAppAwayChanged(callback: (away: boolean) => void): () => void;
     subscribeNotifyRefresh(callback: () => void): () => void;
+    subscribeApprovalFromNotification(
+      callback: (payload: { decision: 'allow' | 'deny' }) => void,
+    ): () => void;
   }
 
   interface Window {

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -149,6 +149,11 @@ declare global {
     showNotification(request: import('./lib/desktop-notification-types.js').DesktopShowNotificationRequest): Promise<boolean>;
     getAppAwayFromUser(): Promise<boolean>;
     reportRendererVisibility(hidden: boolean): Promise<boolean>;
+    syncAttentionPending(flags: {
+      needsApproval: boolean;
+      needsQuestions: boolean;
+      needsTaskComplete: boolean;
+    }): Promise<void>;
     subscribeAppAwayChanged(callback: (away: boolean) => void): () => void;
     subscribeNotifyRefresh(callback: () => void): () => void;
   }

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -43,6 +43,7 @@ import type {
 
 declare global {
   interface SpiritDesktopApi {
+    platform: NodeJS.Platform;
     bootstrap(request?: BootstrapRequest): Promise<DesktopSnapshot>;
     rememberWorkspaceRoot(request: RememberWorkspaceRequest): Promise<DesktopSnapshot>;
     commitChanges(request: CommitChangesRequest): Promise<DesktopSnapshot>;
@@ -145,6 +146,11 @@ declare global {
     ingestBrowserElementScreenshot(base64: string): Promise<string | null>;
     readClipboardText(): string;
     writeClipboardText(text: string): void;
+    showNotification(request: import('./lib/desktop-notification-types.js').DesktopShowNotificationRequest): Promise<boolean>;
+    getAppAwayFromUser(): Promise<boolean>;
+    reportRendererVisibility(hidden: boolean): Promise<boolean>;
+    subscribeAppAwayChanged(callback: (away: boolean) => void): () => void;
+    subscribeNotifyRefresh(callback: () => void): () => void;
   }
 
   interface Window {

--- a/apps/desktop/src/hooks/useDesktopAppAway.ts
+++ b/apps/desktop/src/hooks/useDesktopAppAway.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+
+/** Tracks whether the user has left the desktop window (Electron main process truth). */
+export function useDesktopAppAway(): boolean {
+  const [away, setAway] = useState(false);
+
+  useEffect(() => {
+    const bridge = window.spiritDesktop;
+    if (!bridge?.getAppAwayFromUser || !bridge.reportRendererVisibility) {
+      return;
+    }
+
+    let cancelled = false;
+
+    const reportVisibility = () => {
+      void bridge.reportRendererVisibility(document.hidden);
+    };
+
+    void bridge.getAppAwayFromUser().then((value) => {
+      if (!cancelled) {
+        setAway(value);
+      }
+    });
+
+    reportVisibility();
+
+    const unsubscribeAway = bridge.subscribeAppAwayChanged?.((next) => {
+      setAway(next);
+    });
+
+    document.addEventListener('visibilitychange', reportVisibility);
+    window.addEventListener('focus', reportVisibility);
+    window.addEventListener('blur', reportVisibility);
+
+    return () => {
+      cancelled = true;
+      unsubscribeAway?.();
+      document.removeEventListener('visibilitychange', reportVisibility);
+      window.removeEventListener('focus', reportVisibility);
+      window.removeEventListener('blur', reportVisibility);
+    };
+  }, []);
+
+  return away;
+}
+
+export function useDesktopNotifyRefresh(onRefresh: () => void): void {
+  const onRefreshRef = useRef(onRefresh);
+  onRefreshRef.current = onRefresh;
+
+  useEffect(() => {
+    const bridge = window.spiritDesktop;
+    if (!bridge?.subscribeNotifyRefresh) {
+      return;
+    }
+    return bridge.subscribeNotifyRefresh(() => {
+      onRefreshRef.current();
+    });
+  }, []);
+}

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -19,6 +19,7 @@ import {
   isLogSessionSlashInput,
   matchSkillSlashInput,
 } from "@/lib/skill-slash";
+import { useDesktopSystemNotifications } from "@/hooks/useDesktopSystemNotifications";
 import type {
   AddModelRequest,
   AddMcpServerRequest,
@@ -1926,6 +1927,26 @@ export function useDesktopRuntime() {
           : i18n.t('common.connectingHost'),
     };
   }, [hostError, hostReady, kind, snapshot]);
+
+  const refreshFromHostPoll = useCallback(async () => {
+    if (!api) {
+      return;
+    }
+    try {
+      const next = await api.poll();
+      applySnapshot(next);
+      void refreshSessions();
+    } catch {
+      // ignore poll errors from notification refresh
+    }
+  }, [api, applySnapshot, refreshSessions]);
+
+  useDesktopSystemNotifications({
+    apiKind: kind,
+    snapshot,
+    sessions,
+    onNotifyRefresh: refreshFromHostPoll,
+  });
 
   return {
     apiReady: hostReady,

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1764,6 +1764,16 @@ export function useDesktopRuntime() {
     }
   }, [api, applySnapshot]);
 
+  useEffect(() => {
+    const bridge = window.spiritDesktop;
+    if (!bridge?.subscribeApprovalFromNotification) {
+      return;
+    }
+    return bridge.subscribeApprovalFromNotification(({ decision }) => {
+      void submitApproval({ kind: decision });
+    });
+  }, [submitApproval]);
+
   const submitQuestions = useCallback(async () => {
     if (!api || !pendingQuestions) {
       return;

--- a/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
+++ b/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
@@ -11,6 +11,16 @@ import i18n from '@/lib/i18n';
 
 type NotificationBridge = NonNullable<Window['spiritDesktop']>;
 
+type AttentionFlags = {
+  needsApproval: boolean;
+  needsQuestions: boolean;
+  needsTaskComplete: boolean;
+};
+
+function attentionFlagsKey(flags: AttentionFlags): string {
+  return `${flags.needsApproval}:${flags.needsQuestions}:${flags.needsTaskComplete}`;
+}
+
 function sessionDisplayName(snapshot: DesktopSnapshot | null | undefined): string {
   return snapshot?.activeSession?.displayName?.trim() || i18n.t('notification.defaultSessionName');
 }
@@ -90,10 +100,61 @@ export function useDesktopSystemNotifications(options: {
   const sessionBusyGenRef = useRef<Map<string, number>>(new Map());
   const bgNotifiedGenRef = useRef<Map<string, number>>(new Map());
   const isWindowsRef = useRef(false);
+  const taskCompleteAttentionRef = useRef(false);
+  const lastAttentionSyncKeyRef = useRef('');
+  const snapshotRef = useRef(snapshot);
+  snapshotRef.current = snapshot;
+
+  const syncAttentionPending = (bridge: NotificationBridge, flags: AttentionFlags) => {
+    if (!bridge.syncAttentionPending) {
+      return;
+    }
+    const key = attentionFlagsKey(flags);
+    if (lastAttentionSyncKeyRef.current === key) {
+      return;
+    }
+    lastAttentionSyncKeyRef.current = key;
+    void bridge.syncAttentionPending(flags);
+  };
+
+  const markTaskCompleteAttention = (bridge: NotificationBridge) => {
+    taskCompleteAttentionRef.current = true;
+    const current = snapshotRef.current;
+    syncAttentionPending(bridge, {
+      needsApproval: Boolean(current?.conversation.pendingToolApproval),
+      needsQuestions: Boolean(current?.conversation.pendingQuestions),
+      needsTaskComplete: true,
+    });
+  };
 
   useEffect(() => {
     isWindowsRef.current = window.spiritDesktop?.platform === 'win32';
   }, []);
+
+  useEffect(() => {
+    if (apiKind !== 'electron') {
+      return;
+    }
+    const bridge = window.spiritDesktop;
+    if (!bridge?.subscribeAppAwayChanged) {
+      return;
+    }
+    return bridge.subscribeAppAwayChanged((away) => {
+      if (away) {
+        return;
+      }
+      if (!taskCompleteAttentionRef.current) {
+        return;
+      }
+      taskCompleteAttentionRef.current = false;
+      const current = snapshotRef.current;
+      syncAttentionPending(bridge, {
+        needsApproval: Boolean(current?.conversation.pendingToolApproval),
+        needsQuestions: Boolean(current?.conversation.pendingQuestions),
+        needsTaskComplete: false,
+      });
+    });
+  }, [apiKind]);
 
   useEffect(() => {
     if (apiKind !== 'electron' || !window.spiritDesktop?.showNotification) {
@@ -105,6 +166,12 @@ export function useDesktopSystemNotifications(options: {
     const approval = snapshot?.conversation.pendingToolApproval;
     const questions = snapshot?.conversation.pendingQuestions;
     const isBusy = snapshot?.conversation.isBusy === true;
+
+    syncAttentionPending(bridge, {
+      needsApproval: Boolean(approval),
+      needsQuestions: Boolean(questions),
+      needsTaskComplete: taskCompleteAttentionRef.current,
+    });
 
     if (isBusy && prevBusyRef.current !== true) {
       busyCycleRef.current += 1;
@@ -124,6 +191,12 @@ export function useDesktopSystemNotifications(options: {
           kind: 'task-complete',
           tag: `spirit-task-complete-${dedupeKey}`,
           title: formatSessionPrefixedTitle(sessionName, i18n.t('notification.taskComplete.title')),
+        }).then(() => {
+          void bridge.getAppAwayFromUser?.().then((away) => {
+            if (away) {
+              markTaskCompleteAttention(bridge);
+            }
+          });
         });
       }
     }
@@ -169,6 +242,12 @@ export function useDesktopSystemNotifications(options: {
               session.displayName,
               i18n.t('notification.taskComplete.title'),
             ),
+          }).then(() => {
+            void bridge.getAppAwayFromUser?.().then((away) => {
+              if (away) {
+                markTaskCompleteAttention(bridge);
+              }
+            });
           });
         }
       }

--- a/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
+++ b/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
@@ -1,0 +1,185 @@
+import { useEffect, useRef } from 'react';
+
+import {
+  formatSessionPrefixedTitle,
+  genericApprovalNotificationBody,
+  shellApprovalNotificationBody,
+} from '@/lib/desktop-notification-copy';
+import type { DesktopShowNotificationRequest } from '@/lib/desktop-notification-types';
+import type { DesktopSnapshot, PendingQuestionsSnapshot, PendingToolApprovalSnapshot, SessionListItem } from '@/types';
+import i18n from '@/lib/i18n';
+
+type NotificationBridge = NonNullable<Window['spiritDesktop']>;
+
+function sessionDisplayName(snapshot: DesktopSnapshot | null | undefined): string {
+  return snapshot?.activeSession?.displayName?.trim() || i18n.t('notification.defaultSessionName');
+}
+
+async function requestDesktopNotification(
+  bridge: NotificationBridge,
+  payload: DesktopShowNotificationRequest,
+): Promise<void> {
+  if (!bridge.showNotification) {
+    return;
+  }
+  const away = bridge.getAppAwayFromUser ? await bridge.getAppAwayFromUser() : false;
+  if (!away) {
+    return;
+  }
+  await bridge.showNotification(payload);
+}
+
+function approvalNotificationPayload(
+  sessionName: string,
+  approval: PendingToolApprovalSnapshot,
+  isWindows: boolean,
+): DesktopShowNotificationRequest {
+  const body =
+    approval.toolName === 'run_shell_command'
+      ? shellApprovalNotificationBody(approval.prompt, i18n.t('tool.reasonPrefix'))
+      : genericApprovalNotificationBody(approval.toolName, approval.prompt);
+
+  return {
+    kind: 'approval',
+    tag: 'spirit-approval',
+    title: formatSessionPrefixedTitle(sessionName, i18n.t('notification.approval.title')),
+    body: isWindows ? body : `${body}\n${i18n.t('notification.approval.returnToApp')}`,
+    ...(isWindows
+      ? {
+          actions: [
+            { type: 'button' as const, text: i18n.t('app.allow') },
+            { type: 'button' as const, text: i18n.t('app.deny') },
+          ],
+        }
+      : {}),
+  };
+}
+
+function askQuestionsNotificationPayload(
+  sessionName: string,
+  pending: PendingQuestionsSnapshot,
+): DesktopShowNotificationRequest {
+  const questionCount = pending.request.questions.length;
+  const detail =
+    pending.request.title?.trim() ||
+    (questionCount > 0
+      ? i18n.t('notification.askQuestions.nQuestions', { count: questionCount })
+      : i18n.t('notification.askQuestions.fallback'));
+
+  return {
+    kind: 'ask-questions',
+    tag: `spirit-ask-${pending.toolCallId}`,
+    title: formatSessionPrefixedTitle(sessionName, i18n.t('notification.askQuestions.title')),
+    body: detail,
+  };
+}
+
+export function useDesktopSystemNotifications(options: {
+  apiKind: string | null | undefined;
+  snapshot: DesktopSnapshot | null | undefined;
+  sessions: readonly SessionListItem[];
+  onNotifyRefresh?: () => void;
+}): void {
+  const { apiKind, snapshot, sessions, onNotifyRefresh } = options;
+  const prevBusyRef = useRef<boolean | undefined>(undefined);
+  const prevSessionsBusyRef = useRef<Map<string, boolean>>(new Map());
+  const notifiedTaskCompleteRef = useRef<Set<string>>(new Set());
+  const prevApprovalKeyRef = useRef<string | undefined>(undefined);
+  const prevQuestionsKeyRef = useRef<string | undefined>(undefined);
+  const busyCycleRef = useRef(0);
+  const sessionBusyGenRef = useRef<Map<string, number>>(new Map());
+  const bgNotifiedGenRef = useRef<Map<string, number>>(new Map());
+  const isWindowsRef = useRef(false);
+
+  useEffect(() => {
+    isWindowsRef.current = window.spiritDesktop?.platform === 'win32';
+  }, []);
+
+  useEffect(() => {
+    if (apiKind !== 'electron' || !window.spiritDesktop?.showNotification) {
+      return;
+    }
+    const bridge = window.spiritDesktop;
+
+    const sessionName = sessionDisplayName(snapshot);
+    const approval = snapshot?.conversation.pendingToolApproval;
+    const questions = snapshot?.conversation.pendingQuestions;
+    const isBusy = snapshot?.conversation.isBusy === true;
+
+    if (isBusy && prevBusyRef.current !== true) {
+      busyCycleRef.current += 1;
+      notifiedTaskCompleteRef.current.delete(`${snapshot?.composerSessionKey ?? 'active'}:${busyCycleRef.current}`);
+    }
+
+    if (
+      prevBusyRef.current === true &&
+      !isBusy &&
+      !approval &&
+      !questions
+    ) {
+      const dedupeKey = `${snapshot?.composerSessionKey ?? 'active'}:${busyCycleRef.current}`;
+      if (!notifiedTaskCompleteRef.current.has(dedupeKey)) {
+        notifiedTaskCompleteRef.current.add(dedupeKey);
+        void requestDesktopNotification(bridge, {
+          kind: 'task-complete',
+          tag: `spirit-task-complete-${dedupeKey}`,
+          title: formatSessionPrefixedTitle(sessionName, i18n.t('notification.taskComplete.title')),
+        });
+      }
+    }
+    prevBusyRef.current = isBusy;
+
+    const approvalKey = approval
+      ? `${approval.toolName}:${approval.prompt}`
+      : undefined;
+    if (approval && approvalKey !== prevApprovalKeyRef.current) {
+      void requestDesktopNotification(
+        bridge,
+        approvalNotificationPayload(sessionName, approval, isWindowsRef.current),
+      );
+    }
+    prevApprovalKeyRef.current = approvalKey;
+
+    const questionsKey = questions?.toolCallId;
+    if (questions && questionsKey && questionsKey !== prevQuestionsKeyRef.current) {
+      void requestDesktopNotification(bridge, askQuestionsNotificationPayload(sessionName, questions));
+    }
+    prevQuestionsKeyRef.current = questionsKey;
+
+    const prevMap = prevSessionsBusyRef.current;
+    const nextMap = new Map<string, boolean>();
+    for (const session of sessions) {
+      const wasBusy = prevMap.get(session.path) === true;
+      const nowBusy = session.isBusy === true;
+      nextMap.set(session.path, nowBusy);
+      if (nowBusy && !wasBusy) {
+        sessionBusyGenRef.current.set(
+          session.path,
+          (sessionBusyGenRef.current.get(session.path) ?? 0) + 1,
+        );
+      }
+      if (wasBusy && !nowBusy && !session.isActive) {
+        const gen = sessionBusyGenRef.current.get(session.path) ?? 0;
+        if (bgNotifiedGenRef.current.get(session.path) !== gen) {
+          bgNotifiedGenRef.current.set(session.path, gen);
+          void requestDesktopNotification(bridge, {
+            kind: 'task-complete',
+            tag: `spirit-task-complete-${session.path}`,
+            title: formatSessionPrefixedTitle(
+              session.displayName,
+              i18n.t('notification.taskComplete.title'),
+            ),
+          });
+        }
+      }
+    }
+    prevSessionsBusyRef.current = nextMap;
+  }, [apiKind, snapshot, sessions]);
+
+  useEffect(() => {
+    if (apiKind !== 'electron' || !onNotifyRefresh || !window.spiritDesktop?.subscribeNotifyRefresh) {
+      return;
+    }
+    return window.spiritDesktop.subscribeNotifyRefresh(onNotifyRefresh);
+  }, [apiKind, onNotifyRefresh]);
+}

--- a/apps/desktop/src/lib/desktop-notification-copy.ts
+++ b/apps/desktop/src/lib/desktop-notification-copy.ts
@@ -1,0 +1,46 @@
+const NOTIFICATION_BODY_MAX = 240;
+const APPROVAL_BODY_MAX = 200;
+
+export function formatSessionPrefixedTitle(sessionName: string, body: string): string {
+  const trimmedSession = sessionName.trim() || 'Session';
+  const trimmedBody = body.trim();
+  if (!trimmedBody) {
+    return `[${trimmedSession}]`;
+  }
+  return `[${trimmedSession}] ${trimmedBody}`;
+}
+
+export function truncateNotificationBody(text: string, max = NOTIFICATION_BODY_MAX): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, Math.max(0, max - 1))}…`;
+}
+
+export function stripShellReasonLine(prompt: string, reasonPrefix: string): string {
+  const lines = prompt.split(/\r?\n/);
+  if (!lines[0]?.trim().startsWith(reasonPrefix)) {
+    return prompt;
+  }
+  return lines.slice(1).join('\n').trim();
+}
+
+export function shellApprovalNotificationBody(prompt: string, reasonPrefix: string): string {
+  const lines = prompt.split(/\r?\n/);
+  const reasonLine = lines[0]?.trim().startsWith(reasonPrefix) ? lines[0].trim() : '';
+  const command = stripShellReasonLine(prompt, reasonPrefix).trim();
+  if (reasonLine && command && reasonLine !== command) {
+    return truncateNotificationBody(`${reasonLine}\n${command}`, APPROVAL_BODY_MAX);
+  }
+  return truncateNotificationBody(command || reasonLine || prompt, APPROVAL_BODY_MAX);
+}
+
+export function genericApprovalNotificationBody(toolName: string, prompt: string): string {
+  const label = toolName.trim();
+  const detail = prompt.trim();
+  if (label && detail) {
+    return truncateNotificationBody(`${label}\n${detail}`, APPROVAL_BODY_MAX);
+  }
+  return truncateNotificationBody(detail || label, APPROVAL_BODY_MAX);
+}

--- a/apps/desktop/src/lib/desktop-notification-types.ts
+++ b/apps/desktop/src/lib/desktop-notification-types.ts
@@ -1,0 +1,15 @@
+export type DesktopNotificationKind = 'task-complete' | 'approval' | 'ask-questions' | 'generic';
+
+export type DesktopNotificationAction = {
+  type: 'button';
+  text: string;
+};
+
+export type DesktopShowNotificationRequest = {
+  title: string;
+  body?: string;
+  tag?: string;
+  silent?: boolean;
+  actions?: DesktopNotificationAction[];
+  kind?: DesktopNotificationKind;
+};

--- a/apps/desktop/src/lib/spirit-notification-protocol.ts
+++ b/apps/desktop/src/lib/spirit-notification-protocol.ts
@@ -1,0 +1,51 @@
+export const SPIRIT_NOTIFICATION_PROTOCOL = 'spirit-agent';
+
+export function buildNotificationApprovalProtocolUrl(
+  decision: 'allow' | 'deny',
+  tag?: string,
+): string {
+  const params = new URLSearchParams({ decision });
+  const trimmedTag = tag?.trim();
+  if (trimmedTag) {
+    params.set('tag', trimmedTag);
+  }
+  return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-approval?${params.toString()}`;
+}
+
+export function buildNotificationFocusProtocolUrl(tag?: string): string {
+  const trimmedTag = tag?.trim();
+  if (!trimmedTag) {
+    return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-focus`;
+  }
+  const params = new URLSearchParams({ tag: trimmedTag });
+  return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-focus?${params.toString()}`;
+}
+
+export function parseSpiritNotificationProtocolUrl(
+  raw: string,
+): { kind: 'approval'; decision: 'allow' | 'deny' } | { kind: 'focus' } | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== `${SPIRIT_NOTIFICATION_PROTOCOL}:`) {
+      return null;
+    }
+    const host = url.hostname || url.pathname.replace(/^\/+/, '');
+    if (host === 'notification-approval') {
+      const decision = url.searchParams.get('decision');
+      if (decision === 'allow' || decision === 'deny') {
+        return { kind: 'approval', decision };
+      }
+      return null;
+    }
+    if (host === 'notification-focus') {
+      return { kind: 'focus' };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function findSpiritNotificationProtocolUrl(argv: readonly string[]): string | undefined {
+  return argv.find((entry) => entry.startsWith(`${SPIRIT_NOTIFICATION_PROTOCOL}://`));
+}

--- a/apps/desktop/src/lib/windows-toast-xml.ts
+++ b/apps/desktop/src/lib/windows-toast-xml.ts
@@ -1,0 +1,128 @@
+const SPIRIT_NOTIFICATION_PROTOCOL = 'spirit-agent';
+
+function buildApprovalProtocolUrl(decision: 'allow' | 'deny', tag?: string): string {
+  const params = new URLSearchParams({ decision });
+  const trimmedTag = tag?.trim();
+  if (trimmedTag) {
+    params.set('tag', trimmedTag);
+  }
+  return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-approval?${params.toString()}`;
+}
+
+function buildFocusProtocolUrl(tag?: string): string {
+  const trimmedTag = tag?.trim();
+  if (!trimmedTag) {
+    return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-focus`;
+  }
+  const params = new URLSearchParams({ tag: trimmedTag });
+  return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-focus?${params.toString()}`;
+}
+
+export type WindowsToastPayload = {
+  title: string;
+  body?: string;
+  tag?: string;
+  actions?: Array<{ type: 'button'; text: string }>;
+};
+
+const TOAST_TEXT_LINE_MAX = 4;
+const TOAST_ACTION_MAX = 2;
+
+export function escapeToastXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function toastTextLines(payload: WindowsToastPayload): string[] {
+  const lines: string[] = [];
+  const title = payload.title?.trim();
+  if (title) {
+    lines.push(title);
+  }
+  if (payload.body) {
+    for (const line of payload.body.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (trimmed) {
+        lines.push(trimmed);
+      }
+    }
+  }
+  return lines.slice(0, TOAST_TEXT_LINE_MAX);
+}
+
+/** Build WinRT toast XML with explicit action buttons (Electron `actions` alone may not render on Windows). */
+export function buildWindowsToastXml(payload: WindowsToastPayload): string {
+  const textXml = toastTextLines(payload)
+    .map((line) => `<text>${escapeToastXml(line)}</text>`)
+    .join('');
+  const tag = payload.tag?.trim();
+  const actionsXml = (payload.actions ?? [])
+    .slice(0, TOAST_ACTION_MAX)
+    .map((action, index) => {
+      const decision = index === 0 ? 'allow' : 'deny';
+      const protocolUrl = buildApprovalProtocolUrl(decision, tag);
+      return `<action content="${escapeToastXml(action.text)}" arguments="${escapeToastXml(protocolUrl)}" activationType="protocol" />`;
+    })
+    .join('');
+  const launch = escapeToastXml(buildFocusProtocolUrl(tag));
+  return `<toast launch="${launch}" activationType="protocol"><visual><binding template="ToastGeneric">${textXml}</binding></visual><actions>${actionsXml}</actions></toast>`;
+}
+
+export function shouldUseWindowsToastXml(payload: WindowsToastPayload): boolean {
+  return Boolean(payload.actions && payload.actions.length > 0);
+}
+
+export type WindowsToastActivationDetails = {
+  type?: string;
+  actionIndex?: number;
+  arguments?: string;
+};
+
+/** Normalize WinRT activation payload from `Notification.handleActivation` / `action` events. */
+export function parseWindowsToastActivation(
+  details: WindowsToastActivationDetails,
+): { kind: 'click' } | { kind: 'action'; actionIndex: number } {
+  if (details.type?.toLowerCase() === 'action') {
+    const directIndex = details.actionIndex;
+    if (typeof directIndex === 'number' && directIndex >= 0) {
+      return { kind: 'action', actionIndex: directIndex };
+    }
+  }
+
+  const rawArguments = details.arguments?.trim() ?? '';
+  const params = new URLSearchParams(rawArguments.replace(/;/g, '&'));
+  const activationType = (params.get('type') ?? details.type ?? 'click').toLowerCase();
+  if (activationType !== 'action') {
+    return { kind: 'click' };
+  }
+  const fromDetails =
+    typeof details.actionIndex === 'number' && details.actionIndex >= 0
+      ? details.actionIndex
+      : undefined;
+  const fromArguments = params.get('actionIndex');
+  const actionIndex =
+    fromDetails ?? (fromArguments !== null ? Number(fromArguments) : Number.NaN);
+  if (!Number.isFinite(actionIndex) || actionIndex < 0) {
+    return { kind: 'click' };
+  }
+  return { kind: 'action', actionIndex };
+}
+
+export function resolveNotificationActionIndex(
+  event: unknown,
+  legacyIndex?: number,
+): number | undefined {
+  if (typeof event === 'object' && event !== null && 'actionIndex' in event) {
+    const fromEvent = (event as { actionIndex?: number }).actionIndex;
+    if (typeof fromEvent === 'number' && fromEvent >= 0) {
+      return fromEvent;
+    }
+  }
+  if (typeof legacyIndex === 'number' && legacyIndex >= 0) {
+    return legacyIndex;
+  }
+  return undefined;
+}

--- a/apps/desktop/src/lib/windows-toast-xml.ts
+++ b/apps/desktop/src/lib/windows-toast-xml.ts
@@ -1,22 +1,7 @@
-const SPIRIT_NOTIFICATION_PROTOCOL = 'spirit-agent';
-
-function buildApprovalProtocolUrl(decision: 'allow' | 'deny', tag?: string): string {
-  const params = new URLSearchParams({ decision });
-  const trimmedTag = tag?.trim();
-  if (trimmedTag) {
-    params.set('tag', trimmedTag);
-  }
-  return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-approval?${params.toString()}`;
-}
-
-function buildFocusProtocolUrl(tag?: string): string {
-  const trimmedTag = tag?.trim();
-  if (!trimmedTag) {
-    return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-focus`;
-  }
-  const params = new URLSearchParams({ tag: trimmedTag });
-  return `${SPIRIT_NOTIFICATION_PROTOCOL}://notification-focus?${params.toString()}`;
-}
+import {
+  buildNotificationApprovalProtocolUrl,
+  buildNotificationFocusProtocolUrl,
+} from './spirit-notification-protocol.js';
 
 export type WindowsToastPayload = {
   title: string;
@@ -63,11 +48,11 @@ export function buildWindowsToastXml(payload: WindowsToastPayload): string {
     .slice(0, TOAST_ACTION_MAX)
     .map((action, index) => {
       const decision = index === 0 ? 'allow' : 'deny';
-      const protocolUrl = buildApprovalProtocolUrl(decision, tag);
+      const protocolUrl = buildNotificationApprovalProtocolUrl(decision, tag);
       return `<action content="${escapeToastXml(action.text)}" arguments="${escapeToastXml(protocolUrl)}" activationType="protocol" />`;
     })
     .join('');
-  const launch = escapeToastXml(buildFocusProtocolUrl(tag));
+  const launch = escapeToastXml(buildNotificationFocusProtocolUrl(tag));
   return `<toast launch="${launch}" activationType="protocol"><visual><binding template="ToastGeneric">${textXml}</binding></visual><actions>${actionsXml}</actions></toast>`;
 }
 

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -584,6 +584,21 @@
     "autoWorktreeNameFailedInvalidBranchName": "Auto-generating Worktree name failed: branchName format is invalid ({{branchName}}).",
     "autoWorktreeNameFailedNotObject": "Auto-generating Worktree name failed: model returned JSON that is not an object."
   },
+  "notification": {
+    "defaultSessionName": "Session",
+    "taskComplete": {
+      "title": "Task completed"
+    },
+    "approval": {
+      "title": "Approval required",
+      "returnToApp": "Return to the app to handle approval."
+    },
+    "askQuestions": {
+      "title": "Questions pending",
+      "nQuestions": "{{count}} questions to answer",
+      "fallback": "Return to the app to answer questions."
+    }
+  },
   "tool": {
     "reasonPrefix": "Reason:",
     "runCommand": "Run command",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -584,6 +584,21 @@
     "autoWorktreeNameFailedInvalidBranchName": "自动生成 Worktree 名称失败：branchName 格式无效（{{branchName}}）。",
     "autoWorktreeNameFailedNotObject": "自动生成 Worktree 名称失败：模型返回的 JSON 不是对象。"
   },
+  "notification": {
+    "defaultSessionName": "会话",
+    "taskComplete": {
+      "title": "任务已完成"
+    },
+    "approval": {
+      "title": "待审批",
+      "returnToApp": "返回应用以处理审批。"
+    },
+    "askQuestions": {
+      "title": "待回答问题",
+      "nQuestions": "{{count}} 个问题待回答",
+      "fallback": "请返回应用回答问题。"
+    }
+  },
   "tool": {
     "reasonPrefix": "理由:",
     "runCommand": "运行命令",

--- a/apps/desktop/test/lib/desktop-notification-copy.test.mjs
+++ b/apps/desktop/test/lib/desktop-notification-copy.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  formatSessionPrefixedTitle,
+  genericApprovalNotificationBody,
+  shellApprovalNotificationBody,
+  stripShellReasonLine,
+  truncateNotificationBody,
+} from '../../src/lib/desktop-notification-copy.ts';
+
+test('formatSessionPrefixedTitle prefixes session name', () => {
+  assert.equal(formatSessionPrefixedTitle('My chat', '任务已完成'), '[My chat] 任务已完成');
+  assert.equal(formatSessionPrefixedTitle('  ', 'Done'), '[Session] Done');
+});
+
+test('truncateNotificationBody shortens long text', () => {
+  const long = 'x'.repeat(300);
+  assert.equal(truncateNotificationBody(long, 10).length, 10);
+  assert.match(truncateNotificationBody(long, 10), /…$/u);
+});
+
+test('stripShellReasonLine removes reason header', () => {
+  const prompt = '理由: deploy\nnpm run build';
+  assert.equal(stripShellReasonLine(prompt, '理由:'), 'npm run build');
+});
+
+test('shellApprovalNotificationBody includes reason and command', () => {
+  const prompt = '理由: deploy\nnpm run build';
+  assert.match(shellApprovalNotificationBody(prompt, '理由:'), /理由: deploy/);
+  assert.match(shellApprovalNotificationBody(prompt, '理由:'), /npm run build/);
+});
+
+test('genericApprovalNotificationBody includes tool and prompt', () => {
+  const body = genericApprovalNotificationBody('edit_file', 'path: README.md');
+  assert.match(body, /edit_file/);
+  assert.match(body, /README.md/);
+});

--- a/apps/desktop/test/lib/spirit-notification-protocol.test.mjs
+++ b/apps/desktop/test/lib/spirit-notification-protocol.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildNotificationApprovalProtocolUrl,
+  findSpiritNotificationProtocolUrl,
+  parseSpiritNotificationProtocolUrl,
+} from '../../src/lib/spirit-notification-protocol.ts';
+
+test('buildNotificationApprovalProtocolUrl encodes decision', () => {
+  assert.equal(
+    buildNotificationApprovalProtocolUrl('allow', 'spirit-approval'),
+    'spirit-agent://notification-approval?decision=allow&tag=spirit-approval',
+  );
+});
+
+test('parseSpiritNotificationProtocolUrl reads approval decision', () => {
+  assert.deepEqual(
+    parseSpiritNotificationProtocolUrl(
+      'spirit-agent://notification-approval?decision=deny&tag=spirit-approval',
+    ),
+    { kind: 'approval', decision: 'deny' },
+  );
+});
+
+test('findSpiritNotificationProtocolUrl scans argv', () => {
+  assert.equal(
+    findSpiritNotificationProtocolUrl([
+      'electron.exe',
+      'spirit-agent://notification-approval?decision=allow',
+    ]),
+    'spirit-agent://notification-approval?decision=allow',
+  );
+});

--- a/apps/desktop/test/lib/windows-toast-xml.test.mjs
+++ b/apps/desktop/test/lib/windows-toast-xml.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildWindowsToastXml,
+  escapeToastXml,
+  parseWindowsToastActivation,
+  resolveNotificationActionIndex,
+  shouldUseWindowsToastXml,
+} from '../../src/lib/windows-toast-xml.ts';
+
+test('escapeToastXml escapes reserved characters', () => {
+  assert.equal(escapeToastXml(`a&b<c>d"e`), 'a&amp;b&lt;c&gt;d&quot;e');
+});
+
+test('buildWindowsToastXml includes foreground action buttons', () => {
+  const xml = buildWindowsToastXml({
+    title: '[Session] Pending',
+    body: 'line one\nline two',
+    tag: 'spirit-approval',
+    actions: [
+      { type: 'button', text: 'Allow' },
+      { type: 'button', text: 'Deny' },
+    ],
+  });
+  assert.match(xml, /<action content="Allow"/);
+  assert.match(xml, /spirit-agent:\/\/notification-approval\?decision=allow/);
+  assert.match(xml, /<action content="Deny"/);
+  assert.match(xml, /spirit-agent:\/\/notification-approval\?decision=deny/);
+  assert.match(xml, /activationType="protocol"/);
+});
+
+test('shouldUseWindowsToastXml when actions present', () => {
+  assert.equal(shouldUseWindowsToastXml({ title: 't', actions: [{ type: 'button', text: 'OK' }] }), true);
+  assert.equal(shouldUseWindowsToastXml({ title: 't' }), false);
+});
+
+test('parseWindowsToastActivation reads action index from activation details', () => {
+  assert.deepEqual(
+    parseWindowsToastActivation({ type: 'action', actionIndex: 0 }),
+    { kind: 'action', actionIndex: 0 },
+  );
+});
+
+test('parseWindowsToastActivation reads action index from arguments', () => {
+  assert.deepEqual(
+    parseWindowsToastActivation({
+      type: 'click',
+      arguments: 'type=action&actionIndex=1',
+    }),
+    { kind: 'action', actionIndex: 1 },
+  );
+});
+
+test('resolveNotificationActionIndex prefers event.actionIndex', () => {
+  assert.equal(resolveNotificationActionIndex({ actionIndex: 0 }, 1), 0);
+  assert.equal(resolveNotificationActionIndex({}, 1), 1);
+});


### PR DESCRIPTION
## Summary

- 在用户离开窗口时发送 Electron 系统通知（任务完成、待审批、askQuestions）
- Windows 审批 Toast 使用显式 toastXml 与 spirit-agent:// 协议，支持通知内同意/拒绝并联动渲染进程审批
- 离开窗口时任务栏闪烁提示待办与任务完成（无角标）
- 主进程窗口离开检测、IPC/preload、i18n 与单测