### PR TITLE
feat(desktop): 优化 skill 选择后的 chip 展示与输入框清空问题

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2725,6 +2725,14 @@ export default function App() {
         applyAskSlash();
         return;
       }
+      if (suggestion.kind === "skill") {
+        runtime.setComposer("");
+        setSlashSelectedIndex(-1);
+        queueMicrotask(() => {
+          composerRichInputRef.current?.insertSkillChip(suggestion.alias);
+        });
+        return;
+      }
       applySlashSuggestion(`${suggestion.alias} `);
     },
     [applyLoopSlash, applyPlanSlash, applyAskSlash],

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -450,13 +450,10 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         if (div) {
           div.focus();
         }
-        const current = segmentsRef.current;
-        const caret = selectionToCaret(div!, current) ?? caretAtEnd(current);
-        // Remove any existing skill chip first (only one active skill at a time)
-        const filtered = mergeAdjacentTextSegments(current.filter((s) => s.kind !== "skill"));
+        // 始终从空 segments 开始，确保斜杠查询文本不会残留
         const { segments: next, caret: nextCaret } = insertSegmentAtCaret(
-          filtered,
-          caret,
+          emptySegments(),
+          { segmentIndex: 0, offset: 0 },
           { kind: "skill", alias },
         );
         commitSegments(next, nextCaret);

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -35,6 +35,7 @@ import {
   ensureLoopPinned,
   hasAgentModeSegment,
   hasLoopSegment,
+  hasSkillSegment,
   insertAgentModeSegment,
   insertLoopSegment,
   insertSegmentAtCaret,
@@ -623,7 +624,6 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       const plain = segmentsToPlainText(current);
       const localPlain = normalizeComposerPlain(plain);
       const externalPlain = normalizeComposerPlain(value);
-
       if (skipExternalValueSyncRef.current) {
         const expected = lastSyncedToParentPlainRef.current;
         if (expected !== null && externalPlain !== expected) {
@@ -669,6 +669,11 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
           return;
         }
         if (agentModeChipDismissedRef.current && !hasAgentModeSegment(current)) {
+          return;
+        }
+        // Skill chip 存在时，parent 侧 value 为空（segmentsToPlainText 对 skill 返回 ""），
+        // 但 chip 本身应保留，勿清空。
+        if (hasSkillSegment(current) && isComposerPlainEmpty(plain)) {
           return;
         }
         commitSegments(emptySegments(), { segmentIndex: 0, offset: 0 });

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -118,6 +118,7 @@ export type ComposerRichInputHandle = {
   insertPlanChip(options?: InsertAgentModeChipOptions): void;
   insertAskChip(options?: InsertAgentModeChipOptions): void;
   removeAgentModeChip(): void;
+  insertSkillChip(alias: string): void;
   /** 发送成功后由宿主调用：恢复 chip（若仍为 plan/ask）并将光标置于 chip 后。 */
   resetAfterSend(agentMode: DesktopAgentMode): void;
   getSegments(): RichSegment[];
@@ -442,6 +443,26 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       [insertAgentModeChip],
     );
 
+    const insertSkillChip = useCallback(
+      (alias: string) => {
+        const div = divRef.current;
+        if (div) {
+          div.focus();
+        }
+        const current = segmentsRef.current;
+        const caret = selectionToCaret(div!, current) ?? caretAtEnd(current);
+        // Remove any existing skill chip first (only one active skill at a time)
+        const filtered = mergeAdjacentTextSegments(current.filter((s) => s.kind !== "skill"));
+        const { segments: next, caret: nextCaret } = insertSegmentAtCaret(
+          filtered,
+          caret,
+          { kind: "skill", alias },
+        );
+        commitSegments(next, nextCaret);
+      },
+      [commitSegments],
+    );
+
     const removeAgentModeChip = useCallback(() => {
       if (!hasAgentModeSegment(segmentsRef.current)) {
         return;
@@ -487,6 +508,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         insertPlanChip,
         insertAskChip,
         removeAgentModeChip,
+        insertSkillChip,
         resetAfterSend,
         getSegments,
         setSegments: (next: RichSegment[]) => applySegments(next),
@@ -499,6 +521,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         insertPlanChip,
         insertAskChip,
         removeAgentModeChip,
+        insertSkillChip,
         resetAfterSend,
         getSegments,
         applySegments,

--- a/apps/desktop/src/lib/composer-agent-mode-policy.ts
+++ b/apps/desktop/src/lib/composer-agent-mode-policy.ts
@@ -1,6 +1,6 @@
 import type { DesktopAgentMode } from "@/lib/agent-mode";
 import type { RichSegment } from "@/lib/composer-segment-model";
-import { emptySegments, isComposerPlainEmpty, mergeAdjacentTextSegments, segmentsToPlainText } from "@/lib/composer-segment-model";
+import { emptySegments, hasSkillSegment, isComposerPlainEmpty, mergeAdjacentTextSegments, segmentsToPlainText } from "@/lib/composer-segment-model";
 import { hasLoopSegment } from "@/lib/composer-loop-segments";
 import {
   hasAgentModeSegment,
@@ -41,7 +41,7 @@ export function composerShowsPlaceholder(
   if (opts.composing || opts.attachmentCount > 0) {
     return false;
   }
-  if (hasLoopSegment(segs) || hasAgentModeSegment(segs)) {
+  if (hasLoopSegment(segs) || hasAgentModeSegment(segs) || hasSkillSegment(segs)) {
     return false;
   }
   return isComposerPlainEmpty(segmentsToPlainText(segs));

--- a/apps/desktop/src/lib/composer-inline-chip-caret.ts
+++ b/apps/desktop/src/lib/composer-inline-chip-caret.ts
@@ -3,8 +3,8 @@ import { mergeAdjacentTextSegments } from "./composer-segment-model";
 
 function isInlineAttachmentChip(
   seg: RichSegment | undefined,
-): seg is Extract<RichSegment, { kind: "element" | "workspaceFile" }> {
-  return seg?.kind === "element" || seg?.kind === "workspaceFile";
+): seg is Extract<RichSegment, { kind: "element" | "workspaceFile" | "skill" }> {
+  return seg?.kind === "element" || seg?.kind === "workspaceFile" || seg?.kind === "skill";
 }
 
 function caretAfterInlineChip(segs: RichSegment[], chipIndex: number): SegmentCaret {

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -9,7 +9,8 @@ export type RichSegment =
   | { kind: "workspaceFile"; path: string }
   | { kind: "loop" }
   | { kind: "plan" }
-  | { kind: "ask" };
+  | { kind: "ask" }
+  | { kind: "skill"; alias: string };
 
 export type ActiveWorkspaceFileReferenceQuery = {
   start: number;
@@ -92,6 +93,10 @@ export function segmentsToAttachments(segs: RichSegment[]): BrowserElementAttach
     .map((s) => s.attachment);
 }
 
+export function hasSkillSegment(segs: RichSegment[]): boolean {
+  return segs.some((s) => s.kind === "skill");
+}
+
 /** Separator between serialized parts; avoids extra blank lines around inline chips. */
 export function messageSegmentSeparator(prev: RichSegment, next: RichSegment): string {
   if (prev.kind === "text" && next.kind === "text") return "";
@@ -112,7 +117,7 @@ export function messageSegmentSeparator(prev: RichSegment, next: RichSegment): s
     return "\n";
   }
 
-  if (prev.kind === "workspaceFile" || next.kind === "workspaceFile") {
+  if (prev.kind === "workspaceFile" || next.kind === "workspaceFile" || prev.kind === "skill" || next.kind === "skill") {
     return "";
   }
 
@@ -131,7 +136,9 @@ export function segmentsToMessageText(segs: RichSegment[]): string {
         ? seg.value
         : seg.kind === "workspaceFile"
           ? workspaceFilePlainToken(seg.path)
-          : browserElementContextText(seg.attachment);
+          : seg.kind === "skill"
+            ? seg.alias
+            : browserElementContextText(seg.attachment);
     if (seg.kind === "text" && !piece) continue;
 
     if (!out) {
@@ -182,6 +189,9 @@ export function segmentsEqual(a: RichSegment[], b: RichSegment[]): boolean {
     if (seg.kind === "ask" && other.kind === "ask") {
       return true;
     }
+    if (seg.kind === "skill" && other.kind === "skill") {
+      return seg.alias === other.alias;
+    }
     return false;
   });
 }
@@ -203,8 +213,8 @@ function pinAgentModeChipFromSegments(
 export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string): RichSegment[] {
   const loopPinned = segs.some((s) => s.kind === "loop");
   const inlineChips = segs.filter(
-    (s): s is Extract<RichSegment, { kind: "element" | "workspaceFile" }> =>
-      s.kind === "element" || s.kind === "workspaceFile",
+    (s): s is Extract<RichSegment, { kind: "element" | "workspaceFile" | "skill" }> =>
+      s.kind === "element" || s.kind === "workspaceFile" || s.kind === "skill",
   );
 
   let body: RichSegment[];
@@ -216,7 +226,7 @@ export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string
     const out: RichSegment[] = [];
     let textApplied = false;
     for (const seg of segs) {
-      if (seg.kind === "element" || seg.kind === "workspaceFile") {
+      if (seg.kind === "element" || seg.kind === "workspaceFile" || seg.kind === "skill") {
         out.push(seg);
       } else if (seg.kind === "text" && !textApplied) {
         out.push({ kind: "text", value });
@@ -247,8 +257,8 @@ function textFollowingChipInsert(after: string): string {
 
 function isInlineChipSegment(
   seg: RichSegment | undefined,
-): seg is Extract<RichSegment, { kind: "element" | "workspaceFile" | "loop" }> {
-  return seg?.kind === "element" || seg?.kind === "workspaceFile" || seg?.kind === "loop";
+): seg is Extract<RichSegment, { kind: "element" | "workspaceFile" | "loop" | "skill" }> {
+  return seg?.kind === "element" || seg?.kind === "workspaceFile" || seg?.kind === "loop" || seg?.kind === "skill";
 }
 
 export function insertSegmentAtCaret(
@@ -317,6 +327,17 @@ export function insertSegmentAtCaret(
     );
     if (fileIndex >= 0) {
       afterIndex = fileIndex + 1;
+      const trailing = normalized[afterIndex];
+      if (trailing?.kind === "text" && trailing.value.startsWith(" ")) {
+        caretOffset = 1;
+      }
+    }
+  } else if (newSegment.kind === "skill") {
+    const skillIndex = normalized.findIndex(
+      (s) => s.kind === "skill" && s.alias === newSegment.alias,
+    );
+    if (skillIndex >= 0) {
+      afterIndex = skillIndex + 1;
       const trailing = normalized[afterIndex];
       if (trailing?.kind === "text" && trailing.value.startsWith(" ")) {
         caretOffset = 1;

--- a/apps/desktop/src/lib/composer-segment-selection.ts
+++ b/apps/desktop/src/lib/composer-segment-selection.ts
@@ -16,7 +16,9 @@ function isChip(el: HTMLElement): boolean {
     el.dataset.planChip === "true" ||
     el.getAttribute("data-plan-chip") === "true" ||
     el.dataset.askChip === "true" ||
-    el.getAttribute("data-ask-chip") === "true"
+    el.getAttribute("data-ask-chip") === "true" ||
+    el.dataset.skillChip === "true" ||
+    el.getAttribute("data-skill-chip") === "true"
   );
 }
 

--- a/apps/desktop/src/lib/composer-segments.ts
+++ b/apps/desktop/src/lib/composer-segments.ts
@@ -15,6 +15,7 @@ import { makeSkillChipNode } from "@/lib/skill-chip-styles";
 export {
   caretAtEnd,
   emptySegments,
+  hasSkillSegment,
   insertSegmentAtCaret,
   isComposerPlainEmpty,
   mergeAdjacentTextSegments,

--- a/apps/desktop/src/lib/composer-segments.ts
+++ b/apps/desktop/src/lib/composer-segments.ts
@@ -10,6 +10,7 @@ import {
 import { makeLoopChipNode } from "@/lib/loop-chip-styles";
 import { makePlanChipNode } from "@/lib/plan-chip-styles";
 import { makeAskChipNode } from "@/lib/ask-chip-styles";
+import { makeSkillChipNode } from "@/lib/skill-chip-styles";
 
 export {
   caretAtEnd,
@@ -59,6 +60,7 @@ export {
 
 export { makePlanChipNode } from "@/lib/plan-chip-styles";
 export { makeAskChipNode } from "@/lib/ask-chip-styles";
+export { makeSkillChipNode } from "@/lib/skill-chip-styles";
 
 function mergeTextIntoLast(segs: RichSegment[], chunk: string): void {
   const last = segs[segs.length - 1];
@@ -132,6 +134,13 @@ function appendSegmentFromNode(node: Node, segs: RichSegment[]): void {
     }
     return;
   }
+  if (el.dataset.skillChip === "true" || el.getAttribute("data-skill-chip") === "true") {
+    const alias = el.dataset.skillAlias ?? el.getAttribute("data-skill-alias");
+    if (alias) {
+      segs.push({ kind: "skill", alias });
+    }
+    return;
+  }
   if (el.tagName === "BR") {
     mergeTextIntoLast(segs, "\n");
     return;
@@ -164,6 +173,8 @@ export function segmentsToDom(
       frag.appendChild(makeAskChipNode(doc, opts?.askLabel ?? "Ask"));
     } else if (seg.kind === "workspaceFile") {
       frag.appendChild(makeFileChipNode(seg.path, doc));
+    } else if (seg.kind === "skill") {
+      frag.appendChild(makeSkillChipNode(seg.alias, doc));
     } else {
       frag.appendChild(makeChipNode(seg.attachment, doc));
     }

--- a/apps/desktop/src/lib/skill-chip-styles.ts
+++ b/apps/desktop/src/lib/skill-chip-styles.ts
@@ -1,0 +1,33 @@
+export const SKILL_CHIP_CLASS =
+  "inline-flex items-center gap-1 rounded-md border border-yellow-200/90 bg-yellow-50 px-1.5 py-0.5 text-xs font-medium leading-none text-yellow-900 select-none align-middle mx-0.5 dark:border-yellow-700/60 dark:bg-yellow-950 dark:text-yellow-300";
+
+export const SKILL_CHIP_ICON_CLASS = "text-yellow-600 dark:text-yellow-400";
+
+export function makeSkillChipNode(alias: string, doc: Document): HTMLElement {
+  const span = doc.createElement("span");
+  span.contentEditable = "false";
+  span.setAttribute("data-skill-chip", "true");
+  span.dataset.skillChip = "true";
+  span.dataset.skillAlias = alias;
+  span.setAttribute("data-skill-alias", alias);
+  span.className = SKILL_CHIP_CLASS;
+  span.setAttribute("aria-label", alias);
+
+  const icon = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("width", "10");
+  icon.setAttribute("height", "10");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("class", SKILL_CHIP_ICON_CLASS);
+  icon.setAttribute("aria-hidden", "true");
+  icon.innerHTML =
+    '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/>';
+
+  span.appendChild(icon);
+  span.appendChild(doc.createTextNode(alias));
+  return span;
+}

--- a/apps/desktop/src/lib/skill-chip-styles.ts
+++ b/apps/desktop/src/lib/skill-chip-styles.ts
@@ -1,7 +1,5 @@
 export const SKILL_CHIP_CLASS =
-  "inline-flex items-center gap-1 rounded-md border border-yellow-200/90 bg-yellow-50 px-1.5 py-0.5 text-xs font-medium leading-none text-yellow-900 select-none align-middle mx-0.5 dark:border-yellow-700/60 dark:bg-yellow-950 dark:text-yellow-300";
-
-export const SKILL_CHIP_ICON_CLASS = "text-yellow-600 dark:text-yellow-400";
+  "inline-flex items-center bg-yellow-50 px-0.5 py-0.5 text-xs font-medium leading-none text-yellow-900 select-none align-middle mx-0.5 dark:bg-yellow-950 dark:text-yellow-300";
 
 export function makeSkillChipNode(alias: string, doc: Document): HTMLElement {
   const span = doc.createElement("span");
@@ -13,21 +11,6 @@ export function makeSkillChipNode(alias: string, doc: Document): HTMLElement {
   span.className = SKILL_CHIP_CLASS;
   span.setAttribute("aria-label", alias);
 
-  const icon = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
-  icon.setAttribute("viewBox", "0 0 24 24");
-  icon.setAttribute("width", "10");
-  icon.setAttribute("height", "10");
-  icon.setAttribute("fill", "none");
-  icon.setAttribute("stroke", "currentColor");
-  icon.setAttribute("stroke-width", "2");
-  icon.setAttribute("stroke-linecap", "round");
-  icon.setAttribute("stroke-linejoin", "round");
-  icon.setAttribute("class", SKILL_CHIP_ICON_CLASS);
-  icon.setAttribute("aria-hidden", "true");
-  icon.innerHTML =
-    '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/>';
-
-  span.appendChild(icon);
   span.appendChild(doc.createTextNode(alias));
   return span;
 }

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -17,6 +17,7 @@ import {
   trimMessageTextAroundElements,
   messageContentToRichSegments,
   parseMessageContentParts,
+  segmentsEqual,
 } from "../src/lib/composer-segment-model.ts";
 import {
   ensureLoopPinned,
@@ -516,4 +517,107 @@ test("domParsedMissingRequiredAgentChip when shell has ask but dom lost it", () 
     true,
   );
   assert.equal(shouldPinAgentModeChip({ hostMode: "ask", dismissed: true }), false);
+});
+
+// --- Skill chip tests ---
+
+test("segmentsToMessageText serializes skill chip as alias", () => {
+  const message = segmentsToMessageText([
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: " fix typo" },
+  ]);
+  assert.equal(message, "/git-commit fix typo");
+});
+
+test("segmentsToPlainText returns empty for skill chip", () => {
+  const segs = [
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: " extra" },
+  ];
+  assert.equal(segmentsToPlainText(segs), " extra");
+});
+
+test("insertSegmentAtCaret inserts skill chip with trailing space", () => {
+  const { segments, caret } = insertSegmentAtCaret(
+    [{ kind: "text", value: "" }],
+    { segmentIndex: 0, offset: 0 },
+    { kind: "skill", alias: "/git-push" },
+  );
+  assert.deepEqual(segments, [
+    { kind: "skill", alias: "/git-push" },
+    { kind: "text", value: " " },
+  ]);
+  assert.equal(caret.segmentIndex, 1);
+  assert.equal(caret.offset, 1);
+});
+
+test("isCaretAtInlineChipRemovalPoint detects caret after skill chip", () => {
+  const segs = [
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: " " },
+  ];
+  assert.equal(
+    isCaretAtInlineChipRemovalPoint(segs, { segmentIndex: 1, offset: 0 }),
+    true,
+  );
+  assert.equal(
+    isCaretAtInlineChipRemovalPoint(segs, { segmentIndex: 1, offset: 1 }),
+    false,
+  );
+});
+
+test("removeInlineChipAtRemovalPoint removes skill chip on backspace", () => {
+  const segs = [
+    { kind: "skill", alias: "/git-merge" },
+    { kind: "text", value: " " },
+  ];
+  const removed = removeInlineChipAtRemovalPoint(segs, { segmentIndex: 1, offset: 0 });
+  assert.deepEqual(removed?.segments, [{ kind: "text", value: " " }]);
+  assert.equal(removed?.caret.segmentIndex, 0);
+  assert.equal(removed?.caret.offset, 0);
+});
+
+test("syncSegmentsFromExternalValue preserves skill chip", () => {
+  const synced = syncSegmentsFromExternalValue(
+    [
+      { kind: "text", value: "old" },
+      { kind: "skill", alias: "/git-commit" },
+    ],
+    "new",
+  );
+  assert.deepEqual(synced, [
+    { kind: "text", value: "new" },
+    { kind: "skill", alias: "/git-commit" },
+  ]);
+});
+
+test("segmentsEqual compares skill chips by alias", () => {
+  const a = [{ kind: "skill", alias: "/git-commit" }];
+  const b = [{ kind: "skill", alias: "/git-commit" }];
+  const c = [{ kind: "skill", alias: "/git-push" }];
+  assert.equal(segmentsEqual(a, b), true);
+  assert.equal(segmentsEqual(a, c), false);
+});
+
+test("composerShowsPlaceholder false when skill chip present", () => {
+  assert.equal(
+    composerShowsPlaceholder(
+      [{ kind: "skill", alias: "/git-commit" }, { kind: "text", value: " " }],
+      { composing: false, attachmentCount: 0 },
+    ),
+    false,
+  );
+});
+
+test("normalizeCaretForInlineAttachmentChips snaps caret on skill chip", () => {
+  const segs = [
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: " tail" },
+  ];
+  const snapped = normalizeCaretForInlineAttachmentChips(segs, {
+    segmentIndex: 0,
+    offset: 0,
+  });
+  assert.equal(snapped.segmentIndex, 1);
+  assert.equal(snapped.offset, 1);
 });


### PR DESCRIPTION
## 变更内容

- 新增 skill chip 样式与 segment 模型
- 实现 DOM 解析、渲染与光标处理
- 输入框插入与 slash 菜单路由
- 修复选择 skill 后输入框内容被清空的 bug
- 精简 skill chip 样式（无圆角、无边框、无图标）