### PR TITLE
feat(desktop): 新增 Agent 忙碌时用户消息队列

### DIFF
--- a/apps/desktop/electron/http-host.ts
+++ b/apps/desktop/electron/http-host.ts
@@ -838,6 +838,48 @@ async function handleApiRequest({
     return;
   }
 
+  if (request.method === 'POST' && pathname === '/api/queue/reorder') {
+    writeJson(
+      request,
+      response,
+      200,
+      await runHostCommand('reorderQueuedUserTurn', {
+        request: {
+          queueId: typeof jsonBody?.queueId === 'string' ? jsonBody.queueId : '',
+        },
+      }),
+    );
+    return;
+  }
+
+  if (request.method === 'POST' && pathname === '/api/queue/send-now') {
+    writeJson(
+      request,
+      response,
+      200,
+      await runHostCommand('sendQueuedUserTurnNow', {
+        request: {
+          queueId: typeof jsonBody?.queueId === 'string' ? jsonBody.queueId : '',
+        },
+      }),
+    );
+    return;
+  }
+
+  if (request.method === 'POST' && pathname === '/api/queue/remove') {
+    writeJson(
+      request,
+      response,
+      200,
+      await runHostCommand('removeQueuedUserTurn', {
+        request: {
+          queueId: typeof jsonBody?.queueId === 'string' ? jsonBody.queueId : '',
+        },
+      }),
+    );
+    return;
+  }
+
   if (request.method === 'POST' && pathname === '/api/poll') {
     writeJson(request, response, 200, await runHostCommand('poll'));
     return;

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -140,6 +140,15 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   rewindAndSubmitMessage(request: unknown) {
     return ipcRenderer.invoke('desktop:invoke', 'rewindAndSubmitMessage', { request });
   },
+  reorderQueuedUserTurn(request: unknown) {
+    return ipcRenderer.invoke('desktop:invoke', 'reorderQueuedUserTurn', { request });
+  },
+  sendQueuedUserTurnNow(request: unknown) {
+    return ipcRenderer.invoke('desktop:invoke', 'sendQueuedUserTurnNow', { request });
+  },
+  removeQueuedUserTurn(request: unknown) {
+    return ipcRenderer.invoke('desktop:invoke', 'removeQueuedUserTurn', { request });
+  },
   poll() {
     return ipcRenderer.invoke('desktop:invoke', 'poll');
   },

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1110,17 +1110,28 @@ function ComposerSurface({
               <span className="px-1 text-xs text-muted-foreground">{t('app.noModelsAvailable')}</span>
             )}
           </div>
+          {(() => {
+            const hasComposerPayload =
+              value.trim().length > 0 || localFileAttachments.length > 0;
+            const showAbortButton = canAbort && Boolean(onAbort) && !hasComposerPayload;
+            return (
           <Button
             type="button"
             className={cn(
               "size-8 shrink-0 rounded-full p-0 shadow-none [&_svg]:size-3.5",
               instantHoverMotionClass,
             )}
-            onClick={canAbort ? onAbort : onSubmit}
-            disabled={canAbort ? false : !canSend || busy}
-            title={canAbort ? t('app.abort') : t('app.send')}
+            onClick={showAbortButton ? onAbort : onSubmit}
+            disabled={showAbortButton ? false : !canSend || (busy && !canAbort)}
+            title={
+              showAbortButton
+                ? t('app.abort')
+                : canAbort && hasComposerPayload
+                  ? t('composer.enqueueWhileBusy')
+                  : t('app.send')
+            }
           >
-            {canAbort ? (
+            {showAbortButton ? (
               <Square className="size-3.5" strokeWidth={2.4} aria-hidden />
             ) : busy ? (
               <LoaderCircle className="size-3.5 animate-spin" />
@@ -1128,6 +1139,8 @@ function ComposerSurface({
               <ArrowUp className="size-3.5" strokeWidth={2.25} aria-hidden />
             )}
           </Button>
+            );
+          })()}
         </div>
       </div>
     </div>
@@ -1435,7 +1448,8 @@ function MessageCard({
 }) {
   const { t } = useTranslation();
   const isUser = message.role === "user";
-  const canStartRewind = isUser && message.canRewind === true && !message.pending;
+  const canStartRewind =
+    isUser && message.canRewind === true && !message.pending && message.queued !== true;
   const userBubble =
     "rounded-2xl rounded-br-md border border-border/50 bg-muted px-3 py-2.5 shadow-sm";
   const subagentStatusSurface =
@@ -1540,6 +1554,7 @@ function MessageCard({
             message={message}
             userBubbleClassName={userBubble}
             canStartRewind={canStartRewind}
+            queued={message.queued === true}
             onRewindStart={() => onRewindStart(message, listIndex)}
             readLocalImagePreviewDataUrl={readLocalImagePreviewDataUrl}
           />
@@ -2110,14 +2125,17 @@ export default function App() {
         : t("app.typeMessage");
   const conversationInterruptible = runtime.summary.canInterrupt && !runtime.busyAction;
   const continueBusy = Boolean(runtime.busyAction) || snapshot?.conversation.isBusy === true;
+  const composerHasPayload =
+    Boolean(runtime.composer.trim()) || runtime.composerLocalFileAttachments.length > 0;
   const composerCanSend =
     !compactionDemo.active &&
     !subagentViewActive &&
-    (Boolean(runtime.composer.trim()) || runtime.composerLocalFileAttachments.length > 0) &&
+    composerHasPayload &&
     !activeSessionReadOnly &&
     runtime.busyAction !== "session" &&
     !pendingApproval &&
     !pendingQuestions &&
+    (runtime.summary.canSend || conversationInterruptible) &&
     !(runtime.busyAction === "send" && !conversationInterruptible);
   const startImplementingDisabled =
     !snapshot?.runtimeReady ||

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -151,6 +151,7 @@ import {
 import { WorkspaceFileReferenceMenu } from "@/components/workspace-file-reference-menu";
 import { ActionPickerDialog } from "@/components/action-picker-dialog";
 import { WorkspaceFilePickerDialog } from "@/components/workspace-file-picker-dialog";
+import { QueuedUserMessageHoverActions } from "@/components/queued-user-message-hover-actions";
 import { UserMessageBubble } from "@/components/user-message-bubble";
 import { useCompactionUiDemo } from "@/hooks/useCompactionUiDemo";
 import { useElementBoxHeight } from "@/hooks/use-element-box-height";
@@ -1404,6 +1405,11 @@ function MessageCard({
   readLocalVideoPreviewUrl,
   saveLocalImageAs,
   onOpenSubagentViewer,
+  queuedCanMoveUp = false,
+  queueActionBusy = false,
+  onQueueMoveUp,
+  onQueueSendNow,
+  onQueueDelete,
 }: {
   composerSessionKey: string;
   conversationListScopeKey: string;
@@ -1445,9 +1451,15 @@ function MessageCard({
   readLocalVideoPreviewUrl: ReadLocalVideoPreview;
   saveLocalImageAs: SaveLocalImageAs;
   onOpenSubagentViewer?: (toolCallId: string) => void;
+  queuedCanMoveUp?: boolean;
+  queueActionBusy?: boolean;
+  onQueueMoveUp?(queueId: string): void;
+  onQueueSendNow?(queueId: string): void;
+  onQueueDelete?(queueId: string): void;
 }) {
   const { t } = useTranslation();
   const isUser = message.role === "user";
+  const isQueuedUser = isUser && message.queued === true && typeof message.queueId === "string";
   const canStartRewind =
     isUser && message.canRewind === true && !message.pending && message.queued !== true;
   const userBubble =
@@ -1550,14 +1562,34 @@ function MessageCard({
           />
         ) : null}
         {isUser && !rewindSelected ? (
-          <UserMessageBubble
-            message={message}
-            userBubbleClassName={userBubble}
-            canStartRewind={canStartRewind}
-            queued={message.queued === true}
-            onRewindStart={() => onRewindStart(message, listIndex)}
-            readLocalImagePreviewDataUrl={readLocalImagePreviewDataUrl}
-          />
+          isQueuedUser && message.queueId && onQueueMoveUp && onQueueSendNow && onQueueDelete ? (
+            <QueuedUserMessageHoverActions
+              queueId={message.queueId}
+              canMoveUp={queuedCanMoveUp}
+              busy={queueActionBusy}
+              onMoveUp={onQueueMoveUp}
+              onSendNow={onQueueSendNow}
+              onDelete={onQueueDelete}
+            >
+              <UserMessageBubble
+                message={message}
+                userBubbleClassName={userBubble}
+                canStartRewind={false}
+                queued
+                onRewindStart={() => onRewindStart(message, listIndex)}
+                readLocalImagePreviewDataUrl={readLocalImagePreviewDataUrl}
+              />
+            </QueuedUserMessageHoverActions>
+          ) : (
+            <UserMessageBubble
+              message={message}
+              userBubbleClassName={userBubble}
+              canStartRewind={canStartRewind}
+              queued={message.queued === true}
+              onRewindStart={() => onRewindStart(message, listIndex)}
+              readLocalImagePreviewDataUrl={readLocalImagePreviewDataUrl}
+            />
+          )
         ) : null}
         {!isUser && message.content.trim() ? (
           subagentStatusSurface ? (
@@ -3325,6 +3357,11 @@ export default function App() {
                           const previous = messages[index - 1];
                           const compactAfterPrevious = shouldCompactAfterPreviousMessage(previous, message);
                           const tightenAfterPreviousMeta = shouldTightenAfterPreviousMetaMessage(previous, message);
+                          const queuedBeforeCount = messages
+                            .slice(0, index)
+                            .filter((item) => item.queued === true).length;
+                          const queuedCanMoveUp =
+                            message.queued === true && queuedBeforeCount > 0;
                           return (
                             <MessageCard
                               key={conversationMessageStableId(message, composerSessionKey, conversationListScopeKey)}
@@ -3404,6 +3441,17 @@ export default function App() {
                               onOpenSubagentViewer={
                                 subagentViewActive ? undefined : handleOpenSubagentViewer
                               }
+                              queuedCanMoveUp={queuedCanMoveUp}
+                              queueActionBusy={runtime.busyAction === "send"}
+                              onQueueMoveUp={(queueId) => {
+                                void runtime.reorderQueuedUserTurn(queueId);
+                              }}
+                              onQueueSendNow={(queueId) => {
+                                void runtime.sendQueuedUserTurnNow(queueId);
+                              }}
+                              onQueueDelete={(queueId) => {
+                                void runtime.removeQueuedUserTurn(queueId);
+                              }}
                             />
                           );
                         })}

--- a/apps/desktop/src/adapters/electron.ts
+++ b/apps/desktop/src/adapters/electron.ts
@@ -147,6 +147,15 @@ export async function createElectronHostApi(): Promise<HostApi> {
     rewindAndSubmitMessage(request) {
       return bridge.rewindAndSubmitMessage(request);
     },
+    reorderQueuedUserTurn(request) {
+      return bridge.reorderQueuedUserTurn(request);
+    },
+    sendQueuedUserTurnNow(request) {
+      return bridge.sendQueuedUserTurnNow(request);
+    },
+    removeQueuedUserTurn(request) {
+      return bridge.removeQueuedUserTurn(request);
+    },
     poll() {
       return bridge.poll();
     },

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -31,6 +31,7 @@ import type {
   PreviewModelsRequest,
   PreviewModelsResponse,
   QueryWorkspaceFileReferenceSuggestionsRequest,
+  QueuedUserTurnRequest,
   RewindAndSubmitMessageRequest,
   SessionListItem,
   WorkspaceExplorerListResult,
@@ -198,6 +199,15 @@ export function createWebHostApi(): HostApi {
     },
     rewindAndSubmitMessage(request: RewindAndSubmitMessageRequest) {
       return post<DesktopSnapshot>(baseUrl, '/api/rewind-submit', request);
+    },
+    reorderQueuedUserTurn(request: QueuedUserTurnRequest) {
+      return post<DesktopSnapshot>(baseUrl, '/api/queue/reorder', request);
+    },
+    sendQueuedUserTurnNow(request: QueuedUserTurnRequest) {
+      return post<DesktopSnapshot>(baseUrl, '/api/queue/send-now', request);
+    },
+    removeQueuedUserTurn(request: QueuedUserTurnRequest) {
+      return post<DesktopSnapshot>(baseUrl, '/api/queue/remove', request);
     },
     poll() {
       return post<DesktopSnapshot>(baseUrl, '/api/poll');

--- a/apps/desktop/src/components/queued-user-message-hover-actions.tsx
+++ b/apps/desktop/src/components/queued-user-message-hover-actions.tsx
@@ -1,0 +1,111 @@
+import type { ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ArrowUp, Send, Trash2 } from 'lucide-react';
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card';
+import {
+  DESKTOP_OVERLAY_SHORT_ITEM,
+  DESKTOP_OVERLAY_SHORT_LIST_GAP,
+  DESKTOP_OVERLAY_SHORT_LIST_PADDING,
+  DESKTOP_OVERLAY_SHORT_SHELL,
+} from '@/lib/desktop-chrome';
+import { cn } from '@/lib/utils';
+
+type QueuedUserMessageHoverActionsProps = {
+  queueId: string;
+  canMoveUp: boolean;
+  busy?: boolean;
+  onMoveUp(queueId: string): void | Promise<void>;
+  onSendNow(queueId: string): void | Promise<void>;
+  onDelete(queueId: string): void | Promise<void>;
+  children: ReactNode;
+};
+
+type QueueActionButtonProps = {
+  disabled?: boolean;
+  icon: ReactNode;
+  label: string;
+  onClick(): void;
+};
+
+function QueueActionButton({ disabled = false, icon, label, onClick }: QueueActionButtonProps) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      className={cn(
+        'flex w-full cursor-pointer select-none items-center gap-2 rounded-sm text-left outline-none',
+        DESKTOP_OVERLAY_SHORT_ITEM,
+        'text-popover-foreground hover:bg-accent hover:text-accent-foreground',
+        'focus-visible:bg-accent focus-visible:text-accent-foreground',
+        'disabled:pointer-events-none disabled:opacity-50',
+      )}
+      onClick={onClick}
+    >
+      {icon}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+    </button>
+  );
+}
+
+export function QueuedUserMessageHoverActions({
+  queueId,
+  canMoveUp,
+  busy = false,
+  onMoveUp,
+  onSendNow,
+  onDelete,
+  children,
+}: QueuedUserMessageHoverActionsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
+        <div className="inline-flex max-w-full">{children}</div>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="left"
+        align="end"
+        sideOffset={8}
+        className={cn(DESKTOP_OVERLAY_SHORT_SHELL, 'w-44 p-0')}
+        aria-label={t('queue.actionsAria')}
+      >
+        <div
+          role="menu"
+          className={cn('flex flex-col', DESKTOP_OVERLAY_SHORT_LIST_PADDING, DESKTOP_OVERLAY_SHORT_LIST_GAP)}
+        >
+          <QueueActionButton
+            disabled={busy || !canMoveUp}
+            icon={<ArrowUp className="size-3.5 shrink-0" aria-hidden />}
+            label={t('queue.moveUp')}
+            onClick={() => {
+              void onMoveUp(queueId);
+            }}
+          />
+          <QueueActionButton
+            disabled={busy}
+            icon={<Send className="size-3.5 shrink-0" aria-hidden />}
+            label={t('queue.sendNow')}
+            onClick={() => {
+              void onSendNow(queueId);
+            }}
+          />
+          <QueueActionButton
+            disabled={busy}
+            icon={<Trash2 className="size-3.5 shrink-0" aria-hidden />}
+            label={t('queue.delete')}
+            onClick={() => {
+              void onDelete(queueId);
+            }}
+          />
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/apps/desktop/src/components/queued-user-message-hover-actions.tsx
+++ b/apps/desktop/src/components/queued-user-message-hover-actions.tsx
@@ -65,7 +65,7 @@ export function QueuedUserMessageHoverActions({
   const { t } = useTranslation();
 
   return (
-    <HoverCard openDelay={150} closeDelay={100}>
+    <HoverCard openDelay={50} closeDelay={80}>
       <HoverCardTrigger asChild>
         <div className="inline-flex max-w-full">{children}</div>
       </HoverCardTrigger>

--- a/apps/desktop/src/components/user-message-bubble.tsx
+++ b/apps/desktop/src/components/user-message-bubble.tsx
@@ -59,6 +59,7 @@ type UserMessageBubbleProps = {
   message: ConversationMessageSnapshot;
   userBubbleClassName: string;
   canStartRewind: boolean;
+  queued?: boolean;
   onRewindStart(): void;
   readLocalImagePreviewDataUrl: ReadLocalImagePreview;
 };
@@ -67,6 +68,7 @@ export function UserMessageBubble({
   message,
   userBubbleClassName,
   canStartRewind,
+  queued = false,
   onRewindStart,
   readLocalImagePreviewDataUrl,
 }: UserMessageBubbleProps) {
@@ -99,7 +101,9 @@ export function UserMessageBubble({
     return null;
   }
 
-  const rewindBubbleClassName = cn(
+  const bubbleClassName = cn(
+    userBubbleClassName,
+    queued && "opacity-60",
     canStartRewind &&
       "cursor-pointer transition-colors hover:bg-muted/80 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none",
   );
@@ -116,7 +120,7 @@ export function UserMessageBubble({
       {showText ? (
         <div
           data-spirit-surface="message-bubble"
-          className={cn(userBubbleClassName, rewindBubbleClassName)}
+          className={bubbleClassName}
           role={canStartRewind ? "button" : undefined}
           tabIndex={canStartRewind ? 0 : undefined}
           onClick={canStartRewind ? onRewindStart : undefined}
@@ -143,7 +147,8 @@ export function UserMessageBubble({
       ) : null}
       {hasAttachments ? (
         <div
-          className={cn("w-full", !showText && rewindBubbleClassName)}
+          className={cn("w-full", !showText && queued && "opacity-60", !showText && canStartRewind &&
+            "cursor-pointer transition-colors hover:bg-muted/80 focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none")}
           role={!showText && canStartRewind ? "button" : undefined}
           tabIndex={!showText && canStartRewind ? 0 : undefined}
           onClick={!showText && canStartRewind ? onRewindStart : undefined}

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -96,6 +96,9 @@ declare global {
     abortConversation(): Promise<DesktopSnapshot>;
     continueAssistantCompletion(messageId: number): Promise<DesktopSnapshot>;
     rewindAndSubmitMessage(request: RewindAndSubmitMessageRequest): Promise<DesktopSnapshot>;
+    reorderQueuedUserTurn(request: import('./types.js').QueuedUserTurnRequest): Promise<DesktopSnapshot>;
+    sendQueuedUserTurnNow(request: import('./types.js').QueuedUserTurnRequest): Promise<DesktopSnapshot>;
+    removeQueuedUserTurn(request: import('./types.js').QueuedUserTurnRequest): Promise<DesktopSnapshot>;
     poll(): Promise<DesktopSnapshot>;
     setSubagentViewerTarget(parentToolCallId: string | null): Promise<DesktopSnapshot>;
     listDreamsOverview(): Promise<DesktopDreamOverviewItem[]>;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -2045,6 +2045,70 @@ export function useDesktopRuntime() {
     [api, applySnapshot, refreshSessions],
   );
   
+  const reorderQueuedUserTurn = useCallback(
+    async (queueId: string): Promise<boolean> => {
+      if (!api) {
+        return false;
+      }
+      setBusyAction('send');
+      try {
+        const next = await api.reorderQueuedUserTurn({ queueId });
+        applySnapshot(next);
+        setRuntimeError('');
+        return true;
+      } catch (error) {
+        setRuntimeError(describeError(error));
+        return false;
+      } finally {
+        setBusyAction('');
+      }
+    },
+    [api, applySnapshot],
+  );
+
+  const sendQueuedUserTurnNow = useCallback(
+    async (queueId: string): Promise<boolean> => {
+      if (!api) {
+        return false;
+      }
+      setBusyAction('send');
+      try {
+        const next = await api.sendQueuedUserTurnNow({ queueId });
+        applySnapshot(next);
+        setRuntimeError('');
+        void refreshSessions();
+        return true;
+      } catch (error) {
+        setRuntimeError(describeError(error));
+        return false;
+      } finally {
+        setBusyAction('');
+      }
+    },
+    [api, applySnapshot, refreshSessions],
+  );
+
+  const removeQueuedUserTurn = useCallback(
+    async (queueId: string): Promise<boolean> => {
+      if (!api) {
+        return false;
+      }
+      setBusyAction('send');
+      try {
+        const next = await api.removeQueuedUserTurn({ queueId });
+        applySnapshot(next);
+        setRuntimeError('');
+        return true;
+      } catch (error) {
+        setRuntimeError(describeError(error));
+        return false;
+      } finally {
+        setBusyAction('');
+      }
+    },
+    [api, applySnapshot],
+  );
+
   const rewindAndSubmitMessage = useCallback(
     async (request: RewindAndSubmitMessageRequest): Promise<boolean> => {
       if (!api) {
@@ -2493,6 +2557,9 @@ export function useDesktopRuntime() {
     pairWebHost,
     resetSession,
     rewindAndSubmitMessage,
+    reorderQueuedUserTurn,
+    sendQueuedUserTurnNow,
+    removeQueuedUserTurn,
     saveSettingsPatch,
     resetWebHostPairing,
     installLspProvider,

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1746,22 +1746,17 @@ export function useDesktopRuntime() {
       return false;
     }
 
-    const interruptible =
+    const canEnqueueWhileBusy =
       snapshot?.conversation.isBusy === true &&
       !snapshot.conversation.pendingToolApproval &&
       !snapshot.conversation.pendingQuestions;
-    if (snapshot?.conversation.isBusy && !interruptible) {
+    if (snapshot?.conversation.isBusy && !canEnqueueWhileBusy) {
       setRuntimeError(i18n.t('error.pendingApprovalSend'));
       return false;
     }
 
     setBusyAction("send");
     try {
-      if (interruptible) {
-        const aborted = await api.abortConversation();
-        applySnapshot(aborted);
-      }
-
       const skillSlash = snapshot ? matchSkillSlashInput(text, snapshot.skillsList) : undefined;
       if (
         hasLocalFiles &&
@@ -2342,17 +2337,19 @@ export function useDesktopRuntime() {
   }, [api, applySnapshot, refreshSessions, restoreSessionUi, stashSessionUi]);
 
   const summary = useMemo(() => {
+    const canEnqueueWhileBusy =
+      !!snapshot?.runtimeReady &&
+      !!snapshot.conversation.isBusy &&
+      !snapshot.conversation.pendingToolApproval &&
+      !snapshot.conversation.pendingQuestions;
     return {
       canSend:
         !!snapshot?.runtimeReady &&
         !snapshot.conversation.isBusy &&
         !snapshot.conversation.pendingToolApproval &&
         !snapshot.conversation.pendingQuestions,
-      canInterrupt:
-        !!snapshot?.runtimeReady &&
-        !!snapshot.conversation.isBusy &&
-        !snapshot.conversation.pendingToolApproval &&
-        !snapshot.conversation.pendingQuestions,
+      canEnqueueWhileBusy,
+      canInterrupt: canEnqueueWhileBusy,
       hostStatus: hostError
         ? hostError
         : hostReady

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -34,6 +34,7 @@ import type {
   PreviewModelsResponse,
   QueryWorkspaceFileReferenceSuggestionsRequest,
   RememberWorkspaceRequest,
+  QueuedUserTurnRequest,
   RewindAndSubmitMessageRequest,
   SubmitUserTurnRequest,
   SessionListItem,
@@ -105,6 +106,9 @@ export interface HostApi {
   abortConversation(): Promise<DesktopSnapshot>;
   continueAssistantCompletion(messageId: number): Promise<DesktopSnapshot>;
   rewindAndSubmitMessage(request: RewindAndSubmitMessageRequest): Promise<DesktopSnapshot>;
+  reorderQueuedUserTurn(request: QueuedUserTurnRequest): Promise<DesktopSnapshot>;
+  sendQueuedUserTurnNow(request: QueuedUserTurnRequest): Promise<DesktopSnapshot>;
+  removeQueuedUserTurn(request: QueuedUserTurnRequest): Promise<DesktopSnapshot>;
   poll(): Promise<DesktopSnapshot>;
   setSubagentViewerTarget(parentToolCallId: string | null): Promise<DesktopSnapshot>;
   listDreamsOverview(): Promise<DesktopDreamOverviewItem[]>;

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -77,6 +77,9 @@ export type HostCommandName =
   | 'writeHostTextFile'
   | 'statHostTextFile'
   | 'rewindAndSubmitMessage'
+  | 'reorderQueuedUserTurn'
+  | 'sendQueuedUserTurnNow'
+  | 'removeQueuedUserTurn'
   | 'setSubagentViewerTarget';
 
 /** 与 `apps/cli/src/tool_runtime.rs` 中 `ToolRequest` 对齐的宿主工具请求。 */
@@ -97,6 +100,7 @@ export interface StoredDesktopSession extends ChatArchive {
   approvalLevel?: ApprovalLevel;
   contextUsage?: ConversationContextUsageSnapshot;
   subagentDesktopMessages?: Record<string, ConversationMessageSnapshot[]>;
+  queuedUserTurns?: import('./message-queue.js').QueuedUserTurn[];
 }
 
 export type DesktopHostCommitRequest = CommitChangesRequest;

--- a/apps/desktop/src/host/host-command-payloads.ts
+++ b/apps/desktop/src/host/host-command-payloads.ts
@@ -28,6 +28,7 @@ import type {
   RememberWorkspaceRequest,
   RemoveModelRequest,
   RemoveProviderModelsRequest,
+  QueuedUserTurnRequest,
   RewindAndSubmitMessageRequest,
   RunExtensionRequest,
   SubmitCreateRuleSlashRequest,
@@ -109,5 +110,8 @@ export type CommandPayloads = {
   writeHostTextFile: { request: WriteHostTextFileRequest };
   statHostTextFile: { absolutePath: string };
   rewindAndSubmitMessage: { request: RewindAndSubmitMessageRequest };
+  reorderQueuedUserTurn: { request: QueuedUserTurnRequest };
+  sendQueuedUserTurnNow: { request: QueuedUserTurnRequest };
+  removeQueuedUserTurn: { request: QueuedUserTurnRequest };
   setSubagentViewerTarget: { parentToolCallId: string | null };
 };

--- a/apps/desktop/src/host/host-invoke-dispatch.ts
+++ b/apps/desktop/src/host/host-invoke-dispatch.ts
@@ -72,6 +72,9 @@ export interface HostCommandDelegate {
   writeHostTextFile(request: CommandPayloads['writeHostTextFile']['request']): Promise<unknown>;
   statHostTextFile(absolutePath: string): Promise<unknown>;
   rewindAndSubmitMessage(request: CommandPayloads['rewindAndSubmitMessage']['request']): Promise<unknown>;
+  reorderQueuedUserTurn(request: CommandPayloads['reorderQueuedUserTurn']['request']): Promise<unknown>;
+  sendQueuedUserTurnNow(request: CommandPayloads['sendQueuedUserTurnNow']['request']): Promise<unknown>;
+  removeQueuedUserTurn(request: CommandPayloads['removeQueuedUserTurn']['request']): Promise<unknown>;
   setSubagentViewerTarget(parentToolCallId: string | null): Promise<unknown>;
 }
 
@@ -148,6 +151,9 @@ const hostCommandDispatch = {
   writeHostTextFile: (host, payload) => host.writeHostTextFile(payload.request),
   statHostTextFile: (host, payload) => host.statHostTextFile(payload.absolutePath),
   rewindAndSubmitMessage: (host, payload) => host.rewindAndSubmitMessage(payload.request),
+  reorderQueuedUserTurn: (host, payload) => host.reorderQueuedUserTurn(payload.request),
+  sendQueuedUserTurnNow: (host, payload) => host.sendQueuedUserTurnNow(payload.request),
+  removeQueuedUserTurn: (host, payload) => host.removeQueuedUserTurn(payload.request),
   setSubagentViewerTarget: (host, payload) => host.setSubagentViewerTarget(payload.parentToolCallId),
 } satisfies { [Command in HostCommandName]: HostCommandHandler<Command> };
 

--- a/apps/desktop/src/host/message-queue.ts
+++ b/apps/desktop/src/host/message-queue.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import type { PendingWorkspaceFile } from '@spirit-agent/core';
+
+import i18n from '../lib/i18n-host.js';
+import type { ConversationMessageSnapshot, DesktopSnapshot } from '../types.js';
+import { isSessionBundleBusy } from './direct-media-turn.js';
+import type { SessionBundle } from './session-bundle.js';
+import type { SessionTurnOrchestratorContext } from './session-turn-orchestrator.js';
+
+export interface QueuedUserTurn {
+  queueId: string;
+  messageId: number;
+  text: string;
+  displayText: string;
+  explicitWorkspaceFiles?: PendingWorkspaceFile[];
+  localFileAttachments?: ConversationMessageSnapshot['localFileAttachments'];
+  enqueuedAtUnixMs: number;
+}
+
+export function isSessionBundleQueueBlocked(bundle: SessionBundle): boolean {
+  const runtime = bundle.runtime;
+  if (!runtime) {
+    return false;
+  }
+  return (
+    runtime.currentPendingApproval() !== undefined ||
+    runtime.currentPendingQuestions() !== undefined
+  );
+}
+
+export function canEnqueueUserTurn(bundle: SessionBundle): boolean {
+  if (bundle.activeSession?.readOnly === true) {
+    return false;
+  }
+  if (!isSessionBundleBusy(bundle)) {
+    return false;
+  }
+  if (isSessionBundleQueueBlocked(bundle)) {
+    return false;
+  }
+  return true;
+}
+
+export function projectQueuedUserTurnSnapshots(
+  queued: readonly QueuedUserTurn[],
+): ConversationMessageSnapshot[] {
+  return queued.map((item) => ({
+    id: item.messageId,
+    role: 'user',
+    content: item.displayText,
+    pending: false,
+    queued: true,
+    ...(item.localFileAttachments?.length ? { localFileAttachments: item.localFileAttachments } : {}),
+  }));
+}
+
+export function appendQueuedUserTurnSnapshots(
+  messages: ConversationMessageSnapshot[],
+  queued: readonly QueuedUserTurn[],
+): ConversationMessageSnapshot[] {
+  if (queued.length === 0) {
+    return messages;
+  }
+  return [...messages, ...projectQueuedUserTurnSnapshots(queued)];
+}
+
+function defaultDisplayTextForQueuedTurn(
+  text: string,
+  explicitWorkspaceFiles: readonly PendingWorkspaceFile[],
+): string {
+  const trimmed = text.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  if (explicitWorkspaceFiles.length === 0) {
+    return '';
+  }
+  return i18n.t('error.attachedFiles', {
+    files: explicitWorkspaceFiles.map((file) => path.basename(file.path)).join(', '),
+  });
+}
+
+function pendingWorkspaceFilesToAttachmentSnapshots(
+  files: readonly PendingWorkspaceFile[],
+): ConversationMessageSnapshot['localFileAttachments'] {
+  return files.map((file) => ({
+    path: file.path,
+    name: path.basename(file.path),
+    isImage: file.kind === 'image',
+  }));
+}
+
+export interface EnqueueUserTurnInput {
+  text: string;
+  explicitWorkspaceFiles?: PendingWorkspaceFile[];
+  displayText?: string;
+}
+
+export async function enqueueUserTurnCommand(
+  ctx: SessionTurnOrchestratorContext,
+  input: EnqueueUserTurnInput,
+): Promise<DesktopSnapshot> {
+  const bundle = ctx.activeBundle();
+  const explicitWorkspaceFiles = input.explicitWorkspaceFiles ?? [];
+  const trimmed = input.text.trim();
+  if (!trimmed && explicitWorkspaceFiles.length === 0) {
+    throw new Error(i18n.t('error.messageRequired'));
+  }
+  if (bundle.activeSession?.readOnly === true) {
+    throw new Error(i18n.t('error.readonlySessionSend'));
+  }
+  if (!canEnqueueUserTurn(bundle)) {
+    throw new Error(i18n.t('error.pendingApprovalSend'));
+  }
+
+  const displayText = (
+    input.displayText ?? defaultDisplayTextForQueuedTurn(input.text, explicitWorkspaceFiles)
+  ).trim();
+  if (!displayText) {
+    throw new Error(i18n.t('error.messageRequired'));
+  }
+
+  const localFileAttachments =
+    explicitWorkspaceFiles.length > 0
+      ? pendingWorkspaceFilesToAttachmentSnapshots(explicitWorkspaceFiles)
+      : undefined;
+
+  const queuedItem: QueuedUserTurn = {
+    queueId: randomUUID(),
+    messageId: ctx.allocateMessageId(),
+    text: trimmed || input.text,
+    displayText,
+    ...(explicitWorkspaceFiles.length > 0
+      ? { explicitWorkspaceFiles: [...explicitWorkspaceFiles], localFileAttachments }
+      : {}),
+    enqueuedAtUnixMs: Date.now(),
+  };
+
+  bundle.queuedUserTurns.push(queuedItem);
+  await ctx.persistCurrentSessionIfNeeded();
+  return ctx.buildSnapshot();
+}
+
+export function findQueuedUserTurnIndex(bundle: SessionBundle, queueId: string): number {
+  return bundle.queuedUserTurns.findIndex((item) => item.queueId === queueId);
+}
+
+export function removeQueuedUserTurn(bundle: SessionBundle, queueId: string): QueuedUserTurn | undefined {
+  const index = findQueuedUserTurnIndex(bundle, queueId);
+  if (index < 0) {
+    return undefined;
+  }
+  const [removed] = bundle.queuedUserTurns.splice(index, 1);
+  return removed;
+}
+
+export function moveQueuedUserTurnUp(bundle: SessionBundle, queueId: string): boolean {
+  const index = findQueuedUserTurnIndex(bundle, queueId);
+  if (index <= 0) {
+    return false;
+  }
+  const queue = bundle.queuedUserTurns;
+  const previous = queue[index - 1];
+  queue[index - 1] = queue[index]!;
+  queue[index] = previous!;
+  return true;
+}
+
+export function explicitWorkspaceFilesFromQueuedItem(item: QueuedUserTurn): PendingWorkspaceFile[] {
+  return item.explicitWorkspaceFiles ? [...item.explicitWorkspaceFiles] : [];
+}
+
+export function peekNextQueuedUserTurn(bundle: SessionBundle): QueuedUserTurn | undefined {
+  return bundle.queuedUserTurns[0];
+}
+
+export function shiftNextQueuedUserTurn(bundle: SessionBundle): QueuedUserTurn | undefined {
+  return bundle.queuedUserTurns.shift();
+}
+
+export function canDrainQueuedUserTurn(bundle: SessionBundle): boolean {
+  return (
+    bundle.queuedUserTurns.length > 0 &&
+    !isSessionBundleBusy(bundle) &&
+    !isSessionBundleQueueBlocked(bundle)
+  );
+}

--- a/apps/desktop/src/host/message-queue.ts
+++ b/apps/desktop/src/host/message-queue.ts
@@ -52,6 +52,7 @@ export function projectQueuedUserTurnSnapshots(
     content: item.displayText,
     pending: false,
     queued: true,
+    queueId: item.queueId,
     ...(item.localFileAttachments?.length ? { localFileAttachments: item.localFileAttachments } : {}),
   }));
 }
@@ -154,6 +155,30 @@ export function removeQueuedUserTurn(bundle: SessionBundle, queueId: string): Qu
   }
   const [removed] = bundle.queuedUserTurns.splice(index, 1);
   return removed;
+}
+
+export async function reorderQueuedUserTurnCommand(
+  ctx: SessionTurnOrchestratorContext,
+  queueId: string,
+): Promise<DesktopSnapshot> {
+  const bundle = ctx.activeBundle();
+  if (!moveQueuedUserTurnUp(bundle, queueId)) {
+    throw new Error(i18n.t('error.queuedUserTurnNotFound'));
+  }
+  await ctx.persistCurrentSessionIfNeeded();
+  return ctx.buildSnapshot();
+}
+
+export async function removeQueuedUserTurnCommand(
+  ctx: SessionTurnOrchestratorContext,
+  queueId: string,
+): Promise<DesktopSnapshot> {
+  const bundle = ctx.activeBundle();
+  if (!removeQueuedUserTurn(bundle, queueId)) {
+    throw new Error(i18n.t('error.queuedUserTurnNotFound'));
+  }
+  await ctx.persistCurrentSessionIfNeeded();
+  return ctx.buildSnapshot();
 }
 
 export function moveQueuedUserTurnUp(bundle: SessionBundle, queueId: string): boolean {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -187,6 +187,11 @@ import {
 } from './session-turn-orchestrator.js';
 import { isSessionBundleBusy } from './direct-media-turn.js';
 import {
+  appendQueuedUserTurnSnapshots,
+  canEnqueueUserTurn,
+  enqueueUserTurnCommand,
+} from './message-queue.js';
+import {
   openSessionCommand,
   resetSessionCommand,
   type SessionActivationContext,
@@ -1187,13 +1192,23 @@ class DesktopHostService {
         throw new Error(i18n.t('error.messageRequired'));
       }
 
+      const explicitWorkspaceFiles = await this.resolveExplicitLocalFileAttachments(
+        request.localFilePaths,
+      );
+      if (canEnqueueUserTurn(bundle)) {
+        return enqueueUserTurnCommand(this.sessionTurnContext(), {
+          text: request.text,
+          explicitWorkspaceFiles,
+        });
+      }
+
       const isFirstTurn = bundle.messages.length === 0;
       if (isFirstTurn && bundle.workLocation === 'worktree') {
         await this.bootstrapWorktreeForFirstTurn(trimmed);
       }
 
       return this.submitUserTurnAfterInitialized(request.text, {
-        explicitWorkspaceFiles: await this.resolveExplicitLocalFileAttachments(request.localFilePaths),
+        explicitWorkspaceFiles,
       });
     });
   }
@@ -2130,15 +2145,18 @@ class DesktopHostService {
       conversationSnapshotView: this.activeOrchestration().conversationSnapshotView,
     });
 
-    const rawMessages = this.activeBundle().messages;
+    const activeBundle = this.activeBundle();
+    const rawMessages = activeBundle.messages;
     const rawConversationMessages = this.desktopMessages();
 
-    const conversationMessages = this.activeOrchestration().conversationSnapshotView.buildMessagesWithPendingAssistant({
-      messages: rawConversationMessages,
-      livePendingAux: pendingAux,
-      rewind: this.activeBundle().rewind,
-    });
-    const activeBundle = this.activeBundle();
+    const conversationMessages = appendQueuedUserTurnSnapshots(
+      this.activeOrchestration().conversationSnapshotView.buildMessagesWithPendingAssistant({
+        messages: rawConversationMessages,
+        livePendingAux: pendingAux,
+        rewind: activeBundle.rewind,
+      }),
+      activeBundle.queuedUserTurns,
+    );
     const conversationBusy = isSessionBundleBusy(activeBundle);
 
     this.logContinuationSnapshotState({

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -93,6 +93,7 @@ import type {
   UpdateExtensionSecretRequest,
   UpdateExtensionSettingsRequest,
   PendingAssistantAux,
+  QueuedUserTurnRequest,
   RewindAndSubmitMessageRequest,
   RememberWorkspaceRequest,
   RemoveModelRequest,
@@ -180,6 +181,7 @@ import {
   pollCommand,
   replyPendingApprovalCommand,
   replyPendingQuestionsCommand,
+  sendQueuedUserTurnNowCommand,
   submitUserTurnAfterInitializedCommand,
   tickSessionCommand,
   type SessionTurnOrchestratorContext,
@@ -190,6 +192,8 @@ import {
   appendQueuedUserTurnSnapshots,
   canEnqueueUserTurn,
   enqueueUserTurnCommand,
+  removeQueuedUserTurnCommand,
+  reorderQueuedUserTurnCommand,
 } from './message-queue.js';
 import {
   openSessionCommand,
@@ -1281,6 +1285,27 @@ class DesktopHostService {
 
   async abortConversation(): Promise<DesktopSnapshot> {
     return abortConversationCommand(this.sessionTurnContext());
+  }
+
+  async reorderQueuedUserTurn(request: QueuedUserTurnRequest): Promise<DesktopSnapshot> {
+    return this.runSerialized(async () => {
+      await this.ensureInitialized(undefined, { fastPath: true });
+      return reorderQueuedUserTurnCommand(this.sessionTurnContext(), request.queueId);
+    });
+  }
+
+  async sendQueuedUserTurnNow(request: QueuedUserTurnRequest): Promise<DesktopSnapshot> {
+    return this.runSerialized(async () => {
+      await this.ensureInitialized(undefined, { fastPath: true });
+      return sendQueuedUserTurnNowCommand(this.sessionTurnContext(), request.queueId);
+    });
+  }
+
+  async removeQueuedUserTurn(request: QueuedUserTurnRequest): Promise<DesktopSnapshot> {
+    return this.runSerialized(async () => {
+      await this.ensureInitialized(undefined, { fastPath: true });
+      return removeQueuedUserTurnCommand(this.sessionTurnContext(), request.queueId);
+    });
   }
 
   async continueAssistantCompletion(messageId: number): Promise<DesktopSnapshot> {

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -147,7 +147,7 @@ export function sessionBundleFromRestored(
     deferredRuntimeRefreshWhileBusy: false,
     deferredRuntimeHostEvents: [],
     responsesBuiltInPreviewSeenCallIds: new Set(),
-    queuedUserTurns: [],
+    queuedUserTurns: restored.queuedUserTurns ? [...restored.queuedUserTurns] : [],
     conversationRevision: 0,
     ...(restored.activePlanPath ? { activePlanPath: restored.activePlanPath } : {}),
     ...(restored.sessionTitleSource ? { sessionTitleSource: restored.sessionTitleSource } : {}),

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -16,6 +16,7 @@ import type {
   ConversationMessageSnapshot,
   FileRewindWarning,
 } from '../types.js';
+import type { QueuedUserTurn } from './message-queue.js';
 import type { DesktopTimelineSegmentKind, DesktopMessageTimeline } from './message-timeline.js';
 import { createDesktopRewindMetadata, type StoredDesktopRewindMetadata } from './rewind.js';
 import { createTodoSessionScopeKey } from './todos.js';
@@ -69,6 +70,8 @@ export interface SessionBundle {
   contextUsage?: ConversationContextUsageSnapshot;
   /** Composer 直连生图/生视频后台执行中；与 runtime.isBusy 一并驱动 snapshot.isBusy。 */
   directMediaTurnInFlight?: boolean;
+  /** Per-session user message queue (projected in snapshot until sent). */
+  queuedUserTurns: QueuedUserTurn[];
   /** SubAgent 子会话 desktop 投影（与主 timeline 同构，含 Thought/Compaction/工具卡）。 */
   subagentDesktopMessagesBySessionId: Map<string, ConversationMessageSnapshot[]>;
   subagentConversationProjections: Map<string, SubagentConversationProjection>;
@@ -98,6 +101,7 @@ export function createEmptySessionBundle(workspaceRoot: string, id = '__draft__'
     deferredRuntimeRefreshWhileBusy: false,
     deferredRuntimeHostEvents: [],
     responsesBuiltInPreviewSeenCallIds: new Set(),
+    queuedUserTurns: [],
     todoSessionScopeKey: createTodoSessionScopeKey(),
     conversationRevision: 0,
     subagentDesktopMessagesBySessionId: new Map(),
@@ -143,6 +147,7 @@ export function sessionBundleFromRestored(
     deferredRuntimeRefreshWhileBusy: false,
     deferredRuntimeHostEvents: [],
     responsesBuiltInPreviewSeenCallIds: new Set(),
+    queuedUserTurns: [],
     conversationRevision: 0,
     ...(restored.activePlanPath ? { activePlanPath: restored.activePlanPath } : {}),
     ...(restored.sessionTitleSource ? { sessionTitleSource: restored.sessionTitleSource } : {}),
@@ -188,6 +193,7 @@ export function resetSessionBundleInPlace(bundle: SessionBundle): void {
   bundle.sessionTitleSource = undefined;
   bundle.contextUsage = undefined;
   bundle.directMediaTurnInFlight = false;
+  bundle.queuedUserTurns = [];
   bundle.subagentDesktopMessagesBySessionId = new Map();
   bundle.subagentConversationProjections = new Map();
 }

--- a/apps/desktop/src/host/session-persistence.ts
+++ b/apps/desktop/src/host/session-persistence.ts
@@ -6,6 +6,7 @@ import {
   buildArchiveAssistantAuxFromConversation,
   buildArchiveMessagesFromConversation,
   buildStoredDesktopSession,
+  cloneQueuedUserTurns,
   sanitizeConversationMessagesForPersistence,
 } from './sessions.js';
 import { serializeSubagentDesktopMessagesRecord } from './subagent-conversation-projection.js';
@@ -82,6 +83,9 @@ export async function persistDesktopSessionBundle(
             bundle.subagentDesktopMessagesBySessionId,
           ),
         }
+      : {}),
+    ...(bundle.queuedUserTurns.length > 0
+      ? { queuedUserTurns: cloneQueuedUserTurns(bundle.queuedUserTurns) }
       : {}),
   });
   if (bumpListSortAt) {

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -245,7 +245,7 @@ export async function sendQueuedUserTurnNowCommand(
     throw new Error(i18n.t('error.pendingApprovalSend'));
   }
 
-  const [item] = bundle.queuedUserTurns.splice(index, 1);
+  const item = bundle.queuedUserTurns[index];
   if (!item) {
     throw new Error(i18n.t('error.queuedUserTurnNotFound'));
   }
@@ -255,11 +255,18 @@ export async function sendQueuedUserTurnNowCommand(
     await abortConversationInContext(ctx);
   }
 
-  return submitUserTurnAfterInitializedCommand(ctx, item.text, {
-    displayText: item.displayText,
-    preallocatedMessageId: item.messageId,
-    explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(item),
-  });
+  bundle.queuedUserTurns.splice(index, 1);
+  try {
+    return await submitUserTurnAfterInitializedCommand(ctx, item.text, {
+      displayText: item.displayText,
+      preallocatedMessageId: item.messageId,
+      explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(item),
+    });
+  } catch (error) {
+    bundle.queuedUserTurns.splice(index, 0, item);
+    await ctx.persistCurrentSessionIfNeeded();
+    throw error;
+  }
 }
 
 export async function drainQueuedUserTurnIfIdle(
@@ -273,11 +280,17 @@ export async function drainQueuedUserTurnIfIdle(
   if (!next) {
     return;
   }
-  await submitUserTurnAfterInitializedCommand(ctx, next.text, {
-    displayText: next.displayText,
-    preallocatedMessageId: next.messageId,
-    explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(next),
-  });
+  try {
+    await submitUserTurnAfterInitializedCommand(ctx, next.text, {
+      displayText: next.displayText,
+      preallocatedMessageId: next.messageId,
+      explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(next),
+    });
+  } catch (error) {
+    bundle.queuedUserTurns.unshift(next);
+    await ctx.persistCurrentSessionIfNeeded();
+    throw error;
+  }
 }
 
 export async function pollCommand(ctx: SessionTurnOrchestratorContext): Promise<DesktopSnapshot> {
@@ -321,6 +334,7 @@ export async function tickSessionCommand(
     applyDrainedRuntimeHostEvents(ctx, bundle, []);
   }
   if (options.light) {
+    await drainQueuedUserTurnIfIdle(ctx, bundle);
     return;
   }
   orchestration.runtimeEvents.consumeCompletedTurnResult();

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -27,6 +27,11 @@ import {
   splitRuntimeEventsForIncrementalFinishTaskPreview,
   splitRuntimeEventsForIncrementalResponsesBuiltInToolPreview,
 } from './runtime-event-orchestrator.js';
+import {
+  canDrainQueuedUserTurn,
+  explicitWorkspaceFilesFromQueuedItem,
+  shiftNextQueuedUserTurn,
+} from './message-queue.js';
 import { scheduleDirectMediaTurn, shouldUseComposerDirectMediaTurn } from './direct-media-turn.js';
 import { syncSubagentConversationProjections } from './subagent-conversation-projection.js';
 import { toRuntimeAskQuestionsResult } from './service-utils.js';
@@ -56,6 +61,8 @@ export interface SubmitUserTurnAfterInitializedOptions {
   displayText?: string;
   turnSkills?: LlmActiveSkill[];
   explicitWorkspaceFiles?: PendingWorkspaceFile[];
+  /** Reuse message id from a queued turn when draining the queue. */
+  preallocatedMessageId?: number;
 }
 
 export interface SessionTurnOrchestratorContext {
@@ -143,7 +150,7 @@ export async function submitUserTurnAfterInitializedCommand(
       ? pendingWorkspaceFilesToAttachmentSnapshots(explicitWorkspaceFiles)
       : undefined;
   const userMessage: ConversationMessageSnapshot = {
-    id: ctx.allocateMessageId(),
+    id: options.preallocatedMessageId ?? ctx.allocateMessageId(),
     role: 'user',
     content: displayText,
     pending: false,
@@ -211,7 +218,26 @@ export async function submitUserTurnAfterInitializedCommand(
   orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
   await ctx.flushDeferredRuntimeRefreshIfIdle(bundle);
   await ctx.refreshTodoSnapshotForBundle(bundle);
+  await drainQueuedUserTurnIfIdle(ctx, bundle);
   return ctx.buildSnapshot();
+}
+
+export async function drainQueuedUserTurnIfIdle(
+  ctx: SessionTurnOrchestratorContext,
+  bundle: SessionBundle,
+): Promise<void> {
+  if (!canDrainQueuedUserTurn(bundle)) {
+    return;
+  }
+  const next = shiftNextQueuedUserTurn(bundle);
+  if (!next) {
+    return;
+  }
+  await submitUserTurnAfterInitializedCommand(ctx, next.text, {
+    displayText: next.displayText,
+    preallocatedMessageId: next.messageId,
+    explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(next),
+  });
 }
 
 export async function pollCommand(ctx: SessionTurnOrchestratorContext): Promise<DesktopSnapshot> {
@@ -267,6 +293,7 @@ export async function tickSessionCommand(
   });
   await ctx.flushDeferredRuntimeRefreshIfIdle(bundle);
   await ctx.refreshTodoSnapshotForBundle(bundle);
+  await drainQueuedUserTurnIfIdle(ctx, bundle);
 }
 
 export async function abortConversationCommand(ctx: SessionTurnOrchestratorContext): Promise<DesktopSnapshot> {
@@ -307,6 +334,7 @@ export async function abortConversationCommand(ctx: SessionTurnOrchestratorConte
     }
     await ctx.persistCurrentSessionIfNeeded();
     await ctx.flushDeferredRuntimeRefreshIfIdle();
+    await drainQueuedUserTurnIfIdle(ctx, ctx.activeBundle());
     return ctx.buildSnapshot();
   });
 }

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -30,9 +30,16 @@ import {
 import {
   canDrainQueuedUserTurn,
   explicitWorkspaceFilesFromQueuedItem,
+  findQueuedUserTurnIndex,
+  isSessionBundleQueueBlocked,
+  removeQueuedUserTurn,
   shiftNextQueuedUserTurn,
 } from './message-queue.js';
-import { scheduleDirectMediaTurn, shouldUseComposerDirectMediaTurn } from './direct-media-turn.js';
+import {
+  isSessionBundleBusy,
+  scheduleDirectMediaTurn,
+  shouldUseComposerDirectMediaTurn,
+} from './direct-media-turn.js';
 import { syncSubagentConversationProjections } from './subagent-conversation-projection.js';
 import { toRuntimeAskQuestionsResult } from './service-utils.js';
 
@@ -222,6 +229,39 @@ export async function submitUserTurnAfterInitializedCommand(
   return ctx.buildSnapshot();
 }
 
+export async function sendQueuedUserTurnNowCommand(
+  ctx: SessionTurnOrchestratorContext,
+  queueId: string,
+): Promise<DesktopSnapshot> {
+  const bundle = ctx.activeBundle();
+  const index = findQueuedUserTurnIndex(bundle, queueId);
+  if (index < 0) {
+    throw new Error(i18n.t('error.queuedUserTurnNotFound'));
+  }
+  if (bundle.activeSession?.readOnly === true) {
+    throw new Error(i18n.t('error.readonlySessionSend'));
+  }
+  if (isSessionBundleQueueBlocked(bundle)) {
+    throw new Error(i18n.t('error.pendingApprovalSend'));
+  }
+
+  const [item] = bundle.queuedUserTurns.splice(index, 1);
+  if (!item) {
+    throw new Error(i18n.t('error.queuedUserTurnNotFound'));
+  }
+
+  if (isSessionBundleBusy(bundle)) {
+    await ctx.ensureInitialized(undefined, { fastPath: true });
+    await abortConversationInContext(ctx);
+  }
+
+  return submitUserTurnAfterInitializedCommand(ctx, item.text, {
+    displayText: item.displayText,
+    preallocatedMessageId: item.messageId,
+    explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(item),
+  });
+}
+
 export async function drainQueuedUserTurnIfIdle(
   ctx: SessionTurnOrchestratorContext,
   bundle: SessionBundle,
@@ -296,44 +336,51 @@ export async function tickSessionCommand(
   await drainQueuedUserTurnIfIdle(ctx, bundle);
 }
 
+export async function abortConversationInContext(
+  ctx: SessionTurnOrchestratorContext,
+): Promise<boolean> {
+  const runtime = ctx.requireRuntime();
+  const interruptedAssistantText = runtime.pendingAssistantText().trim();
+  const interruptedThinkingText = runtime.thinkingText().trim();
+  const interruptedCompactionText = runtime.compactionText().trim();
+  const interruptedAssistantAuxText =
+    interruptedThinkingText || interruptedCompactionText;
+  const interruptible =
+    runtime.isBusy() &&
+    !runtime.currentPendingApproval() &&
+    !runtime.currentPendingQuestions();
+
+  if (!interruptible) {
+    return false;
+  }
+
+  runtime.abort();
+  ctx.activeBundle().currentTurnSkills = [];
+  const orchestration = ctx.orchestrationFor(ctx.activeBundle());
+  orchestration.runtimeEvents.applyRuntimeHostEvents(runtime.drainEvents());
+  orchestration.runtimeEvents.finalizeInterruptedDeferredThinking({
+    thinkingText: interruptedThinkingText,
+    compactionText: interruptedCompactionText,
+  });
+  ctx.activeBundle().messageTimeline.abortActiveAssistantSegment();
+  orchestration.runtimeEvents.consumeCompletedTurnResult();
+  orchestration.runtimeEvents.syncPendingToolStates();
+  orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
+  ctx.markInterruptedToolsInCurrentTurn();
+  if (interruptedAssistantText || interruptedAssistantAuxText) {
+    ctx.markAssistantMessageContinuable(interruptedAssistantText);
+  } else {
+    ctx.markLatestRenderableAssistantMessageContinuableInCurrentTurn();
+  }
+  await ctx.persistCurrentSessionIfNeeded();
+  await ctx.flushDeferredRuntimeRefreshIfIdle();
+  return true;
+}
+
 export async function abortConversationCommand(ctx: SessionTurnOrchestratorContext): Promise<DesktopSnapshot> {
   return ctx.runSerialized(async () => {
     await ctx.ensureInitialized(undefined, { fastPath: true });
-    const runtime = ctx.requireRuntime();
-    const interruptedAssistantText = runtime.pendingAssistantText().trim();
-    const interruptedThinkingText = runtime.thinkingText().trim();
-    const interruptedCompactionText = runtime.compactionText().trim();
-    const interruptedAssistantAuxText =
-      interruptedThinkingText || interruptedCompactionText;
-    const interruptible =
-      runtime.isBusy() &&
-      !runtime.currentPendingApproval() &&
-      !runtime.currentPendingQuestions();
-
-    if (!interruptible) {
-      return ctx.buildSnapshot();
-    }
-
-    runtime.abort();
-    ctx.activeBundle().currentTurnSkills = [];
-    const orchestration = ctx.orchestrationFor(ctx.activeBundle());
-    orchestration.runtimeEvents.applyRuntimeHostEvents(runtime.drainEvents());
-    orchestration.runtimeEvents.finalizeInterruptedDeferredThinking({
-      thinkingText: interruptedThinkingText,
-      compactionText: interruptedCompactionText,
-    });
-    ctx.activeBundle().messageTimeline.abortActiveAssistantSegment();
-    orchestration.runtimeEvents.consumeCompletedTurnResult();
-    orchestration.runtimeEvents.syncPendingToolStates();
-    orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
-    ctx.markInterruptedToolsInCurrentTurn();
-    if (interruptedAssistantText || interruptedAssistantAuxText) {
-      ctx.markAssistantMessageContinuable(interruptedAssistantText);
-    } else {
-      ctx.markLatestRenderableAssistantMessageContinuableInCurrentTurn();
-    }
-    await ctx.persistCurrentSessionIfNeeded();
-    await ctx.flushDeferredRuntimeRefreshIfIdle();
+    await abortConversationInContext(ctx);
     await drainQueuedUserTurnIfIdle(ctx, ctx.activeBundle());
     return ctx.buildSnapshot();
   });

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -10,6 +10,7 @@ import type {
 } from '../types.js';
 import { extractActivePlanPathFromLlmHistory, normalizeApprovalLevel } from '@spirit-agent/host-internal';
 import type { ApprovalLevel } from '@spirit-agent/host-internal';
+import type { QueuedUserTurn } from './message-queue.js';
 import type { SessionTitleSource, StoredDesktopSession } from './contracts.js';
 import type { DesktopTimelineTurnSnapshot } from './message-timeline.js';
 import type { SessionBundle } from './session-bundle.js';
@@ -53,6 +54,7 @@ export interface RestoredSessionState {
   sessionTitleSource?: SessionTitleSource;
   contextUsage?: ConversationContextUsageSnapshot;
   subagentDesktopMessagesBySessionId?: Map<string, ConversationMessageSnapshot[]>;
+  queuedUserTurns?: QueuedUserTurn[];
 }
 
 export function isEphemeralCommitSessionPath(filePath: string): boolean {
@@ -200,6 +202,9 @@ export function restoreStoredSessionState(input: {
           ),
         }
       : {}),
+    ...(input.loaded.queuedUserTurns?.length
+      ? { queuedUserTurns: cloneQueuedUserTurns(input.loaded.queuedUserTurns) }
+      : {}),
   };
 }
 
@@ -218,6 +223,7 @@ export function buildStoredDesktopSession(input: {
   approvalLevel: ApprovalLevel;
   contextUsage?: ConversationContextUsageSnapshot;
   subagentDesktopMessages?: Record<string, ConversationMessageSnapshot[]>;
+  queuedUserTurns?: QueuedUserTurn[];
 }): StoredDesktopSession {
   return {
     ...input.archive,
@@ -236,7 +242,22 @@ export function buildStoredDesktopSession(input: {
     rewind: input.rewind,
     ...(input.contextUsage ? { contextUsage: { ...input.contextUsage } } : {}),
     ...(input.subagentDesktopMessages ? { subagentDesktopMessages: input.subagentDesktopMessages } : {}),
+    ...(input.queuedUserTurns?.length
+      ? { queuedUserTurns: cloneQueuedUserTurns(input.queuedUserTurns) }
+      : {}),
   };
+}
+
+export function cloneQueuedUserTurns(queued: readonly QueuedUserTurn[]): QueuedUserTurn[] {
+  return queued.map((item) => ({
+    ...item,
+    ...(item.explicitWorkspaceFiles
+      ? { explicitWorkspaceFiles: item.explicitWorkspaceFiles.map((file) => ({ ...file })) }
+      : {}),
+    ...(item.localFileAttachments
+      ? { localFileAttachments: item.localFileAttachments.map((attachment) => ({ ...attachment })) }
+      : {}),
+  }));
 }
 
 export function sanitizeConversationMessagesForPersistence(

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -703,6 +703,7 @@
     "attachmentsNotSupportedWithSlash": "Attachments are not yet supported with Slash commands.",
     "hostNotSupportLogSession": "The current host does not support /log-session.",
     "pendingApprovalSend": "Currently waiting for approval or questionnaire; cannot send a new message directly.",
+    "queuedUserTurnNotFound": "Queued message was not found.",
     "completeQuestionnaire": "Please complete the questionnaire first.",
     "completeRequiredQuestion": "Please complete the required question first: {{title}}",
     "autoWorktreeNameFailedMissingFields": "Auto-generating Worktree name failed: model did not return worktreeName or branchName field.",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -560,7 +560,14 @@
     "placeholderGenerateVideo": "Describe the video to generate…",
     "contextUsageAria": "Context used {{percent}}%, {{inputTokens}} / {{contextLength}} tokens",
     "contextUsageHoverPercent": "{{percent}}% context used",
-    "contextUsageHoverTokens": "{{input}} / {{total}} tokens"
+    "contextUsageHoverTokens": "{{input}} / {{total}} tokens",
+    "enqueueWhileBusy": "Add to message queue"
+  },
+  "queue": {
+    "moveUp": "Move up",
+    "sendNow": "Send now",
+    "delete": "Delete",
+    "actionsAria": "Queued message actions"
   },
   "error": {
     "runtimeBusy": "A response or approval is already being processed. Please wait.",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -703,6 +703,7 @@
     "attachmentsNotSupportedWithSlash": "附加文件暂不支持与 Slash 指令一起发送。",
     "hostNotSupportLogSession": "当前宿主不支持 /log-session。",
     "pendingApprovalSend": "当前正在等待审批或问卷，无法直接发送新消息。",
+    "queuedUserTurnNotFound": "未找到该排队消息。",
     "completeQuestionnaire": "请先完成问卷。",
     "completeRequiredQuestion": "请先完成必答问题：{{title}}",
     "autoWorktreeNameFailedMissingFields": "自动生成 Worktree 名称失败：模型未返回 worktreeName 或 branchName 字段。",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -560,7 +560,14 @@
     "placeholderGenerateVideo": "描述要生成的视频…",
     "contextUsageAria": "上下文已用 {{percent}}%，{{inputTokens}} / {{contextLength}} tokens",
     "contextUsageHoverPercent": "{{percent}}% 上下文已用",
-    "contextUsageHoverTokens": "{{input}} / {{total}} tokens"
+    "contextUsageHoverTokens": "{{input}} / {{total}} tokens",
+    "enqueueWhileBusy": "加入消息队列"
+  },
+  "queue": {
+    "moveUp": "上移",
+    "sendNow": "发送",
+    "delete": "删除",
+    "actionsAria": "排队消息操作"
   },
   "error": {
     "runtimeBusy": "当前已有响应或审批在处理中，请稍候。",

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -518,6 +518,10 @@ export interface SubmitUserTurnRequest {
   localFilePaths?: string[];
 }
 
+export interface QueuedUserTurnRequest {
+  queueId: string;
+}
+
 export interface DesktopSkillListItem {
   id: string;
   name: string;
@@ -899,6 +903,7 @@ export interface ConversationMessageSnapshot {
   canContinue?: boolean;
   /** UI-only projection for unsent queued user turns (not in message timeline). */
   queued?: boolean;
+  queueId?: string;
 }
 
 export interface MessageRewindDraftState {

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -897,6 +897,8 @@ export interface ConversationMessageSnapshot {
   pending: boolean;
   canRewind?: boolean;
   canContinue?: boolean;
+  /** UI-only projection for unsent queued user turns (not in message timeline). */
+  queued?: boolean;
 }
 
 export interface MessageRewindDraftState {

--- a/apps/desktop/test/host/message-queue.test.mjs
+++ b/apps/desktop/test/host/message-queue.test.mjs
@@ -111,6 +111,17 @@ test('cloneQueuedUserTurns deep-copies queue payload', () => {
   assert.equal(source[0].explicitWorkspaceFiles[0].path, '/tmp/a.png');
 });
 
+test('shift then unshift restores queue head after failed dequeue', () => {
+  const bundle = createBundle({
+    queuedUserTurns: [queuedItem('a', 1, 'one'), queuedItem('b', 2, 'two')],
+  });
+  const removed = shiftNextQueuedUserTurn(bundle);
+  assert.equal(removed?.queueId, 'a');
+  assert.equal(bundle.queuedUserTurns.length, 1);
+  bundle.queuedUserTurns.unshift(removed);
+  assert.deepEqual(bundle.queuedUserTurns.map((item) => item.queueId), ['a', 'b']);
+});
+
 test('shiftNextQueuedUserTurn removes head item', () => {
   const bundle = createBundle({
     queuedUserTurns: [queuedItem('a', 1, 'one'), queuedItem('b', 2, 'two')],

--- a/apps/desktop/test/host/message-queue.test.mjs
+++ b/apps/desktop/test/host/message-queue.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  appendQueuedUserTurnSnapshots,
+  canDrainQueuedUserTurn,
+  canEnqueueUserTurn,
+  isSessionBundleQueueBlocked,
+  moveQueuedUserTurnUp,
+  projectQueuedUserTurnSnapshots,
+  removeQueuedUserTurn,
+  shiftNextQueuedUserTurn,
+} from '../../dist-electron/src/host/message-queue.js';
+import { createEmptySessionBundle } from '../../dist-electron/src/host/session-bundle.js';
+
+function createBundle(overrides = {}) {
+  const bundle = createEmptySessionBundle('/tmp/workspace');
+  return {
+    ...bundle,
+    activeSession: { filePath: '/tmp/chat.json', displayName: 'Test', kind: 'stored' },
+    queuedUserTurns: [],
+    ...overrides,
+  };
+}
+
+function queuedItem(id, messageId, content) {
+  return {
+    queueId: id,
+    messageId,
+    text: content,
+    displayText: content,
+    enqueuedAtUnixMs: Date.now(),
+  };
+}
+
+test('projectQueuedUserTurnSnapshots marks user rows as queued', () => {
+  const snapshots = projectQueuedUserTurnSnapshots([
+    queuedItem('a', 10, 'hello queue'),
+  ]);
+  assert.equal(snapshots.length, 1);
+  assert.equal(snapshots[0].role, 'user');
+  assert.equal(snapshots[0].queued, true);
+  assert.equal(snapshots[0].content, 'hello queue');
+});
+
+test('appendQueuedUserTurnSnapshots appends after visible messages', () => {
+  const merged = appendQueuedUserTurnSnapshots(
+    [{ id: 1, role: 'assistant', content: 'reply', pending: false }],
+    [queuedItem('a', 2, 'next')],
+  );
+  assert.deepEqual(
+    merged.map((message) => `${message.role}:${message.content}:${message.queued === true}`),
+    ['assistant:reply:false', 'user:next:true'],
+  );
+});
+
+test('canEnqueueUserTurn requires busy non-blocked session', () => {
+  const idleBundle = createBundle({
+    runtime: { isBusy: () => false, currentPendingApproval: () => undefined, currentPendingQuestions: () => undefined },
+  });
+  assert.equal(canEnqueueUserTurn(idleBundle), false);
+
+  const busyBundle = createBundle({
+    runtime: { isBusy: () => true, currentPendingApproval: () => undefined, currentPendingQuestions: () => undefined },
+  });
+  assert.equal(canEnqueueUserTurn(busyBundle), true);
+
+  const blockedBundle = createBundle({
+    runtime: {
+      isBusy: () => true,
+      currentPendingApproval: () => ({ toolName: 'bash' }),
+      currentPendingQuestions: () => undefined,
+    },
+  });
+  assert.equal(isSessionBundleQueueBlocked(blockedBundle), true);
+  assert.equal(canEnqueueUserTurn(blockedBundle), false);
+});
+
+test('canDrainQueuedUserTurn requires idle queue with items', () => {
+  const bundle = createBundle({
+    queuedUserTurns: [queuedItem('a', 1, 'one')],
+    runtime: { isBusy: () => false, currentPendingApproval: () => undefined, currentPendingQuestions: () => undefined },
+  });
+  assert.equal(canDrainQueuedUserTurn(bundle), true);
+
+  bundle.runtime = { isBusy: () => true, currentPendingApproval: () => undefined, currentPendingQuestions: () => undefined };
+  assert.equal(canDrainQueuedUserTurn(bundle), false);
+});
+
+test('moveQueuedUserTurnUp swaps with previous item', () => {
+  const bundle = createBundle({
+    queuedUserTurns: [queuedItem('a', 1, 'one'), queuedItem('b', 2, 'two')],
+  });
+  assert.equal(moveQueuedUserTurnUp(bundle, 'b'), true);
+  assert.deepEqual(bundle.queuedUserTurns.map((item) => item.queueId), ['b', 'a']);
+  assert.equal(moveQueuedUserTurnUp(bundle, 'b'), false);
+});
+
+test('shiftNextQueuedUserTurn removes head item', () => {
+  const bundle = createBundle({
+    queuedUserTurns: [queuedItem('a', 1, 'one'), queuedItem('b', 2, 'two')],
+  });
+  const next = shiftNextQueuedUserTurn(bundle);
+  assert.equal(next?.queueId, 'a');
+  assert.equal(bundle.queuedUserTurns.length, 1);
+  assert.equal(removeQueuedUserTurn(bundle, 'missing'), undefined);
+  assert.equal(removeQueuedUserTurn(bundle, 'b')?.queueId, 'b');
+  assert.equal(bundle.queuedUserTurns.length, 0);
+});

--- a/apps/desktop/test/host/message-queue.test.mjs
+++ b/apps/desktop/test/host/message-queue.test.mjs
@@ -12,6 +12,7 @@ import {
   shiftNextQueuedUserTurn,
 } from '../../dist-electron/src/host/message-queue.js';
 import { createEmptySessionBundle } from '../../dist-electron/src/host/session-bundle.js';
+import { cloneQueuedUserTurns } from '../../dist-electron/src/host/sessions.js';
 
 function createBundle(overrides = {}) {
   const bundle = createEmptySessionBundle('/tmp/workspace');
@@ -94,6 +95,20 @@ test('moveQueuedUserTurnUp swaps with previous item', () => {
   assert.equal(moveQueuedUserTurnUp(bundle, 'b'), true);
   assert.deepEqual(bundle.queuedUserTurns.map((item) => item.queueId), ['b', 'a']);
   assert.equal(moveQueuedUserTurnUp(bundle, 'b'), false);
+});
+
+test('cloneQueuedUserTurns deep-copies queue payload', () => {
+  const source = [
+    {
+      ...queuedItem('a', 1, 'one'),
+      explicitWorkspaceFiles: [{ kind: 'image', path: '/tmp/a.png', attachedAtUnixMs: 1 }],
+    },
+  ];
+  const cloned = cloneQueuedUserTurns(source);
+  assert.notEqual(cloned, source);
+  assert.notEqual(cloned[0].explicitWorkspaceFiles, source[0].explicitWorkspaceFiles);
+  cloned[0].explicitWorkspaceFiles[0].path = '/tmp/b.png';
+  assert.equal(source[0].explicitWorkspaceFiles[0].path, '/tmp/a.png');
 });
 
 test('shiftNextQueuedUserTurn removes head item', () => {


### PR DESCRIPTION
## Summary

- Agent 流式输出且可中断时，Composer 发送改为入队；回合结束、中止后自动发送队首消息。
- 队列消息以半透明 User 气泡投影在助手内容下方，支持悬停操作（上移、立即发送、删除）。
- Composer 忙碌态：有输入显示发送入队，空输入显示中止；队列与会话文件持久化。
- 悬停浮层打开延迟 50ms，便于快速点击操作按钮。

## Test plan

- [x] `node --test apps/desktop/test/host/message-queue.test.mjs`（7 项通过）
- [ ] Agent 输出中连续入队多条，助手完成后自动发队首
- [ ] 悬停队列气泡：上移 / 立即发送 / 删除
- [ ] Composer 空=中止、有字=发送入队
- [ ] 审批/提问阻塞时无法入队
- [ ] 保存并重开会话后队列恢复

bugbot run