### PR TITLE
feat(desktop): 侧栏与 Git 分栏布局持久化

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -174,7 +174,7 @@ import {
   DESKTOP_OVERLAY_SHORT_SUBCONTENT,
   instantHoverMotionClass,
 } from "@/lib/desktop-chrome";
-import { readSessionSidebarWidthPx } from "@/lib/layout-prefs";
+import { readSessionSidebarWidthPx, readWorkspaceToolsWidthPx } from "@/lib/layout-prefs";
 import {
   buildModelCatalogDisplayTitleMap,
   modelDisplayTitleFromMap,
@@ -2084,7 +2084,7 @@ export default function App() {
   const [workspaceFileRevealPath, setWorkspaceFileRevealPath] = useState("");
   const [workspaceFileRevealViewMode, setWorkspaceFileRevealViewMode] =
     useState<WorkspaceEditorViewMode>("edit");
-  const [workspaceToolsWidthPx, setWorkspaceToolsWidthPx] = useState(420);
+  const [workspaceToolsWidthPx, setWorkspaceToolsWidthPx] = useState(readWorkspaceToolsWidthPx);
 
   const openBrowserUrlInNewTab = useCallback((rawUrl: string) => {
     if (runtime.hostKind !== "electron") {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -172,9 +172,9 @@ import {
   DESKTOP_OVERLAY_LIST_ITEM_SECONDARY,
   DESKTOP_OVERLAY_LIST_SUB_TRIGGER,
   DESKTOP_OVERLAY_SHORT_SUBCONTENT,
-  SESSION_SIDEBAR_DEFAULT_WIDTH_PX,
   instantHoverMotionClass,
 } from "@/lib/desktop-chrome";
+import { readSessionSidebarWidthPx } from "@/lib/layout-prefs";
 import {
   buildModelCatalogDisplayTitleMap,
   modelDisplayTitleFromMap,
@@ -2054,9 +2054,7 @@ export default function App() {
   const [settingsTab, setSettingsTab] = useState<SettingsSidebarTab>("basic");
   const [extensionSettingsId, setExtensionSettingsId] = useState<string | null>(null);
   const [sessionSidebarOpen, setSessionSidebarOpen] = useState(true);
-  const [sessionSidebarWidthPx, setSessionSidebarWidthPx] = useState(
-    SESSION_SIDEBAR_DEFAULT_WIDTH_PX,
-  );
+  const [sessionSidebarWidthPx, setSessionSidebarWidthPx] = useState(readSessionSidebarWidthPx);
   const [workspaceToolsOpen, setWorkspaceToolsOpen] = useState(false);
   const initialWorkspaceToolsRef = useRef<ReturnType<
     typeof createInitialWorkspaceToolsState

--- a/apps/desktop/src/components/session-sidebar-shell.tsx
+++ b/apps/desktop/src/components/session-sidebar-shell.tsx
@@ -6,6 +6,7 @@ import {
   computeSessionSidebarMaxWidthPx,
   sessionSidebarShellWidth,
 } from "@/lib/desktop-chrome";
+import { writeSessionSidebarWidthPx } from "@/lib/layout-prefs";
 import { cn } from "@/lib/utils";
 
 export type SessionSidebarShellProps = {
@@ -32,6 +33,8 @@ export function SessionSidebarShell({
   const { t } = useTranslation();
   const [isResizing, setIsResizing] = useState(false);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+  const latestWidthPxRef = useRef(widthPx);
+  latestWidthPxRef.current = widthPx;
   const [viewportMaxWidthPx, setViewportMaxWidthPx] = useState(computeSessionSidebarMaxWidthPx);
   const maxWidthPx = maxWidthPxProp ?? viewportMaxWidthPx;
 
@@ -81,13 +84,18 @@ export function SessionSidebarShell({
         return;
       }
       const delta = event.clientX - drag.startX;
-      onWidthPxChange(clampWidth(drag.startWidth + delta));
+      const next = clampWidth(drag.startWidth + delta);
+      latestWidthPxRef.current = next;
+      onWidthPxChange(next);
     },
     [clampWidth, onWidthPxChange],
   );
 
   const endResize = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     setIsResizing(false);
+    if (dragRef.current) {
+      writeSessionSidebarWidthPx(latestWidthPxRef.current);
+    }
     dragRef.current = null;
     try {
       event.currentTarget.releasePointerCapture(event.pointerId);

--- a/apps/desktop/src/components/workspace-git-tab.tsx
+++ b/apps/desktop/src/components/workspace-git-tab.tsx
@@ -72,6 +72,7 @@ export function WorkspaceGitTab({
   latestChangesPaneHeightPxRef.current = changesPaneHeightPx;
   const [isResizingSplit, setIsResizingSplit] = useState(false);
   const splitDragRef = useRef<{ startY: number; startHeight: number } | null>(null);
+  const hasInitializedSplitFromStorageRef = useRef(false);
   const historyLoadMoreInFlightRef = useRef(false);
   const hasLoadedWorkingTreeRef = useRef(false);
 
@@ -91,13 +92,22 @@ export function WorkspaceGitTab({
       return;
     }
     const syncDefaultHeight = (): void => {
+      const containerHeight = container.clientHeight;
+      const panelHidden = container.closest("[hidden]") !== null;
+      if (containerHeight <= 0 || panelHidden) {
+        return;
+      }
       setChangesPaneHeightPx((prev) => {
-        if (prev !== null) {
-          return clampChangesPaneHeight(prev);
+        const storedRatio = readGitChangesPaneRatio(containerHeight);
+        const next = !hasInitializedSplitFromStorageRef.current
+          ? clampChangesPaneHeight(containerHeight * storedRatio)
+          : prev !== null
+            ? clampChangesPaneHeight(prev)
+            : clampChangesPaneHeight(containerHeight * storedRatio);
+        if (!hasInitializedSplitFromStorageRef.current) {
+          hasInitializedSplitFromStorageRef.current = true;
         }
-        return clampChangesPaneHeight(
-          container.clientHeight * readGitChangesPaneRatio(container.clientHeight),
-        );
+        return next;
       });
     };
     syncDefaultHeight();

--- a/apps/desktop/src/components/workspace-git-tab.tsx
+++ b/apps/desktop/src/components/workspace-git-tab.tsx
@@ -4,6 +4,14 @@ import { useTranslation } from "react-i18next";
 import { GitChangesSection } from "@/components/git-changes-section";
 import { GitCommitGraph } from "@/components/git-commit-graph";
 import type { WorkspaceEditorViewMode } from "@/lib/workspace-editor-navigation";
+import {
+  GIT_CHANGES_MIN_PX,
+  GIT_HISTORY_HEADER_PX,
+  GIT_HISTORY_MIN_PX,
+  GIT_SPLITTER_PX,
+  readGitChangesPaneRatio,
+  writeGitChangesPaneRatio,
+} from "@/lib/layout-prefs";
 import { cn } from "@/lib/utils";
 import type {
   DesktopGitSnapshot,
@@ -19,12 +27,6 @@ function describeError(error: unknown): string {
   }
   return String(error);
 }
-
-const GIT_CHANGES_MIN_PX = 88;
-const GIT_HISTORY_MIN_PX = 120;
-const GIT_HISTORY_HEADER_PX = 32;
-const GIT_SPLITTER_PX = 4;
-const GIT_CHANGES_DEFAULT_RATIO = 0.45;
 
 export type WorkspaceGitTabProps = {
   gitSnapshot?: DesktopGitSnapshot;
@@ -65,7 +67,9 @@ export function WorkspaceGitTab({
   const [mergeButtonFlashMerged, setMergeButtonFlashMerged] = useState(false);
   const mergeFlashTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const splitContainerRef = useRef<HTMLDivElement>(null);
+  const latestChangesPaneHeightPxRef = useRef<number | null>(null);
   const [changesPaneHeightPx, setChangesPaneHeightPx] = useState<number | null>(null);
+  latestChangesPaneHeightPxRef.current = changesPaneHeightPx;
   const [isResizingSplit, setIsResizingSplit] = useState(false);
   const splitDragRef = useRef<{ startY: number; startHeight: number } | null>(null);
   const historyLoadMoreInFlightRef = useRef(false);
@@ -91,7 +95,9 @@ export function WorkspaceGitTab({
         if (prev !== null) {
           return clampChangesPaneHeight(prev);
         }
-        return clampChangesPaneHeight(container.clientHeight * GIT_CHANGES_DEFAULT_RATIO);
+        return clampChangesPaneHeight(
+          container.clientHeight * readGitChangesPaneRatio(container.clientHeight),
+        );
       });
     };
     syncDefaultHeight();
@@ -104,10 +110,11 @@ export function WorkspaceGitTab({
     (event: React.PointerEvent<HTMLDivElement>) => {
       event.preventDefault();
       setIsResizingSplit(true);
+      const containerHeight = splitContainerRef.current?.clientHeight ?? 0;
       const startHeight =
         changesPaneHeightPx ??
         clampChangesPaneHeight(
-          (splitContainerRef.current?.clientHeight ?? 0) * GIT_CHANGES_DEFAULT_RATIO,
+          containerHeight * readGitChangesPaneRatio(containerHeight || undefined),
         );
       splitDragRef.current = { startY: event.clientY, startHeight };
       event.currentTarget.setPointerCapture(event.pointerId);
@@ -122,13 +129,22 @@ export function WorkspaceGitTab({
         return;
       }
       const delta = event.clientY - drag.startY;
-      setChangesPaneHeightPx(clampChangesPaneHeight(drag.startHeight + delta));
+      const next = clampChangesPaneHeight(drag.startHeight + delta);
+      latestChangesPaneHeightPxRef.current = next;
+      setChangesPaneHeightPx(next);
     },
     [clampChangesPaneHeight],
   );
 
   const endSplitResize = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     setIsResizingSplit(false);
+    if (splitDragRef.current) {
+      const container = splitContainerRef.current;
+      const height = latestChangesPaneHeightPxRef.current;
+      if (container && container.clientHeight > 0 && height !== null) {
+        writeGitChangesPaneRatio(height / container.clientHeight, container.clientHeight);
+      }
+    }
     splitDragRef.current = null;
     try {
       event.currentTarget.releasePointerCapture(event.pointerId);

--- a/apps/desktop/src/components/workspace-tools-panel.tsx
+++ b/apps/desktop/src/components/workspace-tools-panel.tsx
@@ -9,6 +9,11 @@ import { WorkspaceFilesTab } from "@/components/workspace-files-tab";
 import { WorkspaceGitTab } from "@/components/workspace-git-tab";
 import { WorkspaceShellTab } from "@/components/workspace-shell-tab";
 import { instantHoverMotionClass } from "@/lib/desktop-chrome";
+import {
+  WORKSPACE_TOOLS_MIN_WIDTH_PX,
+  computeWorkspaceToolsMaxWidthPx,
+  writeWorkspaceToolsWidthPx,
+} from "@/lib/layout-prefs";
 import { cn } from "@/lib/utils";
 import type { WorkspaceEditorViewMode } from "@/lib/workspace-editor-navigation";
 import {
@@ -85,17 +90,6 @@ export type WorkspaceToolsDockProps = {
   className?: string;
 };
 
-const DEFAULT_MIN = 240;
-/** 默认可拖至视口宽度约 62%，保证大屏下能占至少一大半。 */
-const VIEWPORT_MAX_WIDTH_RATIO = 0.62;
-
-function computeViewportMaxWidthPx(): number {
-  if (typeof window === "undefined") {
-    return 900;
-  }
-  return Math.round(window.innerWidth * VIEWPORT_MAX_WIDTH_RATIO);
-}
-
 export function WorkspaceToolsDock({
   workspaceRoot,
   listExplorerChildren,
@@ -120,7 +114,7 @@ export function WorkspaceToolsDock({
   onBrowserOpenInNewTab,
   browserTabEnabled = false,
   widthPx,
-  minWidthPx = DEFAULT_MIN,
+  minWidthPx = WORKSPACE_TOOLS_MIN_WIDTH_PX,
   maxWidthPx: maxWidthPxProp,
   onWidthPxChange,
   open,
@@ -134,7 +128,9 @@ export function WorkspaceToolsDock({
   const { t } = useTranslation();
   const [isResizing, setIsResizing] = useState(false);
   const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
-  const [viewportMaxWidthPx, setViewportMaxWidthPx] = useState(computeViewportMaxWidthPx);
+  const latestWidthPxRef = useRef(widthPx);
+  latestWidthPxRef.current = widthPx;
+  const [viewportMaxWidthPx, setViewportMaxWidthPx] = useState(computeWorkspaceToolsMaxWidthPx);
   const maxWidthPx = maxWidthPxProp ?? viewportMaxWidthPx;
 
   useEffect(() => {
@@ -142,7 +138,7 @@ export function WorkspaceToolsDock({
       return;
     }
     const onWindowResize = () => {
-      setViewportMaxWidthPx(computeViewportMaxWidthPx());
+      setViewportMaxWidthPx(computeWorkspaceToolsMaxWidthPx());
     };
     window.addEventListener("resize", onWindowResize);
     return () => window.removeEventListener("resize", onWindowResize);
@@ -183,7 +179,9 @@ export function WorkspaceToolsDock({
         return;
       }
       const delta = drag.startX - event.clientX;
-      onWidthPxChange(clampWidth(drag.startWidth + delta));
+      const next = clampWidth(drag.startWidth + delta);
+      latestWidthPxRef.current = next;
+      onWidthPxChange(next);
     },
     [clampWidth, onWidthPxChange],
   );
@@ -191,8 +189,9 @@ export function WorkspaceToolsDock({
   const endResize = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     setIsResizing(false);
     if (dragRef.current) {
-      dragRef.current = null;
+      writeWorkspaceToolsWidthPx(latestWidthPxRef.current);
     }
+    dragRef.current = null;
     try {
       event.currentTarget.releasePointerCapture(event.pointerId);
     } catch {

--- a/apps/desktop/src/lib/desktop-chrome.ts
+++ b/apps/desktop/src/lib/desktop-chrome.ts
@@ -118,11 +118,11 @@ export function stopOverlayScrollPropagation(event: {
   event.stopPropagation();
 }
 
-/** 左侧会话侧栏默认宽度（原 16rem） */
-export const SESSION_SIDEBAR_DEFAULT_WIDTH_PX = 256;
-
-/** 可拖拽下限：略窄于默认，勿压太多 */
+/** 可拖拽下限：默认宽度与之对齐，首次打开更紧凑 */
 export const SESSION_SIDEBAR_MIN_WIDTH_PX = 232;
+
+/** 左侧会话侧栏默认宽度 */
+export const SESSION_SIDEBAR_DEFAULT_WIDTH_PX = SESSION_SIDEBAR_MIN_WIDTH_PX;
 
 /** 可拖拽上限：相对默认仅略放宽（右侧工具区勿用视口大比例） */
 export const SESSION_SIDEBAR_MAX_WIDTH_PX = 288;

--- a/apps/desktop/src/lib/layout-prefs.ts
+++ b/apps/desktop/src/lib/layout-prefs.ts
@@ -1,0 +1,60 @@
+import {
+  SESSION_SIDEBAR_MIN_WIDTH_PX,
+  computeSessionSidebarMaxWidthPx,
+} from "@/lib/desktop-chrome";
+
+const SESSION_SIDEBAR_WIDTH_STORAGE_KEY = "spirit-desktop-session-sidebar-width-px";
+
+function clampInt(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.round(value)));
+}
+
+function readStoredPositiveInt(
+  key: string,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  try {
+    if (typeof localStorage === "undefined") {
+      return fallback;
+    }
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    if (Number.isFinite(parsed)) {
+      return clampInt(parsed, min, max);
+    }
+  } catch {
+    // ignore
+  }
+  return fallback;
+}
+
+function writeStoredPositiveInt(key: string, value: number): void {
+  try {
+    if (typeof localStorage === "undefined") {
+      return;
+    }
+    localStorage.setItem(key, String(Math.round(value)));
+  } catch {
+    // ignore
+  }
+}
+
+export function readSessionSidebarWidthPx(): number {
+  const max = computeSessionSidebarMaxWidthPx();
+  return readStoredPositiveInt(
+    SESSION_SIDEBAR_WIDTH_STORAGE_KEY,
+    SESSION_SIDEBAR_MIN_WIDTH_PX,
+    SESSION_SIDEBAR_MIN_WIDTH_PX,
+    max,
+  );
+}
+
+export function writeSessionSidebarWidthPx(widthPx: number): void {
+  const max = computeSessionSidebarMaxWidthPx();
+  writeStoredPositiveInt(
+    SESSION_SIDEBAR_WIDTH_STORAGE_KEY,
+    clampInt(widthPx, SESSION_SIDEBAR_MIN_WIDTH_PX, max),
+  );
+}

--- a/apps/desktop/src/lib/layout-prefs.ts
+++ b/apps/desktop/src/lib/layout-prefs.ts
@@ -90,3 +90,91 @@ export function writeWorkspaceToolsWidthPx(widthPx: number): void {
     clampInt(widthPx, WORKSPACE_TOOLS_MIN_WIDTH_PX, max),
   );
 }
+
+const GIT_CHANGES_PANE_RATIO_STORAGE_KEY = "spirit-desktop-git-changes-pane-ratio";
+
+export const GIT_CHANGES_DEFAULT_RATIO = 0.45;
+const GIT_CHANGES_RATIO_LOOSE_MIN = 0.15;
+const GIT_CHANGES_RATIO_LOOSE_MAX = 0.85;
+
+export const GIT_CHANGES_MIN_PX = 88;
+export const GIT_HISTORY_MIN_PX = 120;
+export const GIT_HISTORY_HEADER_PX = 32;
+export const GIT_SPLITTER_PX = 4;
+
+function clampRatio(ratio: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, ratio));
+}
+
+export function computeGitChangesPaneRatioBounds(containerHeightPx: number): {
+  min: number;
+  max: number;
+} {
+  const min = GIT_CHANGES_MIN_PX / containerHeightPx;
+  const max =
+    (containerHeightPx - GIT_HISTORY_MIN_PX - GIT_HISTORY_HEADER_PX - GIT_SPLITTER_PX) /
+    containerHeightPx;
+  return { min, max };
+}
+
+export function clampGitChangesPaneRatio(
+  ratio: number,
+  containerHeightPx?: number,
+): number {
+  if (containerHeightPx && containerHeightPx > 0) {
+    const { min, max } = computeGitChangesPaneRatioBounds(containerHeightPx);
+    if (min <= max) {
+      return clampRatio(ratio, min, max);
+    }
+  }
+  return clampRatio(ratio, GIT_CHANGES_RATIO_LOOSE_MIN, GIT_CHANGES_RATIO_LOOSE_MAX);
+}
+
+function readStoredRatio(
+  key: string,
+  fallback: number,
+  containerHeightPx?: number,
+): number {
+  try {
+    if (typeof localStorage === "undefined") {
+      return fallback;
+    }
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? Number.parseFloat(raw) : Number.NaN;
+    if (Number.isFinite(parsed)) {
+      return clampGitChangesPaneRatio(parsed, containerHeightPx);
+    }
+  } catch {
+    // ignore
+  }
+  return fallback;
+}
+
+function writeStoredRatio(key: string, ratio: number, containerHeightPx?: number): void {
+  try {
+    if (typeof localStorage === "undefined") {
+      return;
+    }
+    localStorage.setItem(
+      key,
+      String(clampGitChangesPaneRatio(ratio, containerHeightPx)),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function readGitChangesPaneRatio(containerHeightPx?: number): number {
+  return readStoredRatio(
+    GIT_CHANGES_PANE_RATIO_STORAGE_KEY,
+    GIT_CHANGES_DEFAULT_RATIO,
+    containerHeightPx,
+  );
+}
+
+export function writeGitChangesPaneRatio(
+  ratio: number,
+  containerHeightPx?: number,
+): void {
+  writeStoredRatio(GIT_CHANGES_PANE_RATIO_STORAGE_KEY, ratio, containerHeightPx);
+}

--- a/apps/desktop/src/lib/layout-prefs.ts
+++ b/apps/desktop/src/lib/layout-prefs.ts
@@ -58,3 +58,35 @@ export function writeSessionSidebarWidthPx(widthPx: number): void {
     clampInt(widthPx, SESSION_SIDEBAR_MIN_WIDTH_PX, max),
   );
 }
+
+const WORKSPACE_TOOLS_WIDTH_STORAGE_KEY = "spirit-desktop-workspace-tools-width-px";
+
+export const WORKSPACE_TOOLS_MIN_WIDTH_PX = 240;
+export const WORKSPACE_TOOLS_DEFAULT_WIDTH_PX = 420;
+const WORKSPACE_TOOLS_VIEWPORT_MAX_WIDTH_RATIO = 0.62;
+
+export function computeWorkspaceToolsMaxWidthPx(
+  viewportWidthPx = typeof window !== "undefined" ? window.innerWidth : 1200,
+): number {
+  return Math.round(viewportWidthPx * WORKSPACE_TOOLS_VIEWPORT_MAX_WIDTH_RATIO);
+}
+
+export function readWorkspaceToolsWidthPx(
+  viewportWidthPx = typeof window !== "undefined" ? window.innerWidth : 1200,
+): number {
+  const max = computeWorkspaceToolsMaxWidthPx(viewportWidthPx);
+  return readStoredPositiveInt(
+    WORKSPACE_TOOLS_WIDTH_STORAGE_KEY,
+    WORKSPACE_TOOLS_DEFAULT_WIDTH_PX,
+    WORKSPACE_TOOLS_MIN_WIDTH_PX,
+    max,
+  );
+}
+
+export function writeWorkspaceToolsWidthPx(widthPx: number): void {
+  const max = computeWorkspaceToolsMaxWidthPx();
+  writeStoredPositiveInt(
+    WORKSPACE_TOOLS_WIDTH_STORAGE_KEY,
+    clampInt(widthPx, WORKSPACE_TOOLS_MIN_WIDTH_PX, max),
+  );
+}


### PR DESCRIPTION
## Summary

- 左侧会话侧栏默认宽度改为可拖最小值（232px），宽度拖拽结束后写入 `localStorage` 并在重启后恢复。
- 右侧工具栏宽度同样持久化（默认仍为 420px）。
- Git Changes / History 分栏以**比例**持久化；修复启动时 Git 选项卡处于 `hidden` 且容器高度为 0 时初始化失败、重启后分栏回退的问题。

新增 [`apps/desktop/src/lib/layout-prefs.ts`](apps/desktop/src/lib/layout-prefs.ts) 集中管理布局偏好的读写与钳制。

## Commits

1. `feat(desktop): 左侧会话侧栏默认最小宽度并持久化`
2. `feat(desktop): 右侧工具栏宽度持久化`
3. `feat(desktop): Git Changes/History 分栏比例持久化`
4. `fix(desktop): 修复 Git 分栏在隐藏面板零高度时初始化失败`

## Test plan

- [ ] 清空相关 `localStorage` 后启动：左侧侧栏默认约 232px
- [ ] 拖拽左/右侧栏宽度后重启，宽度恢复
- [ ] 拖拽 Git Changes/History 分隔条后重启，比例恢复（含非 Git 活跃选项卡启动场景）
- [ ] 缩小窗口后重启，超出当前钳制范围的存储值被正确限制
- [ ] `apps/desktop` 下 `npx tsc --noEmit` 通过