### PR TITLE
fix(desktop): 浮层从触发点方向弹出而非中心缩放

### DIFF
--- a/apps/desktop/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/components/ui/context-menu.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { ContextMenu as ContextMenuPrimitive } from "radix-ui"
 
+import { radixAnchoredOverlayMotion } from "@/lib/overlay-motion"
 import { cn } from "@/lib/utils"
 import { ChevronRightIcon, CheckIcon } from "lucide-react"
 
@@ -66,7 +67,11 @@ function ContextMenuContent({
     <ContextMenuPrimitive.Portal>
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
-        className={cn("z-50 max-h-(--radix-context-menu-content-available-height) min-w-36 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        className={cn(
+          "z-50 max-h-(--radix-context-menu-content-available-height) min-w-36 overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10",
+          radixAnchoredOverlayMotion("context-menu"),
+          className,
+        )}
         {...props}
       />
     </ContextMenuPrimitive.Portal>
@@ -127,7 +132,11 @@ function ContextMenuSubContent({
   return (
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
-      className={cn("z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-lg duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn(
+        "z-50 min-w-32 overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-lg",
+        radixAnchoredOverlayMotion("context-menu"),
+        className,
+      )}
       {...props}
     />
   )

--- a/apps/desktop/src/components/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/components/ui/dropdown-menu.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Check } from "lucide-react";
 import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
 
+import { radixAnchoredOverlayMotion } from "@/lib/overlay-motion";
 import { cn } from "@/lib/utils";
 
 function DropdownMenu({
@@ -51,8 +52,7 @@ function DropdownMenuSubContent({
         data-slot="dropdown-menu-sub-content"
         sideOffset={sideOffset}
         className={cn(
-          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
-          "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          radixAnchoredOverlayMotion("dropdown-menu"),
           "spirit-scroll z-50 max-h-[min(24rem,var(--radix-dropdown-menu-content-available-height))] min-w-32 overflow-y-auto overflow-x-hidden",
           "rounded-xl border border-border/80 bg-popover p-1 text-sm text-popover-foreground shadow-lg",
           "ring-1 ring-white/5 backdrop-blur-sm",
@@ -75,8 +75,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
-          "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          radixAnchoredOverlayMotion("dropdown-menu"),
           "spirit-scroll z-50 max-h-[min(24rem,var(--radix-dropdown-menu-content-available-height))] min-w-32 overflow-y-auto overflow-x-hidden",
           "rounded-xl border border-border/80 bg-popover p-1 text-sm text-popover-foreground shadow-lg",
           "ring-1 ring-white/5 backdrop-blur-sm",

--- a/apps/desktop/src/components/ui/hover-card.tsx
+++ b/apps/desktop/src/components/ui/hover-card.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { HoverCard as HoverCardPrimitive } from "radix-ui";
 
+import { radixAnchoredOverlayMotion } from "@/lib/overlay-motion";
 import { cn } from "@/lib/utils";
 
 function HoverCard({
@@ -29,8 +30,7 @@ function HoverCardContent({
         sideOffset={sideOffset}
         className={cn(
           "z-50 w-72 rounded-xl border border-border/80 bg-popover p-3 text-popover-foreground shadow-lg ring-1 ring-white/5 outline-none backdrop-blur-sm",
-          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
-          "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          radixAnchoredOverlayMotion("hover-card"),
           className,
         )}
         {...props}

--- a/apps/desktop/src/components/ui/popover.tsx
+++ b/apps/desktop/src/components/ui/popover.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Popover as PopoverPrimitive } from "radix-ui";
 
+import { radixAnchoredOverlayMotion } from "@/lib/overlay-motion";
 import { cn } from "@/lib/utils";
 
 function Popover({
@@ -37,8 +38,7 @@ function PopoverContent({
         sideOffset={sideOffset}
         className={cn(
           "z-50 w-80 rounded-xl border border-border/80 bg-popover p-0 text-popover-foreground shadow-lg ring-1 ring-white/5 outline-none backdrop-blur-sm",
-          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
-          "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          radixAnchoredOverlayMotion("popover"),
           className,
         )}
         {...props}

--- a/apps/desktop/src/components/ui/select.tsx
+++ b/apps/desktop/src/components/ui/select.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 
+import { radixAnchoredOverlayMotion } from "@/lib/overlay-motion";
 import { cn } from "@/lib/utils";
 
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
@@ -55,8 +56,7 @@ function SelectContent({
         data-slot="select-content"
         position={position}
         className={cn(
-          "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
-          "data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          radixAnchoredOverlayMotion("select"),
           "relative z-50 max-h-[min(24rem,var(--radix-select-content-available-height))] overflow-hidden",
           "rounded-xl border border-border/80 bg-popover p-1 text-sm text-popover-foreground shadow-lg",
           "ring-1 ring-white/5 backdrop-blur-sm",

--- a/apps/desktop/src/lib/overlay-motion.ts
+++ b/apps/desktop/src/lib/overlay-motion.ts
@@ -1,0 +1,51 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Radix origin-aware overlay motion (see shadcn PR #6945 / Radix "Origin-aware animations").
+ * `transform-origin` follows trigger placement; zoom + slide enter from that corner, not center.
+ */
+const SIDE_SLIDE_IN =
+  "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2";
+
+const OPEN_CLOSE =
+  "duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95";
+
+export type RadixAnchoredOverlayKind =
+  | "popover"
+  | "dropdown-menu"
+  | "select"
+  | "hover-card"
+  | "context-menu";
+
+/** Full class strings per kind so Tailwind can statically scan arbitrary `origin-(…)` utilities. */
+const MOTION_BY_KIND: Record<RadixAnchoredOverlayKind, string> = {
+  popover: cn(
+    "origin-(--radix-popover-content-transform-origin)",
+    SIDE_SLIDE_IN,
+    OPEN_CLOSE,
+  ),
+  "dropdown-menu": cn(
+    "origin-(--radix-dropdown-menu-content-transform-origin)",
+    SIDE_SLIDE_IN,
+    OPEN_CLOSE,
+  ),
+  select: cn(
+    "origin-(--radix-select-content-transform-origin)",
+    SIDE_SLIDE_IN,
+    OPEN_CLOSE,
+  ),
+  "hover-card": cn(
+    "origin-(--radix-hover-card-content-transform-origin)",
+    SIDE_SLIDE_IN,
+    OPEN_CLOSE,
+  ),
+  "context-menu": cn(
+    "origin-(--radix-context-menu-content-transform-origin)",
+    SIDE_SLIDE_IN,
+    OPEN_CLOSE,
+  ),
+};
+
+export function radixAnchoredOverlayMotion(kind: RadixAnchoredOverlayKind): string {
+  return MOTION_BY_KIND[kind];
+}


### PR DESCRIPTION
使用 Radix transform-origin 与侧向 slide-in，统一 Popover、Dropdown、Select、HoverCard、ContextMenu 的入场动画。