### PR TITLE
feat(desktop): 外观设置增加悬停手型光标开关

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -163,6 +163,7 @@ import { isRunSubagentToolCallPending } from "@/lib/subagent-viewer-pending";
 import { useDesktopRuntime } from "@/hooks/useDesktopRuntime";
 import { useWorkspaceFileIndex } from "@/hooks/use-workspace-file-index";
 import { useLocalFileAttachmentPreviews } from "@/hooks/useLocalFileAttachmentPreviews";
+import { useClickablePointerCursor } from "@/hooks/useClickablePointerCursor";
 import { useFont } from "@/hooks/useFont";
 import { useTheme } from "@/hooks/useTheme";
 import { isManagedGeneratedVideoRef } from "@/lib/managed-generated-asset";
@@ -1978,6 +1979,7 @@ export default function App() {
   const { t, i18n } = useTranslation();
   const { theme, setTheme } = useTheme();
   const { font, setFont } = useFont();
+  const { clickablePointerCursor, setClickablePointerCursor } = useClickablePointerCursor();
   const runtime = useDesktopRuntime();
   const snapshot = runtime.snapshot;
   /** 与 Host API 的 `kind` 解耦：壳可能是 Electron，但仍通过 Vite 代理走 Web Host（侧栏会显示 Localhost Web Host）。Mica 与 `spirit-desktop-native` 仍应对 Electron 窗口生效。 */
@@ -3248,6 +3250,8 @@ export default function App() {
               onThemeChange={setTheme}
               font={font}
               onFontChange={setFont}
+              clickablePointerCursor={clickablePointerCursor}
+              onClickablePointerCursorChange={setClickablePointerCursor}
               settings={runtime.settings}
               snapshot={snapshot}
               runtimeError={runtime.runtimeError}

--- a/apps/desktop/src/components/settings-view.tsx
+++ b/apps/desktop/src/components/settings-view.tsx
@@ -118,6 +118,8 @@ type SettingsViewProps = {
   onThemeChange: (value: ThemePreference) => void;
   font: FontPreference;
   onFontChange: (value: FontPreference) => void;
+  clickablePointerCursor: boolean;
+  onClickablePointerCursorChange: (enabled: boolean) => void;
   settings: SettingsFormState;
   snapshot: DesktopSnapshot | null;
   runtimeError: string;
@@ -3764,11 +3766,20 @@ function AppearanceSettingsPanel({
   onThemeChange,
   font,
   onFontChange,
+  clickablePointerCursor,
+  onClickablePointerCursorChange,
   settings,
   onSavePatch,
 }: Pick<
   SettingsViewProps,
-  "theme" | "onThemeChange" | "font" | "onFontChange" | "settings" | "onSavePatch"
+  | "theme"
+  | "onThemeChange"
+  | "font"
+  | "onFontChange"
+  | "clickablePointerCursor"
+  | "onClickablePointerCursorChange"
+  | "settings"
+  | "onSavePatch"
 >) {
   const { t } = useTranslation();
   return (
@@ -3846,6 +3857,21 @@ function AppearanceSettingsPanel({
         ) : (
           <p className="text-sm text-muted-foreground sm:text-right">—</p>
         )}
+      </SettingsRow>
+
+      <SettingsRow
+        label={t('settings.clickablePointerCursor')}
+        description={t('settings.clickablePointerCursorDescription')}
+        htmlFor="settings-clickable-pointer-cursor"
+      >
+        <div className="flex justify-end">
+          <Checkbox
+            id="settings-clickable-pointer-cursor"
+            checked={clickablePointerCursor}
+            onCheckedChange={(value) => onClickablePointerCursorChange(value === true)}
+            className="size-5"
+          />
+        </div>
       </SettingsRow>
     </div>
   );
@@ -3977,6 +4003,8 @@ export function SettingsView({
   onThemeChange,
   font,
   onFontChange,
+  clickablePointerCursor,
+  onClickablePointerCursorChange,
   settings,
   snapshot,
   runtimeError,
@@ -4112,6 +4140,8 @@ export function SettingsView({
                 onThemeChange={onThemeChange}
                 font={font}
                 onFontChange={onFontChange}
+                clickablePointerCursor={clickablePointerCursor}
+                onClickablePointerCursorChange={onClickablePointerCursorChange}
                 settings={settings}
                 onSavePatch={onSavePatch}
               />

--- a/apps/desktop/src/hooks/useClickablePointerCursor.ts
+++ b/apps/desktop/src/hooks/useClickablePointerCursor.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from "react";
+
+import {
+  applyClickablePointerCursorToDocument,
+  getStoredClickablePointerCursor,
+  setStoredClickablePointerCursor,
+} from "@/lib/clickable-pointer-cursor";
+
+export function useClickablePointerCursor() {
+  const [clickablePointerCursor, setClickablePointerCursorState] = useState(() =>
+    getStoredClickablePointerCursor(),
+  );
+
+  const setClickablePointerCursor = useCallback((enabled: boolean) => {
+    setStoredClickablePointerCursor(enabled);
+    setClickablePointerCursorState(enabled);
+    applyClickablePointerCursorToDocument(enabled);
+  }, []);
+
+  return { clickablePointerCursor, setClickablePointerCursor };
+}

--- a/apps/desktop/src/lib/clickable-pointer-cursor.ts
+++ b/apps/desktop/src/lib/clickable-pointer-cursor.ts
@@ -1,0 +1,26 @@
+export const CLICKABLE_POINTER_CURSOR_STORAGE_KEY =
+  "spirit-agent-desktop-clickable-pointer" as const;
+
+export const CLICKABLE_POINTER_CURSOR_CLASS = "spirit-clickable-pointer" as const;
+
+export function getStoredClickablePointerCursor(): boolean {
+  if (typeof localStorage === "undefined") {
+    return false;
+  }
+  return localStorage.getItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY) === "true";
+}
+
+export function setStoredClickablePointerCursor(enabled: boolean): void {
+  if (enabled) {
+    localStorage.setItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY, "true");
+    return;
+  }
+  localStorage.removeItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY);
+}
+
+export function applyClickablePointerCursorToDocument(enabled: boolean): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  document.documentElement.classList.toggle(CLICKABLE_POINTER_CURSOR_CLASS, enabled);
+}

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -99,6 +99,8 @@
     "llmHttpVersionHttp11": "HTTP/1.1",
     "llmHttpVersionHttp2": "HTTP/2",
     "blurEffectUnsupported": "Current host does not support this option.",
+    "clickablePointerCursor": "Hand cursor on hover",
+    "clickablePointerCursorDescription": "Show a hand cursor over buttons, links, and other clickable controls.",
     "langZhCN": "Simplified Chinese",
     "langEn": "English",
     "remoteStatus": "Remote Status",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -99,6 +99,8 @@
     "llmHttpVersionHttp11": "HTTP/1.1",
     "llmHttpVersionHttp2": "HTTP/2",
     "blurEffectUnsupported": "当前宿主不支持此选项。",
+    "clickablePointerCursor": "悬停显示手型",
+    "clickablePointerCursorDescription": "开启后，悬停在按钮、链接等可点击元素上时显示手型光标。",
     "langZhCN": "简体中文",
     "langEn": "English",
     "remoteStatus": "远程状态",

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -4,6 +4,10 @@ import { createRoot } from 'react-dom/client';
 import './lib/i18n';
 import App from './App';
 import { ThemeProvider } from './hooks/useTheme';
+import {
+  applyClickablePointerCursorToDocument,
+  getStoredClickablePointerCursor,
+} from './lib/clickable-pointer-cursor';
 import { applyFontToDocument, getStoredFont } from './lib/font';
 import { applyThemeToDocument, getStoredTheme } from './lib/theme';
 import 'katex/dist/katex.min.css';
@@ -20,6 +24,7 @@ if (typeof document !== 'undefined') {
   }
   applyThemeToDocument(getStoredTheme());
   applyFontToDocument(getStoredFont());
+  applyClickablePointerCursorToDocument(getStoredClickablePointerCursor());
 }
 
 const rootElement = document.getElementById('app');

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -342,11 +342,6 @@ html.spirit-desktop-native.spirit-desktop-mica #app {
     cursor: pointer;
   }
 
-  html:not(.spirit-clickable-pointer)
-    .cursor-pointer:not(:disabled):not([aria-disabled="true"]):not([data-disabled]) {
-    cursor: default;
-  }
-
   button:disabled,
   [role="button"][aria-disabled="true"],
   [role="menuitem"][data-disabled],
@@ -542,4 +537,12 @@ html.spirit-clickable-pointer .workspace-shell-xterm .xterm-link {
 }
 .workspace-shell-xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
   background: color-mix(in oklab, var(--foreground) 24%, transparent);
+}
+
+/* 关闭手型偏好时压过 @layer utilities 的 cursor-pointer（含 enabled:cursor-pointer 等变体） */
+html:not(.spirit-clickable-pointer)
+  :is(.cursor-pointer, [class*="cursor-pointer"]):not(:disabled):not([aria-disabled="true"]):not(
+    [data-disabled]
+  ) {
+  cursor: default;
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -326,20 +326,25 @@ html.spirit-desktop-native.spirit-desktop-mica #app {
     @apply font-sans;
   }
 
-  /* 可点击控件统一手型光标；disabled 保持 not-allowed（组件内 cursor-default 等 utility 仍可覆盖） */
-  button:not(:disabled),
-  [role="button"]:not([aria-disabled="true"]),
-  [role="menuitem"]:not([data-disabled]),
-  [role="option"]:not([data-disabled]),
-  [role="tab"]:not([aria-disabled="true"]),
-  [role="switch"]:not([aria-disabled="true"]),
-  [role="checkbox"]:not([aria-disabled="true"]),
-  [role="radio"]:not([aria-disabled="true"]),
-  [role="combobox"]:not([aria-disabled="true"]),
-  label[for],
-  summary,
-  a[href] {
+  /* 可点击控件手型光标：仅在开启「悬停显示手型」时生效；disabled 保持 not-allowed */
+  html.spirit-clickable-pointer button:not(:disabled),
+  html.spirit-clickable-pointer [role="button"]:not([aria-disabled="true"]),
+  html.spirit-clickable-pointer [role="menuitem"]:not([data-disabled]),
+  html.spirit-clickable-pointer [role="option"]:not([data-disabled]),
+  html.spirit-clickable-pointer [role="tab"]:not([aria-disabled="true"]),
+  html.spirit-clickable-pointer [role="switch"]:not([aria-disabled="true"]),
+  html.spirit-clickable-pointer [role="checkbox"]:not([aria-disabled="true"]),
+  html.spirit-clickable-pointer [role="radio"]:not([aria-disabled="true"]),
+  html.spirit-clickable-pointer [role="combobox"]:not([aria-disabled="true"]),
+  html.spirit-clickable-pointer label[for],
+  html.spirit-clickable-pointer summary,
+  html.spirit-clickable-pointer a[href] {
     cursor: pointer;
+  }
+
+  html:not(.spirit-clickable-pointer)
+    .cursor-pointer:not(:disabled):not([aria-disabled="true"]):not([data-disabled]) {
+    cursor: default;
   }
 
   button:disabled,
@@ -514,8 +519,8 @@ html.spirit-desktop-native.spirit-desktop-mica #app {
   }
 }
 
-/* Shell 内嵌 xterm：可点击链接显示手型光标 */
-.workspace-shell-xterm .xterm-link {
+/* Shell 内嵌 xterm：可点击链接在开启手型偏好时显示手型光标 */
+html.spirit-clickable-pointer .workspace-shell-xterm .xterm-link {
   cursor: pointer;
   text-decoration: underline;
 }


### PR DESCRIPTION
## Summary

- 在设置 → 外观新增「悬停显示手型」开关，默认关闭；通过 localStorage 与 `html.spirit-clickable-pointer` 类名控制可点击元素光标样式。
- 关闭时语义控件与 Tailwind `cursor-pointer` 均显示 default；开启后恢复手型；disabled、输入框及 resize/grab 等专用光标不受影响。
- 修复关闭偏好后 shadcn 组件仍显示手型的问题：将覆盖规则移出 `@layer base`，以压过 utilities 层的 `cursor-pointer`。

## Test plan

- [x] 默认关闭：侧栏菜单、Select、Button、Checkbox 等为箭头光标；会话列表按钮同为 default
- [x] 开启后：上述可点击元素恢复手型
- [x] 禁用控件仍为 `not-allowed`
- [x] 输入框、Composer 富文本保持 I 型光标
- [x] 拖拽分隔条 resize 光标不受影响
- [x] 重启应用后偏好保持
- [x] Vite 构建通过