### PR TITLE
fix(desktop): 无工具回合延迟拆行以恢复思考收起动画

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1059,7 +1059,7 @@ function AssistantThinkingCollapsible({
           <div className="overflow-hidden pt-1.5 [&_p:last-child]:mb-0 [&_ul:last-child]:mb-0 [&_ol:last-child]:mb-0 [&_blockquote:last-child]:mb-0 [&_pre:last-child]:mb-0">
             <AgentMarkdownMessage
               content={thinking}
-              streaming={thinkingActive}
+              streaming={thinkingActive && expanded}
               tone="muted"
               readManagedImagePreviewDataUrl={readManagedImagePreviewDataUrl}
             />
@@ -1250,8 +1250,6 @@ function MessageCard({
         : null,
     [rewindSelected, message.content, message.id],
   );
-  const nextMessage = messages[listIndex + 1];
-
   return (
     <div
       id={conversationMessageStableId(message, composerSessionKey)}

--- a/apps/desktop/src/components/agent-markdown-message.tsx
+++ b/apps/desktop/src/components/agent-markdown-message.tsx
@@ -9,12 +9,7 @@ import {
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
-import {
-  Block,
-  parseMarkdownIntoBlocks,
-  Streamdown,
-  type BlockProps,
-} from "streamdown";
+import { Block, parseMarkdownIntoBlocks, Streamdown, type BlockProps } from "streamdown";
 import type { Pluggable } from "unified";
 
 import type { ReadManagedImagePreviewDataUrl } from "@/components/markdown-image";

--- a/apps/desktop/src/host/message-timeline.ts
+++ b/apps/desktop/src/host/message-timeline.ts
@@ -255,6 +255,8 @@ export class DesktopMessageTimeline {
         this.settlePendingThinkingBeforeAssistantText(segment);
       }
     }
+    // 无工具时不把 after-stream 思考拆成独立行：让 thinking aux 与正文留在同一条
+    // assistant 行上，UI 才能在同一个 Collapsible 实例上由展开过渡到收起（Radix collapsible-up）。
     const row = hasTools
       ? this.ensureStreamingAssistantTextRowAfterTools(segment)
       : this.ensureActiveAssistantTextRow('text');
@@ -425,6 +427,12 @@ export class DesktopMessageTimeline {
     segment.rows.push(row);
     this.logSegmentRows('finalize-thinking', segment);
     return rowToMessage(row);
+  }
+
+  /** Whether the active segment already has tool rows (used to decide thinking-row placement). */
+  activeSegmentHasToolRows(): boolean {
+    const segment = this.activeSegment();
+    return segment ? segmentHasToolRows(segment) : false;
   }
 
   finalizeCompactionSegment(text: string): ConversationMessageSnapshot | undefined {

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -136,6 +136,17 @@ export class DesktopRuntimeEventOrchestrator {
     this.lastApplyEventBatchId = 0;
     this.messageOrderDebugLastVerboseLogMs = 0;
     this.activeGenerateImageTools.clear();
+    this.deferredAfterStreamThinking = undefined;
+  }
+
+  /** 无工具回合里暂挂的 after-stream 思考：在 completed / 空正文收尾时拆成独立思考行。 */
+  private flushDeferredAfterStreamThinking(): void {
+    const deferred = this.deferredAfterStreamThinking;
+    if (!deferred) {
+      return;
+    }
+    this.deferredAfterStreamThinking = undefined;
+    this.options.messageTimeline?.()?.finalizeThinkingSegment(deferred, 'after-stream');
   }
 
   consumeCompletedTurnResult(): void {
@@ -185,6 +196,9 @@ export class DesktopRuntimeEventOrchestrator {
           }
           this.options.messageTimeline?.()?.materializeCompletedAssistantText(result.assistantText, aux);
         } else {
+          // 流式 done 在正文为空时只 remove-pending-assistant，随后 clearStreamingUiState 才定稿思考；
+          // 不会发 assistant-response-completed，须在此消费 deferred 并拆行。
+          this.flushDeferredAfterStreamThinking();
           this.options.messageTimeline?.()?.completeActiveAssistantSegment();
         }
         this.options.setLastRuntimeError('');
@@ -271,13 +285,9 @@ export class DesktopRuntimeEventOrchestrator {
       if (event.kind === 'assistant-response-completed') {
         this.finalizeResponsesBuiltInToolPreviews(messages);
         this.options.assistantMessages.completePendingAssistantMessage();
-        const timeline = this.options.messageTimeline?.();
-        if (this.deferredAfterStreamThinking) {
-          // 收起动画此时已在同一实例上播完，再把思考拆成独立行（与持久化结构一致）。
-          timeline?.finalizeThinkingSegment(this.deferredAfterStreamThinking, 'after-stream');
-          this.deferredAfterStreamThinking = undefined;
-        }
-        timeline?.completeActiveAssistantSegment();
+        // 收起动画此时已在同一实例上播完，再把思考拆成独立行（与持久化结构一致）。
+        this.flushDeferredAfterStreamThinking();
+        this.options.messageTimeline?.()?.completeActiveAssistantSegment();
         continue;
       }
       if (event.kind === 'remove-pending-assistant') {

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -88,6 +88,11 @@ export class DesktopRuntimeEventOrchestrator {
   private lastApplyEventBatchId = 0;
   private messageOrderDebugLastVerboseLogMs = 0;
   private activeGenerateImageTools = new Map<string, ToolBlockSnapshot>();
+  /**
+   * 无工具回合里 after-stream 思考暂不拆行：先留在当前 assistant 行的 aux 上，等正文到来在
+   * 同一个 Collapsible 实例上收起；本段 completed 时再拆成独立思考行。
+   */
+  private deferredAfterStreamThinking: string | undefined;
 
   constructor(private readonly options: DesktopRuntimeEventOrchestratorOptions) {}
 
@@ -215,6 +220,7 @@ export class DesktopRuntimeEventOrchestrator {
       events.length > 0 ? (this.lastApplyEventBatchId += 1) : this.lastApplyEventBatchId;
     for (const event of events) {
       if (event.kind === 'begin-assistant-response') {
+        this.deferredAfterStreamThinking = undefined;
         const insertAt = messages.length;
         const shouldReanchorStandalonePendingAux =
           this.options.conversationSnapshotView.shouldReanchorPersistedStandaloneSubagentStatusOnBeginAssistantResponse(
@@ -265,7 +271,13 @@ export class DesktopRuntimeEventOrchestrator {
       if (event.kind === 'assistant-response-completed') {
         this.finalizeResponsesBuiltInToolPreviews(messages);
         this.options.assistantMessages.completePendingAssistantMessage();
-        this.options.messageTimeline?.()?.completeActiveAssistantSegment();
+        const timeline = this.options.messageTimeline?.();
+        if (this.deferredAfterStreamThinking) {
+          // 收起动画此时已在同一实例上播完，再把思考拆成独立行（与持久化结构一致）。
+          timeline?.finalizeThinkingSegment(this.deferredAfterStreamThinking, 'after-stream');
+          this.deferredAfterStreamThinking = undefined;
+        }
+        timeline?.completeActiveAssistantSegment();
         continue;
       }
       if (event.kind === 'remove-pending-assistant') {
@@ -277,7 +289,18 @@ export class DesktopRuntimeEventOrchestrator {
         if (event.text.trim()) {
           const timeline = this.options.messageTimeline?.();
           this.options.assistantMessages.appendAssistantThinkingSegment(event.text);
-          timeline?.finalizeThinkingSegment(event.text, event.placement);
+          if (
+            event.placement === 'after-stream' &&
+            timeline &&
+            !timeline.activeSegmentHasToolRows()
+          ) {
+            // 无工具：暂不拆行。把思考挂在当前 assistant 行 aux 上，正文到来后在同一个
+            // Collapsible 实例上由展开过渡到收起（Radix collapsible-up）；本段 completed 再拆行。
+            timeline.updatePendingAssistantAux('thinking', event.text);
+            this.deferredAfterStreamThinking = event.text;
+          } else {
+            timeline?.finalizeThinkingSegment(event.text, event.placement);
+          }
         }
         continue;
       }

--- a/apps/desktop/test/conversation-thinking-ui.test.mjs
+++ b/apps/desktop/test/conversation-thinking-ui.test.mjs
@@ -218,3 +218,21 @@ test('shouldShowAssistantThinkingCollapsible keeps substantive standalone thinki
   );
   assert.equal(hasAssistantToolLaterInTurn(messages, 1), true);
 });
+
+test('shouldShowAssistantThinkingCollapsible keeps Thought visible when thinking + body share one row', () => {
+  const messages = [
+    { id: 1, role: 'user', content: 'hi', pending: false },
+    {
+      id: 2,
+      role: 'assistant',
+      content: 'Hello there',
+      pending: false,
+      aux: { thinking: 'Planning the reply.' },
+    },
+  ];
+
+  assert.equal(
+    shouldShowAssistantThinkingCollapsible(messages[1], undefined, messages, 1),
+    true,
+  );
+});

--- a/apps/desktop/test/host/message-timeline.test.mjs
+++ b/apps/desktop/test/host/message-timeline.test.mjs
@@ -289,6 +289,22 @@ test('updatePendingAssistantAux preserves finish_task notice preview on assistan
   );
 });
 
+test('appendAssistantTextChunk keeps no-tool thinking on the same row as the body', () => {
+  const timeline = createTimeline();
+  timeline.beginUserTurn('hi');
+  timeline.beginAssistantSegment('initial');
+  timeline.updatePendingAssistantAux('thinking', 'Planning the greeting.');
+  timeline.appendAssistantTextChunk('Hello!');
+  timeline.completeActiveAssistantSegment();
+
+  const assistantRows = timeline
+    .toMessages()
+    .filter((message) => message.role === 'assistant' && !message.tool);
+  assert.equal(assistantRows.length, 1);
+  assert.equal(assistantRows[0].content, 'Hello!');
+  assert.equal(assistantRows[0].aux?.thinking, 'Planning the greeting.');
+});
+
 test('finalized thinking stays above completed assistant text in the same segment', () => {
   const timeline = createTimeline();
   timeline.beginUserTurn('你好啊');

--- a/apps/desktop/test/host/runtime-event-orchestrator.test.mjs
+++ b/apps/desktop/test/host/runtime-event-orchestrator.test.mjs
@@ -230,6 +230,37 @@ test('after-stream thinking stays on the body row until completion (same-instanc
   ]);
 });
 
+test('empty assistant turn flushes deferred after-stream thinking on consumeCompletedTurnResult', () => {
+  const harness = createHarness();
+  harness.pushUser('hi');
+
+  // Mirrors agent-core `done` with empty pendingAssistantTextStore:
+  // remove-pending-assistant, then clearStreamingUiState thinking finalize — no
+  // assistant-response-completed.
+  harness.orchestrator.applyRuntimeHostEvents([
+    { kind: 'begin-assistant-response' },
+    { kind: 'update-pending-assistant-thinking', text: 'Only thinking, no body.' },
+    { kind: 'remove-pending-assistant' },
+    {
+      kind: 'assistant-thinking-segment-finalized',
+      text: 'Only thinking, no body.',
+      placement: 'after-stream',
+    },
+  ]);
+
+  harness.setCompletedTurnResult({
+    kind: 'completed',
+    assistantText: '',
+    toolExecutions: [],
+  });
+  harness.orchestrator.consumeCompletedTurnResult();
+
+  assert.deepEqual(harness.timeline.toMessages().map(rowToken), [
+    'user',
+    'thinking:Only thinking, no body.',
+  ]);
+});
+
 test('read_file streaming preview shows filename from partial arguments JSON', () => {
   const harness = createHarness();
   harness.pushUser('read Cargo.toml');

--- a/apps/desktop/test/host/runtime-event-orchestrator.test.mjs
+++ b/apps/desktop/test/host/runtime-event-orchestrator.test.mjs
@@ -194,6 +194,42 @@ test('completed Chinese greeting keeps finalized thinking above the final assist
   ]);
 });
 
+test('after-stream thinking stays on the body row until completion (same-instance collapse)', () => {
+  const harness = createHarness();
+  harness.pushUser('hi');
+
+  // Real streaming order: thinking deltas, then after-stream finalize emitted right before
+  // the first body chunk. The thinking must NOT split yet — it stays on the streaming body
+  // row so the Collapsible can collapse on the same instance once the body arrives.
+  harness.orchestrator.applyRuntimeHostEvents([
+    { kind: 'begin-assistant-response' },
+    { kind: 'update-pending-assistant-thinking', text: 'Planning the greeting.' },
+    {
+      kind: 'assistant-thinking-segment-finalized',
+      text: 'Planning the greeting.',
+      placement: 'after-stream',
+    },
+    { kind: 'assistant-chunk', text: 'Hello!' },
+  ]);
+
+  const streaming = harness.timeline
+    .toMessages()
+    .filter((message) => message.role === 'assistant' && !message.tool);
+  assert.equal(streaming.length, 1);
+  assert.equal(streaming[0].content, 'Hello!');
+  assert.equal(streaming[0].aux?.thinking, 'Planning the greeting.');
+
+  harness.orchestrator.applyRuntimeHostEvents([
+    { kind: 'assistant-response-completed' },
+  ]);
+
+  assert.deepEqual(harness.timeline.toMessages().map(rowToken), [
+    'user',
+    'thinking:Planning the greeting.',
+    'assistant:Hello!',
+  ]);
+});
+
 test('read_file streaming preview shows filename from partial arguments JSON', () => {
   const harness = createHarness();
   harness.pushUser('read Cargo.toml');


### PR DESCRIPTION
## Summary

- 修复 #63：正文首包到达后思考区收起无动画。根因是 `after-stream` 思考被过早拆成独立行，Collapsible 在新实例上 closed 启动，Radix 无法测量高度。
- 无工具回合：`after-stream` 思考暂留当前 assistant 行 `aux.thinking`，正文与思考同行，同一 Collapsible 由 `autoExpanded` 展开过渡到收起；`assistant-response-completed` 再拆成思考行 + 正文行（与持久化结构一致）。
- 有工具 / `before-next-tool` 仍立即拆行，行为不变。
- 思考区 Streamdown 逐字仅在 `thinkingActive && expanded` 时开启，收起阶段 DOM 静态，不干扰 `collapsible-up`。

## Test plan

- [x] Desktop 无工具对话：思考阶段可见逐字输出；正文首包时思考丝滑收起（约 220ms），无重复 Thought、幽灵卡片、整页上跳
- [x] Desktop 带工具回合：思考仍显示在工具卡上方，工具预览时正常收起
- [x] `npm run test:host`（`apps/desktop`）：timeline / orchestrator / thinking-ui 相关用例
- [x] 历史会话加载后 Thought 可手动展开/收起

Fixed #63