### PR TITLE
feat(desktop): 启动动画支持原生模糊材质

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3171,7 +3171,7 @@ export default function App() {
         useMicaBackdrop ? "bg-transparent" : "bg-background",
       )}
     >
-      <LaunchSplash active={launchSplashActive} />
+      <LaunchSplash active={launchSplashActive} useMicaBackdrop={useMicaBackdrop} />
       {winElectronChrome ? (
         <DesktopTitleBar useMicaBackdrop={useMicaBackdrop} />
       ) : null}

--- a/apps/desktop/src/components/launch-splash.tsx
+++ b/apps/desktop/src/components/launch-splash.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useState } from "react";
 
-import { useTheme } from "@/hooks/useTheme";
-import { spiritAgentBrandIconSrc } from "@/lib/brand-icon";
+import { SpiritGlassLogo, spiritGlassLogoMaskStyle } from "@/components/spirit-glass-logo";
 import { cn } from "@/lib/utils";
+
+const LAUNCH_LOGO_WIDTH_PX = 72;
 
 const EXIT_MS = 520;
 
@@ -22,22 +23,6 @@ type LaunchSplashProps = {
  * 首屏启动：居中品牌图标 + 骨架屏式线性闪光，宿主就绪后淡出。
  */
 export function LaunchSplash({ active, useMicaBackdrop = false }: LaunchSplashProps) {
-  const { resolvedDark } = useTheme();
-  const iconSrc = spiritAgentBrandIconSrc(resolvedDark);
-  const iconMaskStyle = useMemo<CSSProperties>(
-    () => ({
-      WebkitMaskImage: `url(${iconSrc})`,
-      maskImage: `url(${iconSrc})`,
-      WebkitMaskSize: "contain",
-      maskSize: "contain",
-      WebkitMaskRepeat: "no-repeat",
-      maskRepeat: "no-repeat",
-      WebkitMaskPosition: "center",
-      maskPosition: "center",
-    }),
-    [iconSrc],
-  );
-
   const [phase, setPhase] = useState<Phase>(() => (active ? "running" : "gone"));
 
   useEffect(() => {
@@ -98,21 +83,15 @@ export function LaunchSplash({ active, useMicaBackdrop = false }: LaunchSplashPr
     >
       <div
         className={cn(
-          "relative size-[4.5rem] shrink-0 transition-[opacity,transform] duration-[420ms] ease-out motion-reduce:duration-150",
+          "relative shrink-0 transition-[opacity,transform] duration-[420ms] ease-out motion-reduce:duration-150",
           exiting ? "scale-[0.97] opacity-0 motion-reduce:scale-100" : "scale-100 opacity-100",
         )}
+        style={{ width: LAUNCH_LOGO_WIDTH_PX }}
       >
-        <img
-          src={iconSrc}
-          alt=""
-          width={72}
-          height={72}
-          draggable={false}
-          className="block size-full object-contain select-none"
-        />
+        <SpiritGlassLogo width={LAUNCH_LOGO_WIDTH_PX} className="relative z-0" />
         <div
-          className="pointer-events-none absolute inset-0 overflow-hidden"
-          style={iconMaskStyle}
+          className="pointer-events-none absolute inset-0 z-10 overflow-hidden"
+          style={spiritGlassLogoMaskStyle()}
           aria-hidden
         >
           <div className="spirit-launch-shimmer-sweep" />

--- a/apps/desktop/src/components/launch-splash.tsx
+++ b/apps/desktop/src/components/launch-splash.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 
+import { useTheme } from "@/hooks/useTheme";
+import { spiritAgentBrandIconSrc } from "@/lib/brand-icon";
 import { cn } from "@/lib/utils";
 
 const EXIT_MS = 520;
@@ -7,30 +9,35 @@ const EXIT_MS = 520;
 /** 加载结束后延迟再播退场（毫秒），0 表示立即退场 */
 const EXIT_DELAY_BEFORE_MS = 0;
 
-const ICON_SRC = "./spirit-agent-icon.png";
-
 type Phase = "running" | "leaving" | "gone";
 
 type LaunchSplashProps = {
   /** 为 true 时显示加载态；变为 false 时播放退场后卸载 */
   active: boolean;
-};
-
-const iconMaskStyle: CSSProperties = {
-  WebkitMaskImage: `url(${ICON_SRC})`,
-  maskImage: `url(${ICON_SRC})`,
-  WebkitMaskSize: "contain",
-  maskSize: "contain",
-  WebkitMaskRepeat: "no-repeat",
-  maskRepeat: "no-repeat",
-  WebkitMaskPosition: "center",
-  maskPosition: "center",
+  /** 与侧栏一致：原生窗口模糊时启动层透明，透出系统材质 */
+  useMicaBackdrop?: boolean;
 };
 
 /**
  * 首屏启动：居中品牌图标 + 骨架屏式线性闪光，宿主就绪后淡出。
  */
-export function LaunchSplash({ active }: LaunchSplashProps) {
+export function LaunchSplash({ active, useMicaBackdrop = false }: LaunchSplashProps) {
+  const { resolvedDark } = useTheme();
+  const iconSrc = spiritAgentBrandIconSrc(resolvedDark);
+  const iconMaskStyle = useMemo<CSSProperties>(
+    () => ({
+      WebkitMaskImage: `url(${iconSrc})`,
+      maskImage: `url(${iconSrc})`,
+      WebkitMaskSize: "contain",
+      maskSize: "contain",
+      WebkitMaskRepeat: "no-repeat",
+      maskRepeat: "no-repeat",
+      WebkitMaskPosition: "center",
+      maskPosition: "center",
+    }),
+    [iconSrc],
+  );
+
   const [phase, setPhase] = useState<Phase>(() => (active ? "running" : "gone"));
 
   useEffect(() => {
@@ -59,6 +66,19 @@ export function LaunchSplash({ active }: LaunchSplashProps) {
     return () => window.clearTimeout(id);
   }, [phase]);
 
+  useEffect(() => {
+    const root = document.documentElement;
+    if (phase === "gone") {
+      root.classList.remove("spirit-launch-splash-active", "spirit-launch-splash-exiting");
+      return;
+    }
+    root.classList.add("spirit-launch-splash-active");
+    root.classList.toggle("spirit-launch-splash-exiting", phase === "leaving");
+    return () => {
+      root.classList.remove("spirit-launch-splash-active", "spirit-launch-splash-exiting");
+    };
+  }, [phase]);
+
   if (phase === "gone") {
     return null;
   }
@@ -67,9 +87,11 @@ export function LaunchSplash({ active }: LaunchSplashProps) {
 
   return (
     <div
+      data-spirit-surface="launch-splash"
       aria-hidden={exiting}
       className={cn(
-        "fixed inset-0 z-[200] flex items-center justify-center bg-background",
+        "fixed inset-0 z-[200] flex items-center justify-center",
+        useMicaBackdrop ? "bg-transparent" : "bg-background",
         "transition-opacity duration-500 ease-out motion-reduce:duration-200",
         exiting ? "pointer-events-none opacity-0" : "opacity-100",
       )}
@@ -81,7 +103,7 @@ export function LaunchSplash({ active }: LaunchSplashProps) {
         )}
       >
         <img
-          src={ICON_SRC}
+          src={iconSrc}
           alt=""
           width={72}
           height={72}

--- a/apps/desktop/src/components/spirit-glass-logo.tsx
+++ b/apps/desktop/src/components/spirit-glass-logo.tsx
@@ -1,0 +1,114 @@
+import { useId, type CSSProperties, type SVGProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** 与 spiritagent.app `glass-logo-showcase` 一致的品牌路径 */
+export const SPIRIT_GLASS_LOGO_PATH =
+  "M0 0L141.409 69.4512L70.7825 78.2408C61.5778 79.3863 53.5378 85.016 49.3132 93.2737L16.8979 156.635L0 0Z";
+
+export const SPIRIT_GLASS_LOGO_VIEWBOX = { width: 142, height: 157 } as const;
+
+const MASK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${SPIRIT_GLASS_LOGO_VIEWBOX.width} ${SPIRIT_GLASS_LOGO_VIEWBOX.height}"><path d="${SPIRIT_GLASS_LOGO_PATH}" fill="white"/></svg>`;
+
+/** 供启动层 shimmer 蒙版：与玻璃标轮廓一致 */
+export function spiritGlassLogoMaskStyle(): CSSProperties {
+  const mask = `url("data:image/svg+xml,${encodeURIComponent(MASK_SVG)}")`;
+  return {
+    WebkitMaskImage: mask,
+    maskImage: mask,
+    WebkitMaskSize: "contain",
+    maskSize: "contain",
+    WebkitMaskRepeat: "no-repeat",
+    maskRepeat: "no-repeat",
+    WebkitMaskPosition: "center",
+    maskPosition: "center",
+  };
+}
+
+type SpiritGlassLogoProps = Omit<SVGProps<SVGSVGElement>, "width" | "height" | "viewBox"> & {
+  /** 渲染宽度（px）；高度按站点 CTA 比例推算 */
+  width?: number;
+};
+
+/**
+ * spiritagent.app 页脚 CTA 玻璃品牌标（无 shimmer）。
+ * 源自 `glass-logo-showcase.tsx` 的静态图层。
+ */
+export function SpiritGlassLogo({ width = 72, className, ...props }: SpiritGlassLogoProps) {
+  const uid = useId().replace(/:/g, "");
+  const height = (width * SPIRIT_GLASS_LOGO_VIEWBOX.height) / SPIRIT_GLASS_LOGO_VIEWBOX.width;
+
+  const fillId = `${uid}-fill`;
+  const innerId = `${uid}-inner`;
+  const fresnelId = `${uid}-fresnel`;
+  const blurSmId = `${uid}-blur-sm`;
+  const blurMdId = `${uid}-blur-md`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${SPIRIT_GLASS_LOGO_VIEWBOX.width} ${SPIRIT_GLASS_LOGO_VIEWBOX.height}`}
+      width={width}
+      height={height}
+      aria-hidden
+      className={cn("block overflow-visible select-none", className)}
+      {...props}
+    >
+      <defs>
+        <linearGradient id={fillId} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="rgba(255,255,255,0.16)" />
+          <stop offset="40%" stopColor="rgba(255,255,255,0.04)" />
+          <stop offset="100%" stopColor="rgba(220,230,255,0.02)" />
+        </linearGradient>
+
+        <linearGradient id={innerId} x1="100%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stopColor="rgba(255,255,255,0.06)" />
+          <stop offset="45%" stopColor="rgba(255,255,255,0)" />
+          <stop offset="100%" stopColor="rgba(200,220,255,0.03)" />
+        </linearGradient>
+
+        <linearGradient id={fresnelId} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="rgba(190,215,255,0.35)" />
+          <stop offset="25%" stopColor="rgba(255,200,200,0.1)" />
+          <stop offset="55%" stopColor="rgba(200,255,215,0.1)" />
+          <stop offset="100%" stopColor="rgba(215,200,255,0.25)" />
+        </linearGradient>
+
+        <filter id={blurSmId} x="-20%" y="-20%" width="140%" height="140%">
+          <feGaussianBlur stdDeviation="1.5" />
+        </filter>
+        <filter id={blurMdId} x="-30%" y="-30%" width="160%" height="160%">
+          <feGaussianBlur stdDeviation="4" />
+        </filter>
+      </defs>
+
+      <path d={SPIRIT_GLASS_LOGO_PATH} fill={`url(#${fillId})`} />
+      <path d={SPIRIT_GLASS_LOGO_PATH} fill={`url(#${innerId})`} />
+
+      <path
+        d={SPIRIT_GLASS_LOGO_PATH}
+        fill="none"
+        stroke={`url(#${fresnelId})`}
+        strokeWidth="3"
+        opacity="0.18"
+        filter={`url(#${blurMdId})`}
+      />
+
+      <path
+        d={SPIRIT_GLASS_LOGO_PATH}
+        fill="none"
+        stroke="rgba(255,255,255,0.65)"
+        strokeWidth="0.5"
+        strokeLinejoin="round"
+      />
+
+      <path
+        d={SPIRIT_GLASS_LOGO_PATH}
+        fill="none"
+        stroke="rgba(255,255,255,0.2)"
+        strokeWidth="1.5"
+        filter={`url(#${blurSmId})`}
+        opacity="0.5"
+      />
+    </svg>
+  );
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -232,6 +232,33 @@ html.spirit-desktop-native.spirit-desktop-mica #app {
   background: transparent;
 }
 
+/*
+ * 启动层透明 + 原生模糊：须隐藏其下的应用布局，否则会合成进系统材质（macOS 尤甚）。
+ * 退场时与启动层 opacity 同步交叉淡入，全程保持模糊材质不关。
+ */
+html.spirit-desktop-native.spirit-desktop-mica.spirit-launch-splash-active
+  [data-spirit-surface="app-shell"]
+  > :not([data-spirit-surface="launch-splash"]) {
+  opacity: 0;
+  pointer-events: none;
+}
+
+html.spirit-desktop-native.spirit-desktop-mica.spirit-launch-splash-exiting
+  [data-spirit-surface="app-shell"]
+  > :not([data-spirit-surface="launch-splash"]) {
+  opacity: 1;
+  pointer-events: auto;
+  transition: opacity 500ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html.spirit-desktop-native.spirit-desktop-mica.spirit-launch-splash-exiting
+    [data-spirit-surface="app-shell"]
+    > :not([data-spirit-surface="launch-splash"]) {
+    transition-duration: 200ms;
+  }
+}
+
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: var(--spirit-ui-font-stack);


### PR DESCRIPTION
## Summary

- 开启 Mica / Vibrancy 时，启动层改为透明背景，与侧栏、顶栏一致透出系统模糊材质，不再硬编码 `bg-background` 实色主题。
- 启动期间通过 `spirit-launch-splash-active` 隐藏 `app-shell` 下层布局，避免 macOS 将已渲染的侧栏、主区等 UI 合成进原生模糊层。
- 退场阶段与启动层同步交叉淡入（`spirit-launch-splash-exiting`，500ms），全程保持模糊材质开启，避免退出时关闭模糊造成的视觉割裂。
- 启动图标随主题切换（`spiritAgentBrandIconSrc`），非模糊模式行为与原先一致。

## Test plan

- [x] macOS Electron + 开启模糊：冷启动应看到系统材质 + 居中品牌图标，不应透出侧栏/主区布局
- [x] macOS Electron + 关闭模糊：启动层仍为实色 `bg-background` 遮罩
- [x] Windows Electron + Mica 开启：同上验证透明启动层与退场交叉淡入
- [x] 宿主就绪后退场：主界面应平滑浮现，无模糊开关闪烁
- [x] 浅色 / 深色主题：启动图标与 shimmer 蒙版应匹配当前主题
- [x] `prefers-reduced-motion`：退场淡入时长与启动层一致缩短为 200ms