### PR TITLE
feat(desktop): Desktop 无工作区绑定模式

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -28,6 +28,7 @@ import {
   CornerDownLeft,
   Download,
   FolderPlus,
+  UserRound,
   LoaderCircle,
   Maximize2,
   MessageSquareText,
@@ -257,17 +258,21 @@ function normalizeSlashPath(value: string): string {
 
 type EmptyStateWorkspaceSelectorProps = {
   currentWorkspaceRoot: string;
+  workspaceBinding: DesktopSnapshot["workspaceBinding"];
   availableWorkspaces: DesktopSnapshot["availableWorkspaces"];
   disabled?: boolean;
   onSelectWorkspace(workspaceRoot: string): void;
+  onSelectNoWorkspace(): void;
   onAddWorkspace(): void;
 };
 
 function EmptyStateWorkspaceSelector({
   currentWorkspaceRoot,
+  workspaceBinding,
   availableWorkspaces,
   disabled,
   onSelectWorkspace,
+  onSelectNoWorkspace,
   onAddWorkspace,
 }: EmptyStateWorkspaceSelectorProps) {
   const { t } = useTranslation();
@@ -282,11 +287,14 @@ function EmptyStateWorkspaceSelector({
     );
   }, [availableWorkspaces, workspaceFilter]);
   const currentWorkspaceLabel = useMemo(() => {
+    if (workspaceBinding === "none") {
+      return t("app.noWorkspace");
+    }
     const matched = availableWorkspaces.find((workspace) =>
       sameWorkspacePath(workspace.path, currentWorkspaceRoot),
     );
     return matched?.label ?? deriveWorkspaceLabel(currentWorkspaceRoot);
-  }, [availableWorkspaces, currentWorkspaceRoot]);
+  }, [availableWorkspaces, currentWorkspaceRoot, t, workspaceBinding]);
 
   return (
     <div className="flex justify-start px-0.5">
@@ -327,7 +335,9 @@ function EmptyStateWorkspaceSelector({
               <p className="px-2 py-4 text-center text-xs text-muted-foreground">{t('app.noMatches')}</p>
             ) : (
               filteredWorkspaces.map((workspace) => {
-                const selected = sameWorkspacePath(workspace.path, currentWorkspaceRoot);
+                const selected =
+                  workspaceBinding === "project"
+                  && sameWorkspacePath(workspace.path, currentWorkspaceRoot);
                 return (
                   <DropdownMenuItem
                     key={workspace.path}
@@ -351,6 +361,16 @@ function EmptyStateWorkspaceSelector({
             <DropdownMenuItem onSelect={onAddWorkspace} className="gap-2 px-2 py-2 text-sm">
               <FolderPlus className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
               <span>{t('app.addWorkspace')}</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={onSelectNoWorkspace}
+              className={cn(
+                "gap-2 px-2 py-2 text-sm",
+                workspaceBinding === "none" && "bg-accent/40",
+              )}
+            >
+              <UserRound className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              <span>{t('app.noWorkspace')}</span>
             </DropdownMenuItem>
           </div>
         </DropdownMenuContent>
@@ -1830,6 +1850,8 @@ export default function App() {
     [compactionDemo.active, messages],
   );
   const isEmptySession = !compactionDemo.active && sessionMessages.length === 0;
+  const showWorkspaceBindingControls =
+    isEmptySession || snapshot?.workspaceBinding === "none";
   const conversationPendingAuxState = compactionDemo.active
     ? compactionDemo.pendingAuxState
     : snapshot?.conversation.pendingAuxState;
@@ -3016,17 +3038,28 @@ export default function App() {
                   </p>
                 ) : null}
                 <div className="space-y-2">
-                {isEmptySession ? (
+                {showWorkspaceBindingControls ? (
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-0.5">
                     <EmptyStateWorkspaceSelector
                       currentWorkspaceRoot={snapshot?.workspaceRoot ?? ""}
+                      workspaceBinding={snapshot?.workspaceBinding ?? "project"}
                       availableWorkspaces={snapshot?.availableWorkspaces ?? []}
                       disabled={runtime.busyAction === "bootstrap" || runtime.busyAction === "session"}
                       onSelectWorkspace={(workspaceRoot) => {
-                        if (!snapshot?.workspaceRoot || sameWorkspacePath(snapshot.workspaceRoot, workspaceRoot)) {
+                        if (
+                          snapshot?.workspaceBinding === "project"
+                          && snapshot.workspaceRoot
+                          && sameWorkspacePath(snapshot.workspaceRoot, workspaceRoot)
+                        ) {
                           return;
                         }
                         void runtime.switchWorkspaceRoot(workspaceRoot);
+                      }}
+                      onSelectNoWorkspace={() => {
+                        if (snapshot?.workspaceBinding === "none") {
+                          return;
+                        }
+                        void runtime.switchToNoWorkspaceBinding();
                       }}
                       onAddWorkspace={() => {
                         void (async () => {
@@ -3038,6 +3071,8 @@ export default function App() {
                         })();
                       }}
                     />
+                    {isEmptySession ? (
+                    <>
                     <BranchSelectMenu
                       branches={snapshot?.git.branches ?? []}
                       selectedBranch={snapshot?.git.selectedBranch}
@@ -3070,6 +3105,8 @@ export default function App() {
                         void runtime.setApprovalLevel(level);
                       }}
                     />
+                    </>
+                    ) : null}
                   </div>
                 ) : null}
                 {runtime.runtimeError ? (

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -28,7 +28,6 @@ import {
   CornerDownLeft,
   Download,
   FolderPlus,
-  UserRound,
   LoaderCircle,
   Maximize2,
   MessageSquareText,
@@ -318,9 +317,9 @@ function EmptyStateWorkspaceSelector({
         <DropdownMenuContent
           align="start"
           side="top"
-          className="w-[min(24rem,calc(100vw-1.25rem))] p-0 text-xs"
+          className="flex h-[min(24rem,var(--radix-dropdown-menu-content-available-height))] w-[min(24rem,calc(100vw-1.25rem))] flex-col overflow-hidden p-0 text-xs"
         >
-          <div className="border-b border-border/40 p-1.5">
+          <div className="shrink-0 border-b border-border/40 p-1.5">
             <Input
               value={workspaceFilter}
               onChange={(event) => setWorkspaceFilter(event.target.value)}
@@ -330,34 +329,45 @@ function EmptyStateWorkspaceSelector({
               autoComplete="off"
             />
           </div>
-          <div className="max-h-[min(18rem,var(--radix-dropdown-menu-content-available-height))] overflow-y-auto p-1">
-            {filteredWorkspaces.length === 0 ? (
-              <p className="px-2 py-4 text-center text-xs text-muted-foreground">{t('app.noMatches')}</p>
-            ) : (
-              filteredWorkspaces.map((workspace) => {
-                const selected =
-                  workspaceBinding === "project"
-                  && sameWorkspacePath(workspace.path, currentWorkspaceRoot);
-                return (
-                  <DropdownMenuItem
-                    key={workspace.path}
-                    onSelect={() => onSelectWorkspace(workspace.path)}
-                    className={cn("items-start px-2 py-2", selected && "bg-accent/40")}
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium text-foreground" title={workspace.label}>
-                        {workspace.label}
+          <ScrollArea
+            type="always"
+            className="min-h-0 flex-1 [&>[data-radix-scroll-area-viewport]]:h-full [&>[data-radix-scroll-area-viewport]]:overscroll-contain"
+            onWheel={(event) => {
+              event.stopPropagation();
+            }}
+            onTouchMove={(event) => {
+              event.stopPropagation();
+            }}
+          >
+            <div className="p-1 pr-2">
+              {filteredWorkspaces.length === 0 ? (
+                <p className="px-2 py-4 text-center text-xs text-muted-foreground">{t('app.noMatches')}</p>
+              ) : (
+                filteredWorkspaces.map((workspace) => {
+                  const selected =
+                    workspaceBinding === "project"
+                    && sameWorkspacePath(workspace.path, currentWorkspaceRoot);
+                  return (
+                    <DropdownMenuItem
+                      key={workspace.path}
+                      onSelect={() => onSelectWorkspace(workspace.path)}
+                      className={cn("items-start px-2 py-2", selected && "bg-accent/40")}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-sm font-medium text-foreground" title={workspace.label}>
+                          {workspace.label}
+                        </div>
+                        <div className="truncate text-[11px] text-muted-foreground" title={workspace.path}>
+                          {workspace.path}
+                        </div>
                       </div>
-                      <div className="truncate text-[11px] text-muted-foreground" title={workspace.path}>
-                        {workspace.path}
-                      </div>
-                    </div>
-                  </DropdownMenuItem>
-                );
-              })
-            )}
-          </div>
-          <div className="border-t border-border/40 p-1">
+                    </DropdownMenuItem>
+                  );
+                })
+              )}
+            </div>
+          </ScrollArea>
+          <div className="shrink-0 border-t border-border/40 p-1">
             <DropdownMenuItem onSelect={onAddWorkspace} className="gap-2 px-2 py-2 text-sm">
               <FolderPlus className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
               <span>{t('app.addWorkspace')}</span>
@@ -369,7 +379,7 @@ function EmptyStateWorkspaceSelector({
                 workspaceBinding === "none" && "bg-accent/40",
               )}
             >
-              <UserRound className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              <MessageSquareText className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
               <span>{t('app.noWorkspace')}</span>
             </DropdownMenuItem>
           </div>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2737,6 +2737,7 @@ export default function App() {
               narrow={false}
               mode={settingsMode ? "settings" : "sessions"}
               workspaceRoot={snapshot?.workspaceRoot ?? null}
+              sessionListLayout={snapshot?.workspaceBinding === "none" ? "flat" : "grouped"}
               sessions={runtime.sessions}
               activeFilePath={activeFilePath}
               onNewSession={() => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2737,7 +2737,7 @@ export default function App() {
               narrow={false}
               mode={settingsMode ? "settings" : "sessions"}
               workspaceRoot={snapshot?.workspaceRoot ?? null}
-              sessionListLayout={snapshot?.workspaceBinding === "none" ? "flat" : "grouped"}
+              workspaceBinding={snapshot?.workspaceBinding ?? "project"}
               sessions={runtime.sessions}
               activeFilePath={activeFilePath}
               onNewSession={() => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2736,8 +2736,7 @@ export default function App() {
             <SessionSidebar
               narrow={false}
               mode={settingsMode ? "settings" : "sessions"}
-              workspaceRoot={snapshot?.workspaceRoot ?? null}
-              workspaceBinding={snapshot?.workspaceBinding ?? "project"}
+              userHomeDirectory={snapshot?.userHomeDirectory ?? null}
               sessions={runtime.sessions}
               activeFilePath={activeFilePath}
               onNewSession={() => {

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -23,7 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { resolveWorkspaceGroupingRoot } from "@/lib/workspace-grouping";
 import { cn } from "@/lib/utils";
 import i18n from "@/lib/i18n";
-import type { DesktopSnapshot, SessionListItem } from "@/types";
+import type { DesktopSnapshot, DesktopWorkspaceBinding, SessionListItem } from "@/types";
 
 function samePath(a: string, b: string): boolean {
   return a.replace(/\\/g, "/").toLowerCase() === b.replace(/\\/g, "/").toLowerCase();
@@ -35,8 +35,7 @@ type SessionSidebarProps = {
   narrow: boolean;
   mode?: "sessions" | "settings";
   workspaceRoot?: string | null;
-  /** `flat`：无工作区分组，直接列出当前 cwd 下的会话。 */
-  sessionListLayout?: "grouped" | "flat";
+  workspaceBinding?: DesktopWorkspaceBinding;
   sessions: SessionListItem[];
   activeFilePath: string | null;
   onSelectSession: (path: string) => void;
@@ -133,6 +132,92 @@ function buildWorkspaceGroups(
   );
 }
 
+function isNoWorkspaceSession(session: SessionListItem, homeDirectory: string): boolean {
+  const root = session.workspaceRoot?.trim();
+  if (!root) {
+    return true;
+  }
+  return samePath(root, homeDirectory);
+}
+
+function partitionSessionsForSidebar(
+  sessions: SessionListItem[],
+  workspaceBinding: DesktopWorkspaceBinding,
+  homeDirectory: string | null | undefined,
+): { bound: SessionListItem[]; unbound: SessionListItem[] } {
+  if (workspaceBinding !== "none") {
+    return { bound: sessions, unbound: [] };
+  }
+  const home = homeDirectory?.trim();
+  if (!home) {
+    return { bound: sessions, unbound: [] };
+  }
+  const bound: SessionListItem[] = [];
+  const unbound: SessionListItem[] = [];
+  for (const session of sessions) {
+    if (isNoWorkspaceSession(session, home)) {
+      unbound.push(session);
+    } else {
+      bound.push(session);
+    }
+  }
+  return { bound, unbound };
+}
+
+function sortSessionsByModified(sessions: SessionListItem[]): SessionListItem[] {
+  return [...sessions].sort((left, right) => right.modifiedAtUnixMs - left.modifiedAtUnixMs);
+}
+
+type SessionListRowProps = {
+  session: SessionListItem;
+  nested: boolean;
+  selected: boolean;
+  disabled?: boolean;
+  micaStyle?: boolean;
+  onSelect(): void;
+};
+
+function SessionListRow({
+  session,
+  nested,
+  selected,
+  disabled,
+  micaStyle,
+  onSelect,
+}: SessionListRowProps) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      aria-current={selected ? "true" : undefined}
+      onClick={onSelect}
+      className={cn(
+        "group flex w-full min-w-0 items-center overflow-hidden rounded-md text-left text-sm outline-none",
+        sidebarInteractionMotionClass,
+        "focus-visible:ring-2 focus-visible:ring-sidebar-ring/40",
+        nested ? "py-2 pr-2.5 pl-8" : "h-8 gap-2 px-2.5",
+        selected
+          ? sessionRowSelectedClass(micaStyle)
+          : cn("text-sidebar-foreground/90", sessionRowHoverClass(micaStyle)),
+      )}
+    >
+      <span
+        className="min-w-0 flex-1 basis-0 truncate text-xs font-medium"
+        title={session.displayName}
+      >
+        {session.displayName}
+      </span>
+      {session.isBusy ? (
+        <span
+          className="size-1.5 shrink-0 rounded-full bg-primary animate-pulse"
+          aria-label={t('common.running')}
+        />
+      ) : null}
+    </button>
+  );
+}
+
 const settingsTabs: Array<{
   id: SettingsSidebarTab;
   labelKey: string;
@@ -222,28 +307,12 @@ function sessionRowHoverClass(micaStyle?: boolean) {
   return micaStyle ? sidebarMicaMenuHoverClass : sidebarSessionListHoverClass;
 }
 
-function filterSessionsForWorkspace(
-  sessions: SessionListItem[],
-  workspaceRoot: string | null | undefined,
-): SessionListItem[] {
-  const currentRoot = workspaceRoot?.trim();
-  if (!currentRoot) {
-    return [];
-  }
-  return sessions
-    .filter((session) => {
-      const sessionRoot = session.workspaceRoot?.trim() || currentRoot;
-      return samePath(sessionRoot, currentRoot);
-    })
-    .sort((left, right) => right.modifiedAtUnixMs - left.modifiedAtUnixMs);
-}
-
 export function SessionSidebar({
   className,
   narrow,
   mode = "sessions",
   workspaceRoot,
-  sessionListLayout = "grouped",
+  workspaceBinding = "project",
   sessions,
   activeFilePath,
   onSelectSession,
@@ -266,15 +335,23 @@ export function SessionSidebar({
 }: SessionSidebarProps) {
   const { t, i18n } = useTranslation();
   const settingsMode = mode === "settings";
+  const { bound, unbound } = useMemo(
+    () => partitionSessionsForSidebar(sessions, workspaceBinding, workspaceRoot),
+    [sessions, workspaceBinding, workspaceRoot],
+  );
   const workspaceGroups = useMemo(
-    () => buildWorkspaceGroups(sessions, workspaceRoot),
-    [sessions, workspaceRoot, i18n.language],
+    () =>
+      buildWorkspaceGroups(
+        bound,
+        workspaceBinding === "none" ? undefined : workspaceRoot,
+      ),
+    [bound, workspaceBinding, workspaceRoot, i18n.language],
   );
-  const flatSessions = useMemo(
-    () => filterSessionsForWorkspace(sessions, workspaceRoot),
-    [sessions, workspaceRoot],
-  );
+  const unboundSessions = useMemo(() => sortSessionsByModified(unbound), [unbound]);
   const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = useState<Record<string, boolean>>({});
+
+  const isSessionSelected = (sessionPath: string) =>
+    !marketplaceActive && activeFilePath !== null && samePath(sessionPath, activeFilePath);
 
   const toggleWorkspaceGroup = (groupId: string) => {
     setCollapsedWorkspaceIds((current) => ({
@@ -376,7 +453,7 @@ export function SessionSidebar({
         )}
         aria-hidden={!settingsMode && narrow}
       >
-        {settingsMode || sessionListLayout === "flat" ? null : (
+        {settingsMode || workspaceBinding === "none" ? null : (
           <div className="shrink-0 px-1.5 pt-3 pb-2.5">
             <p className="px-2.5 text-[0.65rem] text-sidebar-faint-foreground">{t('sidebar.workspace')}</p>
           </div>
@@ -448,51 +525,35 @@ export function SessionSidebar({
                 </>
               ) : null}
             </nav>
-          ) : sessionListLayout === "flat" ? (
-            <div className="min-w-0 px-1.5 pb-1.5">
-              <nav className="flex min-w-0 flex-col gap-0.5" aria-label={t('sidebar.sessionNavAria')}>
-                {flatSessions.map((session) => {
-                  const sessionRowSelected =
-                    !marketplaceActive
-                    && activeFilePath !== null
-                    && samePath(session.path, activeFilePath);
-                  return (
-                    <button
-                      key={session.path}
-                      type="button"
-                      disabled={disabled}
-                      aria-current={sessionRowSelected ? "true" : undefined}
-                      onClick={() => onSelectSession(session.path)}
-                      className={cn(
-                        "group flex h-8 w-full min-w-0 items-center gap-2 overflow-hidden rounded-md px-2.5 text-left text-sm",
-                        "outline-none",
-                        sidebarInteractionMotionClass,
-                        "focus-visible:ring-2 focus-visible:ring-sidebar-ring/40",
-                        sessionRowSelected
-                          ? sessionRowSelectedClass(micaStyle)
-                          : cn("text-sidebar-foreground/90", sessionRowHoverClass(micaStyle)),
-                      )}
-                    >
-                      <span
-                        className="min-w-0 flex-1 truncate text-xs font-medium"
-                        title={session.displayName}
-                      >
-                        {session.displayName}
-                      </span>
-                      {session.isBusy ? (
-                        <span
-                          className="size-1.5 shrink-0 rounded-full bg-primary animate-pulse"
-                          aria-label={t('common.running')}
-                        />
-                      ) : null}
-                    </button>
-                  );
-                })}
-              </nav>
-            </div>
           ) : (
             <div className="min-w-0 px-1.5 pb-1.5">
               <nav className="flex min-w-0 flex-col gap-0.5" aria-label={t('sidebar.workspaceSessionsAria')}>
+                {workspaceBinding === "none" && unboundSessions.length > 0 ? (
+                  <>
+                    <p className="px-2.5 pt-2 pb-1 text-[0.65rem] text-sidebar-faint-foreground">
+                      {t('sidebar.noWorkspaceSessions')}
+                    </p>
+                    {unboundSessions.map((session) => (
+                      <SessionListRow
+                        key={session.path}
+                        session={session}
+                        nested={false}
+                        selected={isSessionSelected(session.path)}
+                        disabled={disabled}
+                        micaStyle={micaStyle}
+                        onSelect={() => onSelectSession(session.path)}
+                      />
+                    ))}
+                  </>
+                ) : null}
+                {workspaceBinding === "none" && unboundSessions.length > 0 && workspaceGroups.length > 0 ? (
+                  <div className="h-2" aria-hidden />
+                ) : null}
+                {workspaceBinding === "none" && workspaceGroups.length > 0 ? (
+                  <p className="px-2.5 pt-1 pb-1 text-[0.65rem] text-sidebar-faint-foreground">
+                    {t('sidebar.workspace')}
+                  </p>
+                ) : null}
                 {workspaceGroups.map((group) => {
                   const expanded = collapsedWorkspaceIds[group.id] !== false;
                   const panelId = `workspace-session-group-${group.id.replace(/[^a-z0-9_-]/g, "-")}`;
@@ -525,43 +586,17 @@ export function SessionSidebar({
 
                       <div id={panelId} className={cn("min-w-0", !expanded && "hidden") }>
                         <div className="mt-0.5 flex min-w-0 flex-col gap-0.5">
-                          {group.sessions.map((session) => {
-                            const sessionRowSelected =
-                              !marketplaceActive &&
-                              activeFilePath !== null &&
-                              samePath(session.path, activeFilePath);
-                            return (
-                              <button
-                                key={session.path}
-                                type="button"
-                                disabled={disabled}
-                                aria-current={sessionRowSelected ? "true" : undefined}
-                                onClick={() => onSelectSession(session.path)}
-                                className={cn(
-                                  "group flex w-full min-w-0 items-center overflow-hidden rounded-md py-2 pr-2.5 pl-8 text-left text-sm",
-                                  "outline-none",
-                                  sidebarInteractionMotionClass,
-                                  "focus-visible:ring-2 focus-visible:ring-sidebar-ring/40",
-                                  sessionRowSelected
-                                    ? sessionRowSelectedClass(micaStyle)
-                                    : cn("text-sidebar-foreground/90", sessionRowHoverClass(micaStyle)),
-                                )}
-                              >
-                                <span
-                                  className="min-w-0 flex-1 basis-0 truncate text-xs font-medium"
-                                  title={session.displayName}
-                                >
-                                  {session.displayName}
-                                </span>
-                                {session.isBusy ? (
-                                  <span
-                                    className="size-1.5 shrink-0 rounded-full bg-primary animate-pulse"
-                                    aria-label={t('common.running')}
-                                  />
-                                ) : null}
-                              </button>
-                            );
-                          })}
+                          {group.sessions.map((session) => (
+                            <SessionListRow
+                              key={session.path}
+                              session={session}
+                              nested
+                              selected={isSessionSelected(session.path)}
+                              disabled={disabled}
+                              micaStyle={micaStyle}
+                              onSelect={() => onSelectSession(session.path)}
+                            />
+                          ))}
                         </div>
                       </div>
                     </div>

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -35,6 +35,8 @@ type SessionSidebarProps = {
   narrow: boolean;
   mode?: "sessions" | "settings";
   workspaceRoot?: string | null;
+  /** `flat`：无工作区分组，直接列出当前 cwd 下的会话。 */
+  sessionListLayout?: "grouped" | "flat";
   sessions: SessionListItem[];
   activeFilePath: string | null;
   onSelectSession: (path: string) => void;
@@ -220,11 +222,28 @@ function sessionRowHoverClass(micaStyle?: boolean) {
   return micaStyle ? sidebarMicaMenuHoverClass : sidebarSessionListHoverClass;
 }
 
+function filterSessionsForWorkspace(
+  sessions: SessionListItem[],
+  workspaceRoot: string | null | undefined,
+): SessionListItem[] {
+  const currentRoot = workspaceRoot?.trim();
+  if (!currentRoot) {
+    return [];
+  }
+  return sessions
+    .filter((session) => {
+      const sessionRoot = session.workspaceRoot?.trim() || currentRoot;
+      return samePath(sessionRoot, currentRoot);
+    })
+    .sort((left, right) => right.modifiedAtUnixMs - left.modifiedAtUnixMs);
+}
+
 export function SessionSidebar({
   className,
   narrow,
   mode = "sessions",
   workspaceRoot,
+  sessionListLayout = "grouped",
   sessions,
   activeFilePath,
   onSelectSession,
@@ -250,6 +269,10 @@ export function SessionSidebar({
   const workspaceGroups = useMemo(
     () => buildWorkspaceGroups(sessions, workspaceRoot),
     [sessions, workspaceRoot, i18n.language],
+  );
+  const flatSessions = useMemo(
+    () => filterSessionsForWorkspace(sessions, workspaceRoot),
+    [sessions, workspaceRoot],
   );
   const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = useState<Record<string, boolean>>({});
 
@@ -353,7 +376,7 @@ export function SessionSidebar({
         )}
         aria-hidden={!settingsMode && narrow}
       >
-        {settingsMode ? null : (
+        {settingsMode || sessionListLayout === "flat" ? null : (
           <div className="shrink-0 px-1.5 pt-3 pb-2.5">
             <p className="px-2.5 text-[0.65rem] text-sidebar-faint-foreground">{t('sidebar.workspace')}</p>
           </div>
@@ -425,6 +448,48 @@ export function SessionSidebar({
                 </>
               ) : null}
             </nav>
+          ) : sessionListLayout === "flat" ? (
+            <div className="min-w-0 px-1.5 pb-1.5">
+              <nav className="flex min-w-0 flex-col gap-0.5" aria-label={t('sidebar.sessionNavAria')}>
+                {flatSessions.map((session) => {
+                  const sessionRowSelected =
+                    !marketplaceActive
+                    && activeFilePath !== null
+                    && samePath(session.path, activeFilePath);
+                  return (
+                    <button
+                      key={session.path}
+                      type="button"
+                      disabled={disabled}
+                      aria-current={sessionRowSelected ? "true" : undefined}
+                      onClick={() => onSelectSession(session.path)}
+                      className={cn(
+                        "group flex h-8 w-full min-w-0 items-center gap-2 overflow-hidden rounded-md px-2.5 text-left text-sm",
+                        "outline-none",
+                        sidebarInteractionMotionClass,
+                        "focus-visible:ring-2 focus-visible:ring-sidebar-ring/40",
+                        sessionRowSelected
+                          ? sessionRowSelectedClass(micaStyle)
+                          : cn("text-sidebar-foreground/90", sessionRowHoverClass(micaStyle)),
+                      )}
+                    >
+                      <span
+                        className="min-w-0 flex-1 truncate text-xs font-medium"
+                        title={session.displayName}
+                      >
+                        {session.displayName}
+                      </span>
+                      {session.isBusy ? (
+                        <span
+                          className="size-1.5 shrink-0 rounded-full bg-primary animate-pulse"
+                          aria-label={t('common.running')}
+                        />
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </nav>
+            </div>
           ) : (
             <div className="min-w-0 px-1.5 pb-1.5">
               <nav className="flex min-w-0 flex-col gap-0.5" aria-label={t('sidebar.workspaceSessionsAria')}>

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -23,7 +23,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { resolveWorkspaceGroupingRoot } from "@/lib/workspace-grouping";
 import { cn } from "@/lib/utils";
 import i18n from "@/lib/i18n";
-import type { DesktopSnapshot, DesktopWorkspaceBinding, SessionListItem } from "@/types";
+import type { DesktopSnapshot, SessionListItem } from "@/types";
 
 function samePath(a: string, b: string): boolean {
   return a.replace(/\\/g, "/").toLowerCase() === b.replace(/\\/g, "/").toLowerCase();
@@ -34,8 +34,8 @@ type SessionSidebarProps = {
   /** 窄轨：只换样式/折叠列表，不切换整棵子树，避免与外层 width 动画错拍 */
   narrow: boolean;
   mode?: "sessions" | "settings";
-  workspaceRoot?: string | null;
-  workspaceBinding?: DesktopWorkspaceBinding;
+  /** 用户主目录，用于将主目录会话划入「无工作区」区。 */
+  userHomeDirectory?: string | null;
   sessions: SessionListItem[];
   activeFilePath: string | null;
   onSelectSession: (path: string) => void;
@@ -142,12 +142,8 @@ function isNoWorkspaceSession(session: SessionListItem, homeDirectory: string): 
 
 function partitionSessionsForSidebar(
   sessions: SessionListItem[],
-  workspaceBinding: DesktopWorkspaceBinding,
   homeDirectory: string | null | undefined,
 ): { bound: SessionListItem[]; unbound: SessionListItem[] } {
-  if (workspaceBinding !== "none") {
-    return { bound: sessions, unbound: [] };
-  }
   const home = homeDirectory?.trim();
   if (!home) {
     return { bound: sessions, unbound: [] };
@@ -311,8 +307,7 @@ export function SessionSidebar({
   className,
   narrow,
   mode = "sessions",
-  workspaceRoot,
-  workspaceBinding = "project",
+  userHomeDirectory,
   sessions,
   activeFilePath,
   onSelectSession,
@@ -336,16 +331,12 @@ export function SessionSidebar({
   const { t, i18n } = useTranslation();
   const settingsMode = mode === "settings";
   const { bound, unbound } = useMemo(
-    () => partitionSessionsForSidebar(sessions, workspaceBinding, workspaceRoot),
-    [sessions, workspaceBinding, workspaceRoot],
+    () => partitionSessionsForSidebar(sessions, userHomeDirectory),
+    [sessions, userHomeDirectory],
   );
   const workspaceGroups = useMemo(
-    () =>
-      buildWorkspaceGroups(
-        bound,
-        workspaceBinding === "none" ? undefined : workspaceRoot,
-      ),
-    [bound, workspaceBinding, workspaceRoot, i18n.language],
+    () => buildWorkspaceGroups(bound, undefined),
+    [bound, i18n.language],
   );
   const unboundSessions = useMemo(() => sortSessionsByModified(unbound), [unbound]);
   const [collapsedWorkspaceIds, setCollapsedWorkspaceIds] = useState<Record<string, boolean>>({});
@@ -453,11 +444,6 @@ export function SessionSidebar({
         )}
         aria-hidden={!settingsMode && narrow}
       >
-        {settingsMode || workspaceBinding === "none" ? null : (
-          <div className="shrink-0 px-1.5 pt-3 pb-2.5">
-            <p className="px-2.5 text-[0.65rem] text-sidebar-faint-foreground">{t('sidebar.workspace')}</p>
-          </div>
-        )}
         <ScrollArea className="h-full min-h-0 min-w-0" type="hover" scrollHideDelay={450}>
           {settingsMode ? (
             <nav className="flex min-w-0 flex-col gap-0.5 p-1.5" aria-label={t('sidebar.settingsTabsAria')}>
@@ -528,7 +514,7 @@ export function SessionSidebar({
           ) : (
             <div className="min-w-0 px-1.5 pb-1.5">
               <nav className="flex min-w-0 flex-col gap-0.5" aria-label={t('sidebar.workspaceSessionsAria')}>
-                {workspaceBinding === "none" && unboundSessions.length > 0 ? (
+                {unboundSessions.length > 0 ? (
                   <>
                     <p className="px-2.5 pt-2 pb-1 text-[0.65rem] text-sidebar-faint-foreground">
                       {t('sidebar.noWorkspaceSessions')}
@@ -546,10 +532,10 @@ export function SessionSidebar({
                     ))}
                   </>
                 ) : null}
-                {workspaceBinding === "none" && unboundSessions.length > 0 && workspaceGroups.length > 0 ? (
+                {unboundSessions.length > 0 && workspaceGroups.length > 0 ? (
                   <div className="h-2" aria-hidden />
                 ) : null}
-                {workspaceBinding === "none" && workspaceGroups.length > 0 ? (
+                {workspaceGroups.length > 0 ? (
                   <p className="px-2.5 pt-1 pb-1 text-[0.65rem] text-sidebar-faint-foreground">
                     {t('sidebar.workspace')}
                   </p>

--- a/apps/desktop/src/components/settings-view.tsx
+++ b/apps/desktop/src/components/settings-view.tsx
@@ -872,8 +872,14 @@ function SkillsSettingsPanel({
   const [newDescription, setNewDescription] = useState("");
   const [createRootKind, setCreateRootKind] = useState<DesktopSkillRootKind>("user");
 
-  const items = snapshot?.skillsList ?? [];
-  const localizedSkillCreateRootOptions = skillCreateRootOptions.map((option) => ({
+  const workspaceBindingDisabled = snapshot?.workspaceBinding === "none";
+  const items = (snapshot?.skillsList ?? []).filter(
+    (item) => !workspaceBindingDisabled || item.scope === "user",
+  );
+  const availableSkillCreateRootOptions = workspaceBindingDisabled
+    ? skillCreateRootOptions.filter((option) => option.kind === "user")
+    : skillCreateRootOptions;
+  const localizedSkillCreateRootOptions = availableSkillCreateRootOptions.map((option) => ({
     ...option,
     label: option.labelKey ? t(option.labelKey) : option.labelFallback,
     hint: t(option.hintKey),
@@ -891,6 +897,9 @@ function SkillsSettingsPanel({
         <div className="min-w-0 flex-1 space-y-1">
           <h1 className="text-xl font-semibold tracking-tight text-foreground">Skills</h1>
           <p className="text-sm text-muted-foreground">{t('settings.skillsDescription')}</p>
+          {workspaceBindingDisabled ? (
+            <p className="text-xs text-muted-foreground">{t('app.noWorkspaceBindingHint')}</p>
+          ) : null}
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {onGenerateSkillNavigate ? (
@@ -1651,9 +1660,12 @@ function McpsSettingsPanel({
   "snapshot" | "mcpsBusy" | "onAddMcpServer" | "onDeleteMcpServer" | "onInspectMcpServer"
 >) {
   const { t } = useTranslation();
+  const workspaceBindingDisabled = snapshot?.workspaceBinding === "none";
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<DeleteMcpServerRequest | null>(null);
-  const [createScope, setCreateScope] = useState<DesktopMcpScope>("workspace");
+  const [createScope, setCreateScope] = useState<DesktopMcpScope>(
+    workspaceBindingDisabled ? "user" : "workspace",
+  );
   const [transportType, setTransportType] = useState<DesktopMcpTransportType>("stdio");
   const [newName, setNewName] = useState("");
   const [newEndpoint, setNewEndpoint] = useState("");
@@ -1662,7 +1674,10 @@ function McpsSettingsPanel({
   const [runtimeInfo, setRuntimeInfo] = useState<Record<string, McpServerRuntimeInfo>>({});
 
   const items = snapshot?.mcpServers ?? [];
-  const localizedMcpCreateScopeOptions = mcpCreateScopeOptions.map((option) => ({
+  const availableMcpCreateScopeOptions = workspaceBindingDisabled
+    ? mcpCreateScopeOptions.filter((option) => option.scope === "user")
+    : mcpCreateScopeOptions;
+  const localizedMcpCreateScopeOptions = availableMcpCreateScopeOptions.map((option) => ({
     ...option,
     label: t(option.labelKey),
     hint: t(option.hintKey),
@@ -1731,7 +1746,7 @@ function McpsSettingsPanel({
   }, [items, onInspectMcpServer]);
 
   const resetForm = () => {
-    setCreateScope("workspace");
+    setCreateScope(workspaceBindingDisabled ? "user" : "workspace");
     setTransportType("stdio");
     setNewName("");
     setNewEndpoint("");
@@ -1745,6 +1760,9 @@ function McpsSettingsPanel({
         <div className="min-w-0 flex-1 space-y-1">
           <h1 className="text-xl font-semibold tracking-tight text-foreground">MCPs</h1>
           <p className="text-sm text-muted-foreground">{t('settings.mcpsDescription')}</p>
+          {workspaceBindingDisabled ? (
+            <p className="text-xs text-muted-foreground">{t('app.noWorkspaceBindingHint')}</p>
+          ) : null}
         </div>
         <Button
           type="button"

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -519,7 +519,7 @@ export function useDesktopRuntime() {
       setBusyAction("bootstrap");
       try {
         stashSessionUi(snapshotRef.current);
-        const next = await api.bootstrap({ workspaceRoot });
+        const next = await api.bootstrap({ workspaceRoot, workspaceBinding: 'project' });
         applySnapshot(next);
         restoreSessionUi(next);
         setQuestionError("");
@@ -535,6 +535,29 @@ export function useDesktopRuntime() {
     },
     [api, applySnapshot, refreshSessions, restoreSessionUi, stashSessionUi],
   );
+
+  const switchToNoWorkspaceBinding = useCallback(async (): Promise<boolean> => {
+    if (!api) {
+      return false;
+    }
+
+    setBusyAction("bootstrap");
+    try {
+      stashSessionUi(snapshotRef.current);
+      const next = await api.bootstrap({ workspaceBinding: 'none' });
+      applySnapshot(next);
+      restoreSessionUi(next);
+      setQuestionError("");
+      setRuntimeError("");
+      void refreshSessions();
+      return true;
+    } catch (error) {
+      setRuntimeError(describeError(error));
+      return false;
+    } finally {
+      setBusyAction("");
+    }
+  }, [api, applySnapshot, refreshSessions, restoreSessionUi, stashSessionUi]);
 
   const rememberWorkspaceRoot = useCallback(
     async (workspaceRoot: string): Promise<boolean> => {
@@ -1987,6 +2010,7 @@ export function useDesktopRuntime() {
     updateQuestionDraft,
     bootstrap,
     switchWorkspaceRoot,
+    switchToNoWorkspaceBinding,
     rememberWorkspaceRoot,
     pickWorkspaceDirectory,
     pickLocalFile,

--- a/apps/desktop/src/host/mcp-config.ts
+++ b/apps/desktop/src/host/mcp-config.ts
@@ -111,13 +111,19 @@ function mapServerListItem(
   }
 }
 
-export function listDesktopMcpServersFromDisk(workspaceRoot: string): DesktopMcpServerListItem[] {
+export function listDesktopMcpServersFromDisk(
+  workspaceRoot: string,
+  workspaceBinding: 'project' | 'none' = 'project',
+): DesktopMcpServerListItem[] {
   try {
     const userConfig = loadMcpConfigFileAt(desktopUserMcpConfigPath());
-    const workspaceConfig = loadMcpConfigFileAt(desktopWorkspaceMcpConfigPath(workspaceRoot));
     const userItems = Object.entries(userConfig.servers).map(([name, server]) =>
       mapServerListItem(name, server, 'user'),
     );
+    if (workspaceBinding === 'none') {
+      return userItems;
+    }
+    const workspaceConfig = loadMcpConfigFileAt(desktopWorkspaceMcpConfigPath(workspaceRoot));
     const workspaceItems = Object.entries(workspaceConfig.servers).map(([name, server]) =>
       mapServerListItem(name, server, 'workspace'),
     );

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -25,7 +25,9 @@ import type { GeneratedWorktreeNames } from './worktree-naming.js';
 import {
   type DesktopConfigFile,
   type DesktopWebHostConfigFile,
+  type DesktopWorkspaceBinding,
   mergeRecentWorkspaceRoots,
+  resolveDesktopHomeDirectory,
 } from './storage.js';
 import {
   DESKTOP_WEB_HOST_POLICY,
@@ -40,20 +42,62 @@ export function sameWorkspaceRoot(left: string, right: string): boolean {
   return normalizeWorkspaceRootKey(left) === normalizeWorkspaceRootKey(right);
 }
 
+/** Sessions whose cwd is the user home directory are "unbound" (no project workspace). */
+export function isNoWorkspaceSessionRoot(workspaceRoot: string): boolean {
+  return sameWorkspaceRoot(workspaceRoot, resolveDesktopHomeDirectory());
+}
+
+export function resolveWorkspaceBindingForRequestedRoot(input: {
+  requestedWorkspaceRoot?: string;
+  explicitBinding?: DesktopWorkspaceBinding;
+  previousBinding: DesktopWorkspaceBinding;
+  persistedBinding: DesktopWorkspaceBinding;
+}): DesktopWorkspaceBinding {
+  if (input.explicitBinding === 'none') {
+    return 'none';
+  }
+  if (input.explicitBinding === 'project') {
+    return 'project';
+  }
+  if (!input.requestedWorkspaceRoot?.trim()) {
+    return input.previousBinding;
+  }
+  if (
+    isNoWorkspaceSessionRoot(input.requestedWorkspaceRoot)
+    && (input.previousBinding === 'none' || input.persistedBinding === 'none')
+  ) {
+    return 'none';
+  }
+  return 'project';
+}
+
 export function deriveWorkspaceLabel(workspaceRoot: string): string {
   const normalized = workspaceRoot.replace(/\\/g, '/').replace(/\/+$/g, '');
   const lastSlash = normalized.lastIndexOf('/');
   return lastSlash >= 0 ? normalized.slice(lastSlash + 1) || normalized : normalized;
 }
 
-export function buildAvailableWorkspaces(currentWorkspaceRoot: string, recentWorkspaces?: string[]) {
-  const groupingCurrent = resolveWorkspaceGroupingRoot(currentWorkspaceRoot);
-  const merged = mergeRecentWorkspaceRoots(recentWorkspaces, groupingCurrent);
+export function buildAvailableWorkspaces(
+  currentWorkspaceRoot: string,
+  recentWorkspaces?: string[],
+  workspaceBinding: DesktopWorkspaceBinding = 'project',
+) {
+  const homeKey = normalizeWorkspaceRootKey(resolveDesktopHomeDirectory());
+  const merged =
+    workspaceBinding === 'none'
+      ? (recentWorkspaces ?? [])
+      : mergeRecentWorkspaceRoots(
+          recentWorkspaces,
+          resolveWorkspaceGroupingRoot(currentWorkspaceRoot),
+        );
   const seen = new Set<string>();
   const items: Array<{ path: string; label: string }> = [];
   for (const workspaceRoot of merged) {
     const groupingRoot = resolveWorkspaceGroupingRoot(workspaceRoot);
-    const key = groupingRoot.replace(/\\/g, '/').toLowerCase();
+    const key = normalizeWorkspaceRootKey(groupingRoot);
+    if (workspaceBinding === 'none' && key === homeKey) {
+      continue;
+    }
     if (seen.has(key)) {
       continue;
     }

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -62,10 +62,7 @@ export function resolveWorkspaceBindingForRequestedRoot(input: {
   if (!input.requestedWorkspaceRoot?.trim()) {
     return input.previousBinding;
   }
-  if (
-    isNoWorkspaceSessionRoot(input.requestedWorkspaceRoot)
-    && (input.previousBinding === 'none' || input.persistedBinding === 'none')
-  ) {
+  if (isNoWorkspaceSessionRoot(input.requestedWorkspaceRoot)) {
     return 'none';
   }
   return 'project';
@@ -95,7 +92,7 @@ export function buildAvailableWorkspaces(
   for (const workspaceRoot of merged) {
     const groupingRoot = resolveWorkspaceGroupingRoot(workspaceRoot);
     const key = normalizeWorkspaceRootKey(groupingRoot);
-    if (workspaceBinding === 'none' && key === homeKey) {
+    if (key === homeKey) {
       continue;
     }
     if (seen.has(key)) {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -252,6 +252,7 @@ import {
   parseGeneratedCommitMessageResponse,
   parseGeneratedWorktreeNamingResponse,
   sameDreamCollectorSnapshot,
+  resolveWorkspaceBindingForRequestedRoot,
   sameWorkspaceRoot,
   toRuntimeAskQuestionsResult,
 } from './service-utils.js';
@@ -2580,14 +2581,12 @@ class DesktopHostService {
     const previousBinding = normalizeWorkspaceBinding(
       previousState?.workspaceBinding ?? loadedConfig.workspaceBinding,
     );
-    let workspaceBinding: DesktopWorkspaceBinding;
-    if (options.workspaceBinding === 'none') {
-      workspaceBinding = 'none';
-    } else if (options.workspaceBinding === 'project' || requestedWorkspaceRoot) {
-      workspaceBinding = 'project';
-    } else {
-      workspaceBinding = previousBinding;
-    }
+    const workspaceBinding = resolveWorkspaceBindingForRequestedRoot({
+      requestedWorkspaceRoot,
+      explicitBinding: options.workspaceBinding,
+      previousBinding,
+      persistedBinding: normalizeWorkspaceBinding(loadedConfig.workspaceBinding),
+    });
 
     const workspaceRoot =
       workspaceBinding === 'none'
@@ -2670,7 +2669,6 @@ class DesktopHostService {
     const switchingWorkspace = Boolean(
       previousWorkspaceRoot && !sameWorkspaceRoot(previousWorkspaceRoot, workspaceRoot),
     );
-
     if (switchingWorkspace) {
       await this.extensionManager().deactivateAll();
     }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -172,6 +172,8 @@ import {
   provisionalNewSessionPath,
   loadConfig,
   loadHostMetadata,
+  normalizeWorkspaceBinding,
+  resolveDesktopHomeDirectory,
   loadStoredSession,
   modelSecretKeyPresence,
   mergeRecentWorkspaceRoots,
@@ -189,6 +191,7 @@ import {
   normalizeWebHostConfig,
   type DesktopConfigFile,
   type DesktopWebHostConfigFile,
+  type DesktopWorkspaceBinding,
   type HostMetadataSummary,
 } from './storage.js';
 import { DesktopToolExecutor } from './tool-executor.js';
@@ -406,6 +409,7 @@ type CommandPayloads = {
 
 interface HostState {
   workspaceRoot: string;
+  workspaceBinding: DesktopWorkspaceBinding;
   config: DesktopConfigFile;
   git: DesktopGitSnapshot;
   metadata: HostMetadataSummary;
@@ -603,7 +607,10 @@ class DesktopHostService {
 
   async bootstrap(request?: BootstrapRequest): Promise<DesktopSnapshot> {
     return this.runSerialized(async () => {
-      await this.ensureInitialized(request?.workspaceRoot);
+      await this.ensureInitialized(request?.workspaceRoot, {
+        workspaceBinding: request?.workspaceBinding,
+        ...(request?.workspaceBinding === 'none' ? { preserveRecentWorkspaces: true } : {}),
+      });
       this.startDreamCollectorMonitorIfNeeded();
       return this.buildSnapshot();
     });
@@ -756,6 +763,7 @@ class DesktopHostService {
       if (planModeNow !== prevPlanMode) {
         state.metadata = await loadHostMetadata(state.workspaceRoot, planModeNow, {
           activePlanPath: this.activeBundle().activePlanPath,
+          workspaceBinding: state.workspaceBinding,
         });
       }
 
@@ -1084,6 +1092,15 @@ class DesktopHostService {
         throw new Error(i18n.t('error.runtimeBusySkill'));
       }
       const state = this.requireState();
+      const rootKind = request.rootKind ?? 'workspaceSpirit';
+      if (
+        state.workspaceBinding === 'none'
+        && (rootKind === 'workspaceSpirit' || rootKind === 'workspaceAgents')
+      ) {
+        throw new Error(
+          'Workspace-scoped skills are unavailable when workspace binding is disabled.',
+        );
+      }
       await createSkillFile(state.workspaceRoot, request);
 
       await this.refreshRuntime();
@@ -1112,12 +1129,18 @@ class DesktopHostService {
       }
 
       const scope = request.scope ?? 'workspace';
+      if (scope === 'workspace' && state.workspaceBinding === 'none') {
+        throw new Error(
+          'Workspace-scoped MCP servers are unavailable when workspace binding is disabled.',
+        );
+      }
       const serverConfig = buildMcpServerConfigFromRequest({ ...request, scope });
       await addMcpServerToDisk(scope, state.workspaceRoot, name, serverConfig);
       if (scope === 'user') {
         invalidateSharedUserMcpToolingCache();
       }
-      this.sharedMcpServiceForWorkspace(state.workspaceRoot).startBackgroundRefreshInBackground(true);
+      this.sharedMcpServiceForWorkspace(state.workspaceRoot, state.workspaceBinding)
+        .startBackgroundRefreshInBackground(true);
       this.toolExecutor?.startMcpBackgroundRefresh();
       return this.buildSnapshot();
     });
@@ -1138,7 +1161,8 @@ class DesktopHostService {
       if (scope === 'user') {
         invalidateSharedUserMcpToolingCache();
       }
-      this.sharedMcpServiceForWorkspace(state.workspaceRoot).startBackgroundRefreshInBackground(true);
+      this.sharedMcpServiceForWorkspace(state.workspaceRoot, state.workspaceBinding)
+        .startBackgroundRefreshInBackground(true);
       this.toolExecutor?.startMcpBackgroundRefresh();
       return this.buildSnapshot();
     });
@@ -2544,56 +2568,102 @@ class DesktopHostService {
       preserveRecentWorkspaces?: boolean;
       /** Skip global runtime rebuild after workspace switch; caller will activate a session bundle. */
       deferRuntimeRefresh?: boolean;
+      workspaceBinding?: DesktopWorkspaceBinding;
     } = {},
   ): Promise<void> {
     const requestedWorkspaceRoot = workspaceRootOverride?.trim()
       ? path.resolve(workspaceRootOverride.trim())
       : undefined;
+
+    const loadedConfig = await loadConfig();
+    const previousState = this.state;
+    const previousBinding = normalizeWorkspaceBinding(
+      previousState?.workspaceBinding ?? loadedConfig.workspaceBinding,
+    );
+    let workspaceBinding: DesktopWorkspaceBinding;
+    if (options.workspaceBinding === 'none') {
+      workspaceBinding = 'none';
+    } else if (options.workspaceBinding === 'project' || requestedWorkspaceRoot) {
+      workspaceBinding = 'project';
+    } else {
+      workspaceBinding = previousBinding;
+    }
+
+    const workspaceRoot =
+      workspaceBinding === 'none'
+        ? resolveDesktopHomeDirectory()
+        : requestedWorkspaceRoot
+          ?? (previousState?.workspaceBinding === 'project' ? previousState.workspaceRoot : undefined)
+          ?? loadedConfig.lastProjectWorkspaceRoot
+          ?? loadedConfig.recentWorkspaces?.[0]
+          ?? discoverWorkspaceRoot();
+
     if (
       options.fastPath === true &&
       this.initialized &&
-      this.state?.workspaceRoot &&
-      (!requestedWorkspaceRoot || sameWorkspaceRoot(this.state.workspaceRoot, requestedWorkspaceRoot))
+      previousState?.workspaceRoot &&
+      sameWorkspaceRoot(previousState.workspaceRoot, workspaceRoot) &&
+      previousBinding === workspaceBinding
     ) {
       return;
     }
 
-    const loadedConfig = await loadConfig();
-    const workspaceRoot = requestedWorkspaceRoot
-      ?? (this.initialized && this.state?.workspaceRoot ? this.state.workspaceRoot : undefined)
-      ?? loadedConfig.recentWorkspaces?.[0]
-      ?? discoverWorkspaceRoot();
     const git = await readWorkspaceGitSnapshot(workspaceRoot);
+    let lastProjectWorkspaceRoot = loadedConfig.lastProjectWorkspaceRoot;
+    if (
+      workspaceBinding === 'none'
+      && previousBinding === 'project'
+      && previousState?.workspaceRoot
+      && !sameWorkspaceRoot(previousState.workspaceRoot, resolveDesktopHomeDirectory())
+    ) {
+      lastProjectWorkspaceRoot = previousState.workspaceRoot;
+    }
+
+    const preserveRecent =
+      workspaceBinding === 'none'
+      || options.preserveRecentWorkspaces === true;
     const config = {
       ...loadedConfig,
-      recentWorkspaces:
-        options.preserveRecentWorkspaces === true
-          ? (loadedConfig.recentWorkspaces ?? [])
-          : mergeRecentWorkspaceRoots(
-              loadedConfig.recentWorkspaces,
-              git.primaryRepoRoot ?? workspaceRoot,
-            ),
+      workspaceBinding,
+      ...(lastProjectWorkspaceRoot ? { lastProjectWorkspaceRoot } : {}),
+      recentWorkspaces: preserveRecent
+        ? (loadedConfig.recentWorkspaces ?? [])
+        : mergeRecentWorkspaceRoots(
+            loadedConfig.recentWorkspaces,
+            git.primaryRepoRoot ?? workspaceRoot,
+          ),
     } satisfies DesktopConfigFile;
 
     const recentWorkspacesChanged =
       !loadedConfig.recentWorkspaces ||
       config.recentWorkspaces.length !== loadedConfig.recentWorkspaces.length ||
       config.recentWorkspaces.some((entry, index) => entry !== loadedConfig.recentWorkspaces?.[index]);
-    if (recentWorkspacesChanged) {
+    const bindingChanged = normalizeWorkspaceBinding(loadedConfig.workspaceBinding) !== workspaceBinding;
+    const lastProjectChanged = loadedConfig.lastProjectWorkspaceRoot !== config.lastProjectWorkspaceRoot;
+    if (recentWorkspacesChanged || bindingChanged || lastProjectChanged) {
       await saveConfig(config);
     }
 
-    if (this.initialized && this.state?.workspaceRoot && sameWorkspaceRoot(this.state.workspaceRoot, workspaceRoot)) {
-      this.state.config = config;
-      this.state.git = git;
-      this.state.plan = await loadDesktopPlanSnapshot(
-        this.state.metadata.planMetadata.path,
-        this.state.metadata.planMetadata.exists,
+    if (
+      this.initialized
+      && previousState?.workspaceRoot
+      && sameWorkspaceRoot(previousState.workspaceRoot, workspaceRoot)
+      && previousBinding === workspaceBinding
+    ) {
+      const currentState = this.requireState();
+      currentState.config = config;
+      currentState.git = git;
+      currentState.workspaceBinding = workspaceBinding;
+      currentState.plan = await loadDesktopPlanSnapshot(
+        currentState.metadata.planMetadata.path,
+        currentState.metadata.planMetadata.exists,
       );
       return;
     }
 
-    const metadata = await loadHostMetadata(workspaceRoot, config.planMode === true);
+    const metadata = await loadHostMetadata(workspaceRoot, config.planMode === true, {
+      workspaceBinding,
+    });
     const plan = await loadDesktopPlanSnapshot(metadata.planMetadata.path, metadata.planMetadata.exists);
     const state = this.state;
     const previousWorkspaceRoot = state?.workspaceRoot;
@@ -2618,6 +2688,7 @@ class DesktopHostService {
 
     this.state = {
       workspaceRoot,
+      workspaceBinding,
       config,
       git,
       metadata,
@@ -2663,7 +2734,7 @@ class DesktopHostService {
     state.metadata = await loadHostMetadata(
       state.workspaceRoot,
       state.config.planMode === true,
-      { activePlanPath },
+      { activePlanPath, workspaceBinding: state.workspaceBinding },
     );
     state.plan = await loadDesktopPlanSnapshot(
       state.metadata.planMetadata.path,
@@ -2805,11 +2876,15 @@ class DesktopHostService {
     return bundle.toolExecutor;
   }
 
-  private sharedMcpServiceForWorkspace(workspaceRoot: string): McpService {
-    const key = path.resolve(workspaceRoot);
+  private sharedMcpServiceForWorkspace(
+    workspaceRoot: string,
+    workspaceBinding: DesktopWorkspaceBinding = 'project',
+  ): McpService {
+    const includeWorkspaceConfig = workspaceBinding === 'project';
+    const key = `${path.resolve(workspaceRoot)}|${includeWorkspaceConfig ? 'project' : 'none'}`;
     let service = this.mcpServiceByWorkspaceRoot.get(key);
     if (!service) {
-      service = new McpService(key);
+      service = new McpService(path.resolve(workspaceRoot), includeWorkspaceConfig);
       service.startBackgroundRefreshInBackground(false);
       this.mcpServiceByWorkspaceRoot.set(key, service);
     }
@@ -2825,7 +2900,7 @@ class DesktopHostService {
     const workspaceRoot = bundle.workspaceRoot || state.workspaceRoot;
     const extensions = await this.extensionManager().list();
     return new DesktopToolExecutor(workspaceRoot, {
-      mcp: this.sharedMcpServiceForWorkspace(workspaceRoot),
+      mcp: this.sharedMcpServiceForWorkspace(workspaceRoot, state.workspaceBinding),
       extensionToolDefinitions: buildDesktopExtensionToolDefinitions(extensions),
       fileChangeObserver: {
         recordFileChange: (change) => {
@@ -3282,7 +3357,7 @@ class DesktopHostService {
         this.activeBundle().toolExecutor?.mcpStatusSnapshot()
         ?? this.toolExecutor?.mcpStatusSnapshot()
         ?? emptyMcpStatusSnapshot(),
-      mcpServers: listDesktopMcpServersFromDisk(state.workspaceRoot),
+      mcpServers: listDesktopMcpServersFromDisk(state.workspaceRoot, state.workspaceBinding),
       conversation: {
         revision: activeBundle.conversationRevision,
         messages: conversationMessages,
@@ -4237,6 +4312,7 @@ class DesktopHostService {
       if (bundle.activePlanPath && sameFsPath(change.resolvedPath, bundle.activePlanPath)) {
         state.metadata = await loadHostMetadata(state.workspaceRoot, state.config.planMode === true, {
           activePlanPath: bundle.activePlanPath,
+          workspaceBinding: state.workspaceBinding,
         });
       }
       state.metadata.planMetadata.exists = change.after.exists && change.after.file;

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -21,6 +21,7 @@ import {
   buildAvailableWorkspaces,
   buildWebHostSnapshot,
 } from './service-utils.js';
+import { resolveDesktopHomeDirectory } from './storage.js';
 
 export interface BuildDesktopSnapshotInput {
   workspaceRoot: string;
@@ -45,6 +46,7 @@ export interface BuildDesktopSnapshotInput {
 export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopSnapshot {
   return {
     workspaceRoot: input.workspaceRoot,
+    userHomeDirectory: resolveDesktopHomeDirectory(),
     workspaceBinding: normalizeWorkspaceBinding(input.config.workspaceBinding),
     availableWorkspaces: buildAvailableWorkspaces(
       input.workspaceRoot,

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -49,6 +49,7 @@ export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopS
     availableWorkspaces: buildAvailableWorkspaces(
       input.workspaceRoot,
       input.config.recentWorkspaces,
+      normalizeWorkspaceBinding(input.config.workspaceBinding),
     ),
     git: { ...input.git },
     dreams: {

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -13,6 +13,7 @@ import type {
 import { readModelCatalogCacheSync } from './model-catalog-cache.js';
 import {
   DEFAULT_API_BASE,
+  normalizeWorkspaceBinding,
   type DesktopConfigFile,
   type HostMetadataSummary,
 } from './storage.js';
@@ -44,6 +45,7 @@ export interface BuildDesktopSnapshotInput {
 export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopSnapshot {
   return {
     workspaceRoot: input.workspaceRoot,
+    workspaceBinding: normalizeWorkspaceBinding(input.config.workspaceBinding),
     availableWorkspaces: buildAvailableWorkspaces(
       input.workspaceRoot,
       input.config.recentWorkspaces,

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -644,6 +644,9 @@ function normalizeRecentWorkspaceRoots(value: unknown): string[] {
       continue;
     }
     const key = normalizeWorkspaceKey(workspaceRoot);
+    if (key === normalizeWorkspaceKey(resolveDesktopHomeDirectory())) {
+      continue;
+    }
     if (seen.has(key)) {
       continue;
     }
@@ -663,6 +666,9 @@ export function mergeRecentWorkspaceRoots(
 ): string[] {
   const resolvedWorkspaceRoot = path.resolve(workspaceRoot);
   const targetKey = normalizeWorkspaceKey(resolvedWorkspaceRoot);
+  if (targetKey === normalizeWorkspaceKey(resolveDesktopHomeDirectory())) {
+    return normalizeRecentWorkspaceRoots(existing);
+  }
   return [
     resolvedWorkspaceRoot,
     ...normalizeRecentWorkspaceRoots(existing).filter(

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -7,6 +7,7 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
+import { homedir } from 'node:os';
 import path from 'node:path';
 
 import { Entry } from '@napi-rs/keyring';
@@ -51,16 +52,30 @@ const MAX_RECENT_WORKSPACES = 20;
 const MODEL_CAPABILITIES = ['chat', 'image', 'video', 'imageGeneration'] as const;
 const DEFAULT_CUSTOM_MODEL_CAPABILITIES: DesktopModelCapability[] = ['chat', 'image'];
 
+export type DesktopWorkspaceBinding = 'project' | 'none';
+
 export interface DesktopConfigFile {
   models: ModelProfileSnapshot[];
   activeModel: string;
   imageGenerationModel?: string;
   recentWorkspaces?: string[];
+  /** When `none`, cwd is the user home directory and workspace-scoped instructions/MCP are skipped. */
+  workspaceBinding?: DesktopWorkspaceBinding;
+  /** Last project workspace root before switching to `none`; used when re-selecting a workspace. */
+  lastProjectWorkspaceRoot?: string;
   uiLocale?: string;
   windowsMica?: boolean;
   planMode?: boolean;
   webHost: DesktopWebHostConfigFile;
   dreams: DesktopDreamConfigFile;
+}
+
+export function normalizeWorkspaceBinding(value: unknown): DesktopWorkspaceBinding {
+  return value === 'none' ? 'none' : 'project';
+}
+
+export function resolveDesktopHomeDirectory(): string {
+  return path.resolve(homedir());
 }
 
 export interface DesktopWebHostConfigFile {
@@ -289,11 +304,13 @@ export function createDesktopExtensionStateStore(
 export async function loadHostMetadata(
   workspaceRoot: string,
   planMode = false,
-  options?: { activePlanPath?: string },
+  options?: { activePlanPath?: string; workspaceBinding?: DesktopWorkspaceBinding },
 ): Promise<HostMetadataSummary> {
+  const workspaceBinding = options?.workspaceBinding ?? 'project';
   return loadHostInstructionMetadata({
     workspaceRoot,
     spiritDataDir: spiritAgentDataDir(),
+    includeWorkspaceScope: workspaceBinding === 'project',
   }, {
     planMode,
     activePlanPath: options?.activePlanPath,
@@ -466,6 +483,10 @@ function normalizeConfig(raw: Partial<DesktopConfigFile>): DesktopConfigFile {
     activeModel,
     ...(imageGenerationModel ? { imageGenerationModel } : {}),
     recentWorkspaces: normalizeRecentWorkspaceRoots(raw.recentWorkspaces),
+    workspaceBinding: normalizeWorkspaceBinding(raw.workspaceBinding),
+    ...(typeof raw.lastProjectWorkspaceRoot === 'string' && raw.lastProjectWorkspaceRoot.trim()
+      ? { lastProjectWorkspaceRoot: path.resolve(raw.lastProjectWorkspaceRoot.trim()) }
+      : {}),
     ...(typeof raw.uiLocale === 'string' && raw.uiLocale.trim()
       ? { uiLocale: raw.uiLocale.trim() }
       : {}),

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -332,6 +332,7 @@
     "searchWorkspace": "Search workspaces",
     "noMatches": "No matches",
     "addWorkspace": "Add Workspace",
+    "noWorkspace": "No workspace",
     "previewUnavailable": "Preview unavailable",
     "downloadImage": "Download Image",
     "viewLargeImage": "View Large Image",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -255,6 +255,7 @@
     "newSession": "New Session",
     "extensions": "Extensions",
     "workspace": "Workspace",
+    "noWorkspaceSessions": "No workspace",
     "settingsTabsAria": "Settings Tabs",
     "extensionSettings": "Extension Settings",
     "workspaceSessionsAria": "Workspace Sessions"

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -333,6 +333,7 @@
     "noMatches": "No matches",
     "addWorkspace": "Add Workspace",
     "noWorkspace": "No workspace",
+    "noWorkspaceBindingHint": "Workspace binding is off; only user-level MCP and Skills apply.",
     "previewUnavailable": "Preview unavailable",
     "downloadImage": "Download Image",
     "viewLargeImage": "View Large Image",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -333,6 +333,7 @@
     "noMatches": "无匹配项",
     "addWorkspace": "添加工作区",
     "noWorkspace": "不使用工作区",
+    "noWorkspaceBindingHint": "当前未绑定工作区，仅使用用户级 MCP 与 Skills。",
     "previewUnavailable": "预览不可用",
     "downloadImage": "下载图片",
     "viewLargeImage": "查看大图",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -255,6 +255,7 @@
     "newSession": "新会话",
     "extensions": "扩展",
     "workspace": "工作区",
+    "noWorkspaceSessions": "无工作区",
     "settingsTabsAria": "设置页签",
     "extensionSettings": "扩展设置",
     "workspaceSessionsAria": "工作区会话"

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -332,6 +332,7 @@
     "searchWorkspace": "搜索工作区",
     "noMatches": "无匹配项",
     "addWorkspace": "添加工作区",
+    "noWorkspace": "不使用工作区",
     "previewUnavailable": "预览不可用",
     "downloadImage": "下载图片",
     "viewLargeImage": "查看大图",

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -508,6 +508,8 @@ export interface WriteWorkspaceTextFileRequest {
 
 export interface DesktopSnapshot {
   workspaceRoot: string;
+  /** 用户主目录；侧栏划分「无工作区」会话与项目工作区会话时使用。 */
+  userHomeDirectory: string;
   workspaceBinding: DesktopWorkspaceBinding;
   availableWorkspaces: DesktopWorkspaceListItem[];
   git: DesktopGitSnapshot;

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -5,8 +5,11 @@ import type { WorkspaceFileReferenceSuggestionsResult as HostWorkspaceFileRefere
 import type { BrowserElementAttachment } from './lib/browser-element-attachment.js';
 import type { ComposerLocalFileAttachmentView } from './lib/local-file-attachments.js';
 
+export type DesktopWorkspaceBinding = 'project' | 'none';
+
 export interface BootstrapRequest {
   workspaceRoot?: string;
+  workspaceBinding?: DesktopWorkspaceBinding;
 }
 
 export interface RememberWorkspaceRequest {
@@ -505,6 +508,7 @@ export interface WriteWorkspaceTextFileRequest {
 
 export interface DesktopSnapshot {
   workspaceRoot: string;
+  workspaceBinding: DesktopWorkspaceBinding;
   availableWorkspaces: DesktopWorkspaceListItem[];
   git: DesktopGitSnapshot;
   dreams: DesktopDreamSnapshot;

--- a/apps/desktop/test/host/workspace-binding.test.mjs
+++ b/apps/desktop/test/host/workspace-binding.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  normalizeWorkspaceBinding,
+  resolveDesktopHomeDirectory,
+} from '../../dist-electron/src/host/storage.js';
+
+test('normalizeWorkspaceBinding treats only none as none', () => {
+  assert.equal(normalizeWorkspaceBinding('none'), 'none');
+  assert.equal(normalizeWorkspaceBinding('project'), 'project');
+  assert.equal(normalizeWorkspaceBinding(undefined), 'project');
+  assert.equal(normalizeWorkspaceBinding(''), 'project');
+});
+
+test('resolveDesktopHomeDirectory returns an absolute path', () => {
+  const home = resolveDesktopHomeDirectory();
+  assert.ok(home.length > 0);
+  assert.ok(!home.endsWith('.'));
+});

--- a/apps/desktop/test/host/workspace-binding.test.mjs
+++ b/apps/desktop/test/host/workspace-binding.test.mjs
@@ -35,6 +35,18 @@ test('resolveWorkspaceBindingForRequestedRoot keeps none when opening homedir se
   );
 });
 
+test('resolveWorkspaceBindingForRequestedRoot uses none for homedir even when persisted project', () => {
+  const home = resolveDesktopHomeDirectory();
+  assert.equal(
+    resolveWorkspaceBindingForRequestedRoot({
+      requestedWorkspaceRoot: home,
+      previousBinding: 'project',
+      persistedBinding: 'project',
+    }),
+    'none',
+  );
+});
+
 test('resolveWorkspaceBindingForRequestedRoot uses project for real workspace roots', () => {
   assert.equal(
     resolveWorkspaceBindingForRequestedRoot({
@@ -53,4 +65,12 @@ test('buildAvailableWorkspaces excludes homedir when workspace binding is none',
   const paths = items.map((item) => item.path.replace(/\\/g, '/').toLowerCase());
   assert.ok(!paths.includes(home.replace(/\\/g, '/').toLowerCase()));
   assert.ok(paths.some((entry) => entry.endsWith('/spiritagent')));
+});
+
+test('buildAvailableWorkspaces excludes homedir when workspace binding is project', () => {
+  const home = resolveDesktopHomeDirectory();
+  const recent = [home, 'D:/SpiritAgent'];
+  const items = buildAvailableWorkspaces(home, recent, 'project');
+  const paths = items.map((item) => item.path.replace(/\\/g, '/').toLowerCase());
+  assert.ok(!paths.includes(home.replace(/\\/g, '/').toLowerCase()));
 });

--- a/apps/desktop/test/host/workspace-binding.test.mjs
+++ b/apps/desktop/test/host/workspace-binding.test.mjs
@@ -5,6 +5,10 @@ import {
   normalizeWorkspaceBinding,
   resolveDesktopHomeDirectory,
 } from '../../dist-electron/src/host/storage.js';
+import {
+  buildAvailableWorkspaces,
+  resolveWorkspaceBindingForRequestedRoot,
+} from '../../dist-electron/src/host/service-utils.js';
 
 test('normalizeWorkspaceBinding treats only none as none', () => {
   assert.equal(normalizeWorkspaceBinding('none'), 'none');
@@ -17,4 +21,36 @@ test('resolveDesktopHomeDirectory returns an absolute path', () => {
   const home = resolveDesktopHomeDirectory();
   assert.ok(home.length > 0);
   assert.ok(!home.endsWith('.'));
+});
+
+test('resolveWorkspaceBindingForRequestedRoot keeps none when opening homedir session', () => {
+  const home = resolveDesktopHomeDirectory();
+  assert.equal(
+    resolveWorkspaceBindingForRequestedRoot({
+      requestedWorkspaceRoot: home,
+      previousBinding: 'none',
+      persistedBinding: 'none',
+    }),
+    'none',
+  );
+});
+
+test('resolveWorkspaceBindingForRequestedRoot uses project for real workspace roots', () => {
+  assert.equal(
+    resolveWorkspaceBindingForRequestedRoot({
+      requestedWorkspaceRoot: 'D:/SpiritAgent',
+      previousBinding: 'none',
+      persistedBinding: 'none',
+    }),
+    'project',
+  );
+});
+
+test('buildAvailableWorkspaces excludes homedir when workspace binding is none', () => {
+  const home = resolveDesktopHomeDirectory();
+  const recent = [home, 'D:/SpiritAgent'];
+  const items = buildAvailableWorkspaces(home, recent, 'none');
+  const paths = items.map((item) => item.path.replace(/\\/g, '/').toLowerCase());
+  assert.ok(!paths.includes(home.replace(/\\/g, '/').toLowerCase()));
+  assert.ok(paths.some((entry) => entry.endsWith('/spiritagent')));
 });

--- a/packages/agent-core/src/mcp/config.test.ts
+++ b/packages/agent-core/src/mcp/config.test.ts
@@ -71,3 +71,12 @@ test('findMcpServerNameConflict detects existing names in either scope', () => {
   assert.equal(findMcpServerNameConflict(user, workspace, 'local'), 'workspace');
   assert.equal(findMcpServerNameConflict(user, workspace, 'missing'), undefined);
 });
+
+test('mergeMcpConfigFiles with empty workspace yields user-only servers', () => {
+  const user: McpConfigFile = { servers: { github: stdioServer } };
+  const workspace: McpConfigFile = { servers: { local: stdioServer } };
+
+  const merged = mergeMcpConfigFiles(user, { servers: {} });
+  assert.deepEqual(Object.keys(merged.servers), ['github']);
+  assert.deepEqual(mcpServerScopesFromFiles(user, { servers: {} }), { github: 'user' });
+});

--- a/packages/agent-core/src/mcp/service.ts
+++ b/packages/agent-core/src/mcp/service.ts
@@ -117,7 +117,10 @@ export class McpService {
   private toolingRefreshPromise: Promise<void> | undefined;
   private toolingCacheInitialized = false;
 
-  constructor(private readonly workspaceRootStore = process.cwd()) {
+  constructor(
+    private readonly workspaceRootStore = process.cwd(),
+    private readonly includeWorkspaceConfig = true,
+  ) {
     this.registry.replaceConfig({ servers: {} });
   }
 
@@ -174,7 +177,10 @@ export class McpService {
 
   async refreshConfig(): Promise<void> {
     try {
-      const { merged, serverScopes, user } = await loadMergedMcpConfigForWorkspace(this.workspaceRootStore);
+      const { merged, serverScopes, user } = await loadMergedMcpConfigForWorkspace(
+        this.workspaceRootStore,
+        { includeWorkspace: this.includeWorkspaceConfig },
+      );
       const raw = merged;
       const nextDigest = mcpConfigDigest(raw);
       const nextUserDigest = mcpConfigDigest(user);
@@ -604,7 +610,10 @@ export class McpService {
     const routes = new Map<string, McpToolRoute>();
     const prompts = new Map<string, McpPromptCatalogEntry[]>();
 
-    const { user: userConfigFile } = await loadMergedMcpConfigForWorkspace(this.workspaceRootStore);
+    const { user: userConfigFile } = await loadMergedMcpConfigForWorkspace(
+      this.workspaceRootStore,
+      { includeWorkspace: this.includeWorkspaceConfig },
+    );
     const currentUserDigest = mcpConfigDigest(userConfigFile);
 
     let userCacheHit = false;
@@ -783,7 +792,10 @@ export class McpService {
 
   private primeRegistryFromDisk(): void {
     try {
-      const { merged, serverScopes } = loadMergedMcpConfigForWorkspaceSync(this.workspaceRootStore);
+      const { merged, serverScopes } = loadMergedMcpConfigForWorkspaceSync(
+        this.workspaceRootStore,
+        { includeWorkspace: this.includeWorkspaceConfig },
+      );
       const raw = merged;
       const nextDigest = mcpConfigDigest(raw);
       this.loadedConfigStore = {
@@ -820,14 +832,24 @@ function resolveMcpConfigPaths(workspaceRoot: string): { userPath: string; works
   };
 }
 
-async function loadMergedMcpConfigForWorkspace(workspaceRoot: string): Promise<{
+type LoadMergedMcpConfigOptions = {
+  includeWorkspace?: boolean;
+};
+
+async function loadMergedMcpConfigForWorkspace(
+  workspaceRoot: string,
+  options: LoadMergedMcpConfigOptions = {},
+): Promise<{
   merged: McpConfigFile;
   serverScopes: Record<string, McpConfigScope>;
   user: McpConfigFile;
 }> {
+  const includeWorkspace = options.includeWorkspace !== false;
   const { userPath, workspacePath } = resolveMcpConfigPaths(workspaceRoot);
   const user = await loadMcpConfigFile(userPath);
-  const workspace = await loadMcpConfigFile(workspacePath);
+  const workspace = includeWorkspace
+    ? await loadMcpConfigFile(workspacePath)
+    : { servers: {} };
   return {
     merged: mergeMcpConfigFiles(user, workspace),
     serverScopes: mcpServerScopesFromFiles(user, workspace),
@@ -835,13 +857,19 @@ async function loadMergedMcpConfigForWorkspace(workspaceRoot: string): Promise<{
   };
 }
 
-function loadMergedMcpConfigForWorkspaceSync(workspaceRoot: string): {
+function loadMergedMcpConfigForWorkspaceSync(
+  workspaceRoot: string,
+  options: LoadMergedMcpConfigOptions = {},
+): {
   merged: McpConfigFile;
   serverScopes: Record<string, McpConfigScope>;
 } {
+  const includeWorkspace = options.includeWorkspace !== false;
   const { userPath, workspacePath } = resolveMcpConfigPaths(workspaceRoot);
   const user = loadMcpConfigFileSync(userPath);
-  const workspace = loadMcpConfigFileSync(workspacePath);
+  const workspace = includeWorkspace
+    ? loadMcpConfigFileSync(workspacePath)
+    : { servers: {} };
   return {
     merged: mergeMcpConfigFiles(user, workspace),
     serverScopes: mcpServerScopesFromFiles(user, workspace),

--- a/packages/host-internal/src/discovery-scope.test.ts
+++ b/packages/host-internal/src/discovery-scope.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { discoverRuleEntries, discoverSkillEntries } from './discovery.js';
+import {
+  SKILLS_DIR_NAME,
+  USER_RULE_FILE_NAME,
+  WORKSPACE_RULE_FILE_NAME,
+  WORKSPACE_SPIRIT_SKILLS_DIR,
+} from './storage.js';
+
+test('discoverRuleEntries skips workspace sources when includeWorkspaceScope is false', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-discovery-scope-'));
+  const spiritDataDir = join(workspaceRoot, 'spirit-data');
+  await mkdir(spiritDataDir, { recursive: true });
+  await writeFile(join(workspaceRoot, WORKSPACE_RULE_FILE_NAME), '# workspace rule\n', 'utf8');
+  await writeFile(join(spiritDataDir, USER_RULE_FILE_NAME), '# user rule\n', 'utf8');
+
+  try {
+    const entries = await discoverRuleEntries({
+      workspaceRoot,
+      spiritDataDir,
+      includeWorkspaceScope: false,
+    });
+    const scopes = entries.filter((entry) => entry.exists).map((entry) => entry.source.scope);
+    assert.deepEqual(scopes, ['user']);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('discoverSkillEntries skips workspace roots when includeWorkspaceScope is false', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-discovery-skills-'));
+  const spiritDataDir = join(workspaceRoot, 'spirit-data');
+  const workspaceSkillDir = join(workspaceRoot, WORKSPACE_SPIRIT_SKILLS_DIR, 'ws-skill');
+  const userSkillDir = join(spiritDataDir, SKILLS_DIR_NAME, 'user-skill');
+  await mkdir(workspaceSkillDir, { recursive: true });
+  await mkdir(userSkillDir, { recursive: true });
+  await writeFile(
+    join(workspaceSkillDir, 'SKILL.md'),
+    '---\nname: ws-skill\ndescription: workspace\n---\n',
+    'utf8',
+  );
+  await writeFile(
+    join(userSkillDir, 'SKILL.md'),
+    '---\nname: user-skill\ndescription: user\n---\n',
+    'utf8',
+  );
+
+  try {
+    const entries = await discoverSkillEntries({
+      workspaceRoot,
+      spiritDataDir,
+      includeWorkspaceScope: false,
+    });
+    const names = entries.map((entry) => entry.source.name).sort();
+    assert.deepEqual(names, ['user-skill']);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/host-internal/src/discovery.ts
+++ b/packages/host-internal/src/discovery.ts
@@ -163,6 +163,10 @@ export async function loadHostInstructionMetadata(
   };
 }
 
+function includesWorkspaceScope(context: InstructionDiscoveryContext): boolean {
+  return context.includeWorkspaceScope !== false;
+}
+
 export async function discoverRuleEntries(
   context: InstructionDiscoveryContext,
   state?: HostToggleState,
@@ -170,19 +174,24 @@ export async function discoverRuleEntries(
   const paths = resolveInstructionPaths(context);
   const loadedState = state ?? (await loadToggleState(paths.rulesStateFile));
   const overrides = loadedState.enabledOverrides ?? {};
+  const workspaceSources = includesWorkspaceScope(context)
+    ? [
+        buildRuleSource(
+          paths.workspaceSpiritRuleFile,
+          'workspace',
+          '工作区 Spirit 规则',
+          WORKSPACE_SPIRIT_RULE_FILE_NAME.replace(/\\/gu, '/'),
+        ),
+        buildRuleSource(
+          paths.workspaceAgentsRuleFile,
+          'workspace',
+          '工作区 AGENTS 规则',
+          WORKSPACE_RULE_FILE_NAME,
+        ),
+      ]
+    : [];
   const sources = await Promise.all([
-    buildRuleSource(
-      paths.workspaceSpiritRuleFile,
-      'workspace',
-      '工作区 Spirit 规则',
-      WORKSPACE_SPIRIT_RULE_FILE_NAME.replace(/\\/gu, '/'),
-    ),
-    buildRuleSource(
-      paths.workspaceAgentsRuleFile,
-      'workspace',
-      '工作区 AGENTS 规则',
-      WORKSPACE_RULE_FILE_NAME,
-    ),
+    ...workspaceSources,
     buildRuleSource(paths.userRuleFile, 'user', '用户规则', USER_RULE_FILE_NAME),
   ]);
 
@@ -241,16 +250,20 @@ export async function discoverSkillEntries(
   const loadedState = state ?? (await loadToggleState(paths.skillsStateFile));
   const overrides = loadedState.enabledOverrides ?? {};
   const roots = [
-    {
-      rootPath: paths.workspaceSpiritSkillsDir,
-      scope: 'workspace' as const,
-      rootKind: 'workspaceSpirit' as const,
-    },
-    {
-      rootPath: paths.workspaceAgentsSkillsDir,
-      scope: 'workspace' as const,
-      rootKind: 'workspaceAgents' as const,
-    },
+    ...(includesWorkspaceScope(context)
+      ? [
+          {
+            rootPath: paths.workspaceSpiritSkillsDir,
+            scope: 'workspace' as const,
+            rootKind: 'workspaceSpirit' as const,
+          },
+          {
+            rootPath: paths.workspaceAgentsSkillsDir,
+            scope: 'workspace' as const,
+            rootKind: 'workspaceAgents' as const,
+          },
+        ]
+      : []),
     {
       rootPath: paths.userSkillsDir,
       scope: 'user' as const,

--- a/packages/host-internal/src/storage.ts
+++ b/packages/host-internal/src/storage.ts
@@ -63,6 +63,8 @@ export interface HostStateStorage<Config, Session> {
 export interface InstructionDiscoveryContext {
   workspaceRoot: string;
   spiritDataDir: string;
+  /** When false, skip workspace-scoped rules and skills (user-level only). Defaults to true. */
+  includeWorkspaceScope?: boolean;
 }
 
 export interface ExtensionManagementContext {


### PR DESCRIPTION
## Summary

为 Desktop 增加「不使用工作区」模式：Composer 以用户主目录为 cwd，不加载工作区级 MCP / Skills / Rules，且不把主目录写入 recent 工作区列表。
- **宿主 / agent-core**：`workspaceBinding`（`project` | `none`）、`includeWorkspaceScope` / `includeWorkspaceConfig`，bootstrap 与配置持久化。
- **UI**：空会话工作区下拉可切换项目工作区或「不使用工作区」；设置页在 none 模式下仅展示用户级 MCP/Skills。
- **侧栏**：始终同时展示「无工作区」扁平会话区与各项目工作区折叠分组（`userHomeDirectory` 划分，与 binding 解耦）。
- **修复**：打开主目录 cwd 会话时固定 `none` 绑定，避免切回空会话后 `pc` 误入工作区列表；工作区下拉列表使用与模型选择器一致的 `ScrollArea`（固定高度 + 内层滚动）。