### PR TITLE
feat(desktop): 首条消息后异步生成 LLM 会话标题

### DIFF
--- a/apps/cli/src/chat_store.rs
+++ b/apps/cli/src/chat_store.rs
@@ -15,6 +15,7 @@ fn default_chat_approval_level() -> String {
     "default".to_string()
 }
 
+/// Desktop 会话 JSON 可能含 `sessionTitleSource`（seed/llm）；CLI 读取时忽略该字段。
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ChatFile {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -126,6 +126,7 @@ import {
   setDesktopMarketplaceFetchImplementation,
   setDesktopExtensionHostAdapter,
   subscribeDesktopDreamUpdates,
+  subscribeDesktopSessionListUpdates,
 } from '../src/host/service.js';
 import {
   configFilePath,
@@ -163,6 +164,7 @@ let desktopWebHostConfig: DesktopWebHostConfigFile | undefined;
 let desktopWebHostPairingCode = createDesktopWebPairingCode();
 let quittingAfterDesktopWebHostStop = false;
 let unsubscribeDesktopDreamUpdates: (() => void) | undefined;
+let unsubscribeDesktopSessionListUpdates: (() => void) | undefined;
 
 const workspacePtyManager = new WorkspacePtyManager();
 
@@ -635,6 +637,14 @@ if (gotSpiritSingleInstanceLock) {
     }
   });
 
+  unsubscribeDesktopSessionListUpdates = subscribeDesktopSessionListUpdates(() => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send('desktop:session-list-updated');
+      }
+    }
+  });
+
   ipcMain.handle('desktop:invoke', (_event, command: Parameters<typeof invokeDesktopHostCommand>[0], payload?: unknown) =>
     invokeMainDesktopHostCommand(command, payload),
   );
@@ -919,6 +929,8 @@ if (gotSpiritSingleInstanceLock) {
 app.on('before-quit', (event) => {
   unsubscribeDesktopDreamUpdates?.();
   unsubscribeDesktopDreamUpdates = undefined;
+  unsubscribeDesktopSessionListUpdates?.();
+  unsubscribeDesktopSessionListUpdates = undefined;
   if (quittingAfterDesktopWebHostStop || !desktopWebHost?.isRunning()) {
     return;
   }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -146,6 +146,15 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
       ipcRenderer.removeListener('desktop:dream-updated', onDreamUpdate);
     };
   },
+  sessionListSubscribe(callback: () => void) {
+    const onSessionListUpdate = () => {
+      callback();
+    };
+    ipcRenderer.on('desktop:session-list-updated', onSessionListUpdate);
+    return () => {
+      ipcRenderer.removeListener('desktop:session-list-updated', onSessionListUpdate);
+    };
+  },
   replyPendingApproval(decision: unknown) {
     return ipcRenderer.invoke('desktop:invoke', 'replyPendingApproval', { decision });
   },

--- a/apps/desktop/src/adapters/electron.ts
+++ b/apps/desktop/src/adapters/electron.ts
@@ -147,6 +147,9 @@ export async function createElectronHostApi(): Promise<HostApi> {
     subscribeDreamUpdates(callback) {
       return bridge.dreamSubscribe(callback);
     },
+    subscribeSessionListUpdates(callback) {
+      return bridge.sessionListSubscribe(callback);
+    },
     replyPendingApproval(decision) {
       return bridge.replyPendingApproval(decision);
     },

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -94,6 +94,7 @@ declare global {
     poll(): Promise<DesktopSnapshot>;
     listDreamsOverview(): Promise<DesktopDreamOverviewItem[]>;
     dreamSubscribe(callback: (snapshot: DesktopSnapshot) => void): () => void;
+    sessionListSubscribe(callback: () => void): () => void;
     replyPendingApproval(decision: DesktopApprovalDecision): Promise<DesktopSnapshot>;
     replyPendingQuestions(result: AskQuestionsResult): Promise<DesktopSnapshot>;
     resetSession(): Promise<DesktopSnapshot>;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -851,6 +851,16 @@ export function useDesktopRuntime() {
   }, [api, applySnapshot, refreshSessions]);
 
   useEffect(() => {
+    if (!api?.subscribeSessionListUpdates) {
+      return;
+    }
+
+    return api.subscribeSessionListUpdates(() => {
+      void refreshSessions();
+    });
+  }, [api, refreshSessions]);
+
+  useEffect(() => {
     if (!api || !snapshot || snapshot.conversation.isBusy || !snapshot.dreams.settings.enabled) {
       return;
     }

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -100,6 +100,7 @@ export interface HostApi {
   poll(): Promise<DesktopSnapshot>;
   listDreamsOverview(): Promise<DesktopDreamOverviewItem[]>;
   subscribeDreamUpdates?(callback: (snapshot: DesktopSnapshot) => void): () => void;
+  subscribeSessionListUpdates?(callback: () => void): () => void;
   replyPendingApproval(decision: DesktopApprovalDecision): Promise<DesktopSnapshot>;
   replyPendingQuestions(result: AskQuestionsResult): Promise<DesktopSnapshot>;
   resetSession(): Promise<DesktopSnapshot>;

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -72,9 +72,12 @@ export type HostCommandName =
 /** 与 `apps/cli/src/tool_runtime.rs` 中 `ToolRequest` 对齐的宿主工具请求。 */
 export type DesktopToolRequest = HostToolRequest<AskQuestionsQuestionSpec>;
 
+export type SessionTitleSource = 'seed' | 'llm';
+
 export interface StoredDesktopSession extends ChatArchive {
   savedAtUnixMs: number;
   sessionDisplayName?: string;
+  sessionTitleSource?: SessionTitleSource;
   workspaceRoot?: string;
   gitBranch?: string;
   activePlanPath?: string;

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -1814,6 +1814,12 @@ class DesktopHostService {
       sessionPath: filePath,
       title: result.title,
       registry: this.sessionRegistry,
+      runSerialized: (work) => this.runSerialized(work),
+      persistBundle: (target) =>
+        this.persistSessionBundle(target, {
+          fromRuntime: target.runtime,
+          bumpListSortAt: false,
+        }),
       notifySessionListUpdated: () => this.notifySessionListUpdated(),
     });
   }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -234,6 +234,8 @@ import {
   rememberEphemeralWorktreeSessionRecord,
   removeEphemeralSessionRecord,
 } from './sessions.js';
+import { generateSessionTitleFromModelTask } from './session-title-generation.js';
+import { applyGeneratedSessionTitle } from './session-title-service.js';
 import {
   buildPrimaryTransportConfig,
   modelCapabilitiesFromConfig,
@@ -420,6 +422,8 @@ class DesktopHostService {
   private dreamCollectorLastTickUnixMs = 0;
   private dreamCollectorMonitorTimer: ReturnType<typeof setInterval> | undefined;
   private readonly dreamUpdateListeners = new Set<(snapshot: DesktopSnapshot) => void>();
+  private readonly sessionListUpdateListeners = new Set<() => void>();
+  private readonly sessionTitleGenerationInFlight = new Set<string>();
   private gitRefreshInFlight: Promise<void> | null = null;
   private gitRefreshQueued = false;
   private readonly todoClearingBySession = new Map<
@@ -566,6 +570,8 @@ class DesktopHostService {
       allocateMessageId: () => this.allocateMessageId(),
       resetStreamingPlacementState: (full) => this.resetStreamingPlacementState(full),
       persistCurrentSessionIfNeeded: () => this.persistCurrentSessionIfNeeded(),
+      scheduleSessionTitleGenerationIfNeeded: (seedText) =>
+        this.scheduleSessionTitleGenerationIfNeeded(seedText),
       dispatchUserMessageExtensionEvent: (text, displayText, messageId) =>
         this.dispatchExtensionEvent({
           type: 'onUserMessage',
@@ -829,6 +835,13 @@ class DesktopHostService {
     this.startDreamCollectorMonitorIfNeeded();
     return () => {
       this.dreamUpdateListeners.delete(listener);
+    };
+  }
+
+  subscribeSessionListUpdates(listener: () => void): () => void {
+    this.sessionListUpdateListeners.add(listener);
+    return () => {
+      this.sessionListUpdateListeners.delete(listener);
     };
   }
 
@@ -1735,6 +1748,76 @@ class DesktopHostService {
     }
   }
 
+  private notifySessionListUpdated(): void {
+    if (this.sessionListUpdateListeners.size === 0) {
+      return;
+    }
+    for (const listener of this.sessionListUpdateListeners) {
+      listener();
+    }
+  }
+
+  private scheduleSessionTitleGenerationIfNeeded(seedText: string): void {
+    const bundle = this.activeBundle();
+    const activeSession = bundle.activeSession;
+    if (!activeSession || activeSession.readOnly === true || activeSession.kind === 'ephemeral') {
+      return;
+    }
+
+    const userMessageCount = bundle.messageTimeline
+      .toMessages()
+      .filter((message) => message.role === 'user').length;
+    if (userMessageCount !== 1) {
+      return;
+    }
+
+    if (bundle.sessionTitleSource !== 'seed') {
+      return;
+    }
+
+    if (!resolveLightweightChatModelProfile(this.requireState().config)) {
+      return;
+    }
+
+    const filePath = path.resolve(activeSession.filePath);
+    if (this.sessionTitleGenerationInFlight.has(filePath)) {
+      return;
+    }
+
+    this.sessionTitleGenerationInFlight.add(filePath);
+    void this.generateAndApplySessionTitle(bundle, seedText, filePath)
+      .catch((error) => {
+        console.debug(
+          '[session-title] generation failed:',
+          error instanceof Error ? error.message : String(error),
+        );
+      })
+      .finally(() => {
+        this.sessionTitleGenerationInFlight.delete(filePath);
+      });
+  }
+
+  private async generateAndApplySessionTitle(
+    bundle: SessionBundle,
+    seedText: string,
+    filePath: string,
+  ): Promise<void> {
+    const state = this.requireState();
+    const fallbackSeed = bundle.activeSession?.displayName ?? deriveDisplayNameFromSeed(seedText);
+    const result = await generateSessionTitleFromModelTask({
+      config: state.config,
+      workspaceRoot: bundle.workspaceRoot || state.workspaceRoot,
+      firstUserMessage: seedText,
+      fallbackSeedTitle: fallbackSeed,
+    });
+    await applyGeneratedSessionTitle({
+      sessionPath: filePath,
+      title: result.title,
+      registry: this.sessionRegistry,
+      notifySessionListUpdated: () => this.notifySessionListUpdated(),
+    });
+  }
+
   private async flushDeferredRuntimeRefreshIfIdle(bundle: SessionBundle = this.activeBundle()): Promise<void> {
     if (!bundle.deferredRuntimeRefreshWhileBusy) {
       return;
@@ -2473,6 +2556,10 @@ export function subscribeDesktopDreamUpdates(
   listener: (snapshot: DesktopSnapshot) => void,
 ): () => void {
   return desktopHostService.subscribeDreamUpdates(listener);
+}
+
+export function subscribeDesktopSessionListUpdates(listener: () => void): () => void {
+  return desktopHostService.subscribeSessionListUpdates(listener);
 }
 
 function normalizeApprovalDecision(

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -4,7 +4,7 @@ import type {
   RuntimeEvent,
   SpiritLlmTransport,
 } from '@spirit-agent/agent-core';
-import type { DesktopToolRequest } from './contracts.js';
+import type { DesktopToolRequest, SessionTitleSource } from './contracts.js';
 import type { ApprovalLevel, WorkLocationKind } from '@spirit-agent/host-internal';
 
 import type { DesktopRuntime } from './runtime.js';
@@ -62,6 +62,8 @@ export interface SessionBundle {
   conversationRevision: number;
   /** Last successful create_plan absolute path for this session. */
   activePlanPath?: string;
+  /** Tracks whether the sidebar title is seed-truncated or LLM-generated. */
+  sessionTitleSource?: SessionTitleSource;
 }
 
 export function createEmptySessionBundle(workspaceRoot: string, id = '__draft__'): SessionBundle {
@@ -133,6 +135,7 @@ export function sessionBundleFromRestored(
     responsesBuiltInPreviewSeenCallIds: new Set(),
     conversationRevision: 0,
     ...(restored.activePlanPath ? { activePlanPath: restored.activePlanPath } : {}),
+    ...(restored.sessionTitleSource ? { sessionTitleSource: restored.sessionTitleSource } : {}),
   };
 }
 
@@ -162,4 +165,5 @@ export function resetSessionBundleInPlace(bundle: SessionBundle): void {
   bundle.todoSessionScopeKey = createTodoSessionScopeKey();
   bundle.conversationRevision = 0;
   bundle.activePlanPath = undefined;
+  bundle.sessionTitleSource = undefined;
 }

--- a/apps/desktop/src/host/session-persistence.ts
+++ b/apps/desktop/src/host/session-persistence.ts
@@ -59,10 +59,13 @@ export async function persistDesktopSessionBundle(
   const savedAtUnixMs = bumpListSortAt
     ? Date.now()
     : (bundle.listSortSavedAtUnixMs ?? Date.now());
+  const sessionTitleSource = bundle.sessionTitleSource ?? 'seed';
+  bundle.sessionTitleSource = sessionTitleSource;
   const stored = buildStoredDesktopSession({
     archive,
     savedAtUnixMs,
     sessionDisplayName: activeSession.displayName,
+    sessionTitleSource,
     workspaceRoot: input.workspaceRoot,
     gitBranch: input.gitBranch,
     ...(bundle.activePlanPath ? { activePlanPath: bundle.activePlanPath } : {}),

--- a/apps/desktop/src/host/session-registry.ts
+++ b/apps/desktop/src/host/session-registry.ts
@@ -266,6 +266,7 @@ export class SessionRegistry {
     bundle.archiveSubagentSessions = restored.archiveSubagentSessions;
     bundle.loopEnabled = restored.loopEnabled;
     bundle.approvalLevel = restored.approvalLevel;
+    bundle.sessionTitleSource = restored.sessionTitleSource;
     bundle.rewind = restored.rewind;
     bundle.rewindWarnings = [];
     bundle.messageIdCounter = restored.messages.length > 0

--- a/apps/desktop/src/host/session-title-generation.ts
+++ b/apps/desktop/src/host/session-title-generation.ts
@@ -1,0 +1,63 @@
+// Desktop 首批消费方：首条用户消息后异步生成会话标题；CLI 待产品定义后再接入。
+import { createJsonSchemaTransport } from '@spirit-agent/agent-core';
+import {
+  buildSessionTitlePrompt,
+  normalizeGeneratedSessionTitle,
+  SESSION_TITLE_JSON_SCHEMA,
+} from '@spirit-agent/host-internal';
+
+import { resolveLightweightChatModelProfile } from './lightweight-chat-model.js';
+import { buildPrimaryTransportConfig } from './model-config.js';
+import { currentApiBase } from './service-utils.js';
+import type { DesktopConfigFile } from './storage.js';
+import { resolveApiKeyForConfigModel } from './storage.js';
+
+export type GeneratedSessionTitle = {
+  title: string;
+  modelName: string;
+};
+
+type SessionTitleGenerationContext = {
+  config: DesktopConfigFile;
+  workspaceRoot: string;
+  firstUserMessage: string;
+  fallbackSeedTitle: string;
+};
+
+export async function generateSessionTitleFromModelTask(
+  context: SessionTitleGenerationContext,
+): Promise<GeneratedSessionTitle> {
+  const resolved = resolveLightweightChatModelProfile(context.config);
+  if (!resolved) {
+    throw new Error('Lightweight chat model is not available.');
+  }
+
+  const apiKey = await resolveApiKeyForConfigModel(context.config, resolved.name);
+  if (!apiKey) {
+    throw new Error(`API key is not configured for lightweight chat model: ${resolved.name}`);
+  }
+
+  const transportConfig = buildPrimaryTransportConfig({
+    apiKey,
+    model: resolved.name,
+    baseUrl: resolved.profile.apiBase ?? currentApiBase(context.config),
+    workspaceRoot: context.workspaceRoot,
+    profile: resolved.profile,
+  });
+  const transport = createJsonSchemaTransport(transportConfig);
+  const userPrompt = buildSessionTitlePrompt(context.firstUserMessage);
+  const result = await transport.createJsonSchemaCompletion<{ title: string }>(
+    transportConfig,
+    {
+      userPrompt,
+      schemaName: 'session_title',
+      schema: SESSION_TITLE_JSON_SCHEMA,
+      includeToolAgentHostPrompt: false,
+    },
+  );
+
+  return {
+    title: normalizeGeneratedSessionTitle(result.output.title, context.fallbackSeedTitle),
+    modelName: resolved.name,
+  };
+}

--- a/apps/desktop/src/host/session-title-service.ts
+++ b/apps/desktop/src/host/session-title-service.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+
+import { loadStoredSession, saveStoredSession } from './storage.js';
+import type { SessionRegistry } from './session-registry.js';
+
+export async function applyGeneratedSessionTitle(input: {
+  sessionPath: string;
+  title: string;
+  registry: SessionRegistry;
+  notifySessionListUpdated: () => void;
+}): Promise<void> {
+  const resolvedPath = path.resolve(input.sessionPath);
+  const bundle = input.registry.findBySessionPath(resolvedPath);
+  if (
+    bundle?.activeSession
+    && path.resolve(bundle.activeSession.filePath) === resolvedPath
+  ) {
+    bundle.activeSession.displayName = input.title;
+    bundle.sessionTitleSource = 'llm';
+  }
+
+  const stored = await loadStoredSession(resolvedPath);
+  await saveStoredSession(resolvedPath, {
+    ...stored,
+    sessionDisplayName: input.title,
+    sessionTitleSource: 'llm',
+  });
+  input.notifySessionListUpdated();
+}

--- a/apps/desktop/src/host/session-title-service.ts
+++ b/apps/desktop/src/host/session-title-service.ts
@@ -2,28 +2,39 @@ import path from 'node:path';
 
 import { loadStoredSession, saveStoredSession } from './storage.js';
 import type { SessionRegistry } from './session-registry.js';
+import type { SessionBundle } from './session-bundle.js';
 
 export async function applyGeneratedSessionTitle(input: {
   sessionPath: string;
   title: string;
   registry: SessionRegistry;
+  runSerialized: <T>(work: () => Promise<T>) => Promise<T>;
+  persistBundle: (bundle: SessionBundle) => Promise<void>;
   notifySessionListUpdated: () => void;
 }): Promise<void> {
   const resolvedPath = path.resolve(input.sessionPath);
-  const bundle = input.registry.findBySessionPath(resolvedPath);
-  if (
-    bundle?.activeSession
-    && path.resolve(bundle.activeSession.filePath) === resolvedPath
-  ) {
-    bundle.activeSession.displayName = input.title;
-    bundle.sessionTitleSource = 'llm';
-  }
+  await input.runSerialized(async () => {
+    const bundle = input.registry.findBySessionPath(resolvedPath);
+    if (
+      bundle?.activeSession
+      && path.resolve(bundle.activeSession.filePath) === resolvedPath
+    ) {
+      bundle.activeSession.displayName = input.title;
+      bundle.sessionTitleSource = 'llm';
+      await input.persistBundle(bundle);
+      input.notifySessionListUpdated();
+      return;
+    }
 
-  const stored = await loadStoredSession(resolvedPath);
-  await saveStoredSession(resolvedPath, {
-    ...stored,
-    sessionDisplayName: input.title,
-    sessionTitleSource: 'llm',
+    const stored = await loadStoredSession(resolvedPath);
+    if (stored.sessionTitleSource === 'llm') {
+      return;
+    }
+    await saveStoredSession(resolvedPath, {
+      ...stored,
+      sessionDisplayName: input.title,
+      sessionTitleSource: 'llm',
+    });
+    input.notifySessionListUpdated();
   });
-  input.notifySessionListUpdated();
 }

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -73,6 +73,7 @@ export interface SessionTurnOrchestratorContext {
   allocateMessageId(): number;
   resetStreamingPlacementState(full: boolean): void;
   persistCurrentSessionIfNeeded(): Promise<void>;
+  scheduleSessionTitleGenerationIfNeeded(seedText: string): void;
   dispatchUserMessageExtensionEvent(text: string, displayText: string, messageId: number): Promise<void>;
   ensureToolExecutor(bundle?: SessionBundle): Promise<unknown>;
   refreshArchiveFromRuntime(bundle?: SessionBundle): void;
@@ -146,6 +147,7 @@ export async function submitUserTurnAfterInitializedCommand(
   ctx.resetStreamingPlacementState(false);
   const todoSessionKeyBeforePersist = ctx.resolveTodoSessionKeyForBundle(bundle);
   await ctx.persistCurrentSessionIfNeeded();
+  ctx.scheduleSessionTitleGenerationIfNeeded(displayText);
   await ctx.reconcileTodoScopeAfterSessionPathChange(bundle, todoSessionKeyBeforePersist);
   await ctx.maybeRefreshRuntimeAfterTodoScopeChange(bundle, todoSessionKeyBeforePersist);
   await ctx.dispatchUserMessageExtensionEvent(trimmed, displayText, userMessage.id);

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -9,7 +9,7 @@ import type {
 } from '../types.js';
 import { extractActivePlanPathFromLlmHistory, normalizeApprovalLevel } from '@spirit-agent/host-internal';
 import type { ApprovalLevel } from '@spirit-agent/host-internal';
-import type { StoredDesktopSession } from './contracts.js';
+import type { SessionTitleSource, StoredDesktopSession } from './contracts.js';
 import type { DesktopTimelineTurnSnapshot } from './message-timeline.js';
 import {
   normalizeMessageAuxSnapshot,
@@ -22,6 +22,7 @@ import { createDesktopRewindMetadata, type StoredDesktopRewindMetadata } from '.
 
 export const EPHEMERAL_COMMIT_SESSION_PREFIX = 'ephemeral://commit-message/';
 export const EPHEMERAL_WORKTREE_SESSION_PREFIX = 'ephemeral://worktree-naming/';
+export const EPHEMERAL_SESSION_TITLE_PREFIX = 'ephemeral://session-title/';
 const MAX_EPHEMERAL_COMMIT_SESSIONS = 8;
 const MAX_EPHEMERAL_WORKTREE_SESSIONS = 8;
 
@@ -45,6 +46,7 @@ export interface RestoredSessionState {
   loopEnabled: boolean;
   approvalLevel: ApprovalLevel;
   activePlanPath?: string;
+  sessionTitleSource?: SessionTitleSource;
 }
 
 export function isEphemeralCommitSessionPath(filePath: string): boolean {
@@ -181,6 +183,9 @@ export function restoreStoredSessionState(input: {
     loopEnabled: input.loaded.loopEnabled === true,
     approvalLevel: normalizeApprovalLevel(input.loaded.approvalLevel),
     ...(activePlanPath ? { activePlanPath } : {}),
+    ...(input.loaded.sessionTitleSource === 'seed' || input.loaded.sessionTitleSource === 'llm'
+      ? { sessionTitleSource: input.loaded.sessionTitleSource }
+      : {}),
   };
 }
 
@@ -188,6 +193,7 @@ export function buildStoredDesktopSession(input: {
   archive: ChatArchive;
   savedAtUnixMs?: number;
   sessionDisplayName: string;
+  sessionTitleSource?: SessionTitleSource;
   workspaceRoot: string;
   gitBranch?: string;
   activePlanPath?: string;
@@ -203,6 +209,7 @@ export function buildStoredDesktopSession(input: {
     approvalLevel: input.approvalLevel,
     savedAtUnixMs: input.savedAtUnixMs ?? Date.now(),
     sessionDisplayName: input.sessionDisplayName,
+    ...(input.sessionTitleSource ? { sessionTitleSource: input.sessionTitleSource } : {}),
     workspaceRoot: input.workspaceRoot,
     ...(input.gitBranch ? { gitBranch: input.gitBranch } : {}),
     ...(input.activePlanPath ? { activePlanPath: input.activePlanPath } : {}),

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -422,6 +422,9 @@ function normalizeStoredSession(parsed: Partial<StoredDesktopSession>): StoredDe
     ...(normalizeDisplayName(parsed.sessionDisplayName)
       ? { sessionDisplayName: normalizeDisplayName(parsed.sessionDisplayName) }
       : {}),
+    ...(parsed.sessionTitleSource === 'seed' || parsed.sessionTitleSource === 'llm'
+      ? { sessionTitleSource: parsed.sessionTitleSource }
+      : {}),
     ...(resolveStoredWorkspaceRoot(parsed.workspaceRoot)
       ? { workspaceRoot: resolveStoredWorkspaceRoot(parsed.workspaceRoot) }
       : {}),

--- a/apps/desktop/test/host/session-title.test.mjs
+++ b/apps/desktop/test/host/session-title.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildSessionTitlePrompt,
+  normalizeGeneratedSessionTitle,
+  SESSION_TITLE_MAX_LENGTH,
+} from '@spirit-agent/host-internal';
+
+test('buildSessionTitlePrompt includes user message and language rule', () => {
+  const prompt = buildSessionTitlePrompt('帮我写一个 Desktop 会话标题功能');
+  assert.match(prompt, /same language as the user message/i);
+  assert.match(prompt, /帮我写一个 Desktop 会话标题功能/);
+  assert.match(prompt, /"title"/);
+});
+
+test('normalizeGeneratedSessionTitle trims, strips quotes, and caps length', () => {
+  const fallback = 'seed title';
+  assert.equal(normalizeGeneratedSessionTitle('  hello world  ', fallback), 'hello world');
+  assert.equal(normalizeGeneratedSessionTitle('"quoted title"', fallback), 'quoted title');
+  assert.equal(normalizeGeneratedSessionTitle('', fallback), fallback);
+  assert.equal(
+    normalizeGeneratedSessionTitle('x'.repeat(SESSION_TITLE_MAX_LENGTH + 10), fallback).length,
+    SESSION_TITLE_MAX_LENGTH + 1,
+  );
+});

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -12,6 +12,7 @@ export * from './model-provider-presets.js';
 export * from './openai-models.js';
 export * from './reasoning-effort.js';
 export * from './runtime.js';
+export * from './session-title.js';
 export * from './storage.js';
 export * from './tools.js';
 export * from './workspace-file-reference-query.js';

--- a/packages/host-internal/src/session-title.ts
+++ b/packages/host-internal/src/session-title.ts
@@ -1,0 +1,48 @@
+import type { JsonObject } from '@spirit-agent/agent-core';
+
+export const SESSION_TITLE_MAX_LENGTH = 40;
+
+export const SESSION_TITLE_JSON_SCHEMA: JsonObject = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    title: {
+      type: 'string',
+      minLength: 1,
+      maxLength: SESSION_TITLE_MAX_LENGTH,
+    },
+  },
+  required: ['title'],
+};
+
+export function buildSessionTitlePrompt(firstUserMessage: string): string {
+  const message = firstUserMessage.trim() || '(empty)';
+  return [
+    'Generate a short conversation title for the user message below.',
+    'Return JSON only: {"title":"..."}. No Markdown, no explanations, no extra keys.',
+    'Rules:',
+    '- Use the same language as the user message.',
+    '- Keep it concise (ideally under 12 words).',
+    '- No surrounding quotes, hashtags, or trailing punctuation.',
+  ].join('\n')
+    + '\n\n[user message]\n'
+    + message;
+}
+
+export function normalizeGeneratedSessionTitle(raw: string, fallback: string): string {
+  const collapsed = raw.trim().replace(/\s+/g, ' ');
+  if (!collapsed) {
+    return fallback;
+  }
+
+  const withoutQuotes = collapsed.replace(/^["'「『]+|["'」』]+$/g, '').trim();
+  if (!withoutQuotes) {
+    return fallback;
+  }
+
+  if (withoutQuotes.length <= SESSION_TITLE_MAX_LENGTH) {
+    return withoutQuotes;
+  }
+
+  return `${withoutQuotes.slice(0, SESSION_TITLE_MAX_LENGTH)}…`;
+}


### PR DESCRIPTION
## Summary

- 首条用户消息发送后，用轻量对话模型 + `createJsonSchemaCompletion` 异步生成会话标题；生成完成前侧栏仍显示 `deriveDisplayNameFromSeed` 占位名。
- 在 `host-internal` 新增 schema / prompt / 标题规范化；Desktop 持久化 `sessionTitleSource`（`seed` → `llm`），回写时不 bump `savedAtUnixMs`，避免侧栏排序乱跳。
- 通过 `subscribeSessionListUpdates` + IPC 通知渲染进程刷新会话列表；失败静默保留 seed，不阻塞主对话。
- CLI `chat_store` 注明可忽略 `sessionTitleSource`，暂不实现生成调度。

## Test plan

- [x] `npm run test:host`（含 `session-title.test.mjs`）
- [x] 新会话首条中文消息：侧栏先 seed → 数秒后变为 LLM 中文标题
- [x] 同会话第二条消息不重复生成
- [x] 轻量模型未配置时仍用 seed，主对话正常
- [x] 打开旧会话发消息不触发（已有 user 历史）