### PR TITLE
feat(desktop): 为 get_diagnostics 工具卡片添加执行中与完成态文案

### DIFF
--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -385,6 +385,13 @@ export function toolCallSummaryCopyForRequest(
       }
       return { headline: extensionToolName };
     }
+    case 'get_diagnostics': {
+      const rawPath = typeof record.path === 'string' ? record.path.trim() : '';
+      return {
+        headline: i18n.t('tool.diagnosticsChecking'),
+        ...(rawPath ? { headlineDetail: truncateSummaryDetail(displayBasename(rawPath)) } : {}),
+      };
+    }
     default:
       return undefined;
   }

--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -385,13 +385,6 @@ export function toolCallSummaryCopyForRequest(
       }
       return { headline: extensionToolName };
     }
-    case 'get_diagnostics': {
-      const rawPath = typeof record.path === 'string' ? record.path.trim() : '';
-      return {
-        headline: i18n.t('tool.diagnosticsChecking'),
-        ...(rawPath ? { headlineDetail: truncateSummaryDetail(displayBasename(rawPath)) } : {}),
-      };
-    }
     default:
       return undefined;
   }
@@ -984,6 +977,16 @@ export function toolCallSummaryForStreamingPreview(
   const custom = request !== undefined ? toolCallSummaryCopyForRequest(toolName, request) : undefined;
   if (custom) {
     return custom;
+  }
+
+  if (toolName === 'get_diagnostics' && request && typeof request === 'object') {
+    const rawPath = typeof (request as Record<string, unknown>).path === 'string'
+      ? (request as Record<string, unknown>).path as string
+      : '';
+    return {
+      headline: i18n.t('tool.diagnosticsChecking'),
+      ...(rawPath.trim() ? { headlineDetail: truncateSummaryDetail(displayBasename(rawPath.trim())) } : {}),
+    };
   }
 
   return {

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -58,6 +58,7 @@ import {
   toolCallSummaryCopyForResponsesBuiltInTool,
   toolCallSummaryForPhase,
   toolCallSummaryForStreamingPreview,
+  type ToolCallSummaryCopy,
   isFinishTaskToolName,
   lastAssistantPlainTextInHistory,
   latestUnsyncedAssistantTextInCurrentTurn,
@@ -431,7 +432,9 @@ export class DesktopRuntimeEventOrchestrator {
             ? { headline: i18n.t('tool.generateImage') }
             : event.toolName === 'generate_video'
               ? { headline: i18n.t('tool.generateVideo') }
-              : toolCallSummaryForPhase('running', event.toolName, event.request);
+              : event.toolName === 'get_diagnostics'
+                ? diagnosticsCheckingSummary(event.request)
+                : toolCallSummaryForPhase('running', event.toolName, event.request);
         const runningTool: ToolBlockSnapshot = this.attachLineDelta(
           applyToolCallSummaryCopy(
             {
@@ -1056,6 +1059,16 @@ function truncateText(value: string, maxChars: number): string {
     return value;
   }
   return `${chars.slice(0, maxChars).join('')}...<truncated>`;
+}
+
+function diagnosticsCheckingSummary(request: unknown): ToolCallSummaryCopy {
+  const record = request && typeof request === 'object' ? (request as Record<string, unknown>) : undefined;
+  const rawPath = typeof record?.path === 'string' ? record.path.trim() : '';
+  const basename = rawPath.split(/[\\/]/).filter(Boolean).pop() ?? '';
+  return {
+    headline: i18n.t('tool.diagnosticsChecking'),
+    ...(basename ? { headlineDetail: basename.length > 80 ? `${basename.slice(0, 77)}…` : basename } : {}),
+  };
 }
 
 export function splitRuntimeEventsForIncrementalResponsesBuiltInToolPreview(

--- a/apps/desktop/src/lib/tool-call-display.ts
+++ b/apps/desktop/src/lib/tool-call-display.ts
@@ -98,7 +98,7 @@ export function getToolCallSummaryParts(tool: ToolBlockSnapshot): ToolCallSummar
       };
     }
     if (tool.phase === 'failed') {
-      // 失败时透传上游 headline（如「工具执行失败: get_diagnostics」），不覆盖为 Checking
+      // 失败时透传上游 headline（如「工具执行失败: get_diagnostics」）
       return {
         headline,
         ...(snapshotDetail ? { detail: snapshotDetail } : {}),

--- a/apps/desktop/src/lib/tool-call-display.ts
+++ b/apps/desktop/src/lib/tool-call-display.ts
@@ -45,6 +45,16 @@ export function isResponsesBuiltInToolCard(toolName: string): boolean {
   return RESPONSES_BUILT_IN_TOOL_NAMES.has(toolName);
 }
 
+function countDiagnosticsIssues(outputExcerpt: string | undefined): number {
+  if (!outputExcerpt) {
+    return 0;
+  }
+  return outputExcerpt
+    .split('\n')
+    .filter((line) => /^(error|warning)\s/.test(line.trim()))
+    .length;
+}
+
 export function getToolCallSummaryParts(tool: ToolBlockSnapshot): ToolCallSummaryParts {
   const headline = tool.headline.trim();
   const snapshotDetail = tool.headlineDetail?.trim();
@@ -62,6 +72,39 @@ export function getToolCallSummaryParts(tool: ToolBlockSnapshot): ToolCallSummar
       ...shellToolSummaryFromReason(headline),
       ...(command ? { detail: command } : {}),
     };
+  }
+
+  if (tool.toolName === 'get_diagnostics') {
+    if (
+      tool.phase === 'preview' ||
+      tool.phase === 'running' ||
+      tool.phase === 'pending-approval'
+    ) {
+      return {
+        headline: i18n.t('tool.diagnosticsChecking'),
+        ...(snapshotDetail ? { detail: snapshotDetail } : {}),
+      };
+    }
+    if (tool.phase === 'succeeded') {
+      const output = tool.outputExcerpt?.trim() ?? '';
+      if (output.startsWith('No errors or warnings')) {
+        return {
+          headline: i18n.t('tool.diagnosticsNoIssues'),
+          ...(snapshotDetail ? { detail: snapshotDetail } : {}),
+        };
+      }
+      const issueCount = countDiagnosticsIssues(tool.outputExcerpt);
+      if (issueCount === 0) {
+        return {
+          headline: i18n.t('tool.diagnosticsNoIssues'),
+          ...(snapshotDetail ? { detail: snapshotDetail } : {}),
+        };
+      }
+      return {
+        headline: i18n.t('tool.diagnosticsIssueCount', { count: issueCount }),
+        ...(snapshotDetail ? { detail: snapshotDetail } : {}),
+      };
+    }
   }
 
   return {

--- a/apps/desktop/src/lib/tool-call-display.ts
+++ b/apps/desktop/src/lib/tool-call-display.ts
@@ -49,6 +49,18 @@ function countDiagnosticsIssues(outputExcerpt: string | undefined): number {
   if (!outputExcerpt) {
     return 0;
   }
+  // 优先从 header 解析真实总数，避免 maxItems 截断导致低估：
+  // "Diagnostics for src/x.ts (8 shown, 7 more omitted):" → 15
+  // "Diagnostics for src/x.ts (3 shown):" → 3
+  const headerMatch = /^Diagnostics for .+?\((\d+) shown(?:,\s*(\d+) more omitted)?\):/.exec(
+    outputExcerpt,
+  );
+  if (headerMatch) {
+    const shown = Number(headerMatch[1]) || 0;
+    const omitted = Number(headerMatch[2]) || 0;
+    return shown + omitted;
+  }
+  // 兜底：按行统计（无 header 时）
   return outputExcerpt
     .split('\n')
     .filter((line) => /^(error|warning)\s/.test(line.trim()))
@@ -82,6 +94,13 @@ export function getToolCallSummaryParts(tool: ToolBlockSnapshot): ToolCallSummar
     ) {
       return {
         headline: i18n.t('tool.diagnosticsChecking'),
+        ...(snapshotDetail ? { detail: snapshotDetail } : {}),
+      };
+    }
+    if (tool.phase === 'failed') {
+      // 失败时透传上游 headline（如「工具执行失败: get_diagnostics」），不覆盖为 Checking
+      return {
+        headline,
         ...(snapshotDetail ? { detail: snapshotDetail } : {}),
       };
     }

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -835,7 +835,11 @@
     "lspErrorCount_one": "{{count}} error",
     "lspErrorCount_other": "{{count}} errors",
     "lspWarningCount_one": "{{count}} warning",
-    "lspWarningCount_other": "{{count}} warnings"
+    "lspWarningCount_other": "{{count}} warnings",
+    "diagnosticsChecking": "Checking",
+    "diagnosticsNoIssues": "No issues",
+    "diagnosticsIssueCount_one": "{{count}} issue",
+    "diagnosticsIssueCount_other": "{{count}} issues"
   },
   "demo": {
     "compactionUserText": "Please continue implementing the Desktop connection wizard: automatically compress history when context approaches the limit, and retain the most recent round of tool results.",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -835,7 +835,11 @@
     "lspErrorCount_one": "{{count}} 个错误",
     "lspErrorCount_other": "{{count}} 个错误",
     "lspWarningCount_one": "{{count}} 个警告",
-    "lspWarningCount_other": "{{count}} 个警告"
+    "lspWarningCount_other": "{{count}} 个警告",
+    "diagnosticsChecking": "检查中",
+    "diagnosticsNoIssues": "没有问题",
+    "diagnosticsIssueCount_one": "{{count}} 个问题",
+    "diagnosticsIssueCount_other": "{{count}} 个问题"
   },
   "demo": {
     "compactionUserText": "请继续实现 Desktop 连接向导：在上下文接近上限时自动压缩历史，并保留最近一轮工具结果。",


### PR DESCRIPTION
执行时显示「Checking / 检查中」，执行完毕后根据输出统计 warn + error 数量：
- 无问题显示「No issues / 没有问题」
- 有 X 个问题显示「X issue(s) / X 个问题」，随本地化切换

- message-ordering.ts：toolCallSummaryCopyForRequest 新增 get_diagnostics case， 初始 headline 为「Checking」，headlineDetail 为文件名
- tool-call-display.ts：getToolCallSummaryParts 新增 get_diagnostics 分支， 按 phase + outputExcerpt 动态覆盖 headline；新增 countDiagnosticsIssues 辅助函数统计 error/warning 行数
- en.json / zh-CN.json：新增 diagnosticsChecking、diagnosticsNoIssues、 diagnosticsIssueCount_one/_other 本地化键