### PR TITLE
fix(desktop, cli): macOS 用户数据目录适配

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/.tsbuildinfo*
 **/*.tsbuildinfo
 /apps/desktop/release/
+**/.spirit-agent/

--- a/apps/cli/src/adapters.rs
+++ b/apps/cli/src/adapters.rs
@@ -3,6 +3,7 @@ use std::{env, path::PathBuf};
 
 use crate::{
     chat_store, logging,
+    mcp::spirit_agent_data_dir,
     model_registry::{
         AppConfig, config_file_path, has_model_api_key, keyring_entry, load_config,
         remove_model_api_key, save_config, save_model_api_key,
@@ -38,19 +39,7 @@ impl AppPaths for DefaultAppPaths {
     }
 
     fn permissions_file(&self) -> PathBuf {
-        if let Ok(appdata) = env::var("APPDATA") {
-            return PathBuf::from(appdata)
-                .join("SpiritAgent")
-                .join(PERMISSIONS_FILE);
-        }
-
-        if let Ok(home) = env::var("USERPROFILE") {
-            return PathBuf::from(home)
-                .join(".spirit-agent")
-                .join(PERMISSIONS_FILE);
-        }
-
-        PathBuf::from(format!(".spirit-agent.{}", PERMISSIONS_FILE))
+        spirit_agent_data_dir().join(PERMISSIONS_FILE)
     }
 
     fn log_file(&self) -> PathBuf {

--- a/apps/cli/src/chat_store.rs
+++ b/apps/cli/src/chat_store.rs
@@ -9,6 +9,8 @@ use std::{
 
 use crate::rewind::{ConversationMessageRole, ConversationMessageSnapshot, MessageAuxSnapshot};
 
+use crate::mcp::spirit_agent_data_dir;
+
 const CHAT_DIR_NAME: &str = "chats";
 
 fn default_chat_approval_level() -> String {
@@ -102,19 +104,7 @@ pub struct LoadedChat {
 }
 
 pub fn chat_dir_path() -> PathBuf {
-    if let Ok(appdata) = env::var("APPDATA") {
-        return PathBuf::from(appdata)
-            .join("SpiritAgent")
-            .join(CHAT_DIR_NAME);
-    }
-
-    if let Ok(home) = env::var("USERPROFILE") {
-        return PathBuf::from(home)
-            .join(".spirit-agent")
-            .join(CHAT_DIR_NAME);
-    }
-
-    PathBuf::from(format!(".spirit-agent.{}", CHAT_DIR_NAME))
+    spirit_agent_data_dir().join(CHAT_DIR_NAME)
 }
 
 pub fn list_chat_files() -> Result<Vec<PathBuf>> {

--- a/apps/cli/src/mcp.rs
+++ b/apps/cli/src/mcp.rs
@@ -11,6 +11,7 @@ use crate::logging;
 const MCP_CONFIG_FILE_NAME: &str = "mcp.json";
 const APP_DATA_DIR_NAME: &str = "SpiritAgent";
 const SPIRIT_DIR_NAME: &str = ".spirit";
+const ENV_SPIRIT_AGENT_DATA_DIR: &str = "SPIRIT_AGENT_DATA_DIR";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -137,16 +138,62 @@ pub struct LoadedMcpConfig {
     pub config: McpConfigFile,
 }
 
+fn unix_home_dir() -> Option<PathBuf> {
+    env::var("HOME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+}
+
 pub fn spirit_agent_data_dir() -> PathBuf {
+    if let Ok(dir) = env::var(ENV_SPIRIT_AGENT_DATA_DIR) {
+        let trimmed = dir.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
     if let Ok(appdata) = env::var("APPDATA") {
-        return PathBuf::from(appdata).join(APP_DATA_DIR_NAME);
+        let trimmed = appdata.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed).join(APP_DATA_DIR_NAME);
+        }
+    }
+
+    if let Some(home) = unix_home_dir() {
+        #[cfg(target_os = "macos")]
+        {
+            return home
+                .join("Library")
+                .join("Application Support")
+                .join(APP_DATA_DIR_NAME);
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(xdg_data_home) = env::var("XDG_DATA_HOME") {
+                let trimmed = xdg_data_home.trim();
+                if !trimmed.is_empty() {
+                    return PathBuf::from(trimmed).join(APP_DATA_DIR_NAME);
+                }
+            }
+            return home.join(".local").join("share").join(APP_DATA_DIR_NAME);
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            return home.join(".spirit-agent");
+        }
     }
 
     if let Ok(home) = env::var("USERPROFILE") {
-        return PathBuf::from(home).join(".spirit-agent");
+        let trimmed = home.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed).join(".spirit-agent");
+        }
     }
 
-    PathBuf::from(".spirit-agent")
+    unix_home_dir()
+        .map(|home| home.join(".spirit-agent"))
+        .unwrap_or_else(|| PathBuf::from(".spirit-agent"))
 }
 
 pub fn user_mcp_config_path() -> PathBuf {
@@ -377,6 +424,50 @@ fn default_true() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::shared_env_lock;
+
+    #[test]
+    fn spirit_agent_data_dir_uses_application_support_on_macos() {
+        if !cfg!(target_os = "macos") {
+            return;
+        }
+
+        let _guard = shared_env_lock()
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let home = unique_test_workspace("macos-data-dir");
+        std::fs::create_dir_all(&home).expect("create temp home");
+        unsafe {
+            env::set_var("HOME", &home);
+            env::remove_var("APPDATA");
+            env::remove_var("USERPROFILE");
+            env::remove_var(ENV_SPIRIT_AGENT_DATA_DIR);
+        }
+
+        assert_eq!(
+            spirit_agent_data_dir(),
+            home.join("Library")
+                .join("Application Support")
+                .join(APP_DATA_DIR_NAME)
+        );
+
+        let _ = fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn spirit_agent_data_dir_honors_env_override() {
+        let _guard = shared_env_lock()
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        let override_dir = unique_test_workspace("data-dir-override");
+        unsafe {
+            env::set_var(ENV_SPIRIT_AGENT_DATA_DIR, &override_dir);
+        }
+
+        assert_eq!(spirit_agent_data_dir(), override_dir);
+
+        let _ = fs::remove_dir_all(&override_dir);
+    }
 
     #[test]
     fn load_config_reads_single_user_file() {

--- a/apps/cli/src/model_registry.rs
+++ b/apps/cli/src/model_registry.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use crate::mcp::spirit_agent_data_dir;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::{
@@ -300,19 +301,7 @@ impl AppConfig {
 }
 
 pub fn config_file_path() -> PathBuf {
-    if let Ok(appdata) = env::var("APPDATA") {
-        return PathBuf::from(appdata)
-            .join("SpiritAgent")
-            .join("config.json");
-    }
-
-    if let Ok(home) = env::var("USERPROFILE") {
-        return PathBuf::from(home)
-            .join(".spirit-agent")
-            .join("config.json");
-    }
-
-    PathBuf::from(".spirit-agent.config.json")
+    spirit_agent_data_dir().join("config.json")
 }
 
 pub fn load_config() -> Result<AppConfig> {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -119,6 +119,7 @@ import {
 import {
   configFilePath,
   loadConfig,
+  migrateLegacyCwdSpiritAgentDataDir,
   resolveDefaultSpiritAgentDataDir,
   setSpiritAgentDataDirOverride,
   spiritAgentDataDir,
@@ -599,6 +600,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
 
 if (gotSpiritSingleInstanceLock) {
   app.whenReady().then(async () => {
+  await migrateLegacyCwdSpiritAgentDataDir();
   installSpiritGeneratedAssetProtocolHandler({
     resolveManagedGeneratedAssetPath,
     videoPreviewMimeType,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -119,7 +119,6 @@ import {
 import {
   configFilePath,
   loadConfig,
-  migrateLegacyCwdSpiritAgentDataDir,
   resolveDefaultSpiritAgentDataDir,
   setSpiritAgentDataDirOverride,
   spiritAgentDataDir,
@@ -600,7 +599,6 @@ async function createMainWindow(): Promise<BrowserWindow> {
 
 if (gotSpiritSingleInstanceLock) {
   app.whenReady().then(async () => {
-  await migrateLegacyCwdSpiritAgentDataDir();
   installSpiritGeneratedAssetProtocolHandler({
     resolveManagedGeneratedAssetPath,
     videoPreviewMimeType,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -87,7 +87,7 @@ const gotSpiritSingleInstanceLock = app.requestSingleInstanceLock();
 if (!gotSpiritSingleInstanceLock) {
   app.quit();
 } else {
-  const spiritDataDir = resolveDefaultSpiritAgentDataDir();
+  const spiritDataDir = resolveConfiguredSpiritAgentDataDir();
   app.setPath('userData', spiritDataDir);
   setSpiritAgentDataDirOverride(spiritDataDir);
 
@@ -119,7 +119,7 @@ import {
 import {
   configFilePath,
   loadConfig,
-  resolveDefaultSpiritAgentDataDir,
+  resolveConfiguredSpiritAgentDataDir,
   setSpiritAgentDataDirOverride,
   spiritAgentDataDir,
   type DesktopWebHostConfigFile,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -87,6 +87,10 @@ const gotSpiritSingleInstanceLock = app.requestSingleInstanceLock();
 if (!gotSpiritSingleInstanceLock) {
   app.quit();
 } else {
+  const spiritDataDir = resolveDefaultSpiritAgentDataDir();
+  app.setPath('userData', spiritDataDir);
+  setSpiritAgentDataDirOverride(spiritDataDir);
+
   app.on('second-instance', (_event, argv) => {
     handleSpiritNotificationProtocolArgv(argv);
   });
@@ -115,6 +119,8 @@ import {
 import {
   configFilePath,
   loadConfig,
+  resolveDefaultSpiritAgentDataDir,
+  setSpiritAgentDataDirOverride,
   spiritAgentDataDir,
   type DesktopWebHostConfigFile,
 } from '../src/host/storage.js';

--- a/apps/desktop/electron/web-host.ts
+++ b/apps/desktop/electron/web-host.ts
@@ -4,7 +4,6 @@ import { fileURLToPath } from 'node:url';
 import { invokeDesktopHostCommand } from '../src/host/service.js';
 import {
   loadConfig,
-  migrateLegacyCwdSpiritAgentDataDir,
   resolveDefaultSpiritAgentDataDir,
   setSpiritAgentDataDirOverride,
   type DesktopWebHostConfigFile,
@@ -21,7 +20,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 setSpiritAgentDataDirOverride(resolveDefaultSpiritAgentDataDir());
-await migrateLegacyCwdSpiritAgentDataDir();
 
 const { host, port } = resolveDesktopWebHostFromEnv();
 let webHostConfig: DesktopWebHostConfigFile = (await loadConfig()).webHost;

--- a/apps/desktop/electron/web-host.ts
+++ b/apps/desktop/electron/web-host.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { invokeDesktopHostCommand } from '../src/host/service.js';
 import {
   loadConfig,
+  migrateLegacyCwdSpiritAgentDataDir,
   resolveDefaultSpiritAgentDataDir,
   setSpiritAgentDataDirOverride,
   type DesktopWebHostConfigFile,
@@ -20,6 +21,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 setSpiritAgentDataDirOverride(resolveDefaultSpiritAgentDataDir());
+await migrateLegacyCwdSpiritAgentDataDir();
 
 const { host, port } = resolveDesktopWebHostFromEnv();
 let webHostConfig: DesktopWebHostConfigFile = (await loadConfig()).webHost;

--- a/apps/desktop/electron/web-host.ts
+++ b/apps/desktop/electron/web-host.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { invokeDesktopHostCommand } from '../src/host/service.js';
 import {
   loadConfig,
-  resolveDefaultSpiritAgentDataDir,
+  resolveConfiguredSpiritAgentDataDir,
   setSpiritAgentDataDirOverride,
   type DesktopWebHostConfigFile,
 } from '../src/host/storage.js';
@@ -19,7 +19,7 @@ import { resolveRendererDistPath } from './renderer-dist.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-setSpiritAgentDataDirOverride(resolveDefaultSpiritAgentDataDir());
+setSpiritAgentDataDirOverride(resolveConfiguredSpiritAgentDataDir());
 
 const { host, port } = resolveDesktopWebHostFromEnv();
 let webHostConfig: DesktopWebHostConfigFile = (await loadConfig()).webHost;

--- a/apps/desktop/electron/web-host.ts
+++ b/apps/desktop/electron/web-host.ts
@@ -2,7 +2,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { invokeDesktopHostCommand } from '../src/host/service.js';
-import { loadConfig, type DesktopWebHostConfigFile } from '../src/host/storage.js';
+import {
+  loadConfig,
+  resolveDefaultSpiritAgentDataDir,
+  setSpiritAgentDataDirOverride,
+  type DesktopWebHostConfigFile,
+} from '../src/host/storage.js';
 import { setDesktopWebHostRuntimeStatus } from '../src/host/web-host-state.js';
 import {
   createDesktopHttpHost,
@@ -13,6 +18,8 @@ import { resolveRendererDistPath } from './renderer-dist.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+setSpiritAgentDataDirOverride(resolveDefaultSpiritAgentDataDir());
 
 const { host, port } = resolveDesktopWebHostFromEnv();
 let webHostConfig: DesktopWebHostConfigFile = (await loadConfig()).webHost;

--- a/apps/desktop/src/host/host-initialization.ts
+++ b/apps/desktop/src/host/host-initialization.ts
@@ -9,6 +9,7 @@ import {
   loadConfig,
   loadHostMetadata,
   mergeRecentWorkspaceRoots,
+  migrateLegacyCwdSpiritAgentDataDir,
   normalizeWorkspaceBinding,
   resolveDesktopHomeDirectory,
   saveConfig,
@@ -73,6 +74,7 @@ export async function ensureInitializedCommand(
     ? path.resolve(workspaceRootOverride.trim())
     : undefined;
 
+  await migrateLegacyCwdSpiritAgentDataDir();
   const loadedConfig = await loadConfig();
   applyLlmHttpVersionFromConfig(loadedConfig);
   applyLlmClientVersionFromApp();

--- a/apps/desktop/src/host/host-initialization.ts
+++ b/apps/desktop/src/host/host-initialization.ts
@@ -9,7 +9,6 @@ import {
   loadConfig,
   loadHostMetadata,
   mergeRecentWorkspaceRoots,
-  migrateLegacyCwdSpiritAgentDataDir,
   normalizeWorkspaceBinding,
   resolveDesktopHomeDirectory,
   saveConfig,
@@ -74,7 +73,6 @@ export async function ensureInitializedCommand(
     ? path.resolve(workspaceRootOverride.trim())
     : undefined;
 
-  await migrateLegacyCwdSpiritAgentDataDir();
   const loadedConfig = await loadConfig();
   applyLlmHttpVersionFromConfig(loadedConfig);
   applyLlmClientVersionFromApp();

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import {
+  cp,
   mkdir,
   readdir,
   readFile,
@@ -156,7 +157,7 @@ const ENV_SPIRIT_AGENT_DATA_DIR = 'SPIRIT_AGENT_DATA_DIR';
 
 let spiritAgentDataDirOverride: string | undefined;
 
-export function setSpiritAgentDataDirOverride(dir: string): void {
+export function setSpiritAgentDataDirOverride(dir: string | undefined): void {
   spiritAgentDataDirOverride = dir;
 }
 
@@ -205,6 +206,28 @@ export function spiritAgentDataDir(): string {
   }
 
   return resolveDefaultSpiritAgentDataDir();
+}
+
+export async function migrateLegacyCwdSpiritAgentDataDir(): Promise<void> {
+  const targetDir = spiritAgentDataDir();
+  const targetConfig = path.join(targetDir, CONFIG_FILE_NAME);
+  if (existsSync(targetConfig)) {
+    return;
+  }
+
+  const legacyDir = path.resolve('.spirit-agent');
+  const legacyConfig = path.join(legacyDir, CONFIG_FILE_NAME);
+  if (!existsSync(legacyConfig)) {
+    return;
+  }
+
+  if (path.resolve(targetDir) === path.resolve(legacyDir)) {
+    return;
+  }
+
+  await mkdir(targetDir, { recursive: true });
+  await cp(legacyDir, targetDir, { recursive: true, force: false });
+  console.info(`[spirit-agent] Migrated legacy data from ${legacyDir} to ${targetDir}`);
 }
 
 export function chatsDirPath(): string {

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -194,17 +194,21 @@ export function resolveDefaultSpiritAgentDataDir(): string {
   return path.join(homedir(), '.spirit-agent');
 }
 
-export function spiritAgentDataDir(): string {
-  if (spiritAgentDataDirOverride) {
-    return spiritAgentDataDirOverride;
-  }
-
+export function resolveConfiguredSpiritAgentDataDir(): string {
   const envOverride = process.env[ENV_SPIRIT_AGENT_DATA_DIR]?.trim();
   if (envOverride) {
     return envOverride;
   }
 
   return resolveDefaultSpiritAgentDataDir();
+}
+
+export function spiritAgentDataDir(): string {
+  if (spiritAgentDataDirOverride) {
+    return spiritAgentDataDirOverride;
+  }
+
+  return resolveConfiguredSpiritAgentDataDir();
 }
 
 export function chatsDirPath(): string {

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
 import {
-  cp,
   mkdir,
   readdir,
   readFile,
@@ -206,28 +205,6 @@ export function spiritAgentDataDir(): string {
   }
 
   return resolveDefaultSpiritAgentDataDir();
-}
-
-export async function migrateLegacyCwdSpiritAgentDataDir(): Promise<void> {
-  const targetDir = spiritAgentDataDir();
-  const targetConfig = path.join(targetDir, CONFIG_FILE_NAME);
-  if (existsSync(targetConfig)) {
-    return;
-  }
-
-  const legacyDir = path.resolve('.spirit-agent');
-  const legacyConfig = path.join(legacyDir, CONFIG_FILE_NAME);
-  if (!existsSync(legacyConfig)) {
-    return;
-  }
-
-  if (path.resolve(targetDir) === path.resolve(legacyDir)) {
-    return;
-  }
-
-  await mkdir(targetDir, { recursive: true });
-  await cp(legacyDir, targetDir, { recursive: true, force: false });
-  console.info(`[spirit-agent] Migrated legacy data from ${legacyDir} to ${targetDir}`);
 }
 
 export function chatsDirPath(): string {

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -152,16 +152,59 @@ export type RuleDiscoveryResult = HostRuleDiscoveryResult;
 export type SkillDiscoveryResult = HostSkillDiscoveryResult;
 export type HostMetadataSummary = HostInstructionMetadataSummary;
 
+const ENV_SPIRIT_AGENT_DATA_DIR = 'SPIRIT_AGENT_DATA_DIR';
+
+let spiritAgentDataDirOverride: string | undefined;
+
+export function setSpiritAgentDataDirOverride(dir: string): void {
+  spiritAgentDataDirOverride = dir;
+}
+
+function resolveHomeDirectory(): string | undefined {
+  const home = process.env.HOME?.trim() || homedir()?.trim();
+  return home || undefined;
+}
+
+export function resolveDefaultSpiritAgentDataDir(): string {
+  const appData = process.env.APPDATA?.trim();
+  if (appData) {
+    return path.join(appData, APP_DATA_DIR_NAME);
+  }
+
+  const home = resolveHomeDirectory();
+  if (home) {
+    if (process.platform === 'darwin') {
+      return path.join(home, 'Library', 'Application Support', APP_DATA_DIR_NAME);
+    }
+    if (process.platform === 'linux') {
+      const xdgDataHome = process.env.XDG_DATA_HOME?.trim();
+      if (xdgDataHome) {
+        return path.join(xdgDataHome, APP_DATA_DIR_NAME);
+      }
+      return path.join(home, '.local', 'share', APP_DATA_DIR_NAME);
+    }
+    return path.join(home, '.spirit-agent');
+  }
+
+  const userProfile = process.env.USERPROFILE?.trim();
+  if (userProfile) {
+    return path.join(userProfile, '.spirit-agent');
+  }
+
+  return path.join(homedir(), '.spirit-agent');
+}
+
 export function spiritAgentDataDir(): string {
-  if (process.env.APPDATA?.trim()) {
-    return path.join(process.env.APPDATA.trim(), APP_DATA_DIR_NAME);
+  if (spiritAgentDataDirOverride) {
+    return spiritAgentDataDirOverride;
   }
 
-  if (process.env.USERPROFILE?.trim()) {
-    return path.join(process.env.USERPROFILE.trim(), '.spirit-agent');
+  const envOverride = process.env[ENV_SPIRIT_AGENT_DATA_DIR]?.trim();
+  if (envOverride) {
+    return envOverride;
   }
 
-  return path.resolve('.spirit-agent');
+  return resolveDefaultSpiritAgentDataDir();
 }
 
 export function chatsDirPath(): string {

--- a/apps/desktop/test/host/spirit-agent-data-dir.test.mjs
+++ b/apps/desktop/test/host/spirit-agent-data-dir.test.mjs
@@ -1,15 +1,10 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 
-import {
-  migrateLegacyCwdSpiritAgentDataDir,
-  resolveDefaultSpiritAgentDataDir,
-  setSpiritAgentDataDirOverride,
-  spiritAgentDataDir,
-} from '../../dist-electron/src/host/storage.js';
+import { resolveDefaultSpiritAgentDataDir } from '../../dist-electron/src/host/storage.js';
 
 async function withEnv(vars, run) {
   const previous = new Map();
@@ -57,33 +52,5 @@ test('resolveDefaultSpiritAgentDataDir uses Application Support on macOS', async
     );
   } finally {
     await rm(home, { recursive: true, force: true });
-  }
-});
-
-test('migrateLegacyCwdSpiritAgentDataDir copies cwd legacy config into override target', async () => {
-  const previousCwd = process.cwd();
-  const workspace = await mkdtemp(path.join(tmpdir(), 'spirit-agent-migrate-'));
-  const legacyDir = path.join(workspace, '.spirit-agent');
-  const targetDir = path.join(workspace, 'canonical-data-dir');
-
-  try {
-    process.chdir(workspace);
-    setSpiritAgentDataDirOverride(targetDir);
-    await mkdir(legacyDir, { recursive: true });
-    await writeFile(
-      path.join(legacyDir, 'config.json'),
-      JSON.stringify({ activeModel: 'legacy-model', models: [] }),
-      'utf8',
-    );
-
-    await migrateLegacyCwdSpiritAgentDataDir();
-
-    assert.equal(spiritAgentDataDir(), targetDir);
-    const migratedConfig = await readFile(path.join(targetDir, 'config.json'), 'utf8');
-    assert.match(migratedConfig, /legacy-model/);
-  } finally {
-    setSpiritAgentDataDirOverride(undefined);
-    process.chdir(previousCwd);
-    await rm(workspace, { recursive: true, force: true });
   }
 });

--- a/apps/desktop/test/host/spirit-agent-data-dir.test.mjs
+++ b/apps/desktop/test/host/spirit-agent-data-dir.test.mjs
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 
-import { resolveDefaultSpiritAgentDataDir } from '../../dist-electron/src/host/storage.js';
+import {
+  resolveConfiguredSpiritAgentDataDir,
+  resolveDefaultSpiritAgentDataDir,
+} from '../../dist-electron/src/host/storage.js';
 
 async function withEnv(vars, run) {
   const previous = new Map();
@@ -53,4 +56,20 @@ test('resolveDefaultSpiritAgentDataDir uses Application Support on macOS', async
   } finally {
     await rm(home, { recursive: true, force: true });
   }
+});
+
+test('resolveConfiguredSpiritAgentDataDir honors SPIRIT_AGENT_DATA_DIR', async () => {
+  await withEnv(
+    {
+      SPIRIT_AGENT_DATA_DIR: '/tmp/spirit-agent-custom-data-dir',
+      APPDATA: '/tmp/spirit-agent-appdata',
+      HOME: '/tmp/spirit-agent-home',
+    },
+    async () => {
+      assert.equal(
+        resolveConfiguredSpiritAgentDataDir(),
+        '/tmp/spirit-agent-custom-data-dir',
+      );
+    },
+  );
 });

--- a/apps/desktop/test/host/spirit-agent-data-dir.test.mjs
+++ b/apps/desktop/test/host/spirit-agent-data-dir.test.mjs
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  migrateLegacyCwdSpiritAgentDataDir,
+  resolveDefaultSpiritAgentDataDir,
+  setSpiritAgentDataDirOverride,
+  spiritAgentDataDir,
+} from '../../dist-electron/src/host/storage.js';
+
+async function withEnv(vars, run) {
+  const previous = new Map();
+  for (const [key, value] of Object.entries(vars)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    await run();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test('resolveDefaultSpiritAgentDataDir uses Application Support on macOS', async () => {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  const home = await mkdtemp(path.join(tmpdir(), 'spirit-agent-home-'));
+  try {
+    await withEnv(
+      {
+        APPDATA: undefined,
+        HOME: home,
+        USERPROFILE: undefined,
+        SPIRIT_AGENT_DATA_DIR: undefined,
+      },
+      async () => {
+        assert.equal(
+          resolveDefaultSpiritAgentDataDir(),
+          path.join(home, 'Library', 'Application Support', 'SpiritAgent'),
+        );
+      },
+    );
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('migrateLegacyCwdSpiritAgentDataDir copies cwd legacy config into override target', async () => {
+  const previousCwd = process.cwd();
+  const workspace = await mkdtemp(path.join(tmpdir(), 'spirit-agent-migrate-'));
+  const legacyDir = path.join(workspace, '.spirit-agent');
+  const targetDir = path.join(workspace, 'canonical-data-dir');
+
+  try {
+    process.chdir(workspace);
+    setSpiritAgentDataDirOverride(targetDir);
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(
+      path.join(legacyDir, 'config.json'),
+      JSON.stringify({ activeModel: 'legacy-model', models: [] }),
+      'utf8',
+    );
+
+    await migrateLegacyCwdSpiritAgentDataDir();
+
+    assert.equal(spiritAgentDataDir(), targetDir);
+    const migratedConfig = await readFile(path.join(targetDir, 'config.json'), 'utf8');
+    assert.match(migratedConfig, /legacy-model/);
+  } finally {
+    setSpiritAgentDataDirOverride(undefined);
+    process.chdir(previousCwd);
+    await rm(workspace, { recursive: true, force: true });
+  }
+});

--- a/packages/agent-core/src/mcp/config.test.ts
+++ b/packages/agent-core/src/mcp/config.test.ts
@@ -2,17 +2,97 @@ import assert from 'node:assert/strict';
 import { join } from 'node:path';
 import test from 'node:test';
 
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
 import {
   findMcpServerNameConflict,
   mcpServerScopesFromFiles,
   mcpWorkspaceConfigPath,
   mergeMcpConfigFiles,
+  resolveDefaultSpiritAgentDataDir,
+  spiritAgentDataDir,
 } from './config.js';
 import type { McpConfigFile } from './types.js';
 
 const stdioServer = {
   transport: { type: 'stdio' as const, command: 'echo' },
 };
+
+function withEnv(vars: Record<string, string | undefined>, run: () => void): void {
+  const previous = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(vars)) {
+    previous.set(key, process.env[key]);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    run();
+  } finally {
+    for (const [key, value] of previous.entries()) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test('resolveDefaultSpiritAgentDataDir uses APPDATA on Windows-style hosts', () => {
+  withEnv(
+    {
+      APPDATA: '/tmp/spirit-agent-appdata',
+      HOME: '/tmp/should-not-use',
+      USERPROFILE: undefined,
+      SPIRIT_AGENT_DATA_DIR: undefined,
+    },
+    () => {
+      assert.equal(resolveDefaultSpiritAgentDataDir(), join('/tmp/spirit-agent-appdata', 'SpiritAgent'));
+    },
+  );
+});
+
+test('resolveDefaultSpiritAgentDataDir uses Application Support on macOS', () => {
+  if (process.platform !== 'darwin') {
+    return;
+  }
+
+  const home = mkdtempSync(join(tmpdir(), 'spirit-agent-home-'));
+  try {
+    withEnv(
+      {
+        APPDATA: undefined,
+        HOME: home,
+        USERPROFILE: undefined,
+        SPIRIT_AGENT_DATA_DIR: undefined,
+      },
+      () => {
+        assert.equal(
+          resolveDefaultSpiritAgentDataDir(),
+          join(home, 'Library', 'Application Support', 'SpiritAgent'),
+        );
+      },
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('spiritAgentDataDir honors SPIRIT_AGENT_DATA_DIR override', () => {
+  withEnv(
+    {
+      SPIRIT_AGENT_DATA_DIR: '/tmp/spirit-agent-override',
+      APPDATA: '/tmp/spirit-agent-appdata',
+    },
+    () => {
+      assert.equal(spiritAgentDataDir(), '/tmp/spirit-agent-override');
+    },
+  );
+});
 
 test('mcpWorkspaceConfigPath resolves under .spirit directory', () => {
   assert.equal(

--- a/packages/agent-core/src/mcp/config.ts
+++ b/packages/agent-core/src/mcp/config.ts
@@ -1,4 +1,8 @@
+import { homedir } from 'node:os';
 import { join } from 'node:path';
+
+const APP_DATA_DIR_NAME = 'SpiritAgent';
+const ENV_SPIRIT_AGENT_DATA_DIR = 'SPIRIT_AGENT_DATA_DIR';
 
 import { McpConfigError } from './errors.js';
 import type {
@@ -32,10 +36,30 @@ export function mcpWorkspaceConfigPath(workspaceRoot: string): string {
   return join(workspaceRoot, SPIRIT_DIR_NAME, DEFAULT_MCP_CONFIG_FILE);
 }
 
-export function spiritAgentDataDir(): string {
+function resolveHomeDirectory(): string | undefined {
+  const home = process.env.HOME?.trim() || homedir()?.trim();
+  return home || undefined;
+}
+
+export function resolveDefaultSpiritAgentDataDir(): string {
   const appData = process.env.APPDATA?.trim();
   if (appData) {
-    return join(appData, 'SpiritAgent');
+    return join(appData, APP_DATA_DIR_NAME);
+  }
+
+  const home = resolveHomeDirectory();
+  if (home) {
+    if (process.platform === 'darwin') {
+      return join(home, 'Library', 'Application Support', APP_DATA_DIR_NAME);
+    }
+    if (process.platform === 'linux') {
+      const xdgDataHome = process.env.XDG_DATA_HOME?.trim();
+      if (xdgDataHome) {
+        return join(xdgDataHome, APP_DATA_DIR_NAME);
+      }
+      return join(home, '.local', 'share', APP_DATA_DIR_NAME);
+    }
+    return join(home, '.spirit-agent');
   }
 
   const userProfile = process.env.USERPROFILE?.trim();
@@ -43,7 +67,16 @@ export function spiritAgentDataDir(): string {
     return join(userProfile, '.spirit-agent');
   }
 
-  return '.spirit-agent';
+  return join(homedir(), '.spirit-agent');
+}
+
+export function spiritAgentDataDir(): string {
+  const envOverride = process.env[ENV_SPIRIT_AGENT_DATA_DIR]?.trim();
+  if (envOverride) {
+    return envOverride;
+  }
+
+  return resolveDefaultSpiritAgentDataDir();
 }
 
 export function mergeMcpConfigFiles(


### PR DESCRIPTION
## Summary
- macOS/Linux 用户数据目录统一解析为 `~/Library/Application Support/SpiritAgent`（Windows 仍为 `%APPDATA%/SpiritAgent`），不再回退到 cwd 下的 `./.spirit-agent`
- Desktop Electron 在 `app ready` 前注入 `userData`；CLI Rust 单点 `spirit_agent_data_dir()` 并去除重复路径逻辑
- `.gitignore` 忽略 `**/.spirit-agent/`，并补充路径解析单元测试

## Test plan
- [x] `packages/agent-core` config 测试通过
- [x] `apps/desktop` 路径解析与 host 测试通过
- [x] 本地 Desktop dev 启动，数据写入 `~/Library/Application Support/SpiritAgent`，仓库内不再生成 `.spirit-agent`
- [ ] `cargo test -p spirit-agent`（macOS 路径测试，CI 验证）


Made with [Cursor](https://cursor.com)