### PR TITLE
chore(desktop): 用户可见产品名统一为 Spirit Agent

### DIFF
--- a/apps/desktop/electron/application-menu.ts
+++ b/apps/desktop/electron/application-menu.ts
@@ -57,7 +57,7 @@ function buildSectionTemplate(
             void dialog.showMessageBox(win, {
               type: 'info',
               title: 'Spirit Agent',
-              message: 'Spirit Agent Desktop',
+              message: 'Spirit Agent',
               detail: `版本 ${app.getVersion()}`,
             });
           },

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Spirit Agent Desktop MVP</title>
+    <title>Spirit Agent</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/desktop/test/product-branding.test.mjs
+++ b/apps/desktop/test/product-branding.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const desktopRoot = join(__dirname, '..');
+
+const FORBIDDEN_PATTERNS = [/Spirit Agent Desktop MVP/, /Spirit Agent Desktop/];
+const SCAN_SKIP_DIRS = new Set(['node_modules', 'dist', 'out', 'dist-electron']);
+const SCAN_SKIP_FILES = new Set(['README.md', 'test/product-branding.test.mjs']);
+
+async function collectFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (SCAN_SKIP_DIRS.has(entry.name)) continue;
+      files.push(...(await collectFiles(fullPath)));
+      continue;
+    }
+    if (entry.isFile()) files.push(fullPath);
+  }
+  return files;
+}
+
+test('index.html title is Spirit Agent without Desktop/MVP', async () => {
+  const html = await readFile(join(desktopRoot, 'index.html'), 'utf8');
+  assert.match(html, /<title>Spirit Agent<\/title>/);
+  assert.doesNotMatch(html, /MVP/);
+  assert.doesNotMatch(html, /Spirit Agent Desktop/);
+});
+
+test('about dialog message is Spirit Agent without Desktop/MVP', async () => {
+  const source = await readFile(join(desktopRoot, 'electron/application-menu.ts'), 'utf8');
+  assert.match(source, /message:\s*'Spirit Agent'/);
+  assert.doesNotMatch(source, /message:\s*'Spirit Agent Desktop/);
+  assert.doesNotMatch(source, /Desktop MVP/);
+});
+
+test('apps/desktop has no forbidden product-name strings outside README', async () => {
+  const files = await collectFiles(desktopRoot);
+  const violations = [];
+
+  for (const filePath of files) {
+    const rel = relative(desktopRoot, filePath);
+    if (SCAN_SKIP_FILES.has(rel)) continue;
+
+    const content = await readFile(filePath, 'utf8');
+    for (const pattern of FORBIDDEN_PATTERNS) {
+      if (pattern.test(content)) {
+        violations.push(`${rel} matches ${pattern}`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary

- 将 `index.html` 页面标题与关于对话框主文案从「Spirit Agent Desktop MVP / Spirit Agent Desktop」统一为「Spirit Agent」，与 `electron-builder` 的 `productName` 一致。
- 新增 `product-branding.test.mjs` 回归测试，防止运行时产品名回退为 Desktop/MVP 表述。

## Test plan

- [x] `node --test test/product-branding.test.mjs`（apps/desktop）
- [x] 全仓审计：`apps/desktop` 下仅剩 `README.md` 保留「Spirit Agent Desktop」模块文档名
- [ ] 手动启动 Desktop，确认窗口标题与「关于 Spirit Agent」弹窗显示为 **Spirit Agent**