### PR TITLE
feat(desktop): 新会话快捷键与 macOS 系统菜单集成

### DIFF
--- a/apps/desktop/electron/application-menu.ts
+++ b/apps/desktop/electron/application-menu.ts
@@ -77,6 +77,79 @@ function buildSectionTemplate(
   }
 }
 
+/** macOS 系统菜单栏：包含标准应用菜单与 File 内“新会话”条目。 */
+export function setMacOSApplicationMenu(): void {
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: app.name,
+      submenu: [
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services' },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideOthers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' },
+      ],
+    },
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: '新会话',
+          accelerator: 'CmdOrCtrl+N',
+          click: () => {
+            const win = BrowserWindow.getFocusedWindow();
+            if (win && !win.isDestroyed()) {
+              win.webContents.send('desktop:new-session');
+            }
+          },
+        },
+        { type: 'separator' },
+        { role: 'close', label: '关闭' },
+      ],
+    },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo', label: '撤销' },
+        { role: 'redo', label: '重做' },
+        { type: 'separator' },
+        { role: 'cut', label: '剪切' },
+        { role: 'copy', label: '复制' },
+        { role: 'paste', label: '粘贴' },
+        { role: 'selectAll', label: '全选' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        ...(isDevChrome
+          ? ([
+              { role: 'reload' as const, label: '重新加载' },
+              { role: 'forceReload' as const, label: '强制重新加载' },
+              { role: 'toggleDevTools' as const, label: '开发者工具' },
+              { type: 'separator' as const },
+            ] satisfies Electron.MenuItemConstructorOptions[])
+          : []),
+        { role: 'togglefullscreen', label: '切换全屏' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [
+        { role: 'minimize', label: '最小化' },
+        { role: 'zoom', label: '缩放' },
+        { type: 'separator' },
+        { role: 'front', label: '全部置于最前' },
+      ],
+    },
+  ];
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
 /** 自绘顶栏菜单项：原生子菜单；x/y 为相对内容区原点（勿加 getContentBounds）。 */
 export function popupApplicationMenuSection(
   win: BrowserWindow,

--- a/apps/desktop/electron/application-menu.ts
+++ b/apps/desktop/electron/application-menu.ts
@@ -10,7 +10,16 @@ function buildSectionTemplate(
 ): Electron.MenuItemConstructorOptions[] {
   switch (section) {
     case 'file':
-      return [{ role: 'quit', label: '退出' }];
+      return [
+        {
+          label: '新会话',
+          click: () => {
+            win.webContents.send('desktop:new-session');
+          },
+        },
+        { type: 'separator' },
+        { role: 'quit', label: '退出' },
+      ];
     case 'edit':
       return [
         { role: 'undo', label: '撤销' },

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -126,7 +126,7 @@ import {
   type DesktopWebHostConfigFile,
 } from '../src/host/storage.js';
 import { setDesktopWebHostRuntimeStatus } from '../src/host/web-host-state.js';
-import { type ApplicationMenuSection, popupApplicationMenuSection } from './application-menu.js';
+import { type ApplicationMenuSection, popupApplicationMenuSection, setMacOSApplicationMenu } from './application-menu.js';
 import {
   createDesktopHttpHost,
   createDesktopWebPairingCode,
@@ -647,6 +647,8 @@ if (gotSpiritSingleInstanceLock) {
   registerWindowsToastActivationHandler();
   if (process.platform === 'win32') {
     Menu.setApplicationMenu(null);
+  } else if (process.platform === 'darwin') {
+    setMacOSApplicationMenu();
   }
 
   setDesktopMarketplaceFetchImplementation((input, init) =>

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -536,4 +536,13 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
       ipcRenderer.removeListener('desktop:approval-from-notification', onApproval);
     };
   },
+  subscribeNewSession(callback: () => void) {
+    const onNewSession = () => {
+      callback();
+    };
+    ipcRenderer.on('desktop:new-session', onNewSession);
+    return () => {
+      ipcRenderer.removeListener('desktop:new-session', onNewSession);
+    };
+  },
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -215,7 +215,7 @@ import {
 } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 import { DesktopTitleBar } from "@/components/desktop-title-bar";
-import { isElectronChrome, resolveUseMicaBackdrop } from "@/lib/desktop-shell";
+import { desktopShellPlatform, isElectronChrome, isNativeBackdropBlurSupported, resolveUseMicaBackdrop } from "@/lib/desktop-shell";
 import { LaunchSplash } from "@/components/launch-splash";
 import { SessionSidebar, type SettingsSidebarTab } from "@/components/session-sidebar";
 import { SessionSidebarShell } from "@/components/session-sidebar-shell";
@@ -2448,8 +2448,11 @@ export default function App() {
     void runtime.resetSession();
   }, [runtime]);
 
-  // Cmd/Ctrl+N — 全局快捷键触发新会话
+  // Cmd/Ctrl+N — 全局快捷键触发新会话（macOS 由系统菜单 accelerator 处理，此处跳过）
   useEffect(() => {
+    if (desktopShellPlatform() === 'darwin') {
+      return;
+    }
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.defaultPrevented) {
         return;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2472,6 +2472,15 @@ export default function App() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [handleNewSession]);
 
+  // Electron File 菜单 → “新会话” IPC 订阅
+  useEffect(() => {
+    const bridge = window.spiritDesktop;
+    if (!bridge?.subscribeNewSession) {
+      return;
+    }
+    return bridge.subscribeNewSession(handleNewSession);
+  }, [handleNewSession]);
+
   const handleGenerateAutomation = useCallback(async () => {
     setLastNonSettingsSurface("conversation");
     setActiveSurface("conversation");

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2447,6 +2447,31 @@ export default function App() {
     setActiveSurface("conversation");
     void runtime.resetSession();
   }, [runtime]);
+
+  // Cmd/Ctrl+N — 全局快捷键触发新会话
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (!(event.ctrlKey || event.metaKey) || event.key.toLowerCase() !== 'n') {
+        return;
+      }
+      // 用户在 composer / 富文本编辑区内按键时不触发
+      const target = event.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === 'TEXTAREA' || target.isContentEditable) {
+          return;
+        }
+      }
+      event.preventDefault();
+      handleNewSession();
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [handleNewSession]);
+
   const handleGenerateAutomation = useCallback(async () => {
     setLastNonSettingsSurface("conversation");
     setActiveSurface("conversation");

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -601,7 +601,7 @@ const sidebarInteractionMotionClass =
   "!transition-[opacity,transform,box-shadow] duration-150 active:!translate-y-0";
 
 /** 侧栏交互项默认字色/图标色；hover 与选中回到 sidebar-foreground */
-const sidebarItemDefaultTextClass = "text-popover-foreground";
+const sidebarItemDefaultTextClass = "text-sidebar-action-foreground";
 
 const sidebarItemActiveTextClass = "!text-sidebar-foreground";
 

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -59,8 +59,12 @@ import {
 } from "@/lib/layout-prefs";
 import { resolveWorkspaceGroupingRoot } from "@/lib/workspace-grouping";
 import { cn } from "@/lib/utils";
+import { shortcutLabel } from "@/lib/desktop-shell";
 import i18n from "@/lib/i18n";
 import type { SessionListItem } from "@/types";
+
+/** 平台快捷键提示，模块加载时计算（平台不会运行时变化）。 */
+const newSessionShortcutLabel = shortcutLabel("N");
 
 function samePath(a: string, b: string): boolean {
   return a.replace(/\\/g, "/").toLowerCase() === b.replace(/\\/g, "/").toLowerCase();
@@ -944,6 +948,11 @@ function SessionSidebarInner({
           >
             <SquarePen className="size-3.5" aria-hidden />
             <span className={cn(narrow && "sr-only")}>{t('sidebar.newSession')}</span>
+            {!narrow && (
+              <span className="ml-auto text-[0.65rem] text-sidebar-item-foreground" aria-hidden>
+                {newSessionShortcutLabel}
+              </span>
+            )}
           </Button>
           <Button
             type="button"

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -235,6 +235,7 @@ declare global {
     subscribeApprovalFromNotification(
       callback: (payload: { decision: 'allow' | 'deny' }) => void,
     ): () => void;
+    subscribeNewSession(callback: () => void): () => void;
   }
 
   interface Window {

--- a/apps/desktop/src/lib/desktop-shell.ts
+++ b/apps/desktop/src/lib/desktop-shell.ts
@@ -56,3 +56,18 @@ export function applyDesktopNativeChromeToDocument(): void {
   root.classList.toggle("spirit-desktop-native", native);
   root.classList.toggle("spirit-desktop-mica", native && readStoredNativeBackdropBlur());
 }
+
+/** 当前宿主是否为 macOS（Electron preload 注入的平台值）。 */
+export function isMacDesktopPlatform(): boolean {
+  return desktopShellPlatform() === "darwin";
+}
+
+/**
+ * 根据当前平台格式化快捷键标签。
+ * - macOS: `mod` → `⌘`，拼接无分隔符（如 `⌘N`）
+ * - Windows / Linux: `mod` → `Ctrl`，用 `+` 拼接（如 `Ctrl+N`）
+ */
+export function shortcutLabel(key: string): string {
+  const letter = key.toUpperCase();
+  return isMacDesktopPlatform() ? `⌘${letter}` : `Ctrl+${letter}`;
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -42,7 +42,8 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  /* 侧栏内分级：交互项默认 / 列表正文 / 极淡说明（分区小标题等） */
+  /* 侧栏内分级：交互按钮默认 / 交互项默认 / 列表正文 / 极淡说明（分区小标题等） */
+  --sidebar-action-foreground: #2b2b2b;
   --sidebar-item-foreground: oklch(0.42 0 0);
   --sidebar-list-foreground: oklch(0.4 0 0);
   --sidebar-faint-foreground: oklch(0.5 0 0);
@@ -113,6 +114,7 @@ html.dark,
   --sidebar-accent-foreground: #d4d4d4;
   --sidebar-border: #272727;
   --sidebar-ring: #3f3f3f;
+  --sidebar-action-foreground: #d4d4d4;
   --sidebar-item-foreground: #a3a3a3;
   --sidebar-list-foreground: #717171;
   --sidebar-faint-foreground: #525252;
@@ -269,6 +271,7 @@ html.spirit-desktop-native.spirit-desktop-mica.spirit-launch-splash-exiting
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-action-foreground: var(--sidebar-action-foreground);
   --color-sidebar-item-foreground: var(--sidebar-item-foreground);
   --color-sidebar-list-foreground: var(--sidebar-list-foreground);
   --color-sidebar-faint-foreground: var(--sidebar-faint-foreground);


### PR DESCRIPTION
## Summary

- 新增跨平台快捷键触发新会话：macOS 由系统菜单 `accelerator: CmdOrCtrl+N` 处理（全局生效），Windows/Linux 由渲染进程 `keydown` 监听处理（textarea / contentEditable 内不触发）
- 侧栏"新会话"按钮右侧显示平台快捷键提示（⌘N 或 Ctrl+N），narrow 模式隐藏
- 侧栏按钮字色抽离为独立 `sidebar-action-foreground` token，不再依赖 `popover-foreground`；Light 色值改为 `#2b2b2b`，与 Dark `#d4d4d4` 形成对称偏移
- Electron 自绘弹出菜单与 macOS 系统菜单栏 File 均添加"新会话"条目
- macOS 系统菜单栏新增完整菜单结构（App / File / Edit / View / Window），File 内"关闭"使用 `role: close`（⌘W）

## Test plan

- [ ] macOS: 按 ⌘N 创建新会话（系统菜单 accelerator 全局处理，含编辑区）
- [ ] macOS: 系统菜单栏 File → 新会话 触发创建
- [ ] macOS: File → 关闭 关闭窗口（⌘W）
- [ ] Windows/Linux: 按 Ctrl+N 创建新会话
- [ ] Windows/Linux: textarea / contentEditable 中按 Ctrl+N 不触发
- [ ] 侧栏按钮显示快捷键提示，narrow 模式隐藏
- [ ] Light/Dark 主题下按钮字色正确