### PR TITLE
style(desktop): 编辑文件卡片 LSP 诊断徽章统一为 X issues 格式

### DIFF
--- a/apps/desktop/src/components/file-tool-lsp-diagnostics-badge.tsx
+++ b/apps/desktop/src/components/file-tool-lsp-diagnostics-badge.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 
 import {
-  formatLspDiagnosticsSummaryLabel,
   lspDiagnosticsCounts,
   toolCardSecondaryTextClass,
 } from "@/lib/file-tool-lsp-diagnostics-display";
@@ -15,8 +14,8 @@ export function FileToolLspDiagnosticsBadge({
 }) {
   const { t } = useTranslation();
   const { errorCount, warningCount } = lspDiagnosticsCounts(diagnostics);
-  const label = formatLspDiagnosticsSummaryLabel(errorCount, warningCount, t);
-  if (!label) {
+  const totalIssues = errorCount + warningCount;
+  if (totalIssues === 0) {
     return null;
   }
 
@@ -27,7 +26,7 @@ export function FileToolLspDiagnosticsBadge({
         toolCardSecondaryTextClass,
       )}
     >
-      {label}
+      {t("tool.diagnosticsIssueCount", { count: totalIssues })}
     </span>
   );
 }


### PR DESCRIPTION
复用 get_diagnostics 工具卡片的 diagnosticsIssueCount 本地化键，将原先分开 展示的 X errors, Y warnings 合并为总数 X issues / X 个问题；Popover 悬停 详情（含逐条 error / warning 列表）保持不变。