### PR TITLE
docs: 重写 README 介绍产品与开发指南

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,140 @@
 <div align="center">
-  
-<img src="https://github.com/user-attachments/assets/fa10cc7d-381c-4a70-b4ab-d145ba1363f1" alt="Spirit Agent Readme Hero" />
+
+<img src="https://github.com/user-attachments/assets/fa10cc7d-381c-4a70-b4ab-d145ba1363f1" alt="Spirit Agent" />
 
 # Spirit Agent
 
-<p align="center">An Open Source AI Agent.</p>
+**An open-source AI agent built to multiply your productivity** — grounded in your workspace, equipped with real tools, and ready to plan, execute, and ship alongside you.
 
-> **Note:** This project is in a very early stage. Functionality may not always behave as expected.
+[Desktop app](#desktop) · [CLI](#cli) · [Agent Core](#agent-core) · [Development](#development)
+
+> This project is under active development. Behavior and APIs may change between releases.
+
 </div>
+
+## Overview
+
+Spirit Agent is a monorepo for a **tool-using coding agent** that runs against a real project root. The same runtime powers a native desktop workspace and a terminal UI. Shared logic lives in TypeScript packages; hosts add platform-specific execution, discovery, and UI.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Hosts                                                      │
+│  ┌──────────────────────┐    ┌──────────────────────────┐  │
+│  │  Desktop (Electron)  │    │  CLI (Rust + TUI)        │  │
+│  │  React UI, Git, PTY  │    │  Terminal-first workflow │  │
+│  └──────────┬───────────┘    └────────────┬─────────────┘  │
+│             │                              │                 │
+│             └──────────────┬───────────────┘                 │
+│                            ▼                                 │
+│              packages/host-internal                          │
+│              discovery, tools, workspace, extensions         │
+│                            │                                 │
+│                            ▼                                 │
+│              packages/agent-core                             │
+│              runtime, prompts, tool contracts, transports    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Agent Core
+
+[`packages/agent-core`](packages/agent-core) is the **single source of agent semantics** in this repository. Hosts consume it.
+
+### Runtime and modes
+
+- **Turn machine** — streaming assistant output, tool rounds, compaction, and context usage tracking.
+- **Agent / Plan / Ask modes** — full tool access, planning-only workflows, or read-only Q&A with edit tools stripped at the contract layer.
+- **Subagents** — `run_subagent` delegates focused work to child runs with their own tool surface.
+- **Loop control** — optional `finish_task` when multitask-style looping is enabled.
+- **Rewind-friendly history** — message archive formats designed for host-side rollback and resubmit.
+
+### Model transports
+
+Agent Core routes inference through multiple transports behind one runtime:
+
+| Transport | Typical providers |
+| --- | --- |
+| **OpenAI-compatible** | OpenAI, DeepSeek, Moonshot, MiniMax, Volcengine, custom endpoints |
+| **Open Responses** | OpenAI, xAI, Vercel AI Gateway, OpenRouter, Alibaba (Bailian) |
+| **Anthropic** | Claude via Messages API |
+
+Provider-native capabilities (for example web search on Open Responses, Alibaba built-in search and code interpreter) are injected through the request `tools` field.
+
+### Host tool contracts
+
+Built-in tools are defined once in Agent Core (name, description, JSON Schema). Hosts implement execution:
+
+- **Workspace** — `read_file`, `write_file` / `create_file` / `edit_file` / `delete_file`, `apply_patch` (V4A on supported transports), `glob`, `grep`, `list_directory_files`
+- **Shell** — `run_shell_command` with host-controlled approval
+- **Web** — `web_fetch`; search via provider tools or host search where configured
+- **Delegation** — `run_subagent`
+- **Planning** — `create_plan`, session TODO tools (`todo_list`, `todo_create`, `todo_update`, `todo_complete`)
+- **Multimodal** — `generate_image`, `generate_video`
+- **Dreams** — `dream_list`, `dream_read`, `dream_record`, `dream_update`, `dream_delete` for workspace memory summaries
+- **LSP** — language-server diagnostics surfaced after edits
+
+### System context assembly
+
+Agent Core owns how the model sees project context:
+
+- **Rules** — `AGENTS.md`, `.spirit/rule.md`, and user rule slots merged into system sections.
+- **Skills** — catalog and active-skill injection; hosts discover files on disk.
+- **MCP** — Model Context Protocol client, registry, and tool/resource/prompt bridging.
+- **Mode prompts** — Agent, Plan, and Ask boundaries without re-listing tools in system text.
+
+### Quality and evaluation
+
+- **Smoke suites** — contract, runtime, and live provider checks under `packages/agent-core/src/smoke`.
+- **Eval harness** — scenario comparison and judging for prompt or tool-definition changes (`npm run eval:compare` from the repo root).
+
+`@spirit-agent/core` is published to npm; [`packages/host-internal`](packages/host-internal) is private and holds shared host-side discovery, extensions, marketplace, workspace helpers, and LSP orchestration used by Desktop.
+
+## Desktop
+
+The [Desktop app](apps/desktop) is the primary graphical host: a workspace-bound IDE surface with a conversational agent.
+
+- **Docked panels** — file explorer with Monaco editor, embedded terminal (Electron), Git changes and history, in-app browser for local dev servers.
+- **Sessions** — multi-conversation history, worktree-per-session workflows, tool approval, subagent viewer, structured questionnaires, context usage, and rewind.
+- **Configuration** — model providers and API keys, Skills and Rules, MCP servers, extensions marketplace, Dreams (beta), LSP, themes, and UI locale (English / Simplified Chinese).
+- **Platforms** — Electron on Windows, macOS, and Linux; optional web host with remote pairing.
+
+See [apps/desktop/README.md](apps/desktop/README.md) for Desktop-specific development and layout.
+
+## CLI
+
+The [Rust CLI](apps/cli) (`spirit-agent`) provides a terminal-first host with an optional Ratatui UI. It shares the same Agent Core runtime via the Node bridge and suits scripting, SSH sessions, and minimal environments.
+
+```bash
+npm run dev:cli    # build TS packages, then cargo run -p spirit-agent
+```
+
+## Development
+
+**Requirements:** Node.js 22+, npm. Rust toolchain required for CLI builds.
+
+| Command | Description |
+| --- | --- |
+| `npm run dev:desktop` | Build shared packages and start Desktop (Vite + Electron) |
+| `npm run dev:desktop:web` | Desktop renderer with browser web host |
+| `npm run dev:cli` | CLI with TUI |
+| `npm run build` | Production build of agent-core, host-internal, and Desktop |
+| `npm run eval:compare` | Run eval comparison after agent-core changes |
+
+### Repository layout
+
+```
+apps/
+  desktop/           Electron + React host
+  cli/               Rust CLI and TUI
+packages/
+  agent-core/        Agent runtime, prompts, tool definitions, transports, MCP, eval
+  host-internal/     Shared host discovery, tools, extensions, LSP helpers
+scripts/             Release, eval, and repo automation
+```
+
+## Contributing
+
+Read [AGENTS.md](AGENTS.md) and [`.github/copilot-instructions.md`](.github/copilot-instructions.md) for architecture boundaries, commit conventions, and agent-core change guidelines.
+
+## License
+
+[MIT](LICENSE)

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,3 +1,99 @@
 # Spirit Agent Desktop
 
-WIP
+**An AI agent built to multiply your productivity** — a native desktop workspace where models read your repo, run tools, and ship changes alongside you.
+
+Spirit Agent Desktop is the graphical host for [Spirit Agent](https://github.com/N123999/SpiritAgent). It pairs a conversational agent with an integrated development surface: file explorer, terminal, Git panel, in-app browser, and Monaco-based editor — all bound to a workspace root so context stays grounded in your project.
+
+## Features
+
+### Conversational agent
+
+- **Agent, Plan, and Ask modes** — full tool access, planning-only workflows, or read-only Q&A.
+- **Multi-session history** — open, switch, and delete saved conversations per workspace.
+- **Tool approval** — review and allow, deny, or always-trust host tool calls before they run.
+- **Subagent viewer** — inspect delegated `run_subagent` runs in a dedicated overlay.
+- **Structured questionnaires** — answer clarifying questions when the host needs input to continue.
+- **Context usage** — see how much of the model context window the current thread consumes.
+- **Rewind** — roll back recent edits and resubmit from an earlier point in the conversation.
+
+### Workspace tools
+
+Docked panels attach to the active workspace:
+
+| Panel | Description |
+| --- | --- |
+| **Files** | Browse and edit workspace files; Markdown preview; plan files under `plans/`. |
+| **Shell** | Embedded PTY terminal (Electron only). |
+| **Git** | Working tree changes, commit history graph, commit / push / merge actions, and built-in `/git-commit`, `/git-push`, `/git-merge` skills. |
+| **Browser** | Probe local dev servers and browse pages inside the app (Electron only). |
+
+**Worktrees** — work in an isolated Git worktree per session; merge back when ready.
+
+### Configuration and extensibility
+
+- **Models** — configure inference providers, API keys, reasoning effort, and a lightweight background model.
+- **Skills and Rules** — discover workspace and user-level skills; manage Spirit rule slots (`AGENTS.md`, `.spirit/rule.md`, and user `rule.md`).
+- **MCP servers** — add stdio or HTTP Model Context Protocol servers from settings.
+- **Extensions** — import ZIP packages or install from the built-in marketplace; extensions can contribute tools, Desktop CSS, CLI hooks, and settings pages.
+- **Dreams** (beta) — background summarization of recent session trends for the current workspace and branch.
+- **LSP** — optional language-server diagnostics after file edits.
+- **Appearance** — theme, font, and UI locale (English / Simplified Chinese).
+
+### Platform
+
+- **Electron shell** — native window, system notifications, title-bar integration, and OS terminal fallback.
+- **Web host** — optional browser-based UI with remote pairing (`npm run dev:web`).
+- **Packaged builds** — produce installable artifacts via `electron-builder`.
+
+## Requirements
+
+- **Node.js** 22 or newer
+- **npm** (comes with Node)
+- **Rust toolchain** — only when building the CLI from the monorepo root; not required for Desktop-only development after dependencies are built
+- **Windows, macOS, or Linux** — Electron targets all three; some features (embedded shell, in-app browser) require the Electron shell
+
+## Development
+
+From the repository root:
+
+```bash
+npm run dev:desktop
+```
+
+This builds shared packages (`agent-core`, `host-internal`), starts the Vite renderer on `http://127.0.0.1:1420`, and launches Electron.
+
+From `apps/desktop`:
+
+```bash
+npm install
+npm run dev          # Electron + hot-reload renderer
+npm run dev:web      # Browser UI + local web host
+```
+
+Other useful scripts:
+
+```bash
+npm run build        # Production renderer + Electron main/preload
+npm run dist         # Build and package installers (electron-builder)
+npm run test:lib     # Renderer/unit tests
+npm run test:host    # Host service tests
+```
+
+## Project layout
+
+```
+apps/desktop/
+  electron/          # Main process, preload, PTY, notifications, browser views
+  src/               # React renderer (Vite + Tailwind)
+  builtin-skills/    # Seeded git-commit / git-push / git-merge skills
+  scripts/           # Build helpers, icon generation
+```
+
+Shared logic lives in monorepo packages:
+
+- `packages/agent-core` — agent runtime, tool definitions, prompts
+- `packages/host-internal` — host contracts, workspace/git helpers
+
+## License
+
+See the [repository root LICENSE](https://github.com/N123999/SpiritAgent/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- Rewrite the root README with Hero, monorepo architecture, and Agent Core capabilities (runtime, transports, host tools, MCP/Skills/Rules).
- Replace the Desktop README WIP placeholder with product positioning, feature overview, requirements, and development instructions.

## Test plan

- [ ] Open root README.md and apps/desktop/README.md on GitHub and verify Markdown rendering.
- [ ] Confirm internal anchor links (Desktop, CLI, Agent Core, Development) resolve correctly.