### PR TITLE
feat(desktop): Composer 直连生图/生视频

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2669,10 +2669,10 @@ export default function App() {
       }
     }
 
+    composerRichInputRef.current?.resetAfterSend(runtime.settings.agentMode);
     void runtime.sendMessage(payload).then((ok) => {
       if (ok) {
         setComposerBrowserElementAttachments([]);
-        composerRichInputRef.current?.resetAfterSend(runtime.settings.agentMode);
       }
     });
   };

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -21,6 +21,10 @@ import {
 
 import { type DesktopAgentMode } from "@/lib/agent-mode";
 import {
+  resolveComposerDirectMediaTool,
+  type DirectMediaTool,
+} from "@/lib/composer-direct-media";
+import {
   pickEmptySessionGreetingVariant,
   resolveEmptySessionGreeting,
   type EmptySessionGreetingVariantId,
@@ -842,6 +846,7 @@ type ComposerSurfaceProps = {
   conversationBusy?: boolean;
   agentModeChipDismissed?: boolean;
   onAgentModeChipDismissChange?(dismissed: boolean): void;
+  directMediaMode?: DirectMediaTool | null;
 };
 
 function ComposerSurface({
@@ -880,6 +885,7 @@ function ComposerSurface({
   conversationBusy = false,
   agentModeChipDismissed = false,
   onAgentModeChipDismissChange,
+  directMediaMode = null,
 }: ComposerSurfaceProps) {
   const { t } = useTranslation();
   const [modelFilter, setModelFilter] = useState("");
@@ -898,6 +904,12 @@ function ComposerSurface({
         activeModelProfile.reasoningEffort,
       )
     : activeModel;
+  const directMediaBadgeLabel =
+    directMediaMode === "generate_image"
+      ? t("composer.directMediaImageBadge")
+      : directMediaMode === "generate_video"
+        ? t("composer.directMediaVideoBadge")
+        : null;
   const modelGroups = useMemo(
     () => groupModelsForPicker(models, catalogHints),
     [models, catalogHints],
@@ -1005,6 +1017,14 @@ function ComposerSurface({
                       <span className="min-w-0 flex-1 truncate" title={activeModelSummary}>
                         {activeModelSummary}
                       </span>
+                      {directMediaBadgeLabel ? (
+                        <Badge
+                          variant="secondary"
+                          className="h-4 shrink-0 px-1 text-[10px] font-medium leading-none"
+                        >
+                          {directMediaBadgeLabel}
+                        </Badge>
+                      ) : null}
                       <ChevronDown className="size-3 shrink-0 text-muted-foreground/80" aria-hidden />
                     </button>
                   </FilteredOverlayMenuTrigger>
@@ -1993,6 +2013,19 @@ export default function App() {
   const [composerBrowserElementAttachments, setComposerBrowserElementAttachments] = useState<BrowserElementAttachment[]>([]);
 
   const activeSessionReadOnly = snapshot?.activeSession?.readOnly === true;
+  const composerDirectMediaMode = useMemo(() => {
+    if (!snapshot?.config) {
+      return null;
+    }
+    return resolveComposerDirectMediaTool(runtime.settings.activeModel, snapshot.config);
+  }, [runtime.settings.activeModel, snapshot?.config]);
+  const composerPlaceholder = activeSessionReadOnly
+    ? t("app.readOnlySession")
+    : composerDirectMediaMode === "generate_image"
+      ? t("composer.placeholderGenerateImage")
+      : composerDirectMediaMode === "generate_video"
+        ? t("composer.placeholderGenerateVideo")
+        : t("app.typeMessage");
   const conversationInterruptible = runtime.summary.canInterrupt && !runtime.busyAction;
   const continueBusy = Boolean(runtime.busyAction) || snapshot?.conversation.isBusy === true;
   const composerCanSend =
@@ -3392,11 +3425,12 @@ export default function App() {
                     browserElementAttachments={composerBrowserElementAttachments}
                     onElementAttachmentsChange={setComposerBrowserElementAttachments}
                     onAbort={() => void runtime.abortConversation()}
-                    placeholder={activeSessionReadOnly ? t('app.readOnlySession') : t('app.typeMessage')}
+                    placeholder={composerPlaceholder}
                     localFileAttachments={runtime.composerLocalFileAttachments}
                     models={models}
                     catalogHints={snapshot?.config.modelCatalogHints}
                     activeModel={runtime.settings.activeModel}
+                    directMediaMode={composerDirectMediaMode}
                     agentMode={runtime.settings.agentMode}
                     loopEnabled={snapshot?.conversation.loopEnabled === true}
                     onModelSelect={runtime.setActiveModel}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2001,8 +2001,8 @@ export default function App() {
     if (!snapshot?.config) {
       return null;
     }
-    return resolveComposerDirectMediaTool(runtime.settings.activeModel, snapshot.config);
-  }, [runtime.settings.activeModel, snapshot?.config]);
+    return resolveComposerDirectMediaTool(snapshot.config.activeModel, snapshot.config);
+  }, [snapshot?.config]);
   const composerPlaceholder = activeSessionReadOnly
     ? t("app.readOnlySession")
     : composerDirectMediaMode === "generate_image"
@@ -2653,10 +2653,10 @@ export default function App() {
       }
     }
 
-    composerRichInputRef.current?.resetAfterSend(runtime.settings.agentMode);
     void runtime.sendMessage(payload).then((ok) => {
       if (ok) {
         setComposerBrowserElementAttachments([]);
+        composerRichInputRef.current?.resetAfterSend(runtime.settings.agentMode);
       }
     });
   };

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -846,7 +846,6 @@ type ComposerSurfaceProps = {
   conversationBusy?: boolean;
   agentModeChipDismissed?: boolean;
   onAgentModeChipDismissChange?(dismissed: boolean): void;
-  directMediaMode?: DirectMediaTool | null;
 };
 
 function ComposerSurface({
@@ -885,7 +884,6 @@ function ComposerSurface({
   conversationBusy = false,
   agentModeChipDismissed = false,
   onAgentModeChipDismissChange,
-  directMediaMode = null,
 }: ComposerSurfaceProps) {
   const { t } = useTranslation();
   const [modelFilter, setModelFilter] = useState("");
@@ -904,12 +902,6 @@ function ComposerSurface({
         activeModelProfile.reasoningEffort,
       )
     : activeModel;
-  const directMediaBadgeLabel =
-    directMediaMode === "generate_image"
-      ? t("composer.directMediaImageBadge")
-      : directMediaMode === "generate_video"
-        ? t("composer.directMediaVideoBadge")
-        : null;
   const modelGroups = useMemo(
     () => groupModelsForPicker(models, catalogHints),
     [models, catalogHints],
@@ -1017,14 +1009,6 @@ function ComposerSurface({
                       <span className="min-w-0 flex-1 truncate" title={activeModelSummary}>
                         {activeModelSummary}
                       </span>
-                      {directMediaBadgeLabel ? (
-                        <Badge
-                          variant="secondary"
-                          className="h-4 shrink-0 px-1 text-[10px] font-medium leading-none"
-                        >
-                          {directMediaBadgeLabel}
-                        </Badge>
-                      ) : null}
                       <ChevronDown className="size-3 shrink-0 text-muted-foreground/80" aria-hidden />
                     </button>
                   </FilteredOverlayMenuTrigger>
@@ -3430,7 +3414,6 @@ export default function App() {
                     models={models}
                     catalogHints={snapshot?.config.modelCatalogHints}
                     activeModel={runtime.settings.activeModel}
-                    directMediaMode={composerDirectMediaMode}
                     agentMode={runtime.settings.agentMode}
                     loopEnabled={snapshot?.conversation.loopEnabled === true}
                     onModelSelect={runtime.setActiveModel}

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1701,17 +1701,6 @@ export function useDesktopRuntime() {
     }
 
     setBusyAction("send");
-    const composerDraftBeforeSend = {
-      text: request.text,
-      localFilePaths: [...localFilePaths],
-    };
-    clearActiveComposerDraft();
-    const restoreComposerDraftOnFailure = () => {
-      setComposer(composerDraftBeforeSend.text);
-      setComposerLocalFileAttachments(
-        attachmentsFromPaths(composerDraftBeforeSend.localFilePaths),
-      );
-    };
     try {
       if (interruptible) {
         const aborted = await api.abortConversation();
@@ -1725,7 +1714,6 @@ export function useDesktopRuntime() {
           isCompactSlashInput(text) ||
           skillSlash)
       ) {
-        restoreComposerDraftOnFailure();
         setRuntimeError(i18n.t('error.attachmentsNotSupportedWithSlash'));
         return false;
       }
@@ -1744,11 +1732,11 @@ export function useDesktopRuntime() {
             ...(hasLocalFiles ? { localFilePaths } : {}),
           });
       applySnapshot(next);
+      clearActiveComposerDraft();
       setRuntimeError("");
       void refreshSessions();
       return true;
     } catch (error) {
-      restoreComposerDraftOnFailure();
       setRuntimeError(describeError(error));
       return false;
     } finally {

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1701,6 +1701,17 @@ export function useDesktopRuntime() {
     }
 
     setBusyAction("send");
+    const composerDraftBeforeSend = {
+      text: request.text,
+      localFilePaths: [...localFilePaths],
+    };
+    clearActiveComposerDraft();
+    const restoreComposerDraftOnFailure = () => {
+      setComposer(composerDraftBeforeSend.text);
+      setComposerLocalFileAttachments(
+        attachmentsFromPaths(composerDraftBeforeSend.localFilePaths),
+      );
+    };
     try {
       if (interruptible) {
         const aborted = await api.abortConversation();
@@ -1714,6 +1725,7 @@ export function useDesktopRuntime() {
           isCompactSlashInput(text) ||
           skillSlash)
       ) {
+        restoreComposerDraftOnFailure();
         setRuntimeError(i18n.t('error.attachmentsNotSupportedWithSlash'));
         return false;
       }
@@ -1732,11 +1744,11 @@ export function useDesktopRuntime() {
             ...(hasLocalFiles ? { localFilePaths } : {}),
           });
       applySnapshot(next);
-      clearActiveComposerDraft();
       setRuntimeError("");
       void refreshSessions();
       return true;
     } catch (error) {
+      restoreComposerDraftOnFailure();
       setRuntimeError(describeError(error));
       return false;
     } finally {

--- a/apps/desktop/src/host/conversation-continuation.ts
+++ b/apps/desktop/src/host/conversation-continuation.ts
@@ -269,6 +269,21 @@ export function syncSubagentToolStreamingOutput(
   }
 }
 
+export function syncRuntimeHistoryFromBundleArchive(bundle: SessionBundle): void {
+  if (!bundle.runtime) {
+    return;
+  }
+
+  const desktopMessages = bundle.messageTimeline.toMessages();
+  bundle.runtime.replaceFromArchive({
+    messages: buildArchiveMessagesFromConversation(desktopMessages),
+    assistantAux: buildArchiveAssistantAuxFromConversation(desktopMessages),
+    llmHistory: bundle.archiveHistory,
+    subagentSessions: bundle.archiveSubagentSessions ?? [],
+    loopEnabled: bundle.loopEnabled,
+  });
+}
+
 export function refreshArchiveFromRuntime(
   ctx: ConversationContinuationContext,
   bundle: SessionBundle = ctx.activeBundle(),

--- a/apps/desktop/src/host/direct-media-turn.ts
+++ b/apps/desktop/src/host/direct-media-turn.ts
@@ -23,6 +23,7 @@ import {
   type DirectMediaTool as HostDirectMediaTool,
 } from './model-config.js';
 import type { SessionBundle } from './session-bundle.js';
+import { syncRuntimeHistoryFromBundleArchive } from './conversation-continuation.js';
 import type { SessionTurnOrchestratorContext } from './session-turn-orchestrator.js';
 import type { DesktopConfigFile } from './storage.js';
 import type { DesktopToolExecutor } from './tool-executor.js';
@@ -200,6 +201,8 @@ export async function executeDirectMediaTurn(
       summaryText: failedOutput.summaryText,
     });
   }
+
+  syncRuntimeHistoryFromBundleArchive(input.bundle);
 
   input.bundle.messages = input.bundle.messageTimeline.toMessages();
   await ctx.recordRewindCheckpoint(input.userMessageId, input.beforeUserCheckpoint);

--- a/apps/desktop/src/host/direct-media-turn.ts
+++ b/apps/desktop/src/host/direct-media-turn.ts
@@ -1,0 +1,227 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+  createLlmMessageContentFromText,
+  createLlmTransport,
+  createToolExecutionTextOutput,
+  DEFAULT_IMAGE_GENERATION_SIZE,
+  type ImageGenerationRequest,
+  type RuntimeEvent,
+  type RuntimeToolExecution,
+  type StoredLlmMessageArchiveEntry,
+  type ToolExecutionOutput,
+} from '@spirit-agent/agent-core';
+
+import i18n from '../lib/i18n-host.js';
+import {
+  resolveComposerDirectMediaTool,
+  type DirectMediaTool,
+} from '../lib/composer-direct-media.js';
+import type { DesktopToolRequest } from './contracts.js';
+import {
+  buildMediaOnlyTransportConfig,
+  type DirectMediaTool as HostDirectMediaTool,
+} from './model-config.js';
+import type { SessionBundle } from './session-bundle.js';
+import type { SessionTurnOrchestratorContext } from './session-turn-orchestrator.js';
+import type { DesktopConfigFile } from './storage.js';
+import type { DesktopToolExecutor } from './tool-executor.js';
+
+export interface DirectMediaTurnInput {
+  bundle: SessionBundle;
+  toolName: HostDirectMediaTool;
+  prompt: string;
+  userMessageId: number;
+  beforeUserCheckpoint: unknown;
+}
+
+function buildMediaToolRequest(toolName: DirectMediaTool, prompt: string): DesktopToolRequest {
+  if (toolName === 'generate_image') {
+    return { name: 'generate_image', prompt };
+  }
+  return { name: 'generate_video', prompt };
+}
+
+function buildMediaToolExecution(
+  toolCallId: string,
+  toolName: DirectMediaTool,
+  request: DesktopToolRequest,
+  output: ToolExecutionOutput,
+  failed: boolean,
+): RuntimeToolExecution<DesktopToolRequest> {
+  const artifacts: RuntimeToolExecution<DesktopToolRequest>['artifacts'] = [];
+  for (const part of output.content) {
+    if (part.type === 'image') {
+      artifacts.push({ kind: 'image', path: part.path });
+      continue;
+    }
+    if (part.type === 'video') {
+      artifacts.push({ kind: 'video', path: part.path });
+    }
+  }
+
+  return {
+    toolCallId,
+    toolName,
+    request,
+    output: output.summaryText,
+    failed,
+    ...(artifacts.length > 0 ? { artifacts } : {}),
+  };
+}
+
+export function appendDirectMediaTurnToArchive(
+  bundle: SessionBundle,
+  input: {
+    prompt: string;
+    toolCallId: string;
+    toolName: DirectMediaTool;
+    request: DesktopToolRequest;
+    summaryText: string;
+  },
+): void {
+  const userEntry: StoredLlmMessageArchiveEntry = {
+    role: 'user',
+    content: createLlmMessageContentFromText(input.prompt),
+  };
+  const assistantEntry: StoredLlmMessageArchiveEntry = {
+    role: 'assistant',
+    content: createLlmMessageContentFromText(''),
+    toolCalls: [
+      {
+        id: input.toolCallId,
+        name: input.toolName,
+        argumentsJson: JSON.stringify(input.request),
+      },
+    ],
+  };
+  const toolEntry: StoredLlmMessageArchiveEntry = {
+    role: 'tool',
+    content: createLlmMessageContentFromText(input.summaryText),
+    toolCallId: input.toolCallId,
+  };
+
+  bundle.archiveHistory = [...bundle.archiveHistory, userEntry, assistantEntry, toolEntry];
+}
+
+function renderDirectMediaError(error: unknown): string {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim();
+  }
+  return String(error);
+}
+
+export async function executeDirectMediaTurn(
+  ctx: SessionTurnOrchestratorContext,
+  input: DirectMediaTurnInput,
+): Promise<void> {
+  const config = ctx.requireConfig();
+  const profile = config.models.find((model) => model.name === config.activeModel);
+  if (!profile) {
+    throw new Error(i18n.t('error.modelNotFound', { model: config.activeModel }));
+  }
+
+  const apiKey = await ctx.resolveApiKeyForConfigModel(profile.name);
+  if (!apiKey) {
+    throw new Error(i18n.t('error.apiKeyNotConfigured'));
+  }
+
+  const mediaTransportConfig = buildMediaOnlyTransportConfig(input.toolName, {
+    profile,
+    apiKey,
+  });
+  const toolExecutor = (await ctx.ensureToolExecutor(input.bundle)) as DesktopToolExecutor;
+  const llmTransport = input.bundle.runtimeTransport ?? createLlmTransport();
+  const toolCallId = randomUUID();
+  const request = buildMediaToolRequest(input.toolName, input.prompt);
+  const orchestration = ctx.orchestrationFor(input.bundle);
+
+  const startedEvent: RuntimeEvent<DesktopToolRequest> = {
+    kind: 'tool-call-started',
+    toolCallId,
+    toolName: input.toolName,
+    request,
+  };
+  orchestration.runtimeEvents.applyRuntimeHostEvents([startedEvent]);
+  input.bundle.messages = input.bundle.messageTimeline.toMessages();
+  ctx.emitLiveSnapshotUpdate();
+
+  try {
+    let output: ToolExecutionOutput;
+    if (input.toolName === 'generate_image') {
+      const imageRequest: ImageGenerationRequest = {
+        prompt: input.prompt,
+        size: DEFAULT_IMAGE_GENERATION_SIZE,
+      };
+      output = await llmTransport.generateImage(
+        mediaTransportConfig,
+        imageRequest,
+        (saveRequest) => toolExecutor.saveGeneratedImage(saveRequest),
+      );
+    } else {
+      output = await llmTransport.generateVideo(
+        mediaTransportConfig,
+        { prompt: input.prompt },
+        (saveRequest) => toolExecutor.saveGeneratedVideo(saveRequest),
+      );
+    }
+
+    const execution = buildMediaToolExecution(toolCallId, input.toolName, request, output, false);
+    orchestration.runtimeEvents.applyRuntimeHostEvents([
+      { kind: 'tool-execution-finished', execution },
+    ]);
+    appendDirectMediaTurnToArchive(input.bundle, {
+      prompt: input.prompt,
+      toolCallId,
+      toolName: input.toolName,
+      request,
+      summaryText: output.summaryText,
+    });
+  } catch (error) {
+    const message = renderDirectMediaError(error);
+    const failedOutput = createToolExecutionTextOutput(
+      `${input.toolName} failed: ${message}`,
+    );
+    const execution = buildMediaToolExecution(
+      toolCallId,
+      input.toolName,
+      request,
+      failedOutput,
+      true,
+    );
+    orchestration.runtimeEvents.applyRuntimeHostEvents([
+      { kind: 'tool-execution-finished', execution },
+    ]);
+    appendDirectMediaTurnToArchive(input.bundle, {
+      prompt: input.prompt,
+      toolCallId,
+      toolName: input.toolName,
+      request,
+      summaryText: failedOutput.summaryText,
+    });
+  }
+
+  input.bundle.messages = input.bundle.messageTimeline.toMessages();
+  await ctx.recordRewindCheckpoint(input.userMessageId, input.beforeUserCheckpoint);
+  await ctx.persistSessionBundle(input.bundle, { bumpListSortAt: false });
+  ctx.emitLiveSnapshotUpdate();
+}
+
+export function shouldUseComposerDirectMediaTurn(
+  config: DesktopConfigFile,
+  activeModel: string,
+  explicitWorkspaceFileCount: number,
+): DirectMediaTool | null {
+  const directMediaTool = resolveComposerDirectMediaTool(activeModel, config);
+  if (!directMediaTool) {
+    return null;
+  }
+  if (explicitWorkspaceFileCount > 0) {
+    console.debug(
+      '[desktop][composer-direct-media] attachments present; falling back to chat',
+      { activeModel, tool: directMediaTool },
+    );
+    return null;
+  }
+  return directMediaTool;
+}

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -35,9 +35,16 @@ import {
   usesProviderListedModelCatalogMetadata,
 } from './model-catalog-metadata.js';
 import {
+  resolveComposerDirectMediaTool,
+  type DirectMediaTool,
+} from '../lib/composer-direct-media.js';
+import {
   DEFAULT_API_BASE,
   defaultCustomModelCapabilities,
+  type DesktopConfigFile,
 } from './storage.js';
+
+export { resolveComposerDirectMediaTool, type DirectMediaTool };
 
 export function resolveDesktopTransportKind(
   profile?: Pick<ModelProfileSnapshot, 'provider' | 'transportKind'>,
@@ -234,6 +241,22 @@ export function supportsVideoGeneration(model: { capabilities?: readonly Desktop
   return model.capabilities?.includes('videoGeneration') === true;
 }
 
+export function buildImageGenerationSubConfig(input: {
+  profile: Pick<ModelProfileSnapshot, 'name' | 'apiBase' | 'provider' | 'capabilities'>;
+  apiKey: string;
+}) {
+  const imageGenerationVendor = openAiCompatibleVendorFromProvider(input.profile.provider);
+  return {
+    apiKey: input.apiKey,
+    model: input.profile.name,
+    baseUrl: input.profile.apiBase || DEFAULT_API_BASE,
+    ...(imageGenerationVendor ? { llmVendor: imageGenerationVendor } : {}),
+    ...(input.profile.capabilities
+      ? { modelCapabilities: modelCapabilitiesFromConfig(input.profile.capabilities) }
+      : {}),
+  };
+}
+
 export function buildVideoGenerationSubConfig(input: {
   profile: Pick<ModelProfileSnapshot, 'name' | 'apiBase' | 'provider' | 'capabilities'>;
   apiKey: string;
@@ -248,6 +271,33 @@ export function buildVideoGenerationSubConfig(input: {
       ? { modelCapabilities: modelCapabilitiesFromConfig(input.profile.capabilities) }
       : {}),
   };
+}
+
+export function buildMediaOnlyTransportConfig(
+  toolName: DirectMediaTool,
+  input: {
+    profile: Pick<ModelProfileSnapshot, 'name' | 'apiBase' | 'provider' | 'capabilities'>;
+    apiKey: string;
+  },
+): LlmTransportConfig {
+  const shell = {
+    transportKind: 'openai-compatible' as const,
+    apiKey: input.apiKey,
+    model: input.profile.name,
+    baseUrl: input.profile.apiBase || DEFAULT_API_BASE,
+  };
+
+  if (toolName === 'generate_image') {
+    return {
+      ...shell,
+      imageGeneration: buildImageGenerationSubConfig(input),
+    } as LlmTransportConfig;
+  }
+
+  return {
+    ...shell,
+    videoGeneration: buildVideoGenerationSubConfig(input),
+  } as LlmTransportConfig;
 }
 
 export function attachVideoGenerationToTransportConfig(

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -561,6 +561,9 @@ class DesktopHostService {
       ensureInitialized: (workspaceRootOverride, options) => this.ensureInitialized(workspaceRootOverride, options),
       requireRuntime: () => this.requireRuntime(),
       requireState: () => this.requireState(),
+      requireConfig: () => this.requireState().config,
+      resolveApiKeyForConfigModel: (model) =>
+        resolveApiKeyForConfigModel(this.requireState().config, model),
       activeBundle: () => this.activeBundle(),
       allBundles: () => this.sessionRegistry.all(),
       getActiveBundle: () => this.sessionRegistry.getActive(),

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -27,6 +27,7 @@ import {
   splitRuntimeEventsForIncrementalFinishTaskPreview,
   splitRuntimeEventsForIncrementalResponsesBuiltInToolPreview,
 } from './runtime-event-orchestrator.js';
+import { executeDirectMediaTurn, shouldUseComposerDirectMediaTurn } from './direct-media-turn.js';
 import { toRuntimeAskQuestionsResult } from './service-utils.js';
 
 type RuntimeEventsFacade = {
@@ -57,6 +58,8 @@ export interface SessionTurnOrchestratorContext {
   ensureInitialized(workspaceRootOverride?: string, options?: { fastPath?: boolean }): Promise<void>;
   requireRuntime(): DesktopRuntime;
   requireState(): { workspaceRoot: string };
+  requireConfig(): import('./storage.js').DesktopConfigFile;
+  resolveApiKeyForConfigModel(model: string): Promise<string | undefined>;
   activeBundle(): SessionBundle;
   allBundles(): Iterable<SessionBundle>;
   getActiveBundle(): SessionBundle | undefined;
@@ -157,6 +160,43 @@ export async function submitUserTurnAfterInitializedCommand(
     ctx.syncActiveRuntimePointer();
   }
   await ctx.dispatchUserMessageExtensionEvent(trimmed, displayText, userMessage.id);
+
+  const config = ctx.requireConfig();
+  const directMediaTool = shouldUseComposerDirectMediaTurn(
+    config,
+    config.activeModel,
+    explicitWorkspaceFiles.length,
+  );
+
+  if (directMediaTool && trimmed) {
+    await ctx.ensureToolExecutor(bundle);
+    try {
+      await executeDirectMediaTurn(ctx, {
+        bundle,
+        toolName: directMediaTool,
+        prompt: trimmed,
+        userMessageId: userMessage.id,
+        beforeUserCheckpoint,
+      });
+    } catch (error) {
+      ctx.activeBundle().currentTurnSkills = [];
+      ctx.orchestrationFor(ctx.activeBundle()).assistantMessages.handleMessageRemoved(
+        ctx.activeBundle().messages.length - 1,
+        userMessage.id,
+        'send-user-rollback',
+      );
+      ctx.activeBundle().messages.pop();
+      ctx.rebuildMessageTimelineFromMessages();
+      throw error;
+    }
+
+    const directOrchestration = ctx.orchestrationFor(ctx.activeBundle());
+    directOrchestration.runtimeEvents.syncPendingToolStates();
+    directOrchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
+    await ctx.flushDeferredRuntimeRefreshIfIdle(bundle);
+    await ctx.refreshTodoSnapshotForBundle(bundle);
+    return ctx.buildSnapshot();
+  }
 
   // Re-resolve after promote/persist may have replaced bundle.runtime (todo scope refresh).
   const runtime = ctx.requireRuntime();

--- a/apps/desktop/src/lib/composer-direct-media.ts
+++ b/apps/desktop/src/lib/composer-direct-media.ts
@@ -19,6 +19,10 @@ function supportsVideoGeneration(model: ModelWithCapabilities): boolean {
   return model.capabilities?.includes('videoGeneration') === true;
 }
 
+function supportsChat(model: ModelWithCapabilities): boolean {
+  return model.capabilities?.includes('chat') === true;
+}
+
 export function resolveComposerDirectMediaTool(
   activeModel: string,
   config: ComposerDirectMediaConfig,
@@ -48,6 +52,16 @@ export function resolveComposerDirectMediaTool(
   if (matchesImageSlot) {
     const profile = config.models.find((model) => model.name === trimmedActive);
     if (profile && supportsImageGeneration(profile)) {
+      return 'generate_image';
+    }
+  }
+
+  const profile = config.models.find((model) => model.name === trimmedActive);
+  if (profile && !supportsChat(profile)) {
+    if (supportsVideoGeneration(profile)) {
+      return 'generate_video';
+    }
+    if (supportsImageGeneration(profile)) {
       return 'generate_image';
     }
   }

--- a/apps/desktop/src/lib/composer-direct-media.ts
+++ b/apps/desktop/src/lib/composer-direct-media.ts
@@ -1,0 +1,56 @@
+export type DirectMediaTool = 'generate_image' | 'generate_video';
+
+type ModelWithCapabilities = {
+  name: string;
+  capabilities?: readonly string[];
+};
+
+type ComposerDirectMediaConfig = {
+  models: readonly ModelWithCapabilities[];
+  imageGenerationModel?: string;
+  videoGenerationModel?: string;
+};
+
+function supportsImageGeneration(model: ModelWithCapabilities): boolean {
+  return model.capabilities?.includes('imageGeneration') === true;
+}
+
+function supportsVideoGeneration(model: ModelWithCapabilities): boolean {
+  return model.capabilities?.includes('videoGeneration') === true;
+}
+
+export function resolveComposerDirectMediaTool(
+  activeModel: string,
+  config: ComposerDirectMediaConfig,
+): DirectMediaTool | null {
+  const trimmedActive = activeModel.trim();
+  if (!trimmedActive) {
+    return null;
+  }
+
+  const matchesVideoSlot = config.videoGenerationModel?.trim() === trimmedActive;
+  const matchesImageSlot = config.imageGenerationModel?.trim() === trimmedActive;
+
+  if (matchesVideoSlot && matchesImageSlot) {
+    console.debug(
+      '[desktop][composer-direct-media] active model matches both image and video default slots; preferring generate_video',
+      { activeModel: trimmedActive },
+    );
+  }
+
+  if (matchesVideoSlot) {
+    const profile = config.models.find((model) => model.name === trimmedActive);
+    if (profile && supportsVideoGeneration(profile)) {
+      return 'generate_video';
+    }
+  }
+
+  if (matchesImageSlot) {
+    const profile = config.models.find((model) => model.name === trimmedActive);
+    if (profile && supportsImageGeneration(profile)) {
+      return 'generate_image';
+    }
+  }
+
+  return null;
+}

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -517,9 +517,7 @@
     "planChipLabel": "Plan",
     "askChipLabel": "Ask",
     "placeholderGenerateImage": "Describe the image to generate…",
-    "placeholderGenerateVideo": "Describe the video to generate…",
-    "directMediaImageBadge": "Image",
-    "directMediaVideoBadge": "Video"
+    "placeholderGenerateVideo": "Describe the video to generate…"
   },
   "error": {
     "runtimeBusy": "A response or approval is already being processed. Please wait.",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -515,7 +515,11 @@
     "removeAttachment": "Remove {{name}}",
     "loopChipLabel": "Loop",
     "planChipLabel": "Plan",
-    "askChipLabel": "Ask"
+    "askChipLabel": "Ask",
+    "placeholderGenerateImage": "Describe the image to generate…",
+    "placeholderGenerateVideo": "Describe the video to generate…",
+    "directMediaImageBadge": "Image",
+    "directMediaVideoBadge": "Video"
   },
   "error": {
     "runtimeBusy": "A response or approval is already being processed. Please wait.",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -517,9 +517,7 @@
     "planChipLabel": "Plan",
     "askChipLabel": "Ask",
     "placeholderGenerateImage": "描述要生成的图片…",
-    "placeholderGenerateVideo": "描述要生成的视频…",
-    "directMediaImageBadge": "生图",
-    "directMediaVideoBadge": "生视频"
+    "placeholderGenerateVideo": "描述要生成的视频…"
   },
   "error": {
     "runtimeBusy": "当前已有响应或审批在处理中，请稍候。",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -515,7 +515,11 @@
     "removeAttachment": "移除 {{name}}",
     "loopChipLabel": "Loop",
     "planChipLabel": "Plan",
-    "askChipLabel": "Ask"
+    "askChipLabel": "Ask",
+    "placeholderGenerateImage": "描述要生成的图片…",
+    "placeholderGenerateVideo": "描述要生成的视频…",
+    "directMediaImageBadge": "生图",
+    "directMediaVideoBadge": "生视频"
   },
   "error": {
     "runtimeBusy": "当前已有响应或审批在处理中，请稍候。",

--- a/apps/desktop/test/host/composer-direct-media.test.mjs
+++ b/apps/desktop/test/host/composer-direct-media.test.mjs
@@ -72,6 +72,21 @@ test('resolveComposerDirectMediaTool returns null when slot matches but capabili
   );
 });
 
+test('resolveComposerDirectMediaTool routes image-only active model without slot match', () => {
+  assert.equal(
+    resolveComposerDirectMediaTool('openai/gpt-image-2', {
+      models: [
+        {
+          name: 'openai/gpt-image-2',
+          capabilities: ['imageGeneration'],
+        },
+      ],
+      imageGenerationModel: 'openai/gpt-image-1',
+    }),
+    'generate_image',
+  );
+});
+
 test('resolveComposerDirectMediaTool prefers video when same model fills both slots', () => {
   assert.equal(
     resolveComposerDirectMediaTool('dual-media', {

--- a/apps/desktop/test/host/composer-direct-media.test.mjs
+++ b/apps/desktop/test/host/composer-direct-media.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resolveComposerDirectMediaTool } from '../../dist-electron/src/host/model-config.js';
+
+const chatModel = {
+  name: 'gpt-4o-mini',
+  apiBase: 'https://api.openai.com/v1',
+  capabilities: ['chat'],
+};
+
+const imageModel = {
+  name: 'dall-e-3',
+  apiBase: 'https://api.openai.com/v1',
+  capabilities: ['imageGeneration'],
+};
+
+const videoModel = {
+  name: 'doubao-seedance',
+  apiBase: 'https://ark.cn-beijing.volces.com/api/v3',
+  provider: 'volcengine',
+  capabilities: ['videoGeneration'],
+};
+
+const dualMediaModel = {
+  name: 'dual-media',
+  apiBase: 'https://example.invalid/v1',
+  capabilities: ['imageGeneration', 'videoGeneration'],
+};
+
+test('resolveComposerDirectMediaTool returns generate_video when active matches video slot', () => {
+  assert.equal(
+    resolveComposerDirectMediaTool('doubao-seedance', {
+      models: [chatModel, videoModel],
+      imageGenerationModel: 'dall-e-3',
+      videoGenerationModel: 'doubao-seedance',
+    }),
+    'generate_video',
+  );
+});
+
+test('resolveComposerDirectMediaTool returns generate_image when active matches image slot', () => {
+  assert.equal(
+    resolveComposerDirectMediaTool('dall-e-3', {
+      models: [chatModel, imageModel, videoModel],
+      imageGenerationModel: 'dall-e-3',
+      videoGenerationModel: 'doubao-seedance',
+    }),
+    'generate_image',
+  );
+});
+
+test('resolveComposerDirectMediaTool returns null when active is chat model', () => {
+  assert.equal(
+    resolveComposerDirectMediaTool('gpt-4o-mini', {
+      models: [chatModel, imageModel, videoModel],
+      imageGenerationModel: 'dall-e-3',
+      videoGenerationModel: 'doubao-seedance',
+    }),
+    null,
+  );
+});
+
+test('resolveComposerDirectMediaTool returns null when slot matches but capability missing', () => {
+  assert.equal(
+    resolveComposerDirectMediaTool('gpt-4o-mini', {
+      models: [chatModel],
+      imageGenerationModel: 'gpt-4o-mini',
+      videoGenerationModel: 'gpt-4o-mini',
+    }),
+    null,
+  );
+});
+
+test('resolveComposerDirectMediaTool prefers video when same model fills both slots', () => {
+  assert.equal(
+    resolveComposerDirectMediaTool('dual-media', {
+      models: [dualMediaModel],
+      imageGenerationModel: 'dual-media',
+      videoGenerationModel: 'dual-media',
+    }),
+    'generate_video',
+  );
+});

--- a/apps/desktop/test/host/direct-media-archive.test.mjs
+++ b/apps/desktop/test/host/direct-media-archive.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { appendDirectMediaTurnToArchive } from '../../dist-electron/src/host/direct-media-turn.js';
+
+test('appendDirectMediaTurnToArchive appends user, assistant tool_calls, and tool rows', () => {
+  const bundle = {
+    archiveHistory: [],
+  };
+
+  appendDirectMediaTurnToArchive(bundle, {
+    prompt: 'a moonlit courtyard',
+    toolCallId: 'call-direct-video',
+    toolName: 'generate_video',
+    request: { name: 'generate_video', prompt: 'a moonlit courtyard' },
+    summaryText: [
+      '[generated video]',
+      'video_ref: spirit-agent://generated/video/courtyard.mp4',
+    ].join('\n'),
+  });
+
+  assert.equal(bundle.archiveHistory.length, 3);
+  assert.equal(bundle.archiveHistory[0].role, 'user');
+  assert.equal(bundle.archiveHistory[0].content[0].text, 'a moonlit courtyard');
+  assert.equal(bundle.archiveHistory[1].role, 'assistant');
+  assert.equal(bundle.archiveHistory[1].toolCalls?.[0]?.name, 'generate_video');
+  assert.equal(bundle.archiveHistory[1].toolCalls?.[0]?.id, 'call-direct-video');
+  assert.match(
+    bundle.archiveHistory[1].toolCalls?.[0]?.argumentsJson ?? '',
+    /a moonlit courtyard/,
+  );
+  assert.equal(bundle.archiveHistory[2].role, 'tool');
+  assert.equal(bundle.archiveHistory[2].toolCallId, 'call-direct-video');
+  assert.match(bundle.archiveHistory[2].content[0].text, /spirit-agent:\/\/generated\/video/);
+});

--- a/apps/desktop/test/host/direct-media-turn.test.mjs
+++ b/apps/desktop/test/host/direct-media-turn.test.mjs
@@ -64,10 +64,22 @@ function createDirectMediaHarness() {
     bindFileChangesToToolMessage: () => {},
   });
 
+  const runtimeHistory = [];
   const bundle = {
     archiveHistory: [],
     messages: [],
     messageTimeline: timeline,
+    loopEnabled: false,
+    archiveSubagentSessions: [],
+    runtime: {
+      history() {
+        return runtimeHistory;
+      },
+      replaceFromArchive(archive) {
+        runtimeHistory.length = 0;
+        runtimeHistory.push(...archive.llmHistory);
+      },
+    },
     runtimeTransport: {
       async generateImage(_config, request, saveGenerated) {
         await saveGenerated({
@@ -133,4 +145,7 @@ test('executeDirectMediaTurn emits succeeded generate_image tool card and archiv
   assert.deepEqual(toolMessage.tool.imagePaths, ['generated/direct-test.png']);
   assert.equal(harness.bundle.archiveHistory.length, 3);
   assert.match(harness.bundle.archiveHistory[2].content[0].text, /spirit-agent:\/\/generated\/image/);
+  assert.equal(harness.bundle.runtime.history().length, 3);
+  assert.equal(harness.bundle.runtime.history()[1].role, 'assistant');
+  assert.equal(harness.bundle.runtime.history()[1].toolCalls?.[0]?.name, 'generate_image');
 });

--- a/apps/desktop/test/host/direct-media-turn.test.mjs
+++ b/apps/desktop/test/host/direct-media-turn.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { DesktopAssistantMessageStateMachine } from '../../dist-electron/src/host/assistant-message-state.js';
+import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
+import { DesktopRuntimeEventOrchestrator } from '../../dist-electron/src/host/runtime-event-orchestrator.js';
+import {
+  executeDirectMediaTurn,
+  shouldUseComposerDirectMediaTurn,
+} from '../../dist-electron/src/host/direct-media-turn.js';
+
+const imageModel = {
+  name: 'dall-e-3',
+  apiBase: 'https://api.openai.com/v1',
+  capabilities: ['imageGeneration'],
+};
+
+const config = {
+  activeModel: 'dall-e-3',
+  models: [imageModel],
+  imageGenerationModel: 'dall-e-3',
+};
+
+test('shouldUseComposerDirectMediaTurn returns null when attachments are present', () => {
+  assert.equal(shouldUseComposerDirectMediaTurn(config, 'dall-e-3', 1), null);
+});
+
+function createDirectMediaHarness() {
+  let messages = [];
+  let nextMessageId = 1;
+  let nextTimelineMessageId = 1;
+  const timeline = new DesktopMessageTimeline({
+    allocateMessageId: () => nextTimelineMessageId++,
+    reserveMessageId: (messageId) => {
+      if (messageId >= nextTimelineMessageId) {
+        nextTimelineMessageId = messageId + 1;
+      }
+    },
+  });
+  const assistantMessages = new DesktopAssistantMessageStateMachine({
+    messages: () => messages,
+    setMessages: (nextMessages) => {
+      messages = nextMessages;
+    },
+    allocateMessageId: () => nextMessageId++,
+    isRuntimeBusy: () => false,
+  });
+  const orchestrator = new DesktopRuntimeEventOrchestrator({
+    runtime: () => ({
+      takeCompletedTurnResult: () => undefined,
+    }),
+    messages: () => messages,
+    allocateMessageId: () => nextMessageId++,
+    assistantMessages,
+    messageTimeline: () => timeline,
+    takeNextAssistantSegmentKind: () => 'initial',
+    conversationSnapshotView: {
+      snapshotFromMessages: () => ({ messages: [] }),
+    },
+    clearCurrentTurnSkills: () => {},
+    setLastRuntimeError: () => {},
+    refreshArchiveFromRuntime: () => {},
+    dispatchExtensionEvent: () => {},
+    bindFileChangesToToolMessage: () => {},
+  });
+
+  const bundle = {
+    archiveHistory: [],
+    messages: [],
+    messageTimeline: timeline,
+    runtimeTransport: {
+      async generateImage(_config, request, saveGenerated) {
+        await saveGenerated({
+          data: new Uint8Array([1, 2, 3]),
+          mediaType: 'image/png',
+          prompt: request.prompt,
+          model: 'dall-e-3',
+        });
+        return {
+          content: [
+            { type: 'text', text: '[generated image]' },
+            { type: 'image', path: 'generated/direct-test.png' },
+          ],
+          summaryText: [
+            '[generated image]',
+            'image_ref: spirit-agent://generated/image/direct-test.png',
+          ].join('\n'),
+        };
+      },
+    },
+  };
+
+  timeline.beginUserTurn('draw a square poster', { messageId: 1 });
+  bundle.messages = timeline.toMessages();
+
+  const ctx = {
+    requireConfig: () => config,
+    resolveApiKeyForConfigModel: async () => 'test-key',
+    ensureToolExecutor: async () => ({
+      async saveGeneratedImage(request) {
+        return {
+          path: 'generated/direct-test.png',
+          mimeType: request.mediaType,
+          markdownRef: 'spirit-agent://generated/image/direct-test.png',
+        };
+      },
+    }),
+    orchestrationFor: () => ({
+      runtimeEvents: orchestrator,
+    }),
+    emitLiveSnapshotUpdate: () => {},
+    recordRewindCheckpoint: async () => {},
+    persistSessionBundle: async () => {},
+  };
+
+  return { bundle, ctx, messages: () => messages };
+}
+
+test('executeDirectMediaTurn emits succeeded generate_image tool card and archive rows', async () => {
+  const harness = createDirectMediaHarness();
+
+  await executeDirectMediaTurn(harness.ctx, {
+    bundle: harness.bundle,
+    toolName: 'generate_image',
+    prompt: 'draw a square poster',
+    userMessageId: 1,
+    beforeUserCheckpoint: undefined,
+  });
+
+  const toolMessage = harness.messages().find((message) => message.tool?.toolName === 'generate_image');
+  assert.ok(toolMessage);
+  assert.equal(toolMessage.tool.phase, 'succeeded');
+  assert.deepEqual(toolMessage.tool.imagePaths, ['generated/direct-test.png']);
+  assert.equal(harness.bundle.archiveHistory.length, 3);
+  assert.match(harness.bundle.archiveHistory[2].content[0].text, /spirit-agent:\/\/generated\/image/);
+});

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -676,6 +676,11 @@ function createAiSdkLanguageModel(config: OpenAiTransportConfig): any {
 }
 
 function createAiSdkImageModel(config: OpenAiImageGenerationConfig): any {
+  if (isVercelAiGatewayImageConfig(config)) {
+    // Gateway 生图走 v3 image-model 协议，不能复用 chat 预设的 /v1 baseUrl。
+    return createGateway({ apiKey: config.apiKey }).image(config.model);
+  }
+
   return createAiSdkOpenAiCompatibleProvider(config, { includeChatVendorExtras: false }).imageModel(config.model);
 }
 
@@ -1590,6 +1595,12 @@ function isVercelAiGatewayProvider(config: OpenAiTransportConfig): boolean {
   return config.llmVendor === 'vercel-ai-gateway';
 }
 
+function isVercelAiGatewayImageConfig(
+  config: OpenAiImageGenerationConfig,
+): boolean {
+  return config.llmVendor === 'vercel-ai-gateway';
+}
+
 function isOpenAiOfficialAiSdkProvider(config: OpenAiTransportConfig): boolean {
   return config.llmVendor === 'openai';
 }
@@ -1605,6 +1616,10 @@ function xaiChatReasoningEffort(
 }
 
 function buildAiSdkImageGenerationUrl(config: OpenAiImageGenerationConfig): string {
+  if (isVercelAiGatewayImageConfig(config)) {
+    return 'https://ai-gateway.vercel.sh/v3/ai/image-model';
+  }
+
   const baseUrl = (config.baseUrl ?? DEFAULT_OPENAI_COMPATIBLE_BASE_URL).replace(/\/$/, '');
   return `${baseUrl}/images/generations`;
 }
@@ -1615,7 +1630,7 @@ function logAiSdkImageGenerationStart(
   requestUrl: string,
 ): void {
   console.error('[agent-core][generate-image] request.start', {
-    adapter: 'openai-compatible-image',
+    adapter: isVercelAiGatewayImageConfig(config) ? 'ai-sdk-gateway-image' : 'openai-compatible-image',
     vendor: config.llmVendor ?? 'custom',
     model: config.model,
     baseUrl: config.baseUrl ?? DEFAULT_OPENAI_COMPATIBLE_BASE_URL,


### PR DESCRIPTION
## Summary

- 当当前推理模型匹配默认生图/生视频槽位，或为无 chat 能力的纯 media 模型时，Composer 发送走直连 generate_image / generate_video，绕过 LLM chat completion。
- 直连轮次写入 LLM 归档（user + assistant tool_calls + tool），并在完成后同步 untime.history，切回聊天模型后续聊可引用生成结果。
- Vercel AI Gateway 纯生图模型改用 v3 image-model 协议，避免误走 language-model 端点。
- Composer 在直连模式下切换生图/生视频占位符；发送后乐观清空输入框，失败时恢复草稿。
- 移除模型选择器旁的 Image/Video 徽章（占位符仍提示模式）。

## Test plan

- [x] \pps/desktop/test/host/composer-direct-media.test.mjs\
- [x] \pps/desktop/test/host/direct-media-archive.test.mjs\
- [x] \pps/desktop/test/host/direct-media-turn.test.mjs\
- [x] 手动：GPT Image 2 直连生图 → 切换 deepseek → 发送后续消息，\/log-session\ 导出应含生图轮三段且模型能感知前文
- [x] 手动：Gateway 纯生图模型直连不再报 language-model 404
- [ ] 火山 Seedance 直连生视频 E2E（未在本 PR 环境复测）