### PR TITLE
feat(agent-core): LLM 出站请求统一携带 SpiritAgent UA

### DIFF
--- a/apps/cli/src/ts_bridge.rs
+++ b/apps/cli/src/ts_bridge.rs
@@ -619,6 +619,7 @@ impl TsBridgeRuntime {
         runtime.set_todo_session_key(&session_key)?;
         runtime.initialize_bridge()?;
         runtime.apply_llm_http_version_from_config()?;
+        runtime.apply_llm_client_version_from_build()?;
         Ok(runtime)
     }
 
@@ -1331,6 +1332,19 @@ impl TsBridgeRuntime {
         Ok(())
     }
 
+    pub fn set_llm_client_version(&mut self, client_version: &str) -> Result<()> {
+        if self.bridge_failed {
+            return Err(anyhow!("TS bridge 已处于失败状态。"));
+        }
+        self.call_bridge(
+            "runtime.setLlmClientVersion",
+            Some(json!({
+                "clientVersion": client_version,
+            })),
+        )?;
+        Ok(())
+    }
+
     pub fn store_config(&mut self, config: AppConfig) {
         self.config = config;
     }
@@ -1341,6 +1355,13 @@ impl TsBridgeRuntime {
         }
         let version = self.config.networks.llm_http_version.clone();
         self.set_llm_http_version(&version)
+    }
+
+    fn apply_llm_client_version_from_build(&mut self) -> Result<()> {
+        if self.bridge_failed {
+            return Err(anyhow!("TS bridge 已处于失败状态。"));
+        }
+        self.set_llm_client_version(env!("CARGO_PKG_VERSION"))
     }
 
     pub fn abort(&mut self) {
@@ -1773,6 +1794,7 @@ impl TsBridgeRuntime {
         )?;
         self.apply_snapshot(serde_json::from_value(snapshot)?);
         self.apply_llm_http_version_from_config()?;
+        self.apply_llm_client_version_from_build()?;
         Ok(())
     }
 

--- a/apps/desktop/src/host/host-initialization.ts
+++ b/apps/desktop/src/host/host-initialization.ts
@@ -4,6 +4,7 @@ import { resolveDesktopAgentMode } from '../lib/agent-mode.js';
 import type { PlanSnapshot } from '../types.js';
 import {
   discoverWorkspaceRoot,
+  applyLlmClientVersionFromApp,
   applyLlmHttpVersionFromConfig,
   loadConfig,
   loadHostMetadata,
@@ -74,6 +75,7 @@ export async function ensureInitializedCommand(
 
   const loadedConfig = await loadConfig();
   applyLlmHttpVersionFromConfig(loadedConfig);
+  applyLlmClientVersionFromApp();
   await ensureBuiltinUserSkills(spiritAgentDataDir());
   const previousState = ctx.state();
   const previousBinding = normalizeWorkspaceBinding(

--- a/apps/desktop/src/host/host-model-commands.ts
+++ b/apps/desktop/src/host/host-model-commands.ts
@@ -45,6 +45,7 @@ import {
   normalizeDreamConfig,
   normalizeAgentsConfig,
   normalizeNetworksConfig,
+  applyLlmClientVersionFromApp,
   applyLlmHttpVersionFromConfig,
   normalizeModelCapabilities,
   normalizeWebHostConfig,
@@ -221,6 +222,7 @@ export async function updateConfigCommand(
         llmHttpVersion: request.networks.llmHttpVersion,
       });
       applyLlmHttpVersionFromConfig(state.config);
+      applyLlmClientVersionFromApp();
     }
     await saveConfig(state.config);
     if (request.apiKey?.trim()) {

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import {
   mkdir,
   readdir,
@@ -15,6 +16,7 @@ import { Entry } from '@napi-rs/keyring';
 import i18n from '../lib/i18n-host.js';
 import { normalizeLightweightChatModel } from './lightweight-chat-model.js';
 import {
+  configureLlmClientVersion,
   configureLlmHttpVersion,
   normalizeLlmHttpVersion,
   type LlmHttpVersion,
@@ -590,6 +592,17 @@ export function normalizeNetworksConfig(raw: unknown): DesktopNetworksConfigFile
   return {
     llmHttpVersion: normalizeLlmHttpVersion(record.llmHttpVersion),
   };
+}
+
+const require = createRequire(import.meta.url);
+const desktopPackageVersion = (require('../../package.json') as { version: string }).version;
+
+export function resolveDesktopAppVersion(): string {
+  return desktopPackageVersion;
+}
+
+export function applyLlmClientVersionFromApp(): void {
+  configureLlmClientVersion(resolveDesktopAppVersion());
 }
 
 export function applyLlmHttpVersionFromConfig(config: Pick<DesktopConfigFile, 'networks'>): void {

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -46,7 +46,11 @@ import {
   readSpiritAgentModeFromTransportConfig,
   type SpiritAgentMode,
 } from './ports.js';
-import { configureLlmHttpVersion, normalizeLlmHttpVersion } from './llm-fetch.js';
+import {
+  configureLlmClientVersion,
+  configureLlmHttpVersion,
+  normalizeLlmHttpVersion,
+} from './llm-fetch.js';
 import { createLlmTransport } from './transport-factory.js';
 import type {
   GeneratedImageSaveRequest,
@@ -2064,6 +2068,12 @@ peer.on('runtime.setApprovalLevel', async (rawParams) => {
 peer.on('runtime.setLlmHttpVersion', async (rawParams) => {
   const params = rawParams as import('./host-bridge/protocol.js').RuntimeSetLlmHttpVersionParams;
   configureLlmHttpVersion(normalizeLlmHttpVersion(params.llmHttpVersion));
+  return null;
+});
+
+peer.on('runtime.setLlmClientVersion', async (rawParams) => {
+  const params = rawParams as import('./host-bridge/protocol.js').RuntimeSetLlmClientVersionParams;
+  configureLlmClientVersion(params.clientVersion);
   return null;
 });
 

--- a/packages/agent-core/src/host-bridge/protocol.ts
+++ b/packages/agent-core/src/host-bridge/protocol.ts
@@ -106,6 +106,10 @@ export interface RuntimeSetLlmHttpVersionParams {
   llmHttpVersion: 'http1.1' | 'http2';
 }
 
+export interface RuntimeSetLlmClientVersionParams {
+  clientVersion: string;
+}
+
 export interface RuntimeSetLoopEnabledParams {
   enabled: boolean;
 }

--- a/packages/agent-core/src/llm-fetch.test.ts
+++ b/packages/agent-core/src/llm-fetch.test.ts
@@ -6,9 +6,11 @@ import {
   configureLlmClientVersion,
   configureLlmHttpVersion,
   getLlmClientVersion,
+  getLlmFetch,
   getLlmHttpVersion,
   mergeLlmFetchInit,
   normalizeLlmHttpVersion,
+  setLlmFetchTransportOverrideForTests,
 } from './llm-fetch.js';
 
 test('normalizeLlmHttpVersion accepts common aliases and defaults to http2', () => {
@@ -71,4 +73,20 @@ test('mergeLlmFetchInit overwrites existing User-Agent', () => {
     },
   });
   assert.equal((merged.headers as Headers).get('User-Agent'), 'SpiritAgent/9.9.9');
+});
+
+test('getLlmFetch applies SpiritAgent User-Agent on outbound calls', async () => {
+  configureLlmClientVersion('4.5.6');
+  let capturedInit: RequestInit | undefined;
+  setLlmFetchTransportOverrideForTests(async (_input, init) => {
+    capturedInit = init;
+    return new Response('ok');
+  });
+  try {
+    await getLlmFetch()('https://example.com/v1/chat/completions', { method: 'POST' });
+    assert.ok(capturedInit?.headers instanceof Headers);
+    assert.equal((capturedInit.headers as Headers).get('User-Agent'), 'SpiritAgent/4.5.6');
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
 });

--- a/packages/agent-core/src/llm-fetch.test.ts
+++ b/packages/agent-core/src/llm-fetch.test.ts
@@ -2,8 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  buildSpiritAgentUserAgent,
+  configureLlmClientVersion,
   configureLlmHttpVersion,
+  getLlmClientVersion,
   getLlmHttpVersion,
+  mergeLlmFetchInit,
   normalizeLlmHttpVersion,
 } from './llm-fetch.js';
 
@@ -21,4 +25,50 @@ test('configureLlmHttpVersion updates getLlmHttpVersion', () => {
   assert.equal(getLlmHttpVersion(), 'http1.1');
   configureLlmHttpVersion('http2');
   assert.equal(getLlmHttpVersion(), 'http2');
+});
+
+test('buildSpiritAgentUserAgent formats product and version', () => {
+  assert.equal(buildSpiritAgentUserAgent('1.2.3'), 'SpiritAgent/1.2.3');
+  assert.equal(buildSpiritAgentUserAgent(' 0.1.0 '), 'SpiritAgent/0.1.0');
+});
+
+test('configureLlmClientVersion updates getLlmClientVersion and ignores empty strings', () => {
+  configureLlmClientVersion('2.0.0');
+  assert.equal(getLlmClientVersion(), '2.0.0');
+  configureLlmClientVersion('   ');
+  assert.equal(getLlmClientVersion(), '2.0.0');
+  configureLlmClientVersion('0.1.0');
+});
+
+test('mergeLlmFetchInit sets User-Agent from record headers', () => {
+  configureLlmClientVersion('1.0.0');
+  const merged = mergeLlmFetchInit({
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer token',
+    },
+  });
+  assert.equal(merged.method, 'POST');
+  assert.ok(merged.headers instanceof Headers);
+  assert.equal((merged.headers as Headers).get('Authorization'), 'Bearer token');
+  assert.equal((merged.headers as Headers).get('User-Agent'), 'SpiritAgent/1.0.0');
+});
+
+test('mergeLlmFetchInit sets User-Agent from Headers instance without mutating source', () => {
+  configureLlmClientVersion('3.4.5');
+  const source = new Headers({ 'Content-Type': 'application/json' });
+  const merged = mergeLlmFetchInit({ headers: source });
+  assert.equal(source.get('User-Agent'), null);
+  assert.equal((merged.headers as Headers).get('Content-Type'), 'application/json');
+  assert.equal((merged.headers as Headers).get('User-Agent'), 'SpiritAgent/3.4.5');
+});
+
+test('mergeLlmFetchInit overwrites existing User-Agent', () => {
+  configureLlmClientVersion('9.9.9');
+  const merged = mergeLlmFetchInit({
+    headers: {
+      'User-Agent': 'other-client/1.0',
+    },
+  });
+  assert.equal((merged.headers as Headers).get('User-Agent'), 'SpiritAgent/9.9.9');
 });

--- a/packages/agent-core/src/llm-fetch.ts
+++ b/packages/agent-core/src/llm-fetch.ts
@@ -14,6 +14,12 @@ const LLM_HTTP_VERSIONS: readonly LlmHttpVersion[] = ['http1.1', 'http2'];
 let configuredVersion: LlmHttpVersion = 'http2';
 let llmDispatcher: Agent | undefined;
 let configuredClientVersion: string = defaultClientVersion;
+let llmFetchTransportOverride: typeof fetch | undefined;
+
+/** @internal Unit tests may replace the underlying transport after UA merge. */
+export function setLlmFetchTransportOverrideForTests(fetchImpl: typeof fetch | undefined): void {
+  llmFetchTransportOverride = fetchImpl;
+}
 
 export function buildSpiritAgentUserAgent(version: string): string {
   return `${SPIRIT_AGENT_UA_PRODUCT}/${version.trim()}`;
@@ -97,10 +103,15 @@ function llmDispatcherInstance(): Agent {
 /** LLM 出站请求：undici fetch；HTTP/2 由配置决定（TLS ALPN，对端不支持时回退 HTTP/1.1）。 */
 export function getLlmFetch(): typeof fetch {
   const dispatcher = llmDispatcherInstance();
-  const fetchWithDispatcher = (input: RequestInfo | URL, init?: RequestInit) =>
-    undiciFetch(
+  const fetchWithDispatcher = (input: RequestInfo | URL, init?: RequestInit) => {
+    const mergedInit = mergeLlmFetchInit(init);
+    if (llmFetchTransportOverride) {
+      return llmFetchTransportOverride(input, mergedInit);
+    }
+    return undiciFetch(
       input as Parameters<typeof undiciFetch>[0],
-      { ...mergeLlmFetchInit(init), dispatcher } as Parameters<typeof undiciFetch>[1],
+      { ...mergedInit, dispatcher } as Parameters<typeof undiciFetch>[1],
     );
+  };
   return fetchWithDispatcher as unknown as typeof fetch;
 }

--- a/packages/agent-core/src/llm-fetch.ts
+++ b/packages/agent-core/src/llm-fetch.ts
@@ -1,11 +1,61 @@
+import { createRequire } from 'node:module';
+
 import { Agent, fetch as undiciFetch } from 'undici';
 
 export type LlmHttpVersion = 'http1.1' | 'http2';
+
+export const SPIRIT_AGENT_UA_PRODUCT = 'SpiritAgent';
+
+const require = createRequire(import.meta.url);
+const defaultClientVersion = (require('../package.json') as { version: string }).version;
 
 const LLM_HTTP_VERSIONS: readonly LlmHttpVersion[] = ['http1.1', 'http2'];
 
 let configuredVersion: LlmHttpVersion = 'http2';
 let llmDispatcher: Agent | undefined;
+let configuredClientVersion: string = defaultClientVersion;
+
+export function buildSpiritAgentUserAgent(version: string): string {
+  return `${SPIRIT_AGENT_UA_PRODUCT}/${version.trim()}`;
+}
+
+export function getLlmClientVersion(): string {
+  return configuredClientVersion;
+}
+
+export function configureLlmClientVersion(version: string): void {
+  const trimmed = version.trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+  configuredClientVersion = trimmed;
+}
+
+export function mergeLlmFetchInit(init?: RequestInit): RequestInit {
+  const userAgent = buildSpiritAgentUserAgent(configuredClientVersion);
+  const sourceHeaders = init?.headers;
+
+  if (sourceHeaders instanceof Headers) {
+    const headers = new Headers(sourceHeaders);
+    headers.set('User-Agent', userAgent);
+    return { ...init, headers };
+  }
+
+  const headers = new Headers();
+  if (Array.isArray(sourceHeaders)) {
+    for (const [key, value] of sourceHeaders) {
+      headers.append(key, value);
+    }
+  } else if (sourceHeaders && typeof sourceHeaders === 'object') {
+    for (const [key, value] of Object.entries(sourceHeaders)) {
+      if (value !== undefined) {
+        headers.set(key, value);
+      }
+    }
+  }
+  headers.set('User-Agent', userAgent);
+  return { ...init, headers };
+}
 
 export function normalizeLlmHttpVersion(value: unknown): LlmHttpVersion {
   if (typeof value === 'string') {
@@ -50,7 +100,7 @@ export function getLlmFetch(): typeof fetch {
   const fetchWithDispatcher = (input: RequestInfo | URL, init?: RequestInit) =>
     undiciFetch(
       input as Parameters<typeof undiciFetch>[0],
-      { ...init, dispatcher } as Parameters<typeof undiciFetch>[1],
+      { ...mergeLlmFetchInit(init), dispatcher } as Parameters<typeof undiciFetch>[1],
     );
   return fetchWithDispatcher as unknown as typeof fetch;
 }

--- a/packages/agent-core/src/open-responses/gateway-web-search.ts
+++ b/packages/agent-core/src/open-responses/gateway-web-search.ts
@@ -1,5 +1,6 @@
 import { createGateway } from '@ai-sdk/gateway';
 
+import { getLlmFetch } from '../llm-fetch.js';
 import type { JsonObject } from '../ports.js';
 import type { OpenResponsesTransportConfig } from './responses-compat.js';
 
@@ -8,7 +9,7 @@ export function shouldUseGatewayWebSearch(config: OpenResponsesTransportConfig):
 }
 
 export function buildGatewayWebSearchTool(config: OpenResponsesTransportConfig): unknown {
-  return createGateway({ apiKey: config.apiKey }).tools.perplexitySearch();
+  return createGateway({ apiKey: config.apiKey, fetch: getLlmFetch() }).tools.perplexitySearch();
 }
 
 export function buildGatewayResponsesWebSearchToolRequestEntry(): JsonObject {

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -684,7 +684,7 @@ function createAiSdkLanguageModel(config: OpenAiTransportConfig): any {
 function createAiSdkImageModel(config: OpenAiImageGenerationConfig): any {
   if (isVercelAiGatewayImageConfig(config)) {
     // Gateway 生图走 v3 image-model 协议，不能复用 chat 预设的 /v1 baseUrl。
-    return createGateway({ apiKey: config.apiKey }).image(config.model);
+    return createGateway({ apiKey: config.apiKey, fetch: getLlmFetch() }).image(config.model);
   }
 
   return createAiSdkOpenAiCompatibleProvider(config, { includeChatVendorExtras: false }).imageModel(config.model);

--- a/packages/agent-core/src/openai/moonshot-files.test.ts
+++ b/packages/agent-core/src/openai/moonshot-files.test.ts
@@ -5,6 +5,10 @@ import { tmpdir } from 'node:os';
 import test from 'node:test';
 
 import {
+  configureLlmClientVersion,
+  setLlmFetchTransportOverrideForTests,
+} from '../llm-fetch.js';
+import {
   clearMoonshotVideoUploadCache,
   uploadMoonshotVideoFile,
 } from './moonshot-files.js';
@@ -13,20 +17,22 @@ const MINIMAL_MP4_HEADER = Buffer.from([
   0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
 ]);
 
-test('uploadMoonshotVideoFile posts multipart with purpose=video and returns ms:// url', async () => {
+test('uploadMoonshotVideoFile posts multipart with purpose=video, User-Agent, and returns ms:// url', async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-agent-core-moonshot-upload-'));
   const videoPath = join(workspaceRoot, 'clip.mp4');
-  const originalFetch = globalThis.fetch;
   let capturedBody: FormData | undefined;
+  let capturedUserAgent: string | null = null;
 
   try {
     await writeFile(videoPath, MINIMAL_MP4_HEADER);
     clearMoonshotVideoUploadCache();
-
-    globalThis.fetch = (async (_input, init) => {
+    configureLlmClientVersion('1.2.3');
+    setLlmFetchTransportOverrideForTests(async (_input, init) => {
       capturedBody = init?.body as FormData;
+      const headers = init?.headers;
+      capturedUserAgent = headers instanceof Headers ? headers.get('User-Agent') : null;
       return new Response(JSON.stringify({ id: 'file-abc123' }), { status: 200 });
-    }) as typeof fetch;
+    });
 
     const url = await uploadMoonshotVideoFile(
       { apiKey: 'test-key', baseUrl: 'https://api.moonshot.cn/v1' },
@@ -36,6 +42,7 @@ test('uploadMoonshotVideoFile posts multipart with purpose=video and returns ms:
     assert.equal(url, 'ms://file-abc123');
     assert.equal(capturedBody?.get('purpose'), 'video');
     assert.ok(capturedBody?.get('file'));
+    assert.equal(capturedUserAgent, 'SpiritAgent/1.2.3');
 
     const cached = await uploadMoonshotVideoFile(
       { apiKey: 'test-key', baseUrl: 'https://api.moonshot.cn/v1' },
@@ -43,7 +50,8 @@ test('uploadMoonshotVideoFile posts multipart with purpose=video and returns ms:
     );
     assert.equal(cached, 'ms://file-abc123');
   } finally {
-    globalThis.fetch = originalFetch;
+    setLlmFetchTransportOverrideForTests(undefined);
+    configureLlmClientVersion('0.1.0');
     clearMoonshotVideoUploadCache();
     await rm(workspaceRoot, { recursive: true, force: true });
   }

--- a/packages/agent-core/src/openai/moonshot-files.ts
+++ b/packages/agent-core/src/openai/moonshot-files.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from 'node:fs/promises';
 import { basename } from 'node:path';
 
+import { getLlmFetch } from '../llm-fetch.js';
 import type { OpenAiTransportConfig } from './openai-compat.js';
 
 /** Moonshot AI 视频理解：经 Files API 上传，purpose 必须为 video。 */
@@ -28,7 +29,7 @@ export async function uploadMoonshotVideoFile(
   form.append('file', new Blob([bytes]), basename(absolutePath));
   form.append('purpose', 'video');
 
-  const response = await fetch(`${normalizeMoonshotApiBase(config.baseUrl)}/files`, {
+  const response = await getLlmFetch()(`${normalizeMoonshotApiBase(config.baseUrl)}/files`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${config.apiKey}`,

--- a/packages/agent-core/src/video-generation/ai-sdk-gateway-backend.ts
+++ b/packages/agent-core/src/video-generation/ai-sdk-gateway-backend.ts
@@ -1,6 +1,7 @@
 import { createGateway, type GatewayVideoModelId } from '@ai-sdk/gateway';
 import { experimental_generateVideo as generateVideo } from 'ai';
 
+import { getLlmFetch } from '../llm-fetch.js';
 import type { OpenAiVideoGenerationConfig } from '../openai/openai-compat.js';
 
 /** Gateway 视频走 v3 AI 协议（默认 `…/v3/ai/video-model`），不能用 chat 预设的 `/v1` baseUrl。 */
@@ -27,7 +28,10 @@ export class AiSdkGatewayVideoBackend implements VideoGenerationBackend {
     request: VideoGenerationRequest,
     saveGeneratedVideo: (request: GeneratedVideoSaveRequest) => Promise<GeneratedVideoFile>,
   ): Promise<ToolExecutionOutput> {
-    const provider = createGateway(resolveAiGatewayVideoProviderOptions(config));
+    const provider = createGateway({
+      ...resolveAiGatewayVideoProviderOptions(config),
+      fetch: getLlmFetch(),
+    });
 
     console.error('[agent-core][generate-video] request.start', {
       adapter: this.id,

--- a/packages/agent-core/src/video-generation/openrouter-videos-backend.ts
+++ b/packages/agent-core/src/video-generation/openrouter-videos-backend.ts
@@ -1,3 +1,4 @@
+import { getLlmFetch } from '../llm-fetch.js';
 import type { OpenAiVideoGenerationConfig } from '../openai/openai-compat.js';
 import type {
   GeneratedVideoFile,
@@ -38,7 +39,7 @@ export class OpenRouterVideosBackend implements VideoGenerationBackend {
       createUrl,
     });
 
-    const createResponse = await fetch(createUrl, {
+    const createResponse = await getLlmFetch()(createUrl, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${config.apiKey}`,
@@ -65,7 +66,7 @@ export class OpenRouterVideosBackend implements VideoGenerationBackend {
     }
 
     const completed = await pollUntil(async () => {
-      const statusResponse = await fetch(pollingUrl, {
+      const statusResponse = await getLlmFetch()(pollingUrl, {
         headers: {
           Authorization: `Bearer ${config.apiKey}`,
         },

--- a/packages/agent-core/src/video-generation/volcengine-ark-backend.ts
+++ b/packages/agent-core/src/video-generation/volcengine-ark-backend.ts
@@ -1,3 +1,4 @@
+import { getLlmFetch } from '../llm-fetch.js';
 import type { OpenAiVideoGenerationConfig } from '../openai/openai-compat.js';
 import type {
   GeneratedVideoFile,
@@ -42,7 +43,7 @@ export class VolcengineArkVideoBackend implements VideoGenerationBackend {
       resolution: request.resolution,
     });
 
-    const createResponse = await fetch(createUrl, {
+    const createResponse = await getLlmFetch()(createUrl, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${config.apiKey}`,
@@ -70,7 +71,7 @@ export class VolcengineArkVideoBackend implements VideoGenerationBackend {
 
     const statusUrl = `${baseUrl}/contents/generations/tasks/${encodeURIComponent(taskId)}`;
     const completed = await pollUntil(async () => {
-      const statusResponse = await fetch(statusUrl, {
+      const statusResponse = await getLlmFetch()(statusUrl, {
         headers: {
           Authorization: `Bearer ${config.apiKey}`,
         },


### PR DESCRIPTION
## Summary

- 在 `getLlmFetch()` 集中合并 `User-Agent: SpiritAgent/{version}`，支持宿主通过 `configureLlmClientVersion` 注入版本，默认回退 agent-core package.json。
- 补齐 Moonshot Files、Volcengine/OpenRouter 视频 API 及未传 `fetch` 的 Gateway 生图/生视频/web search 路径；视频 CDN 下载仍使用原生 fetch。
- Desktop 启动时从 package.json 注入版本；CLI 经 `runtime.setLlmClientVersion` RPC 注入 `CARGO_PKG_VERSION`。
- 补充 llm-fetch 与 moonshot-files 单测，断言出站 UA 格式与上传请求头。

## Test plan

- [x] `node --test dist/llm-fetch.test.js dist/openai/moonshot-files.test.js`（9 项通过）
- [x] `cargo check -p spirit-agent`
- [x] `npm run build`（agent-core）
- [ ] Desktop dev 发一条 chat，确认出站含 `User-Agent: SpiritAgent/0.1.0`（未执行）
- [ ] CLI 发一条 chat 确认 UA（未执行）