### PR TITLE
feat(desktop): SubAgent 后台会话查看器与思考/工具卡隔离

### DIFF
--- a/apps/desktop/electron/http-host.ts
+++ b/apps/desktop/electron/http-host.ts
@@ -798,6 +798,21 @@ async function handleApiRequest({
     return;
   }
 
+  if (request.method === 'POST' && pathname === '/api/subagent-viewer-target') {
+    writeJson(
+      request,
+      response,
+      200,
+      await runHostCommand('setSubagentViewerTarget', {
+        parentToolCallId:
+          typeof jsonBody?.parentToolCallId === 'string' || jsonBody?.parentToolCallId === null
+            ? jsonBody.parentToolCallId
+            : null,
+      }),
+    );
+    return;
+  }
+
   if (request.method === 'POST' && pathname === '/api/abort') {
     writeJson(request, response, 200, await runHostCommand('abortConversation'));
     return;

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -134,6 +134,9 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   poll() {
     return ipcRenderer.invoke('desktop:invoke', 'poll');
   },
+  setSubagentViewerTarget(parentToolCallId: string | null) {
+    return ipcRenderer.invoke('desktop:invoke', 'setSubagentViewerTarget', { parentToolCallId });
+  },
   listDreamsOverview() {
     return ipcRenderer.invoke('desktop:invoke', 'listDreamsOverview');
   },

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -118,6 +118,7 @@ import { SkillSlashMenu } from "@/components/skill-slash-menu";
 import { SettingsView } from "@/components/settings-view";
 import { ComposerTodoCard } from "@/components/composer-todo-card";
 import { MinimalToolCallCard } from "@/components/minimal-tool-call-card";
+import { PendingApprovalCard } from "@/components/pending-approval-card";
 import { SubagentViewerBanner } from "@/components/subagent-viewer-banner";
 import { ToolCallDiffHostProvider } from "@/components/tool-call-diff-host-context";
 import { isMinimalToolCallMessage, toolHasExpandableContent } from "@/lib/tool-call-display";
@@ -2045,6 +2046,13 @@ export default function App() {
       : snapshot?.conversation.pendingAuxState;
   const rewindWarnings = snapshot?.conversation.rewindWarnings ?? [];
   const pendingApproval = snapshot?.conversation.pendingToolApproval;
+  const showPendingApprovalInComposer = Boolean(
+    pendingApproval
+    && (
+      !subagentViewActive
+      || pendingApproval.subagentSessionId === snapshot?.subagentViewer?.sessionId
+    ),
+  );
   const pendingQuestions = runtime.pendingQuestions;
   useLocalFileAttachmentPreviews(
     runtime.composerLocalFileAttachments,
@@ -3357,88 +3365,30 @@ export default function App() {
                   </div>
                 ) : null}
 
-                {pendingApproval ? (
-                  <Card className="border-border/50 bg-background/55 text-sm shadow-sm backdrop-blur-xl dark:border-white/12 supports-[backdrop-filter]:bg-background/40">
-                    <CardHeader className="space-y-1.5 px-3 py-2.5">
-                      <CardTitle className="min-w-0 truncate text-sm leading-tight">
-                        {pendingApproval.toolName}
-                      </CardTitle>
-                      <CardDescription className="text-xs leading-relaxed">
-                        <ScrollArea
-                          type="always"
-                          className="pr-3 [&>[data-radix-scroll-area-viewport]]:max-h-24 [&>[data-radix-scroll-area-viewport]]:overscroll-contain"
-                        >
-                          <div className="whitespace-pre-wrap">
-                            {pendingApproval.prompt}
-                          </div>
-                        </ScrollArea>
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent className="grid gap-2 px-3 pb-3 pt-0">
-                      <div className="grid gap-1.5">
-                        <Button
-                          size="sm"
-                          className="h-8 w-full justify-start px-2.5"
-                          onClick={() => void runtime.submitApproval({ kind: "allow" })}
-                          disabled={runtime.busyAction === "approve"}
-                        >
-                          <Check data-icon="inline-start" />
-                          {t('app.allow')}
-                          <CornerDownLeft className="ml-auto size-3.5 shrink-0 opacity-70" aria-hidden />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-8 w-full justify-start px-2.5"
-                          onClick={() =>
-                            void runtime.submitApproval({ kind: "allow", persistTrust: true })
-                          }
-                          disabled={
-                            runtime.busyAction === "approve" || !pendingApproval.trustTarget
-                          }
-                        >
-                          <ShieldCheck data-icon="inline-start" />
-                          {t('app.alwaysTrust')}
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          className="h-8 w-full justify-start px-2.5"
-                          onClick={() => void runtime.submitApproval({ kind: "deny" })}
-                          disabled={runtime.busyAction === "approve"}
-                        >
-                          <X data-icon="inline-start" />
-                          {t('app.deny')}
-                        </Button>
-                      </div>
-                      <div className="flex min-h-9 items-stretch overflow-hidden rounded-md border border-input bg-transparent focus-within:border-ring/60 focus-within:ring-2 focus-within:ring-ring/20">
-                        <Textarea
-                          value={runtime.approvalGuidance}
-                          onChange={(event) => runtime.setApprovalGuidance(event.target.value)}
-                          placeholder={t('app.approvalGuidancePlaceholder')}
-                          className="min-h-9 flex-1 resize-none rounded-none border-0 bg-transparent px-2.5 py-2 text-sm shadow-none focus-visible:ring-0"
-                        />
-                        <Button
-                          size="icon-sm"
-                          variant="outline"
-                          className="h-auto w-9 self-stretch rounded-none border-0 border-l border-border/60 bg-transparent text-muted-foreground shadow-none hover:bg-muted/35 hover:text-foreground disabled:bg-transparent"
-                          onClick={() =>
-                            void runtime.submitApproval({
-                              kind: "guidance",
-                              userMessage: runtime.approvalGuidance,
-                            })
-                          }
-                          disabled={
-                            runtime.busyAction === "approve" ||
-                            runtime.approvalGuidance.trim().length === 0
-                          }
-                        >
-                          <MessageSquareText />
-                          <span className="sr-only">{t('app.sendGuidance')}</span>
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
+                {showPendingApprovalInComposer && pendingApproval ? (
+                  <PendingApprovalCard
+                    pendingApproval={pendingApproval}
+                    approvalGuidance={runtime.approvalGuidance}
+                    approveBusy={runtime.busyAction === "approve"}
+                    onApprovalGuidanceChange={runtime.setApprovalGuidance}
+                    onSubmitApproval={(decision) => {
+                      if (decision.kind === "allow") {
+                        void runtime.submitApproval({
+                          kind: "allow",
+                          ...(decision.persistTrust ? { persistTrust: true } : {}),
+                        });
+                        return;
+                      }
+                      if (decision.kind === "deny") {
+                        void runtime.submitApproval({ kind: "deny" });
+                        return;
+                      }
+                      void runtime.submitApproval({
+                        kind: "guidance",
+                        userMessage: decision.userMessage ?? "",
+                      });
+                    }}
+                  />
                 ) : null}
 
                 <div className="relative">

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -118,6 +118,7 @@ import { SkillSlashMenu } from "@/components/skill-slash-menu";
 import { SettingsView } from "@/components/settings-view";
 import { ComposerTodoCard } from "@/components/composer-todo-card";
 import { MinimalToolCallCard } from "@/components/minimal-tool-call-card";
+import { SubagentViewerBanner } from "@/components/subagent-viewer-banner";
 import { ToolCallDiffHostProvider } from "@/components/tool-call-diff-host-context";
 import { isMinimalToolCallMessage, toolHasExpandableContent } from "@/lib/tool-call-display";
 import {
@@ -147,6 +148,7 @@ import {
 import { WorkspaceFileReferenceMenu } from "@/components/workspace-file-reference-menu";
 import { UserMessageBubble } from "@/components/user-message-bubble";
 import { useCompactionUiDemo } from "@/hooks/useCompactionUiDemo";
+import { useSubagentViewer } from "@/hooks/useSubagentViewer";
 import { useDesktopRuntime } from "@/hooks/useDesktopRuntime";
 import { useLocalFileAttachmentPreviews } from "@/hooks/useLocalFileAttachmentPreviews";
 import { useFont } from "@/hooks/useFont";
@@ -434,12 +436,14 @@ function ToolCallCollapsible({
   readLocalVideoPreviewUrl,
   readManagedVideoPreviewUrl,
   saveLocalImageAs,
+  onOpenSubagentViewer,
 }: {
   tool: ToolBlockSnapshot;
   readLocalImagePreviewDataUrl: ReadLocalImagePreview;
   readLocalVideoPreviewUrl: ReadLocalVideoPreview;
   readManagedVideoPreviewUrl: ReadManagedVideoPreview;
   saveLocalImageAs: SaveLocalImageAs;
+  onOpenSubagentViewer?: (toolCallId: string) => void;
 }) {
   if (tool.toolName === "finish_task") {
     return null;
@@ -465,7 +469,9 @@ function ToolCallCollapsible({
     );
   }
 
-  return <MinimalToolCallCard tool={tool} />;
+  return (
+    <MinimalToolCallCard tool={tool} onOpenSubagentViewer={onOpenSubagentViewer} />
+  );
 }
 
 function ImageGenerationToolCard({
@@ -1386,6 +1392,7 @@ function MessageCard({
   readLocalImagePreviewDataUrl,
   readLocalVideoPreviewUrl,
   saveLocalImageAs,
+  onOpenSubagentViewer,
 }: {
   composerSessionKey: string;
   messages: readonly ConversationMessageSnapshot[];
@@ -1425,6 +1432,7 @@ function MessageCard({
   readLocalImagePreviewDataUrl: ReadLocalImagePreview;
   readLocalVideoPreviewUrl: ReadLocalVideoPreview;
   saveLocalImageAs: SaveLocalImageAs;
+  onOpenSubagentViewer?: (toolCallId: string) => void;
 }) {
   const { t } = useTranslation();
   const isUser = message.role === "user";
@@ -1564,6 +1572,7 @@ function MessageCard({
             readLocalVideoPreviewUrl={readLocalVideoPreviewUrl}
             readManagedVideoPreviewUrl={readManagedVideoPreviewUrl}
             saveLocalImageAs={saveLocalImageAs}
+            onOpenSubagentViewer={onOpenSubagentViewer}
           />
         ) : null}
         {!isUser && showContinueButton && continueTarget ? (
@@ -1970,6 +1979,15 @@ export default function App() {
   }, [isElectronShell, snapshot?.config.windowsMica]);
 
   const compactionDemo = useCompactionUiDemo();
+  const subagentViewer = useSubagentViewer(runtime.setSubagentViewerTarget);
+  const subagentViewActive = subagentViewer.active && Boolean(snapshot?.subagentViewer);
+  const handleOpenSubagentViewer = useCallback(
+    (toolCallId: string) => {
+      compactionDemo.stop();
+      void subagentViewer.open(toolCallId);
+    },
+    [compactionDemo, subagentViewer],
+  );
   const models = snapshot?.config.models ?? [];
   const composerSessionKey = snapshot?.composerSessionKey ?? "";
   const emptySessionGreetingCacheRef = useRef(new Map<string, EmptySessionGreetingVariantId>());
@@ -2008,17 +2026,23 @@ export default function App() {
   const sessionMessages = snapshot?.conversation.messages ?? [];
   const messagesDuringRewindSuppressed =
     runtime.busyAction === "rewind" ? [] : sessionMessages;
-  const messages = compactionDemo.active ? compactionDemo.messages : messagesDuringRewindSuppressed;
+  const messages = subagentViewActive
+    ? (snapshot?.subagentViewer?.messages ?? [])
+    : compactionDemo.active
+      ? compactionDemo.messages
+      : messagesDuringRewindSuppressed;
   const turnContinue = useMemo(
-    () => (compactionDemo.active ? undefined : resolveTurnContinuePresentation(messages)),
-    [compactionDemo.active, messages],
+    () => (compactionDemo.active || subagentViewActive ? undefined : resolveTurnContinuePresentation(messages)),
+    [compactionDemo.active, messages, subagentViewActive],
   );
-  const isEmptySession = !compactionDemo.active && sessionMessages.length === 0;
+  const isEmptySession = !compactionDemo.active && !subagentViewActive && sessionMessages.length === 0;
   /** 仅空会话展示工作区/分支等待选控件；有消息后隐藏（含无工作区绑定会话）。 */
   const showWorkspaceBindingControls = isEmptySession;
-  const conversationPendingAuxState = compactionDemo.active
-    ? compactionDemo.pendingAuxState
-    : snapshot?.conversation.pendingAuxState;
+  const conversationPendingAuxState = subagentViewActive
+    ? snapshot?.subagentViewer?.pendingAuxState
+    : compactionDemo.active
+      ? compactionDemo.pendingAuxState
+      : snapshot?.conversation.pendingAuxState;
   const rewindWarnings = snapshot?.conversation.rewindWarnings ?? [];
   const pendingApproval = snapshot?.conversation.pendingToolApproval;
   const pendingQuestions = runtime.pendingQuestions;
@@ -2048,6 +2072,7 @@ export default function App() {
   const continueBusy = Boolean(runtime.busyAction) || snapshot?.conversation.isBusy === true;
   const composerCanSend =
     !compactionDemo.active &&
+    !subagentViewActive &&
     (Boolean(runtime.composer.trim()) || runtime.composerLocalFileAttachments.length > 0) &&
     !activeSessionReadOnly &&
     runtime.busyAction !== "session" &&
@@ -3072,6 +3097,16 @@ export default function App() {
                   </div>
                 </div>
               ) : null}
+              {subagentViewActive && snapshot?.subagentViewer ? (
+                <SubagentViewerBanner
+                  promptText={snapshot.subagentViewer.promptText}
+                  gutterClassName={CONVERSATION_GUTTER_X}
+                  maxWidthClassName={CONVERSATION_MAX_W}
+                  onExit={() => {
+                    void subagentViewer.close();
+                  }}
+                />
+              ) : null}
               {rewindDraft ? (
                 <button
                   type="button"
@@ -3193,6 +3228,9 @@ export default function App() {
                               readLocalImagePreviewDataUrl={runtime.readLocalImagePreviewDataUrl}
                               readLocalVideoPreviewUrl={runtime.readLocalVideoPreviewUrl}
                               saveLocalImageAs={runtime.saveLocalImageAs}
+                              onOpenSubagentViewer={
+                                subagentViewActive ? undefined : handleOpenSubagentViewer
+                              }
                             />
                           );
                         })}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -227,17 +227,10 @@ import type {
   WorkspaceFileReferenceSuggestionsResponse,
 } from "@/types";
 
-/** Stable list identity — must not include list index (rows insert above tools during finalize-thinking). */
-function conversationMessageStableId(
-  message: ConversationMessageSnapshot,
-  composerSessionKey = "",
-): string {
-  const sessionPart = composerSessionKey.trim() ? `${composerSessionKey.trim()}:` : "";
-  const toolPart =
-    message.tool?.toolCallId ??
-    (message.tool ? `${message.tool.toolName}:${message.tool.phase}` : "");
-  return `${sessionPart}message-${message.id}-${message.pending ? "p" : "m"}-${toolPart}`;
-}
+import {
+  conversationMessageStableId,
+  resolveConversationListScopeKey,
+} from "@/lib/conversation-list-scope";
 
 /** 主会话列最大宽度（居中） */
 const CONVERSATION_MAX_W = "max-w-[min(86vw,44rem)]";
@@ -1356,6 +1349,7 @@ function AssistantCompactionCollapsible({
 
 function MessageCard({
   composerSessionKey,
+  conversationListScopeKey,
   messages,
   message,
   listIndex,
@@ -1396,6 +1390,7 @@ function MessageCard({
   onOpenSubagentViewer,
 }: {
   composerSessionKey: string;
+  conversationListScopeKey: string;
   messages: readonly ConversationMessageSnapshot[];
   pendingAuxState?: PendingAssistantAux;
   message: ConversationMessageSnapshot;
@@ -1465,7 +1460,7 @@ function MessageCard({
   );
   return (
     <div
-      id={conversationMessageStableId(message, composerSessionKey)}
+      id={conversationMessageStableId(message, composerSessionKey, conversationListScopeKey)}
       data-spirit-surface="message-row"
       data-spirit-message-role={message.role}
       data-spirit-message-pending={message.pending ? "true" : "false"}
@@ -2032,6 +2027,11 @@ export default function App() {
     : compactionDemo.active
       ? compactionDemo.messages
       : messagesDuringRewindSuppressed;
+  const conversationListScopeKey = resolveConversationListScopeKey({
+    subagentViewActive,
+    subagentToolCallId: subagentViewer.toolCallId,
+    compactionDemoActive: compactionDemo.active,
+  });
   const turnContinue = useMemo(
     () => (compactionDemo.active || subagentViewActive ? undefined : resolveTurnContinuePresentation(messages)),
     [compactionDemo.active, messages, subagentViewActive],
@@ -3177,7 +3177,7 @@ export default function App() {
                         }}
                       >
                       <div
-                        key={composerSessionKey || "__no-session__"}
+                        key={`${composerSessionKey || "__no-session__"}:${conversationListScopeKey}`}
                         data-spirit-surface="conversation-list"
                         className="space-y-3"
                       >
@@ -3192,8 +3192,9 @@ export default function App() {
                           const tightenAfterPreviousMeta = shouldTightenAfterPreviousMetaMessage(previous, message);
                           return (
                             <MessageCard
-                              key={conversationMessageStableId(message, composerSessionKey)}
+                              key={conversationMessageStableId(message, composerSessionKey, conversationListScopeKey)}
                               composerSessionKey={composerSessionKey}
+                              conversationListScopeKey={conversationListScopeKey}
                               messages={messages}
                               pendingAuxState={conversationPendingAuxState}
                               listIndex={index}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2095,6 +2095,28 @@ export default function App() {
     Boolean(pendingQuestions) ||
     (runtime.busyAction === "send" && !conversationInterruptible);
   const [rewindDraft, setRewindDraft] = useState<MessageRewindDraftState | null>(null);
+  const previousComposerSessionKeyRef = useRef(composerSessionKey);
+
+  useEffect(() => {
+    if (previousComposerSessionKeyRef.current !== composerSessionKey) {
+      previousComposerSessionKeyRef.current = composerSessionKey;
+      if (subagentViewer.active) {
+        void subagentViewer.close();
+      }
+    }
+  }, [composerSessionKey, subagentViewer]);
+
+  useEffect(() => {
+    if (subagentViewer.active && !snapshot?.subagentViewer) {
+      void subagentViewer.close();
+    }
+  }, [snapshot?.subagentViewer, subagentViewer]);
+
+  useEffect(() => {
+    if (rewindDraft && subagentViewer.active) {
+      void subagentViewer.close();
+    }
+  }, [rewindDraft, subagentViewer]);
   useLocalFileAttachmentPreviews(
     rewindDraft?.localFileAttachments ?? [],
     (update) => {
@@ -3134,10 +3156,12 @@ export default function App() {
                   data-spirit-surface="conversation-scroll-body"
                   className={cn(
                     "min-h-full w-full bg-background",
-                    !isEmptySession && "pb-[calc(12rem+env(safe-area-inset-bottom,0px))]",
+                    !isEmptySession || subagentViewActive
+                      ? "pb-[calc(12rem+env(safe-area-inset-bottom,0px))]"
+                      : undefined,
                   )}
                 >
-                  {!isEmptySession ? (
+                  {!isEmptySession || subagentViewActive ? (
                     <div
                       data-spirit-surface="conversation-list-shell"
                       className={cn(
@@ -3157,6 +3181,11 @@ export default function App() {
                         data-spirit-surface="conversation-list"
                         className="space-y-3"
                       >
+                        {subagentViewActive && messages.length === 0 ? (
+                          <p className="text-sm leading-relaxed text-muted-foreground">
+                            {t("app.subagentViewerEmpty")}
+                          </p>
+                        ) : null}
                         {messages.map((message, index) => {
                           const previous = messages[index - 1];
                           const compactAfterPrevious = shouldCompactAfterPreviousMessage(previous, message);

--- a/apps/desktop/src/adapters/electron.ts
+++ b/apps/desktop/src/adapters/electron.ts
@@ -141,6 +141,9 @@ export async function createElectronHostApi(): Promise<HostApi> {
     poll() {
       return bridge.poll();
     },
+    setSubagentViewerTarget(parentToolCallId) {
+      return bridge.setSubagentViewerTarget(parentToolCallId);
+    },
     listDreamsOverview() {
       return bridge.listDreamsOverview();
     },

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -188,6 +188,9 @@ export function createWebHostApi(): HostApi {
     poll() {
       return post<DesktopSnapshot>(baseUrl, '/api/poll');
     },
+    setSubagentViewerTarget(parentToolCallId: string | null) {
+      return post<DesktopSnapshot>(baseUrl, '/api/subagent-viewer-target', { parentToolCallId });
+    },
     listDreamsOverview() {
       return get<DesktopDreamOverviewItem[]>(baseUrl, '/api/dreams');
     },

--- a/apps/desktop/src/components/minimal-tool-call-card.tsx
+++ b/apps/desktop/src/components/minimal-tool-call-card.tsx
@@ -432,12 +432,12 @@ export function MinimalToolCallCard({
   );
 
   const collapsibleTriggerButton = canOpenSubagentViewer ? (
-    <div className="group flex w-full min-w-0 items-center gap-1">
+    <div className="group inline-flex max-w-full min-w-0 items-center gap-1">
       <button
         type="button"
         onClick={() => onOpenSubagentViewer?.(subagentToolCallId)}
         className={cn(
-          "min-w-0 flex-1 text-left outline-none",
+          "min-w-0 text-left outline-none",
           "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring/50",
         )}
       >
@@ -447,7 +447,10 @@ export function MinimalToolCallCard({
         type="button"
         aria-expanded={open}
         aria-label={open ? "Collapse tool details" : "Expand tool details"}
-        onClick={() => setOpen((value) => !value)}
+        onClick={(event) => {
+          event.stopPropagation();
+          setOpen((value) => !value);
+        }}
         className={cn(
           "shrink-0 outline-none",
           "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring/50",

--- a/apps/desktop/src/components/minimal-tool-call-card.tsx
+++ b/apps/desktop/src/components/minimal-tool-call-card.tsx
@@ -354,10 +354,19 @@ function ShellToolExpandedBody({
   );
 }
 
-export function MinimalToolCallCard({ tool }: { tool: ToolBlockSnapshot }) {
+export function MinimalToolCallCard({
+  tool,
+  onOpenSubagentViewer,
+}: {
+  tool: ToolBlockSnapshot;
+  onOpenSubagentViewer?: (toolCallId: string) => void;
+}) {
   const summary = getToolCallSummaryParts(tool);
   const shimmerActive = toolCallPhaseShowsShimmer(tool.phase);
   const isShell = tool.toolName === "run_shell_command";
+  const isSubagent = tool.toolName === "run_subagent";
+  const subagentToolCallId = tool.toolCallId?.trim() ?? "";
+  const canOpenSubagentViewer = Boolean(isSubagent && onOpenSubagentViewer && subagentToolCallId);
   const isFileDiff = isFileDiffTool(tool.toolName);
   const isResponsesBuiltIn = isResponsesBuiltInToolCard(tool.toolName);
   const shellCommand = useMemo(
@@ -382,7 +391,18 @@ export function MinimalToolCallCard({ tool }: { tool: ToolBlockSnapshot }) {
   );
 
   if (!expandable) {
-    const plainCard = (
+    const plainCard = canOpenSubagentViewer ? (
+      <button
+        type="button"
+        onClick={() => onOpenSubagentViewer?.(subagentToolCallId)}
+        className={cn(
+          "w-full min-w-0 text-left outline-none",
+          "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring/50",
+        )}
+      >
+        <p className={shimmerActive ? undefined : summaryClass}>{summaryRow}</p>
+      </button>
+    ) : (
       <p className={shimmerActive ? undefined : summaryClass}>{summaryRow}</p>
     );
     if (!lspDiagnostics) {
@@ -411,7 +431,39 @@ export function MinimalToolCallCard({ tool }: { tool: ToolBlockSnapshot }) {
     </div>
   );
 
-  const collapsibleTriggerButton = (
+  const collapsibleTriggerButton = canOpenSubagentViewer ? (
+    <div className="group flex w-full min-w-0 items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onOpenSubagentViewer?.(subagentToolCallId)}
+        className={cn(
+          "min-w-0 flex-1 text-left outline-none",
+          "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring/50",
+        )}
+      >
+        {summaryRow}
+      </button>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-label={open ? "Collapse tool details" : "Expand tool details"}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          "shrink-0 outline-none",
+          "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring/50",
+        )}
+      >
+        <ChevronRight
+          className={cn(
+            "size-3 text-muted-foreground/55 transition-all duration-150",
+            "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100",
+            open && "rotate-90",
+          )}
+          aria-hidden
+        />
+      </button>
+    </div>
+  ) : (
     <button
       type="button"
       aria-expanded={open}

--- a/apps/desktop/src/components/pending-approval-card.tsx
+++ b/apps/desktop/src/components/pending-approval-card.tsx
@@ -1,0 +1,105 @@
+import { Check, CornerDownLeft, MessageSquareText, ShieldCheck, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Textarea } from "@/components/ui/textarea";
+import type { PendingToolApprovalSnapshot } from "@/types";
+
+type PendingApprovalCardProps = {
+  pendingApproval: PendingToolApprovalSnapshot;
+  approvalGuidance: string;
+  approveBusy: boolean;
+  onApprovalGuidanceChange(value: string): void;
+  onSubmitApproval(decision: {
+    kind: "allow" | "deny" | "guidance";
+    persistTrust?: boolean;
+    userMessage?: string;
+  }): void;
+};
+
+export function PendingApprovalCard({
+  pendingApproval,
+  approvalGuidance,
+  approveBusy,
+  onApprovalGuidanceChange,
+  onSubmitApproval,
+}: PendingApprovalCardProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="border-border/50 bg-background/55 text-sm shadow-sm backdrop-blur-xl dark:border-white/12 supports-[backdrop-filter]:bg-background/40">
+      <CardHeader className="space-y-1.5 px-3 py-2.5">
+        <CardTitle className="min-w-0 truncate text-sm leading-tight">
+          {pendingApproval.toolName}
+        </CardTitle>
+        <CardDescription className="text-xs leading-relaxed">
+          <ScrollArea
+            type="always"
+            className="pr-3 [&>[data-radix-scroll-area-viewport]]:max-h-24 [&>[data-radix-scroll-area-viewport]]:overscroll-contain"
+          >
+            <div className="whitespace-pre-wrap">{pendingApproval.prompt}</div>
+          </ScrollArea>
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-2 px-3 pb-3 pt-0">
+        <div className="grid gap-1.5">
+          <Button
+            size="sm"
+            className="h-8 w-full justify-start px-2.5"
+            onClick={() => onSubmitApproval({ kind: "allow" })}
+            disabled={approveBusy}
+          >
+            <Check data-icon="inline-start" />
+            {t("app.allow")}
+            <CornerDownLeft className="ml-auto size-3.5 shrink-0 opacity-70" aria-hidden />
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 w-full justify-start px-2.5"
+            onClick={() => onSubmitApproval({ kind: "allow", persistTrust: true })}
+            disabled={approveBusy || !pendingApproval.trustTarget}
+          >
+            <ShieldCheck data-icon="inline-start" />
+            {t("app.alwaysTrust")}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 w-full justify-start px-2.5"
+            onClick={() => onSubmitApproval({ kind: "deny" })}
+            disabled={approveBusy}
+          >
+            <X data-icon="inline-start" />
+            {t("app.deny")}
+          </Button>
+        </div>
+        <div className="flex min-h-9 items-stretch overflow-hidden rounded-md border border-input bg-transparent focus-within:border-ring/60 focus-within:ring-2 focus-within:ring-ring/20">
+          <Textarea
+            value={approvalGuidance}
+            onChange={(event) => onApprovalGuidanceChange(event.target.value)}
+            placeholder={t("app.approvalGuidancePlaceholder")}
+            className="min-h-9 flex-1 resize-none rounded-none border-0 bg-transparent px-2.5 py-2 text-sm shadow-none focus-visible:ring-0"
+          />
+          <Button
+            size="icon-sm"
+            variant="outline"
+            className="h-auto w-9 self-stretch rounded-none border-0 border-l border-border/60 bg-transparent text-muted-foreground shadow-none hover:bg-muted/35 hover:text-foreground disabled:bg-transparent"
+            onClick={() =>
+              onSubmitApproval({
+                kind: "guidance",
+                userMessage: approvalGuidance,
+              })
+            }
+            disabled={approveBusy || approvalGuidance.trim().length === 0}
+          >
+            <MessageSquareText />
+            <span className="sr-only">{t("app.sendGuidance")}</span>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/desktop/src/components/subagent-viewer-banner.tsx
+++ b/apps/desktop/src/components/subagent-viewer-banner.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+type SubagentViewerBannerProps = {
+  promptText: string;
+  gutterClassName: string;
+  maxWidthClassName: string;
+  onExit: () => void;
+};
+
+export function SubagentViewerBanner({
+  promptText,
+  gutterClassName,
+  maxWidthClassName,
+  onExit,
+}: SubagentViewerBannerProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div data-spirit-surface="subagent-viewer-banner" className="shrink-0 bg-background">
+      <div
+        className={cn(
+          'mx-auto flex w-full flex-wrap items-center justify-between gap-2 py-2',
+          gutterClassName,
+          maxWidthClassName,
+        )}
+      >
+        <div className="min-w-0 flex-1">
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">{t('app.subagentViewerTitle')}</span>
+            {promptText ? (
+              <>
+                <span className="hidden sm:inline"> · </span>
+                <span className="block sm:inline">{promptText}</span>
+              </>
+            ) : null}
+          </p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={onExit}>
+          {t('app.exitSubagentViewer')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -92,6 +92,7 @@ declare global {
     continueAssistantCompletion(messageId: number): Promise<DesktopSnapshot>;
     rewindAndSubmitMessage(request: RewindAndSubmitMessageRequest): Promise<DesktopSnapshot>;
     poll(): Promise<DesktopSnapshot>;
+    setSubagentViewerTarget(parentToolCallId: string | null): Promise<DesktopSnapshot>;
     listDreamsOverview(): Promise<DesktopDreamOverviewItem[]>;
     dreamSubscribe(callback: (snapshot: DesktopSnapshot) => void): () => void;
     sessionListSubscribe(callback: () => void): () => void;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1829,6 +1829,22 @@ export function useDesktopRuntime() {
     }
   }, [api, applySnapshot, refreshSessions]);
 
+  const setSubagentViewerTarget = useCallback(async (parentToolCallId: string | null): Promise<boolean> => {
+    if (!api?.setSubagentViewerTarget) {
+      return false;
+    }
+
+    try {
+      const next = await api.setSubagentViewerTarget(parentToolCallId);
+      applySnapshot(next);
+      setRuntimeError("");
+      return true;
+    } catch (error) {
+      setRuntimeError(describeError(error));
+      return false;
+    }
+  }, [api, applySnapshot]);
+
   const setApprovalLevel = useCallback(async (approvalLevel: import('@spirit-agent/host-internal').ApprovalLevel): Promise<boolean> => {
     if (!api) {
       return false;
@@ -2350,6 +2366,7 @@ export function useDesktopRuntime() {
     inspectMcpServer,
     abortConversation,
     setLoopEnabled,
+    setSubagentViewerTarget,
     setApprovalLevel,
     setPendingGitBranch,
     setWorkLocation,

--- a/apps/desktop/src/hooks/useSubagentViewer.ts
+++ b/apps/desktop/src/hooks/useSubagentViewer.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+
+export function useSubagentViewer(
+  setSubagentViewerTarget: (parentToolCallId: string | null) => Promise<boolean>,
+) {
+  const [activeToolCallId, setActiveToolCallId] = useState<string | null>(null);
+
+  const open = useCallback(
+    async (toolCallId: string) => {
+      const trimmed = toolCallId.trim();
+      if (!trimmed) {
+        return;
+      }
+      setActiveToolCallId(trimmed);
+      await setSubagentViewerTarget(trimmed);
+    },
+    [setSubagentViewerTarget],
+  );
+
+  const close = useCallback(async () => {
+    setActiveToolCallId(null);
+    await setSubagentViewerTarget(null);
+  }, [setSubagentViewerTarget]);
+
+  return {
+    active: activeToolCallId !== null,
+    toolCallId: activeToolCallId,
+    open,
+    close,
+  };
+}

--- a/apps/desktop/src/hooks/useSubagentViewer.ts
+++ b/apps/desktop/src/hooks/useSubagentViewer.ts
@@ -11,8 +11,10 @@ export function useSubagentViewer(
       if (!trimmed) {
         return;
       }
-      setActiveToolCallId(trimmed);
-      await setSubagentViewerTarget(trimmed);
+      const ok = await setSubagentViewerTarget(trimmed);
+      if (ok) {
+        setActiveToolCallId(trimmed);
+      }
     },
     [setSubagentViewerTarget],
   );

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -98,6 +98,7 @@ export interface HostApi {
   continueAssistantCompletion(messageId: number): Promise<DesktopSnapshot>;
   rewindAndSubmitMessage(request: RewindAndSubmitMessageRequest): Promise<DesktopSnapshot>;
   poll(): Promise<DesktopSnapshot>;
+  setSubagentViewerTarget(parentToolCallId: string | null): Promise<DesktopSnapshot>;
   listDreamsOverview(): Promise<DesktopDreamOverviewItem[]>;
   subscribeDreamUpdates?(callback: (snapshot: DesktopSnapshot) => void): () => void;
   subscribeSessionListUpdates?(callback: () => void): () => void;

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -68,7 +68,8 @@ export type HostCommandName =
   | 'listWorkspaceExplorerChildren'
   | 'readWorkspaceTextFile'
   | 'writeWorkspaceTextFile'
-  | 'rewindAndSubmitMessage';
+  | 'rewindAndSubmitMessage'
+  | 'setSubagentViewerTarget';
 
 /** 与 `apps/cli/src/tool_runtime.rs` 中 `ToolRequest` 对齐的宿主工具请求。 */
 export type DesktopToolRequest = HostToolRequest<AskQuestionsQuestionSpec>;

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -88,6 +88,7 @@ export interface StoredDesktopSession extends ChatArchive {
   rewind?: StoredDesktopRewindMetadata;
   approvalLevel?: ApprovalLevel;
   contextUsage?: ConversationContextUsageSnapshot;
+  subagentDesktopMessages?: Record<string, ConversationMessageSnapshot[]>;
 }
 
 export type DesktopHostCommitRequest = CommitChangesRequest;

--- a/apps/desktop/src/host/conversation-continuation.ts
+++ b/apps/desktop/src/host/conversation-continuation.ts
@@ -7,7 +7,6 @@ import {
   buildArchiveMessagesFromConversation,
 } from './sessions.js';
 import {
-  hasActiveRunSubagentToolInMessages,
   hasInFlightSubagentDelegationInMessages,
   isSubagentStatusSurfaceMessage,
   messageIndexIsInCurrentTurn,
@@ -342,7 +341,10 @@ function describeContinuationMessage(message: ConversationMessageSnapshot): stri
 
 function purgeSubagentLeakTextInCurrentTurn(bundle: SessionBundle): void {
   const messages = bundle.messageTimeline.toMessages();
-  if (!hasActiveRunSubagentToolInMessages(messages)) {
+  const liveSubagentSession = bundle.archiveSubagentSessions.some(
+    (session) => session.summary.status === 'running' || session.summary.status === 'blocked',
+  );
+  if (!hasInFlightSubagentDelegationInMessages(messages) && !liveSubagentSession) {
     return;
   }
 
@@ -354,23 +356,16 @@ function purgeSubagentLeakTextInCurrentTurn(bundle: SessionBundle): void {
     }
   }
 
-  let activeSubagentToolIndex = -1;
+  let runSubagentIndex = -1;
   for (let index = lastUserIndex + 1; index < messages.length; index += 1) {
     const message = messages[index];
-    if (
-      message?.role === 'assistant' &&
-      message.tool?.toolName === 'run_subagent' &&
-      (message.tool.phase === 'preview' || message.tool.phase === 'running')
-    ) {
-      activeSubagentToolIndex = index;
+    if (message?.role === 'assistant' && message.tool?.toolName === 'run_subagent') {
+      runSubagentIndex = index;
     }
   }
 
-  if (activeSubagentToolIndex < 0) {
-    return;
-  }
-
-  for (let index = activeSubagentToolIndex + 1; index < messages.length; index += 1) {
+  const startIndex = runSubagentIndex >= 0 ? runSubagentIndex + 1 : lastUserIndex + 1;
+  for (let index = startIndex; index < messages.length; index += 1) {
     const message = messages[index];
     if (message.role !== 'assistant' || message.tool || !message.content.trim()) {
       break;

--- a/apps/desktop/src/host/conversation-continuation.ts
+++ b/apps/desktop/src/host/conversation-continuation.ts
@@ -8,6 +8,7 @@ import {
 } from './sessions.js';
 import {
   hasActiveRunSubagentToolInMessages,
+  hasInFlightSubagentDelegationInMessages,
   isSubagentStatusSurfaceMessage,
   messageIndexIsInCurrentTurn,
   messageOrderDebugLevel,
@@ -23,6 +24,7 @@ import {
 type ContinuationOrchestration = {
   assistantMessages: {
     upsertToolMessage(toolCallId: string, tool: NonNullable<ConversationMessageSnapshot['tool']>, ordinal: number): void;
+    removeToolMessage(toolCallId: string): void;
   };
 };
 
@@ -227,6 +229,7 @@ export function syncSubagentToolStreamingOutput(
   refreshArchiveFromRuntime(ctx, bundle);
 
   purgeSubagentLeakTextInCurrentTurn(bundle);
+  purgeSubagentLeakedToolRowsInCurrentTurn(ctx, bundle);
 
   const sessions = bundle.archiveSubagentSessions;
   if (sessions.length === 0) {
@@ -376,5 +379,49 @@ function purgeSubagentLeakTextInCurrentTurn(bundle: SessionBundle): void {
       continue;
     }
     bundle.messageTimeline.clearSubagentStatusLeak(message.id);
+  }
+}
+
+function purgeSubagentLeakedToolRowsInCurrentTurn(
+  ctx: ConversationContinuationContext,
+  bundle: SessionBundle,
+): void {
+  const messages = bundle.messageTimeline.toMessages();
+  const liveSubagentSession = bundle.archiveSubagentSessions.some(
+    (session) => session.summary.status === 'running' || session.summary.status === 'blocked',
+  );
+  if (!hasInFlightSubagentDelegationInMessages(messages) && !liveSubagentSession) {
+    return;
+  }
+
+  let lastUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === 'user') {
+      lastUserIndex = index;
+      break;
+    }
+  }
+
+  let runSubagentIndex = -1;
+  for (let index = lastUserIndex + 1; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message?.role === 'assistant' && message.tool?.toolName === 'run_subagent') {
+      runSubagentIndex = index;
+    }
+  }
+
+  const startIndex = runSubagentIndex >= 0 ? runSubagentIndex + 1 : lastUserIndex + 1;
+  const orchestration = ctx.orchestrationFor(bundle);
+  for (let index = messages.length - 1; index >= startIndex; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== 'assistant' || !message.tool || message.tool.toolName === 'run_subagent') {
+      continue;
+    }
+    const toolCallId = message.tool.toolCallId?.trim();
+    if (!toolCallId) {
+      continue;
+    }
+    orchestration.assistantMessages.removeToolMessage(toolCallId);
+    bundle.messageTimeline.removeToolMessage(toolCallId);
   }
 }

--- a/apps/desktop/src/host/host-command-payloads.ts
+++ b/apps/desktop/src/host/host-command-payloads.ts
@@ -97,4 +97,5 @@ export type CommandPayloads = {
   readWorkspaceTextFile: { relativePath: string };
   writeWorkspaceTextFile: { request: WriteWorkspaceTextFileRequest };
   rewindAndSubmitMessage: { request: RewindAndSubmitMessageRequest };
+  setSubagentViewerTarget: { parentToolCallId: string | null };
 };

--- a/apps/desktop/src/host/host-invoke-dispatch.ts
+++ b/apps/desktop/src/host/host-invoke-dispatch.ts
@@ -64,6 +64,7 @@ export interface HostCommandDelegate {
   readWorkspaceTextFile(relativePath: string): Promise<unknown>;
   writeWorkspaceTextFile(request: CommandPayloads['writeWorkspaceTextFile']['request']): Promise<unknown>;
   rewindAndSubmitMessage(request: CommandPayloads['rewindAndSubmitMessage']['request']): Promise<unknown>;
+  setSubagentViewerTarget(parentToolCallId: string | null): Promise<unknown>;
 }
 
 type HostCommandHandler<Command extends HostCommandName> = (
@@ -131,6 +132,7 @@ const hostCommandDispatch = {
   readWorkspaceTextFile: (host, payload) => host.readWorkspaceTextFile(payload.relativePath),
   writeWorkspaceTextFile: (host, payload) => host.writeWorkspaceTextFile(payload.request),
   rewindAndSubmitMessage: (host, payload) => host.rewindAndSubmitMessage(payload.request),
+  setSubagentViewerTarget: (host, payload) => host.setSubagentViewerTarget(payload.parentToolCallId),
 } satisfies { [Command in HostCommandName]: HostCommandHandler<Command> };
 
 export function createHostInvokeDispatch(host: HostCommandDelegate) {

--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -13,6 +13,7 @@ import {
 import { isStandaloneThinkingMessage } from '../lib/conversation-thinking-ui.js';
 import {
   hasActiveRunSubagentToolInMessages,
+  hasInFlightSubagentDelegationInMessages,
   hasRunSubagentToolInCurrentTurn,
   isLivePendingReasoningAux,
   isSubagentStatusSurfaceMessage,
@@ -29,6 +30,7 @@ import type { DesktopToolRequest, StoredDesktopSession } from './contracts.js';
 
 export {
   hasActiveRunSubagentToolInMessages,
+  hasInFlightSubagentDelegationInMessages,
   hasRunSubagentToolInCurrentTurn,
   isSubagentStatusSurfaceMessage,
   isSubagentStatusSurfaceText,

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -52,6 +52,7 @@ import {
   finishTaskSummaryFromExecution,
   applyToolCallSummaryCopy,
   hasActiveRunSubagentToolInMessages,
+  hasInFlightSubagentDelegationInMessages,
   isSubagentStatusSurfaceText,
   toolCallSummaryCopyForResponsesBuiltInTool,
   toolCallSummaryForPhase,
@@ -113,6 +114,15 @@ export class DesktopRuntimeEventOrchestrator {
   private deferredAfterStreamThinking: string | undefined;
 
   constructor(private readonly options: DesktopRuntimeEventOrchestratorOptions) {}
+
+  private shouldSuppressMainTimelineChildToolSurface(toolName: string): boolean {
+    if (toolName === 'run_subagent') {
+      return false;
+    }
+    const timelineMessages =
+      this.options.messageTimeline?.()?.toMessages() ?? this.options.messages();
+    return hasInFlightSubagentDelegationInMessages(timelineMessages);
+  }
 
   private findExistingToolSnapshot(toolCallId: string | undefined): ToolBlockSnapshot | undefined {
     if (!toolCallId) {
@@ -377,6 +387,9 @@ export class DesktopRuntimeEventOrchestrator {
         if (isFinishTaskToolName(event.toolName)) {
           continue;
         }
+        if (this.shouldSuppressMainTimelineChildToolSurface(event.toolName)) {
+          continue;
+        }
         const runningSummary =
           event.toolName === 'generate_image'
             ? { headline: i18n.t('tool.generateImage') }
@@ -429,6 +442,9 @@ export class DesktopRuntimeEventOrchestrator {
         continue;
       }
       if (event.kind === 'tool-execution-finished') {
+        if (this.shouldSuppressMainTimelineChildToolSurface(event.execution.toolName)) {
+          continue;
+        }
         if (event.execution.toolName === 'generate_image' && event.execution.toolCallId) {
           this.activeGenerateImageTools.delete(event.execution.toolCallId);
         }
@@ -459,6 +475,9 @@ export class DesktopRuntimeEventOrchestrator {
         if (notice) {
           this.applyFinishTaskNoticePreview(notice);
         }
+        continue;
+      }
+      if (this.shouldSuppressMainTimelineChildToolSurface(event.toolName)) {
         continue;
       }
       // 工具预览前先把 defer 在正文 aux 上的思考固化为独立行（before-tools），避免插入工具后 strip 抹掉。
@@ -662,8 +681,16 @@ export class DesktopRuntimeEventOrchestrator {
 
   syncPendingToolStates(): void {
     const runtime = this.options.runtime();
+    const timelineMessages =
+      this.options.messageTimeline?.()?.toMessages() ?? this.options.messages();
+    const suppressSubagentChildToolSurface =
+      hasInFlightSubagentDelegationInMessages(timelineMessages);
     const approval = runtime?.currentPendingApproval();
-    if (approval) {
+    if (
+      approval &&
+      !approval.subagentSessionId &&
+      !suppressSubagentChildToolSurface
+    ) {
       const approvalSummary = toolCallSummaryForPhase(
         'pending-approval',
         approval.toolName,
@@ -688,7 +715,7 @@ export class DesktopRuntimeEventOrchestrator {
     }
 
     const questions = runtime?.currentPendingQuestions();
-    if (questions) {
+    if (questions && !suppressSubagentChildToolSurface) {
       const pendingTool: ToolBlockSnapshot = {
         toolCallId: toolMessageKey(questions),
         toolName: questions.toolName,
@@ -732,6 +759,9 @@ export class DesktopRuntimeEventOrchestrator {
     source: 'event' | 'turn-result',
   ): void {
     for (const execution of executions) {
+      if (this.shouldSuppressMainTimelineChildToolSurface(execution.toolName)) {
+        continue;
+      }
       if (isFinishTaskToolName(execution.toolName)) {
         const toolCallId = execution.toolCallId || `tool:${execution.toolName}`;
         this.options.assistantMessages.removeToolMessage(toolCallId);

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -665,6 +665,7 @@ class DesktopHostService {
       scheduleSessionExtensionWarmup: (event) =>
         this.scheduleExtensionWarmup({ type: 'session', event }),
       buildSnapshot: () => this.buildSnapshot(),
+      clearSubagentViewerTarget: () => this.clearSubagentViewerTarget(),
     };
   }
 
@@ -1369,6 +1370,10 @@ class DesktopHostService {
     const trimmed = parentToolCallId?.trim();
     this.subagentViewerTargetToolCallId = trimmed && trimmed.length > 0 ? trimmed : null;
     return this.buildSnapshot();
+  }
+
+  private clearSubagentViewerTarget(): void {
+    this.subagentViewerTargetToolCallId = null;
   }
 
   private applyDrainedRuntimeHostEvents(

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2137,7 +2137,15 @@ class DesktopHostService {
           ? { pendingAuxState: mapPendingAuxState(pendingAux)! }
           : {}),
         ...(pendingApproval
-          ? { pendingToolApproval: mapPendingToolApproval(pendingApproval) }
+          ? {
+              pendingToolApproval: mapPendingToolApproval({
+                toolName: pendingApproval.toolName,
+                request: pendingApproval.request as DesktopToolRequest,
+                prompt: pendingApproval.prompt,
+                trustTarget: pendingApproval.trustTarget,
+                subagentSessionId: pendingApproval.subagentSessionId,
+              }),
+            }
           : {}),
         ...(pendingQuestions
           ? { pendingQuestions: mapPendingQuestions(pendingQuestions) }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -349,6 +349,7 @@ import {
   readWorkspaceGitSnapshot,
 } from './git.js';
 import { generateWorktreeNamesFromModelTask } from './ephemeral-llm-tasks.js';
+import { buildSubagentViewerSnapshot } from './subagent-viewer.js';
 import { persistDesktopSessionBundle } from './session-persistence.js';
 import { SessionRegistry } from './session-registry.js';
 import type { SessionBundle } from './session-bundle.js';
@@ -438,6 +439,7 @@ class DesktopHostService {
   private readonly dreamUpdateListeners = new Set<(snapshot: DesktopSnapshot) => void>();
   private readonly sessionListUpdateListeners = new Set<() => void>();
   private readonly sessionTitleGenerationInFlight = new Set<string>();
+  private subagentViewerTargetToolCallId: string | null = null;
   private gitRefreshInFlight: Promise<void> | null = null;
   private contextUsageCatalogRefreshInFlight: Promise<void> | null = null;
   private pendingContextUsageCatalogRefresh:
@@ -1363,6 +1365,12 @@ class DesktopHostService {
     return pollCommand(this.sessionTurnContext());
   }
 
+  async setSubagentViewerTarget(parentToolCallId: string | null): Promise<DesktopSnapshot> {
+    const trimmed = parentToolCallId?.trim();
+    this.subagentViewerTargetToolCallId = trimmed && trimmed.length > 0 ? trimmed : null;
+    return this.buildSnapshot();
+  }
+
   private applyDrainedRuntimeHostEvents(
     bundle: SessionBundle,
     drained: RuntimeEvent<DesktopToolRequest>[],
@@ -2143,6 +2151,15 @@ class DesktopHostService {
       },
       ...(activeBundle.activeSession ? { activeSession: activeBundle.activeSession } : {}),
       composerSessionKey: this.resolveTodoSessionKeyForBundle(activeBundle),
+      ...(this.subagentViewerTargetToolCallId
+        ? (() => {
+            const subagentViewer = buildSubagentViewerSnapshot(
+              activeBundle,
+              this.subagentViewerTargetToolCallId,
+            );
+            return subagentViewer ? { subagentViewer } : {};
+          })()
+        : {}),
     });
   }
 

--- a/apps/desktop/src/host/session-activation.ts
+++ b/apps/desktop/src/host/session-activation.ts
@@ -66,11 +66,13 @@ export interface SessionActivationContext {
   setLastRuntimeError(error: string): void;
   scheduleSessionExtensionWarmup(event: HostExtensionEvent): void;
   buildSnapshot(): DesktopSnapshot;
+  clearSubagentViewerTarget(): void;
 }
 
 export async function resetSessionCommand(ctx: SessionActivationContext): Promise<DesktopSnapshot> {
   return ctx.runSerialized(async () => {
     await ctx.ensureInitialized(undefined, { fastPath: true });
+    ctx.clearSubagentViewerTarget();
 
     const state = ctx.requireState();
     const leaving = ctx.sessionRegistry().getActive();
@@ -101,6 +103,8 @@ export async function openSessionCommand(
   filePath: string,
 ): Promise<DesktopSnapshot> {
   return ctx.runSerialized(async () => {
+    ctx.clearSubagentViewerTarget();
+
     const leaving = ctx.sessionRegistry().getActive();
     const leavingMessageCount = leaving?.messageTimeline.toMessages().length ?? 0;
     if (

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -21,6 +21,7 @@ import { createDesktopRewindMetadata, type StoredDesktopRewindMetadata } from '.
 import { createTodoSessionScopeKey } from './todos.js';
 import { rehydrateFinishTaskNoticesForRestoredSession } from './finish-task-notice-rehydrate.js';
 import { nextMessageIdFromMessages, type RestoredSessionState } from './sessions.js';
+import type { SubagentConversationProjection } from './subagent-conversation-projection.js';
 import { DesktopMessageTimeline as TimelineCtor } from './message-timeline.js';
 
 export interface SessionBundle {
@@ -68,6 +69,9 @@ export interface SessionBundle {
   contextUsage?: ConversationContextUsageSnapshot;
   /** Composer 直连生图/生视频后台执行中；与 runtime.isBusy 一并驱动 snapshot.isBusy。 */
   directMediaTurnInFlight?: boolean;
+  /** SubAgent 子会话 desktop 投影（与主 timeline 同构，含 Thought/Compaction/工具卡）。 */
+  subagentDesktopMessagesBySessionId: Map<string, ConversationMessageSnapshot[]>;
+  subagentConversationProjections: Map<string, SubagentConversationProjection>;
 }
 
 export function createEmptySessionBundle(workspaceRoot: string, id = '__draft__'): SessionBundle {
@@ -96,6 +100,8 @@ export function createEmptySessionBundle(workspaceRoot: string, id = '__draft__'
     responsesBuiltInPreviewSeenCallIds: new Set(),
     todoSessionScopeKey: createTodoSessionScopeKey(),
     conversationRevision: 0,
+    subagentDesktopMessagesBySessionId: new Map(),
+    subagentConversationProjections: new Map(),
   };
 }
 
@@ -141,6 +147,15 @@ export function sessionBundleFromRestored(
     ...(restored.activePlanPath ? { activePlanPath: restored.activePlanPath } : {}),
     ...(restored.sessionTitleSource ? { sessionTitleSource: restored.sessionTitleSource } : {}),
     ...(restored.contextUsage ? { contextUsage: { ...restored.contextUsage } } : {}),
+    subagentDesktopMessagesBySessionId: restored.subagentDesktopMessagesBySessionId
+      ? new Map(
+          [...restored.subagentDesktopMessagesBySessionId.entries()].map(([sessionId, messages]) => [
+            sessionId,
+            messages.map((message) => ({ ...message })),
+          ]),
+        )
+      : new Map(),
+    subagentConversationProjections: new Map(),
   };
 }
 
@@ -173,4 +188,6 @@ export function resetSessionBundleInPlace(bundle: SessionBundle): void {
   bundle.sessionTitleSource = undefined;
   bundle.contextUsage = undefined;
   bundle.directMediaTurnInFlight = false;
+  bundle.subagentDesktopMessagesBySessionId = new Map();
+  bundle.subagentConversationProjections = new Map();
 }

--- a/apps/desktop/src/host/session-delete.ts
+++ b/apps/desktop/src/host/session-delete.ts
@@ -52,6 +52,7 @@ export async function deleteSessionCommand(
     }
 
     if (wasActive) {
+      ctx.clearSubagentViewerTarget();
       const bundle = registry.beginNewActive(state.workspaceRoot);
       await ctx.finalizeTodoScopeForNewActiveBundle(bundle, state.workspaceRoot);
       ctx.resetStreamingPlacementState(true, bundle);

--- a/apps/desktop/src/host/session-persistence.ts
+++ b/apps/desktop/src/host/session-persistence.ts
@@ -8,6 +8,7 @@ import {
   buildStoredDesktopSession,
   sanitizeConversationMessagesForPersistence,
 } from './sessions.js';
+import { serializeSubagentDesktopMessagesRecord } from './subagent-conversation-projection.js';
 import type { SessionBundle } from './session-bundle.js';
 import type { DesktopRuntime } from './runtime.js';
 import { saveStoredSession } from './storage.js';
@@ -75,6 +76,13 @@ export async function persistDesktopSessionBundle(
     loopEnabled: bundle.loopEnabled,
     approvalLevel: bundle.approvalLevel,
     ...(bundle.contextUsage ? { contextUsage: { ...bundle.contextUsage } } : {}),
+    ...(serializeSubagentDesktopMessagesRecord(bundle.subagentDesktopMessagesBySessionId)
+      ? {
+          subagentDesktopMessages: serializeSubagentDesktopMessagesRecord(
+            bundle.subagentDesktopMessagesBySessionId,
+          ),
+        }
+      : {}),
   });
   if (bumpListSortAt) {
     bundle.listSortSavedAtUnixMs = savedAtUnixMs;

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -28,6 +28,7 @@ import {
   splitRuntimeEventsForIncrementalResponsesBuiltInToolPreview,
 } from './runtime-event-orchestrator.js';
 import { scheduleDirectMediaTurn, shouldUseComposerDirectMediaTurn } from './direct-media-turn.js';
+import { syncSubagentConversationProjections } from './subagent-conversation-projection.js';
 import { toRuntimeAskQuestionsResult } from './service-utils.js';
 
 type RuntimeEventsFacade = {
@@ -235,8 +236,10 @@ export async function tickSessionCommand(
   const orchestration = ctx.orchestrationFor(bundle);
   if (bundle.runtime) {
     bundle.runtime.tickThinkingSpinner();
+    syncSubagentConversationProjections(bundle, bundle.runtime);
     if (!options.light) {
       await bundle.runtime.poll();
+      syncSubagentConversationProjections(bundle, bundle.runtime);
       applyDrainedRuntimeHostEvents(ctx, bundle, bundle.runtime.drainEvents());
     } else {
       const drained = bundle.runtime.drainEvents();

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -21,6 +21,7 @@ import {
   shouldHideEmptyPendingAssistantSnapshot,
 } from './message-ordering.js';
 import { cloneArchiveHistory, cloneArchiveSubagentSessions } from './service-utils.js';
+import { cloneSubagentDesktopMessagesRecord } from './subagent-conversation-projection.js';
 import { createDesktopRewindMetadata, type StoredDesktopRewindMetadata } from './rewind.js';
 
 export const EPHEMERAL_COMMIT_SESSION_PREFIX = 'ephemeral://commit-message/';
@@ -51,6 +52,7 @@ export interface RestoredSessionState {
   activePlanPath?: string;
   sessionTitleSource?: SessionTitleSource;
   contextUsage?: ConversationContextUsageSnapshot;
+  subagentDesktopMessagesBySessionId?: Map<string, ConversationMessageSnapshot[]>;
 }
 
 export function isEphemeralCommitSessionPath(filePath: string): boolean {
@@ -191,6 +193,13 @@ export function restoreStoredSessionState(input: {
       ? { sessionTitleSource: input.loaded.sessionTitleSource }
       : {}),
     ...(input.loaded.contextUsage ? { contextUsage: { ...input.loaded.contextUsage } } : {}),
+    ...(input.loaded.subagentDesktopMessages
+      ? {
+          subagentDesktopMessagesBySessionId: cloneSubagentDesktopMessagesRecord(
+            input.loaded.subagentDesktopMessages,
+          ),
+        }
+      : {}),
   };
 }
 
@@ -208,6 +217,7 @@ export function buildStoredDesktopSession(input: {
   loopEnabled: boolean;
   approvalLevel: ApprovalLevel;
   contextUsage?: ConversationContextUsageSnapshot;
+  subagentDesktopMessages?: Record<string, ConversationMessageSnapshot[]>;
 }): StoredDesktopSession {
   return {
     ...input.archive,
@@ -225,6 +235,7 @@ export function buildStoredDesktopSession(input: {
       : {}),
     rewind: input.rewind,
     ...(input.contextUsage ? { contextUsage: { ...input.contextUsage } } : {}),
+    ...(input.subagentDesktopMessages ? { subagentDesktopMessages: input.subagentDesktopMessages } : {}),
   };
 }
 

--- a/apps/desktop/src/host/snapshot-mappers.ts
+++ b/apps/desktop/src/host/snapshot-mappers.ts
@@ -40,6 +40,7 @@ export function mapPendingToolApproval(input: {
   request: DesktopToolRequest;
   prompt: string;
   trustTarget?: unknown;
+  subagentSessionId?: string;
 }): PendingToolApprovalSnapshot {
   return {
     toolName: displayTitleForTool(
@@ -52,6 +53,9 @@ export function mapPendingToolApproval(input: {
     ),
     ...(typeof input.trustTarget === 'string'
       ? { trustTarget: input.trustTarget }
+      : {}),
+    ...(typeof input.subagentSessionId === 'string' && input.subagentSessionId.trim()
+      ? { subagentSessionId: input.subagentSessionId.trim() }
       : {}),
   };
 }

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -44,6 +44,7 @@ export interface BuildDesktopSnapshotInput {
   conversation: ConversationSnapshot;
   activeSession?: ActiveSessionSnapshot;
   composerSessionKey: string;
+  subagentViewer?: DesktopSnapshot['subagentViewer'];
 }
 
 export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopSnapshot {
@@ -120,6 +121,7 @@ export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopS
     conversation: input.conversation,
     ...(input.activeSession ? { activeSession: { ...input.activeSession } } : {}),
     composerSessionKey: input.composerSessionKey,
+    ...(input.subagentViewer ? { subagentViewer: input.subagentViewer } : {}),
   };
 }
 

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -454,6 +454,9 @@ function normalizeStoredSession(parsed: Partial<StoredDesktopSession>): StoredDe
       : {}),
     ...(contextUsage ? { contextUsage } : {}),
     rewind: normalizeDesktopRewindMetadata(parsed.rewind),
+    ...(parsed.subagentDesktopMessages && typeof parsed.subagentDesktopMessages === 'object'
+      ? { subagentDesktopMessages: parsed.subagentDesktopMessages as Record<string, ConversationMessageSnapshot[]> }
+      : {}),
   } satisfies StoredDesktopSession;
 }
 

--- a/apps/desktop/src/host/subagent-conversation-projection.ts
+++ b/apps/desktop/src/host/subagent-conversation-projection.ts
@@ -1,0 +1,230 @@
+import type { RuntimeEvent, SubagentSessionArchiveEntry } from '@spirit-agent/core';
+import { llmMessageTextContent } from '@spirit-agent/core';
+
+import type { ConversationMessageSnapshot } from '../types.js';
+import { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';
+import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
+import type { DesktopToolRequest } from './contracts.js';
+import {
+  DesktopMessageTimeline,
+  type DesktopTimelineSegmentKind,
+} from './message-timeline.js';
+import {
+  DesktopRuntimeEventOrchestrator,
+  runtimeEventsIncludeAppliedResponsesBuiltInToolPreview,
+  splitRuntimeEventsForIncrementalFinishTaskPreview,
+  splitRuntimeEventsForIncrementalResponsesBuiltInToolPreview,
+} from './runtime-event-orchestrator.js';
+import type { DesktopRuntime } from './runtime.js';
+import type { SessionBundle } from './session-bundle.js';
+import { sanitizeConversationMessagesForPersistence } from './sessions.js';
+
+function nextMessageIdFromMessages(messages: ConversationMessageSnapshot[]): number {
+  return Math.max(0, ...messages.map((message) => message.id)) + 1;
+}
+
+function historyText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return llmMessageTextContent(content);
+  }
+  return '';
+}
+
+function seedMessagesFromSubagentSession(
+  session: SubagentSessionArchiveEntry,
+): ConversationMessageSnapshot[] {
+  for (const entry of session.llmHistory) {
+    if (entry.role !== 'user') {
+      continue;
+    }
+    const content = historyText(entry.content).trim();
+    if (!content) {
+      continue;
+    }
+    return [{
+      id: 1,
+      role: 'user',
+      content,
+      pending: false,
+    }];
+  }
+  return [];
+}
+
+export class SubagentConversationProjection {
+  readonly messageTimeline: DesktopMessageTimeline;
+  private readonly assistantMessages: DesktopAssistantMessageStateMachine;
+  private readonly runtimeEvents: DesktopRuntimeEventOrchestrator;
+  private messageIdCounter: number;
+  private deferredRuntimeHostEvents: RuntimeEvent<DesktopToolRequest>[] = [];
+  private responsesBuiltInPreviewSeenCallIds = new Set<string>();
+  private nextTimelineAssistantSegmentKind: DesktopTimelineSegmentKind = 'initial';
+
+  private constructor(
+    readonly sessionId: string,
+    messages: ConversationMessageSnapshot[],
+  ) {
+    this.messageIdCounter = nextMessageIdFromMessages(messages);
+    this.messageTimeline = DesktopMessageTimeline.fromMessages(messages, {
+      allocateMessageId: () => this.allocateMessageId(),
+      reserveMessageId: (messageId) => {
+        this.messageIdCounter = Math.max(this.messageIdCounter, messageId + 1);
+      },
+    });
+    const conversationSnapshotView = new DesktopConversationSnapshotView(() => this.allocateMessageId());
+    const messageBuffer: ConversationMessageSnapshot[] = [...messages];
+    this.assistantMessages = new DesktopAssistantMessageStateMachine({
+      messages: () => messageBuffer,
+      setMessages: (nextMessages) => {
+        messageBuffer.splice(0, messageBuffer.length, ...nextMessages);
+      },
+      allocateMessageId: () => this.allocateMessageId(),
+      isRuntimeBusy: () => true,
+    });
+    this.runtimeEvents = new DesktopRuntimeEventOrchestrator({
+      runtime: () => undefined,
+      messages: () => this.messageTimeline.toMessages(),
+      allocateMessageId: () => this.allocateMessageId(),
+      assistantMessages: this.assistantMessages,
+      messageTimeline: () => this.messageTimeline,
+      takeNextAssistantSegmentKind: () => this.nextTimelineAssistantSegmentKind,
+      conversationSnapshotView,
+      clearCurrentTurnSkills: () => {},
+      setLastRuntimeError: () => {},
+      refreshArchiveFromRuntime: () => {},
+      dispatchExtensionEvent: () => {},
+      bindFileChangesToToolMessage: () => {},
+    });
+  }
+
+  static fromSession(
+    session: SubagentSessionArchiveEntry,
+    existingMessages?: ConversationMessageSnapshot[],
+  ): SubagentConversationProjection {
+    const messages = existingMessages?.length
+      ? existingMessages.map((message) => ({ ...message }))
+      : seedMessagesFromSubagentSession(session);
+    return new SubagentConversationProjection(session.summary.sessionId, messages);
+  }
+
+  applyDrainedEvents(drained: RuntimeEvent<DesktopToolRequest>[]): void {
+    const queued = [...this.deferredRuntimeHostEvents, ...drained];
+    this.deferredRuntimeHostEvents = [];
+    const splitFinish = splitRuntimeEventsForIncrementalFinishTaskPreview(queued);
+    const splitBuiltin = splitRuntimeEventsForIncrementalResponsesBuiltInToolPreview(
+      splitFinish.toApply,
+      this.responsesBuiltInPreviewSeenCallIds,
+    );
+    this.deferredRuntimeHostEvents = [...splitFinish.deferred, ...splitBuiltin.deferred];
+    this.runtimeEvents.applyRuntimeHostEvents(splitBuiltin.toApply);
+    for (const event of splitBuiltin.toApply) {
+      if (
+        event.kind === 'streaming-tool-preview'
+        && runtimeEventsIncludeAppliedResponsesBuiltInToolPreview([event])
+      ) {
+        this.responsesBuiltInPreviewSeenCallIds.add(event.toolCallId);
+      }
+    }
+  }
+
+  toMessages(): ConversationMessageSnapshot[] {
+    return sanitizeConversationMessagesForPersistence(this.messageTimeline.toMessages());
+  }
+
+  private allocateMessageId(): number {
+    const next = this.messageIdCounter;
+    this.messageIdCounter += 1;
+    return next;
+  }
+}
+
+function resolveSubagentSessionForProjection(
+  bundle: SessionBundle,
+  runtime: DesktopRuntime | undefined,
+  sessionId: string,
+): SubagentSessionArchiveEntry | undefined {
+  if (runtime) {
+    for (const entry of runtime.childSessionArchives()) {
+      if (entry.summary.sessionId === sessionId) {
+        return entry;
+      }
+    }
+  }
+  return bundle.archiveSubagentSessions.find((entry) => entry.summary.sessionId === sessionId);
+}
+
+export function ensureSubagentConversationProjection(
+  bundle: SessionBundle,
+  session: SubagentSessionArchiveEntry,
+): SubagentConversationProjection {
+  const existing = bundle.subagentConversationProjections.get(session.summary.sessionId);
+  if (existing) {
+    return existing;
+  }
+
+  const stored = bundle.subagentDesktopMessagesBySessionId.get(session.summary.sessionId);
+  const projection = SubagentConversationProjection.fromSession(
+    session,
+    stored?.map((message) => ({ ...message })),
+  );
+  bundle.subagentConversationProjections.set(session.summary.sessionId, projection);
+  return projection;
+}
+
+export function syncSubagentConversationProjections(
+  bundle: SessionBundle,
+  runtime: DesktopRuntime | undefined,
+): void {
+  if (!runtime) {
+    return;
+  }
+
+  const childDrain = runtime.drainActiveChildSessionEvents();
+  if (!childDrain) {
+    return;
+  }
+
+  const session = resolveSubagentSessionForProjection(bundle, runtime, childDrain.sessionId);
+  if (!session) {
+    return;
+  }
+
+  const projection = ensureSubagentConversationProjection(bundle, session);
+  projection.applyDrainedEvents(childDrain.events);
+  const syncedMessages = projection.toMessages();
+  bundle.subagentDesktopMessagesBySessionId.set(
+    childDrain.sessionId,
+    syncedMessages,
+  );
+}
+
+export function cloneSubagentDesktopMessagesRecord(
+  record: Record<string, ConversationMessageSnapshot[]> | undefined,
+): Map<string, ConversationMessageSnapshot[]> {
+  const next = new Map<string, ConversationMessageSnapshot[]>();
+  if (!record) {
+    return next;
+  }
+  for (const [sessionId, messages] of Object.entries(record)) {
+    next.set(sessionId, messages.map((message) => ({ ...message })));
+  }
+  return next;
+}
+
+export function serializeSubagentDesktopMessagesRecord(
+  map: Map<string, ConversationMessageSnapshot[]>,
+): Record<string, ConversationMessageSnapshot[]> | undefined {
+  if (map.size === 0) {
+    return undefined;
+  }
+  const record: Record<string, ConversationMessageSnapshot[]> = {};
+  for (const [sessionId, messages] of map.entries()) {
+    if (messages.length > 0) {
+      record[sessionId] = messages.map((message) => ({ ...message }));
+    }
+  }
+  return Object.keys(record).length > 0 ? record : undefined;
+}

--- a/apps/desktop/src/host/subagent-viewer.ts
+++ b/apps/desktop/src/host/subagent-viewer.ts
@@ -1,0 +1,136 @@
+import type { SubagentSessionArchiveEntry } from '@spirit-agent/core';
+import {
+  buildSubagentConversationSnapshots,
+  resolveSubagentPromptFromTaskFields,
+  type SubagentViewerMessage,
+} from '@spirit-agent/host-internal';
+
+import type {
+  ConversationMessageSnapshot,
+  PendingAssistantAux,
+  SubagentViewerSnapshot,
+  ToolBlockSnapshot,
+} from '../types.js';
+import {
+  applyToolCallSummaryCopy,
+  toolCallSummaryForPhase,
+} from './message-ordering.js';
+import { mapPendingAuxState } from './snapshot-mappers.js';
+import type { SessionBundle } from './session-bundle.js';
+
+function enrichSubagentToolBlock(input: {
+  toolName: string;
+  phase: ToolBlockSnapshot['phase'];
+  request: unknown;
+  tool: SubagentViewerMessage['tool'];
+}): ToolBlockSnapshot {
+  const base = input.tool ?? {
+    toolName: input.toolName,
+    phase: input.phase,
+    headline: input.toolName,
+    detailLines: [],
+  };
+  const summary = toolCallSummaryForPhase(input.phase, input.toolName, input.request);
+  return applyToolCallSummaryCopy(base as ToolBlockSnapshot, summary);
+}
+
+function toConversationMessages(messages: SubagentViewerMessage[]): ConversationMessageSnapshot[] {
+  return messages.map((message) => ({
+    id: message.id,
+    role: message.role,
+    content: message.content,
+    pending: message.pending,
+    ...(message.tool ? { tool: message.tool as ToolBlockSnapshot } : {}),
+    ...(message.aux ? { aux: message.aux } : {}),
+  }));
+}
+
+export function resolveSubagentSessionByToolCallId(
+  bundle: SessionBundle,
+  toolCallId: string,
+): SubagentSessionArchiveEntry | undefined {
+  const trimmed = toolCallId.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const runtime = bundle.runtime;
+  if (runtime) {
+    for (const entry of runtime.childSessionArchives()) {
+      if (entry.summary.parentToolCallId === trimmed) {
+        return entry;
+      }
+    }
+  }
+
+  return bundle.archiveSubagentSessions.find(
+    (session) => session.summary.parentToolCallId === trimmed,
+  );
+}
+
+export function resolveSubagentPromptText(
+  bundle: SessionBundle,
+  toolCallId: string,
+): string {
+  const trimmed = toolCallId.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const timelineMessages = bundle.messageTimeline.toMessages();
+  for (let index = timelineMessages.length - 1; index >= 0; index -= 1) {
+    const message = timelineMessages[index];
+    if (
+      message?.tool?.toolCallId === trimmed
+      && message.tool.toolName === 'run_subagent'
+    ) {
+      const detail = message.tool.headlineDetail?.trim();
+      if (detail) {
+        return detail;
+      }
+    }
+  }
+
+  const session = resolveSubagentSessionByToolCallId(bundle, trimmed);
+  return resolveSubagentPromptFromTaskFields({
+    title: session?.summary.title,
+  });
+}
+
+export function buildSubagentViewerSnapshot(
+  bundle: SessionBundle,
+  toolCallId: string,
+): SubagentViewerSnapshot | undefined {
+  const trimmed = toolCallId.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const session = resolveSubagentSessionByToolCallId(bundle, trimmed);
+  if (!session) {
+    return undefined;
+  }
+
+  const runtime = bundle.runtime;
+  const pendingAuxRuntime = runtime?.childSessionPendingAuxState(session.summary.sessionId);
+  const pendingAuxState: PendingAssistantAux | undefined = pendingAuxRuntime
+    ? mapPendingAuxState(pendingAuxRuntime)
+    : undefined;
+
+  const messages = toConversationMessages(
+    buildSubagentConversationSnapshots(session.llmHistory, {
+      sessionStatus: session.summary.status,
+      enrichToolBlock: ({ toolName, phase, request, tool }) =>
+        enrichSubagentToolBlock({ toolName, phase, request, tool }),
+    }),
+  );
+
+  return {
+    parentToolCallId: trimmed,
+    sessionId: session.summary.sessionId,
+    status: session.summary.status,
+    promptText: resolveSubagentPromptText(bundle, trimmed),
+    messages,
+    ...(pendingAuxState ? { pendingAuxState } : {}),
+  };
+}

--- a/apps/desktop/src/host/subagent-viewer.ts
+++ b/apps/desktop/src/host/subagent-viewer.ts
@@ -17,6 +17,10 @@ import {
 } from './message-ordering.js';
 import { mapPendingAuxState } from './snapshot-mappers.js';
 import type { SessionBundle } from './session-bundle.js';
+import {
+  ensureSubagentConversationProjection,
+  syncSubagentConversationProjections,
+} from './subagent-conversation-projection.js';
 
 function enrichSubagentToolBlock(input: {
   toolName: string;
@@ -97,6 +101,43 @@ export function resolveSubagentPromptText(
   });
 }
 
+function countThinkingRows(messages: readonly ConversationMessageSnapshot[]): number {
+  return messages.filter((message) => message.aux?.thinking?.trim()).length;
+}
+
+function resolveSubagentViewerMessages(input: {
+  projected?: ConversationMessageSnapshot[];
+  historyMessages: ConversationMessageSnapshot[];
+  isLiveSession: boolean;
+}): { messages: ConversationMessageSnapshot[]; source: string } {
+  const projected = input.projected?.map((message) => ({ ...message })) ?? [];
+  const history = input.historyMessages;
+
+  if (input.isLiveSession && projected.length > 0) {
+    return { messages: projected, source: 'projected-live' };
+  }
+  if (projected.length === 0) {
+    return { messages: history, source: history.length > 0 ? 'history-only' : 'empty' };
+  }
+  if (history.length === 0) {
+    return { messages: projected, source: 'projected-only' };
+  }
+
+  const projectedThinking = countThinkingRows(projected);
+  const historyThinking = countThinkingRows(history);
+  if (projectedThinking > historyThinking) {
+    return { messages: projected, source: 'projected-richer-thinking' };
+  }
+  if (historyThinking > projectedThinking) {
+    return { messages: history, source: 'history-richer-thinking' };
+  }
+
+  if (projected.length >= history.length) {
+    return { messages: projected, source: 'projected-parity' };
+  }
+  return { messages: history, source: 'history-parity' };
+}
+
 export function buildSubagentViewerSnapshot(
   bundle: SessionBundle,
   toolCallId: string,
@@ -117,13 +158,33 @@ export function buildSubagentViewerSnapshot(
     ? mapPendingAuxState(pendingAuxRuntime)
     : undefined;
 
-  const messages = toConversationMessages(
+  syncSubagentConversationProjections(bundle, runtime);
+
+  const historyMessages = toConversationMessages(
     buildSubagentConversationSnapshots(session.llmHistory, {
       sessionStatus: session.summary.status,
       enrichToolBlock: ({ toolName, phase, request, tool }) =>
         enrichSubagentToolBlock({ toolName, phase, request, tool }),
     }),
   );
+
+  const projected = bundle.subagentDesktopMessagesBySessionId.get(session.summary.sessionId);
+  const isLiveSession =
+    session.summary.status === 'running' || session.summary.status === 'blocked';
+
+  const resolved = resolveSubagentViewerMessages({
+    projected,
+    historyMessages,
+    isLiveSession,
+  });
+  const messages = resolved.messages;
+
+  if (
+    isLiveSession
+    && !projected?.length
+  ) {
+    ensureSubagentConversationProjection(bundle, session);
+  }
 
   return {
     parentToolCallId: trimmed,

--- a/apps/desktop/src/lib/conversation-list-scope.ts
+++ b/apps/desktop/src/lib/conversation-list-scope.ts
@@ -1,0 +1,30 @@
+import type { ConversationMessageSnapshot } from '@/types';
+
+/** Which message source is rendered in the conversation column (keys must not collide across sources). */
+export function resolveConversationListScopeKey(input: {
+  subagentViewActive: boolean;
+  subagentToolCallId: string | null;
+  compactionDemoActive: boolean;
+}): string {
+  if (input.subagentViewActive && input.subagentToolCallId) {
+    return `subagent:${input.subagentToolCallId}`;
+  }
+  if (input.compactionDemoActive) {
+    return 'compaction-demo';
+  }
+  return 'main';
+}
+
+/** Stable list identity — must not include list index (rows insert above tools during finalize-thinking). */
+export function conversationMessageStableId(
+  message: ConversationMessageSnapshot,
+  composerSessionKey = '',
+  listScopeKey = 'main',
+): string {
+  const sessionPart = composerSessionKey.trim() ? `${composerSessionKey.trim()}:` : '';
+  const scopePart = `${listScopeKey}:`;
+  const toolPart =
+    message.tool?.toolCallId ??
+    (message.tool ? `${message.tool.toolName}:${message.tool.phase}` : '');
+  return `${sessionPart}${scopePart}message-${message.id}-${message.pending ? 'p' : 'm'}-${toolPart}`;
+}

--- a/apps/desktop/src/lib/subagent-display.ts
+++ b/apps/desktop/src/lib/subagent-display.ts
@@ -187,6 +187,20 @@ export function hasActiveRunSubagentToolInMessages(
   );
 }
 
+/** run_subagent 仍在当前回合执行/等待审批时，主 timeline 不应展示子会话工具卡。 */
+export function hasInFlightSubagentDelegationInMessages(
+  messages: ReadonlyArray<ConversationMessageSnapshot>,
+): boolean {
+  return messages.some(
+    (message) =>
+      message.role === 'assistant' &&
+      message.tool?.toolName === 'run_subagent' &&
+      (message.tool.phase === 'preview' ||
+        message.tool.phase === 'running' ||
+        message.tool.phase === 'pending-approval'),
+  );
+}
+
 export function isSubagentStatusSurfaceMessage(
   message: ConversationMessageSnapshot | undefined,
 ): boolean {

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -412,6 +412,7 @@
     "exitDemo": "Exit Demo",
     "subagentViewerTitle": "Subagent",
     "exitSubagentViewer": "Exit",
+    "subagentViewerEmpty": "This subagent has no visible messages yet.",
     "cancelRewind": "Cancel Rewind Edit",
     "commitMode": "Commit Mode",
     "commitMessagePlaceholder": "Commit message; will be auto-generated if left empty",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -410,6 +410,8 @@
     "compactionDemo": "Context Compaction UI Demo",
     "compactionDemoDescription": "Simulate Compressing \u2192 Compaction summary \u2192 Compacted reply (not written to session)",
     "exitDemo": "Exit Demo",
+    "subagentViewerTitle": "Subagent",
+    "exitSubagentViewer": "Exit",
     "cancelRewind": "Cancel Rewind Edit",
     "commitMode": "Commit Mode",
     "commitMessagePlaceholder": "Commit message; will be auto-generated if left empty",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -412,6 +412,7 @@
     "exitDemo": "退出演示",
     "subagentViewerTitle": "子智能体",
     "exitSubagentViewer": "退出",
+    "subagentViewerEmpty": "子智能体尚未产生可见消息。",
     "cancelRewind": "取消回溯编辑",
     "commitMode": "提交方式",
     "commitMessagePlaceholder": "提交信息，为空将自动生成",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -410,6 +410,8 @@
     "compactionDemo": "上下文压缩 UI 演示",
     "compactionDemoDescription": "模拟 Compressing \u2192 Compaction 摘要 \u2192 压缩后回复（不写入会话）",
     "exitDemo": "退出演示",
+    "subagentViewerTitle": "子智能体",
+    "exitSubagentViewer": "退出",
     "cancelRewind": "取消回溯编辑",
     "commitMode": "提交方式",
     "commitMessagePlaceholder": "提交信息，为空将自动生成",

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -600,6 +600,20 @@ export interface DesktopSnapshot {
   activeSession?: ActiveSessionSnapshot;
   /** Stable key for per-session composer draft persistence (`filePath` or synthetic bundle id). */
   composerSessionKey: string;
+  /** Active SubAgent viewer overlay; present while renderer has a tool card open in viewer mode. */
+  subagentViewer?: SubagentViewerSnapshot;
+}
+
+export type SubagentViewerSessionStatus = 'running' | 'completed' | 'failed' | 'blocked';
+
+export interface SubagentViewerSnapshot {
+  parentToolCallId: string;
+  sessionId: string;
+  status: SubagentViewerSessionStatus;
+  /** Same text as run_subagent tool card headlineDetail (delegated task). */
+  promptText: string;
+  messages: ConversationMessageSnapshot[];
+  pendingAuxState?: PendingAssistantAux;
 }
 
 export interface DesktopExtensionCssLayer {
@@ -896,6 +910,7 @@ export interface PendingToolApprovalSnapshot {
   toolName: string;
   prompt: string;
   trustTarget?: string;
+  subagentSessionId?: string;
 }
 
 export type DesktopApprovalDecision =

--- a/apps/desktop/test/host/snapshot-mappers.test.mjs
+++ b/apps/desktop/test/host/snapshot-mappers.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { mapPendingToolApproval } from '../../dist-electron/src/host/snapshot-mappers.js';
+
+test('mapPendingToolApproval forwards subagentSessionId when present', () => {
+  const mapped = mapPendingToolApproval({
+    toolName: 'run_shell_command',
+    request: { command: 'git status' },
+    prompt: 'Run git status?',
+    trustTarget: 'shell:git status',
+    subagentSessionId: 'subagent-123',
+  });
+
+  assert.equal(mapped.subagentSessionId, 'subagent-123');
+  assert.equal(mapped.toolName, 'run_shell_command');
+});
+
+test('mapPendingToolApproval omits blank subagentSessionId', () => {
+  const mapped = mapPendingToolApproval({
+    toolName: 'read_file',
+    request: { path: 'README.md' },
+    prompt: 'Read README.md?',
+    subagentSessionId: '   ',
+  });
+
+  assert.equal(mapped.subagentSessionId, undefined);
+});

--- a/apps/desktop/test/host/subagent-viewer.test.mjs
+++ b/apps/desktop/test/host/subagent-viewer.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  buildSubagentConversationSnapshots,
+  resolveSubagentPromptFromTaskFields,
+} from '@spirit-agent/host-internal';
+
+test('buildSubagentConversationSnapshots maps user, assistant text, and tool results', () => {
+  const messages = buildSubagentConversationSnapshots(
+    [
+      { role: 'user', content: 'Inspect the repo layout' },
+      {
+        role: 'assistant',
+        content: 'I will read README first.',
+        toolCalls: [
+          {
+            id: 'call_read_1',
+            name: 'read_file',
+            argumentsJson: '{"path":"README.md"}',
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'call_read_1',
+        content: '# Spirit Agent',
+      },
+      { role: 'assistant', content: 'README mentions Desktop host.' },
+    ],
+    { sessionStatus: 'completed' },
+  );
+
+  assert.equal(messages.length, 4);
+  assert.equal(messages[0]?.role, 'user');
+  assert.equal(messages[0]?.content, 'Inspect the repo layout');
+  assert.equal(messages[1]?.role, 'assistant');
+  assert.equal(messages[1]?.content, 'I will read README first.');
+  assert.equal(messages[2]?.tool?.toolName, 'read_file');
+  assert.equal(messages[2]?.tool?.phase, 'succeeded');
+  assert.match(messages[2]?.tool?.outputExcerpt ?? '', /Spirit Agent/);
+  assert.equal(messages[3]?.content, 'README mentions Desktop host.');
+});
+
+test('buildSubagentConversationSnapshots marks unresolved tools as running while session runs', () => {
+  const messages = buildSubagentConversationSnapshots(
+    [
+      { role: 'user', content: 'Run shell check' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_shell_1',
+            name: 'run_shell_command',
+            argumentsJson: '{"command":"git status"}',
+          },
+        ],
+      },
+    ],
+    { sessionStatus: 'running' },
+  );
+
+  assert.equal(messages.length, 2);
+  assert.equal(messages[1]?.tool?.phase, 'running');
+  assert.equal(messages[1]?.pending, true);
+});
+
+test('buildSubagentConversationSnapshots marks last unresolved tool as pending-approval when blocked', () => {
+  const messages = buildSubagentConversationSnapshots(
+    [
+      { role: 'user', content: 'Delete temp file' },
+      {
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            id: 'call_delete_1',
+            name: 'delete_file',
+            argumentsJson: '{"path":"tmp.txt"}',
+          },
+        ],
+      },
+    ],
+    { sessionStatus: 'blocked' },
+  );
+
+  assert.equal(messages[1]?.tool?.phase, 'pending-approval');
+});
+
+test('resolveSubagentPromptFromTaskFields prefers task then context summary', () => {
+  assert.equal(
+    resolveSubagentPromptFromTaskFields({
+      task: '  Run tests  ',
+      contextSummary: 'fallback',
+      title: 'title',
+    }),
+    'Run tests',
+  );
+  assert.equal(
+    resolveSubagentPromptFromTaskFields({
+      contextSummary: 'Need grep',
+      title: 'title',
+    }),
+    'Need grep',
+  );
+});

--- a/apps/desktop/test/host/subagent-viewer.test.mjs
+++ b/apps/desktop/test/host/subagent-viewer.test.mjs
@@ -88,6 +88,27 @@ test('buildSubagentConversationSnapshots marks last unresolved tool as pending-a
   assert.equal(messages[1]?.tool?.phase, 'pending-approval');
 });
 
+test('buildSubagentConversationSnapshots maps assistant reasoning to thinking aux rows', () => {
+  const messages = buildSubagentConversationSnapshots(
+    [
+      { role: 'user', content: 'Say hello' },
+      {
+        role: 'assistant',
+        content: '你好',
+        providerState: { reasoning_content: '子智能体输出你好' },
+      },
+    ],
+    { sessionStatus: 'completed' },
+  );
+
+  assert.equal(messages.length, 3);
+  assert.equal(messages[0]?.role, 'user');
+  assert.equal(messages[1]?.role, 'assistant');
+  assert.equal(messages[1]?.content, '');
+  assert.equal(messages[1]?.aux?.thinking, '子智能体输出你好');
+  assert.equal(messages[2]?.content, '你好');
+});
+
 test('resolveSubagentPromptFromTaskFields prefers task then context summary', () => {
   assert.equal(
     resolveSubagentPromptFromTaskFields({

--- a/apps/desktop/test/lib/conversation-list-scope.test.mjs
+++ b/apps/desktop/test/lib/conversation-list-scope.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  conversationMessageStableId,
+  resolveConversationListScopeKey,
+} from '../../src/lib/conversation-list-scope.ts';
+
+test('resolveConversationListScopeKey isolates subagent viewer from main list', () => {
+  assert.equal(
+    resolveConversationListScopeKey({
+      subagentViewActive: true,
+      subagentToolCallId: 'call_abc',
+      compactionDemoActive: false,
+    }),
+    'subagent:call_abc',
+  );
+  assert.equal(
+    resolveConversationListScopeKey({
+      subagentViewActive: false,
+      subagentToolCallId: 'call_abc',
+      compactionDemoActive: false,
+    }),
+    'main',
+  );
+});
+
+test('conversationMessageStableId namespaces ids across list scopes', () => {
+  const message = { id: 1, role: 'assistant', content: 'hi', pending: false };
+  const sessionKey = 'session-1';
+  const mainKey = conversationMessageStableId(message, sessionKey, 'main');
+  const subagentKey = conversationMessageStableId(message, sessionKey, 'subagent:call_abc');
+  assert.notEqual(mainKey, subagentKey);
+  assert.match(mainKey, /:main:message-1-/);
+  assert.match(subagentKey, /:subagent:call_abc:message-1-/);
+});

--- a/apps/desktop/test/lib/subagent-display.test.mjs
+++ b/apps/desktop/test/lib/subagent-display.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  hasInFlightSubagentDelegationInMessages,
   isGenericPendingCompactionStatusText,
   isGenericPendingThinkingStatusText,
   isSubagentStatusSurfaceText,
@@ -75,5 +76,42 @@ test('parsePendingSubagentStatusText only accepts subagent runtime status', () =
   assert.equal(
     parsePendingSubagentStatusText('| 用户想回退：删除未跟踪文件'),
     undefined,
+  );
+});
+
+test('hasInFlightSubagentDelegationInMessages includes pending-approval run_subagent', () => {
+  assert.equal(
+    hasInFlightSubagentDelegationInMessages([
+      {
+        id: 1,
+        role: 'assistant',
+        content: '',
+        pending: false,
+        tool: {
+          toolName: 'run_subagent',
+          phase: 'pending-approval',
+          headline: 'SubAgent',
+          detailLines: [],
+        },
+      },
+    ]),
+    true,
+  );
+  assert.equal(
+    hasInFlightSubagentDelegationInMessages([
+      {
+        id: 1,
+        role: 'assistant',
+        content: '',
+        pending: false,
+        tool: {
+          toolName: 'run_subagent',
+          phase: 'succeeded',
+          headline: 'SubAgent',
+          detailLines: [],
+        },
+      },
+    ]),
+    false,
   );
 });

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -15,6 +15,7 @@ import type {
   ToolRequestExecutionMetadata,
   ToolAgentRoundCompletion,
   ToolCallRequest,
+  StoredLlmMessageArchiveEntry,
 } from './ports.js';
 import {
   DEFAULT_IMAGE_GENERATION_SIZE,
@@ -290,10 +291,7 @@ export class AgentRuntime<
   childSessionArchives(): readonly RuntimeSubagentSessionArchiveEntry[] {
     return this.childSessionsStore.map((entry) => ({
       summary: { ...entry.summary },
-      llmHistory: entry.llmHistory.map((message) => ({
-        role: message.role,
-        content: cloneLlmMessageContent(message.content),
-      })),
+      llmHistory: entry.llmHistory.map((message) => serializeRuntimeLlmMessageForArchive(message)),
     }));
   }
 
@@ -305,10 +303,24 @@ export class AgentRuntime<
 
     return {
       summary: { ...entry.summary },
-      llmHistory: entry.llmHistory.map((message) => ({
-        role: message.role,
-        content: cloneLlmMessageContent(message.content),
-      })),
+      llmHistory: entry.llmHistory.map((message) => serializeRuntimeLlmMessageForArchive(message)),
+    };
+  }
+
+  drainActiveChildSessionEvents(): {
+    sessionId: string;
+    parentToolCallId: string;
+    events: RuntimeEvent<ToolRequest>[];
+  } | undefined {
+    const pending = this.pendingSubagentExecution;
+    if (!pending) {
+      return undefined;
+    }
+
+    return {
+      sessionId: pending.childRecord.summary.sessionId,
+      parentToolCallId: pending.childRecord.summary.parentToolCallId,
+      events: pending.childRuntime.drainEvents(),
     };
   }
 
@@ -2749,10 +2761,7 @@ export class AgentRuntime<
     record: RuntimeSubagentSessionArchiveEntry,
     childRuntime: AgentRuntime<Config, State, ToolRequest, TrustTarget>,
   ): void {
-    record.llmHistory = childRuntime.history().map((message) => ({
-      role: message.role,
-      content: cloneLlmMessageContent(message.content),
-    }));
+    record.llmHistory = childRuntime.history().map((message) => serializeRuntimeLlmMessageForArchive(message));
     const pendingAssistant = childRuntime.pendingAssistantText().trim();
     if (pendingAssistant.length > 0) {
       record.llmHistory.push({
@@ -2801,7 +2810,7 @@ export class AgentRuntime<
     }
 
     await pending.childRuntime.poll();
-    pending.childRuntime.drainEvents();
+    // 不在此处 drain：子会话事件由 desktop syncSubagentConversationProjections 消费。
     this.refreshChildSessionRecord(pending.childRecord, pending.childRuntime);
 
     const childApproval = pending.childRuntime.currentPendingApproval();
@@ -3316,4 +3325,24 @@ function readOptionalStringArrayField(
 
 function isJsonObject(value: unknown): value is Record<string, JsonValue> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function serializeRuntimeLlmMessageForArchive(message: LlmMessage): StoredLlmMessageArchiveEntry {
+  return {
+    role: message.role,
+    content: cloneLlmMessageContent(message.content),
+    ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
+    ...(message.toolCalls !== undefined
+      ? {
+          toolCalls: message.toolCalls.map((toolCall) => ({
+            id: toolCall.id,
+            name: toolCall.name,
+            argumentsJson: toolCall.argumentsJson,
+          })),
+        }
+      : {}),
+    ...(message.providerState !== undefined
+      ? { providerState: cloneLlmProviderState(message.providerState) }
+      : {}),
+  };
 }

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -13,6 +13,7 @@ export * from './openai-models.js';
 export * from './reasoning-effort.js';
 export * from './runtime.js';
 export * from './session-title.js';
+export * from './subagent-viewer.js';
 export * from './storage.js';
 export * from './managed-generated-asset.js';
 export * from './tools.js';

--- a/packages/host-internal/src/subagent-viewer.ts
+++ b/packages/host-internal/src/subagent-viewer.ts
@@ -1,0 +1,258 @@
+import type { LlmMessageContent, LlmToolCall, StoredLlmMessageArchiveEntry } from '@spirit-agent/core';
+import { llmMessageTextContent } from '@spirit-agent/core';
+
+export type SubagentViewerSessionStatus = 'running' | 'completed' | 'failed' | 'blocked';
+
+export type SubagentViewerToolPhase =
+  | 'preview'
+  | 'pending-approval'
+  | 'running'
+  | 'succeeded'
+  | 'failed';
+
+export interface SubagentViewerToolBlock {
+  toolCallId?: string;
+  toolName: string;
+  phase: SubagentViewerToolPhase;
+  headline: string;
+  headlineDetail?: string;
+  detailLines: string[];
+  argsExcerpt?: string;
+  outputExcerpt?: string;
+}
+
+export interface SubagentViewerMessage {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  tool?: SubagentViewerToolBlock;
+  aux?: { thinking?: string };
+  pending: boolean;
+}
+
+export type SubagentLlmHistoryEntry = StoredLlmMessageArchiveEntry | {
+  role: string;
+  content: unknown;
+  toolCallId?: string;
+  toolCalls?: LlmToolCall[];
+};
+
+export interface BuildSubagentConversationSnapshotsOptions {
+  sessionStatus: SubagentViewerSessionStatus;
+  enrichToolBlock?: (input: {
+    toolName: string;
+    phase: SubagentViewerToolPhase;
+    request: unknown;
+    tool: SubagentViewerToolBlock;
+  }) => SubagentViewerToolBlock;
+}
+
+function historyText(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return llmMessageTextContent(content);
+  }
+  return '';
+}
+
+function truncateExcerpt(value: string, maxChars: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxChars) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxChars)}…`;
+}
+
+function inferToolPhase(
+  sessionStatus: SubagentViewerSessionStatus,
+  hasOutput: boolean,
+  isLastUnresolvedTool: boolean,
+): SubagentViewerToolPhase {
+  if (hasOutput) {
+    return sessionStatus === 'failed' ? 'failed' : 'succeeded';
+  }
+  if (sessionStatus === 'failed') {
+    return 'failed';
+  }
+  if (sessionStatus === 'blocked' && isLastUnresolvedTool) {
+    return 'pending-approval';
+  }
+  if (sessionStatus === 'running' || sessionStatus === 'blocked') {
+    return 'running';
+  }
+  return 'succeeded';
+}
+
+function parseToolRequest(argumentsJson: string): unknown {
+  const trimmed = argumentsJson.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(trimmed) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildSubagentConversationSnapshots(
+  llmHistory: ReadonlyArray<SubagentLlmHistoryEntry>,
+  options: BuildSubagentConversationSnapshotsOptions,
+): SubagentViewerMessage[] {
+  const toolOutputs = new Map<string, string>();
+  for (const entry of llmHistory) {
+    if (entry.role !== 'tool') {
+      continue;
+    }
+    const toolCallId = entry.toolCallId?.trim();
+    if (!toolCallId) {
+      continue;
+    }
+    toolOutputs.set(toolCallId, historyText(entry.content));
+  }
+
+  const unresolvedToolCallIds = new Set<string>();
+  for (const entry of llmHistory) {
+    if (entry.role !== 'assistant') {
+      continue;
+    }
+    for (const toolCall of entry.toolCalls ?? []) {
+      const id = toolCall.id?.trim();
+      if (!id) {
+        continue;
+      }
+      if (!toolOutputs.get(id)?.trim()) {
+        unresolvedToolCallIds.add(id);
+      }
+    }
+  }
+
+  let lastUnresolvedToolCallId: string | undefined;
+  for (let index = llmHistory.length - 1; index >= 0; index -= 1) {
+    const entry = llmHistory[index];
+    if (entry?.role !== 'assistant') {
+      continue;
+    }
+    const toolCalls = entry.toolCalls ?? [];
+    for (let toolIndex = toolCalls.length - 1; toolIndex >= 0; toolIndex -= 1) {
+      const id = toolCalls[toolIndex]?.id?.trim();
+      if (id && unresolvedToolCallIds.has(id)) {
+        lastUnresolvedToolCallId = id;
+        break;
+      }
+    }
+    if (lastUnresolvedToolCallId) {
+      break;
+    }
+  }
+
+  const messages: SubagentViewerMessage[] = [];
+  let nextId = 1;
+
+  for (const entry of llmHistory) {
+    if (entry.role === 'tool') {
+      continue;
+    }
+
+    if (entry.role === 'user') {
+      const content = historyText(entry.content).trim();
+      if (!content) {
+        continue;
+      }
+      messages.push({
+        id: nextId,
+        role: 'user',
+        content,
+        pending: false,
+      });
+      nextId += 1;
+      continue;
+    }
+
+    if (entry.role !== 'assistant') {
+      continue;
+    }
+
+    const toolCalls = entry.toolCalls ?? [];
+    const text = historyText(entry.content).trim();
+
+    if (toolCalls.length > 0) {
+      if (text) {
+        messages.push({
+          id: nextId,
+          role: 'assistant',
+          content: text,
+          pending: false,
+        });
+        nextId += 1;
+      }
+
+      for (const toolCall of toolCalls) {
+        const toolCallId = toolCall.id?.trim();
+        const output = toolCallId ? toolOutputs.get(toolCallId) : undefined;
+        const hasOutput = Boolean(output?.trim());
+        const isLastUnresolvedTool = Boolean(
+          toolCallId && toolCallId === lastUnresolvedToolCallId,
+        );
+        const phase = inferToolPhase(options.sessionStatus, hasOutput, isLastUnresolvedTool);
+        const request = parseToolRequest(toolCall.argumentsJson);
+        let tool: SubagentViewerToolBlock = {
+          toolCallId,
+          toolName: toolCall.name,
+          phase,
+          headline: toolCall.name,
+          detailLines: [],
+          argsExcerpt: truncateExcerpt(toolCall.argumentsJson, 500),
+          ...(output ? { outputExcerpt: truncateExcerpt(output, 4_000) } : {}),
+        };
+        if (options.enrichToolBlock) {
+          tool = options.enrichToolBlock({
+            toolName: toolCall.name,
+            phase,
+            request,
+            tool,
+          });
+        }
+        messages.push({
+          id: nextId,
+          role: 'assistant',
+          content: '',
+          tool,
+          pending: phase === 'running' || phase === 'preview' || phase === 'pending-approval',
+        });
+        nextId += 1;
+      }
+      continue;
+    }
+
+    if (text) {
+      messages.push({
+        id: nextId,
+        role: 'assistant',
+        content: text,
+        pending: false,
+      });
+      nextId += 1;
+    }
+  }
+
+  return messages;
+}
+
+export function resolveSubagentPromptFromTaskFields(input: {
+  task?: string;
+  contextSummary?: string;
+  title?: string;
+}): string {
+  const task = input.task?.trim();
+  if (task) {
+    return task;
+  }
+  const contextSummary = input.contextSummary?.trim();
+  if (contextSummary) {
+    return contextSummary;
+  }
+  return input.title?.trim() ?? '';
+}

--- a/packages/host-internal/src/subagent-viewer.ts
+++ b/packages/host-internal/src/subagent-viewer.ts
@@ -97,6 +97,65 @@ function parseToolRequest(argumentsJson: string): unknown {
   }
 }
 
+function extractAssistantReasoningFromHistoryEntry(entry: SubagentLlmHistoryEntry): string {
+  if (entry.role !== 'assistant') {
+    return '';
+  }
+
+  const providerState =
+    'providerState' in entry &&
+    entry.providerState &&
+    typeof entry.providerState === 'object' &&
+    !Array.isArray(entry.providerState)
+      ? (entry.providerState as Record<string, unknown>)
+      : undefined;
+  if (providerState) {
+    for (const key of ['reasoning_content', 'reasoningContent', 'reasoning', 'thinking'] as const) {
+      const value = providerState[key];
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim();
+      }
+    }
+  }
+
+  if (Array.isArray(entry.content)) {
+    const reasoningParts: string[] = [];
+    for (const part of entry.content) {
+      if (!part || typeof part !== 'object') {
+        continue;
+      }
+      const record = part as Record<string, unknown>;
+      if (record.type === 'reasoning' && typeof record.text === 'string' && record.text.trim()) {
+        reasoningParts.push(record.text.trim());
+      }
+    }
+    if (reasoningParts.length > 0) {
+      return reasoningParts.join('\n\n');
+    }
+  }
+
+  return '';
+}
+
+function pushAssistantThinkingMessage(
+  messages: SubagentViewerMessage[],
+  nextIdRef: { value: number },
+  thinking: string,
+): void {
+  const trimmed = thinking.trim();
+  if (!trimmed) {
+    return;
+  }
+  messages.push({
+    id: nextIdRef.value,
+    role: 'assistant',
+    content: '',
+    aux: { thinking: trimmed },
+    pending: false,
+  });
+  nextIdRef.value += 1;
+}
+
 export function buildSubagentConversationSnapshots(
   llmHistory: ReadonlyArray<SubagentLlmHistoryEntry>,
   options: BuildSubagentConversationSnapshotsOptions,
@@ -149,7 +208,7 @@ export function buildSubagentConversationSnapshots(
   }
 
   const messages: SubagentViewerMessage[] = [];
-  let nextId = 1;
+  const nextIdRef = { value: 1 };
 
   for (const entry of llmHistory) {
     if (entry.role === 'tool') {
@@ -162,12 +221,12 @@ export function buildSubagentConversationSnapshots(
         continue;
       }
       messages.push({
-        id: nextId,
+        id: nextIdRef.value,
         role: 'user',
         content,
         pending: false,
       });
-      nextId += 1;
+      nextIdRef.value += 1;
       continue;
     }
 
@@ -177,16 +236,20 @@ export function buildSubagentConversationSnapshots(
 
     const toolCalls = entry.toolCalls ?? [];
     const text = historyText(entry.content).trim();
+    const reasoning = extractAssistantReasoningFromHistoryEntry(entry);
 
     if (toolCalls.length > 0) {
+      if (reasoning && reasoning !== text) {
+        pushAssistantThinkingMessage(messages, nextIdRef, reasoning);
+      }
       if (text) {
         messages.push({
-          id: nextId,
+          id: nextIdRef.value,
           role: 'assistant',
           content: text,
           pending: false,
         });
-        nextId += 1;
+        nextIdRef.value += 1;
       }
 
       for (const toolCall of toolCalls) {
@@ -216,25 +279,30 @@ export function buildSubagentConversationSnapshots(
           });
         }
         messages.push({
-          id: nextId,
+          id: nextIdRef.value,
           role: 'assistant',
           content: '',
           tool,
           pending: phase === 'running' || phase === 'preview' || phase === 'pending-approval',
         });
-        nextId += 1;
+        nextIdRef.value += 1;
       }
       continue;
     }
 
     if (text) {
+      if (reasoning && reasoning !== text) {
+        pushAssistantThinkingMessage(messages, nextIdRef, reasoning);
+      }
       messages.push({
-        id: nextId,
+        id: nextIdRef.value,
         role: 'assistant',
         content: text,
         pending: false,
       });
-      nextId += 1;
+      nextIdRef.value += 1;
+    } else if (reasoning) {
+      pushAssistantThinkingMessage(messages, nextIdRef, reasoning);
     }
   }
 


### PR DESCRIPTION
## Summary

- 新增 SubAgent 查看器：点击 run_subagent 工具卡进入与主会话相同 UI 的后台会话页（禁用发送），支持实时刷新与 blocked 时在查看器内审批。
- host 层从子会话 llmHistory / desktop 投影构建快照，IPC setSubagentViewerTarget 驱动 renderer 数据源切换。
- 新增子会话 desktop 消息投影与持久化，查看器 Thought 与主 Agent timeline 对齐；已完成会话优先保留含推理行的投影。
- 修复查看器打开竞态（IPC 完成前 active 导致 auto-close）、Thought 列表 key 冲突，以及子 Agent 工具卡/审批泄漏到主会话（仅 composer 审批卡 + run_subagent 卡）。

## Test plan

- [x] apps/desktop/test/host/subagent-viewer.test.mjs
- [x] apps/desktop/test/lib/conversation-list-scope.test.mjs
- [x] apps/desktop/test/lib/subagent-display.test.mjs
- [x] npm run build:electron
- [ ] 手动：run_subagent → 打开查看器 → Thought 可见；主会话无子工具卡；审批仅在 composer