### PR TITLE
feat(desktop): 输入框斜杠任意位置唤起与多 chip 组合

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3127,6 +3127,55 @@ export default function App() {
 
   const handleComposerSuggestionKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     const fileReferenceItems = fileReferenceSuggestions?.suggestions ?? [];
+
+    if (slashQuery) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDismissedSlashQueryKey(skillSlashQueryKey(slashQuery));
+        setSlashSelectedIndex(-1);
+        return;
+      }
+
+      if (slashSuggestions.length > 0) {
+        if (event.key === "ArrowDown") {
+          event.preventDefault();
+          setSlashSelectedIndex((current) => {
+            if (current < 0) {
+              return 0;
+            }
+            return (current + 1) % slashSuggestions.length;
+          });
+          return;
+        }
+
+        if (event.key === "ArrowUp") {
+          event.preventDefault();
+          setSlashSelectedIndex((current) =>
+            current <= 0 ? slashSuggestions.length - 1 : current - 1,
+          );
+          return;
+        }
+
+        if (event.key === "Tab") {
+          event.preventDefault();
+          const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
+          if (selected) {
+            applySlashSuggestionItem(selected);
+          }
+          return;
+        }
+
+        if (event.key === "Enter" && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+          event.preventDefault();
+          const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
+          if (selected) {
+            applySlashSuggestionItem(selected);
+          }
+          return;
+        }
+      }
+    }
+
     if (fileReferenceItems.length > 0) {
       if (event.key === "ArrowDown") {
         event.preventDefault();
@@ -3169,56 +3218,6 @@ export default function App() {
         const selected = fileReferenceItems[fileReferenceSelectedIndex] ?? fileReferenceItems[0];
         if (selected) {
           applyFileReferenceSuggestion(selected);
-        }
-        return;
-      }
-    }
-
-    if (slashQuery) {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setDismissedSlashQueryKey(skillSlashQueryKey(slashQuery));
-        setSlashSelectedIndex(-1);
-        return;
-      }
-
-      if (slashSuggestions.length === 0) {
-        return;
-      }
-
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setSlashSelectedIndex((current) => {
-          if (current < 0) {
-            return 0;
-          }
-          return (current + 1) % slashSuggestions.length;
-        });
-        return;
-      }
-
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setSlashSelectedIndex((current) =>
-          current <= 0 ? slashSuggestions.length - 1 : current - 1,
-        );
-        return;
-      }
-
-      if (event.key === "Tab") {
-        event.preventDefault();
-        const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
-        if (selected) {
-          applySlashSuggestionItem(selected);
-        }
-        return;
-      }
-
-      if (event.key === "Enter" && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
-        event.preventDefault();
-        const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
-        if (selected) {
-          applySlashSuggestionItem(selected);
         }
       }
     }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2747,6 +2747,7 @@ export default function App() {
     setSlashSelectedIndex(-1);
     setDismissedSlashQueryKey(null);
     void runtime.saveSettingsPatch({ agentMode: "plan" });
+    runtime.setAgentModeChipDismissed(false);
     composerRichInputRef.current?.insertPlanChip({ clearText: false });
     if (slashQuery) {
       composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);
@@ -2757,6 +2758,7 @@ export default function App() {
     setSlashSelectedIndex(-1);
     setDismissedSlashQueryKey(null);
     void runtime.saveSettingsPatch({ agentMode: "ask" });
+    runtime.setAgentModeChipDismissed(false);
     composerRichInputRef.current?.insertAskChip({ clearText: false });
     if (slashQuery) {
       composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);
@@ -2767,6 +2769,7 @@ export default function App() {
     setSlashSelectedIndex(-1);
     setDismissedSlashQueryKey(null);
     void runtime.saveSettingsPatch({ agentMode: "debug" });
+    runtime.setAgentModeChipDismissed(false);
     composerRichInputRef.current?.insertDebugChip({ clearText: false });
     if (slashQuery) {
       composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -204,7 +204,8 @@ import {
 } from "@/lib/action-palette";
 import {
   buildSkillSlashSuggestions,
-  currentSkillSlashQuery,
+  currentSkillSlashQueryAtCursor,
+  skillSlashQueryKey,
   type SkillSlashSuggestion,
 } from "@/lib/skill-slash";
 import {
@@ -2407,6 +2408,7 @@ export default function App() {
     useState<WorkspaceFileReferenceSuggestionsResponse>(null);
   const [fileReferenceSelectedIndex, setFileReferenceSelectedIndex] = useState(-1);
   const [dismissedFileReferenceKey, setDismissedFileReferenceKey] = useState<string | null>(null);
+  const [dismissedSlashQueryKey, setDismissedSlashQueryKey] = useState<string | null>(null);
   const [filePickerOpen, setFilePickerOpen] = useState(false);
   const [actionPickerOpen, setActionPickerOpen] = useState(false);
   const [branchCheckoutDialogOpen, setBranchCheckoutDialogOpen] = useState(false);
@@ -2505,12 +2507,6 @@ export default function App() {
   const marketplaceMode = activeSurface === "marketplace";
   const automationsMode = activeSurface === "automations" || activeSurface === "automation-detail";
   const automationDetailMode = activeSurface === "automation-detail";
-  const slashQuery = useMemo(() => currentSkillSlashQuery(runtime.composer), [runtime.composer]);
-  const slashSuggestions = useMemo(
-    () => buildSkillSlashSuggestions(slashQuery, snapshot?.skillsList ?? []),
-    [slashQuery, snapshot?.skillsList],
-  );
-
   useEffect(() => {
     const plan = snapshot?.plan;
     const sessionPath = snapshot?.activeSession?.filePath ?? null;
@@ -2577,6 +2573,20 @@ export default function App() {
     () => codeUnitIndexToCharCount(runtime.composer, composerCursorCodeUnits),
     [composerCursorCodeUnits, runtime.composer],
   );
+  const slashQuery = useMemo(() => {
+    const query = currentSkillSlashQueryAtCursor(runtime.composer, composerCursorChars);
+    if (!query) {
+      return undefined;
+    }
+    if (dismissedSlashQueryKey === skillSlashQueryKey(query)) {
+      return undefined;
+    }
+    return query;
+  }, [composerCursorChars, dismissedSlashQueryKey, runtime.composer]);
+  const slashSuggestions = useMemo(
+    () => buildSkillSlashSuggestions(slashQuery?.raw, snapshot?.skillsList ?? []),
+    [slashQuery, snapshot?.skillsList],
+  );
   const fileReferenceQuery = useMemo(
     () => currentWorkspaceFileReferenceQuery(runtime.composer, composerCursorChars),
     [composerCursorChars, runtime.composer],
@@ -2607,7 +2617,7 @@ export default function App() {
 
   useEffect(() => {
     setSlashSelectedIndex(-1);
-  }, [slashQuery]);
+  }, [slashQuery?.raw, slashQuery?.start, slashQuery?.end]);
 
   useEffect(() => {
     if (!fileReferenceQuery || dismissedFileReferenceKey === fileReferenceQueryKey) {
@@ -2857,6 +2867,7 @@ export default function App() {
     setFileReferenceSelectedIndex(-1);
     setFileReferenceSuggestions(null);
     setDismissedFileReferenceKey(null);
+    setDismissedSlashQueryKey(null);
     queueMicrotask(() => {
       composerRichInputRef.current?.focus();
     });
@@ -3137,43 +3148,52 @@ export default function App() {
       }
     }
 
-    if (!slashQuery || slashSuggestions.length === 0) {
-      return;
-    }
-
-    if (event.key === "ArrowDown") {
-      event.preventDefault();
-      setSlashSelectedIndex((current) => {
-        if (current < 0) {
-          return 0;
-        }
-        return (current + 1) % slashSuggestions.length;
-      });
-      return;
-    }
-
-    if (event.key === "ArrowUp") {
-      event.preventDefault();
-      setSlashSelectedIndex((current) =>
-        current <= 0 ? slashSuggestions.length - 1 : current - 1,
-      );
-      return;
-    }
-
-    if (event.key === "Tab") {
-      event.preventDefault();
-      const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
-      if (selected) {
-        applySlashSuggestionItem(selected);
+    if (slashQuery) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDismissedSlashQueryKey(skillSlashQueryKey(slashQuery));
+        setSlashSelectedIndex(-1);
+        return;
       }
-      return;
-    }
 
-    if (event.key === "Enter" && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
-      event.preventDefault();
-      const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
-      if (selected) {
-        applySlashSuggestionItem(selected);
+      if (slashSuggestions.length === 0) {
+        return;
+      }
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSlashSelectedIndex((current) => {
+          if (current < 0) {
+            return 0;
+          }
+          return (current + 1) % slashSuggestions.length;
+        });
+        return;
+      }
+
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSlashSelectedIndex((current) =>
+          current <= 0 ? slashSuggestions.length - 1 : current - 1,
+        );
+        return;
+      }
+
+      if (event.key === "Tab") {
+        event.preventDefault();
+        const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
+        if (selected) {
+          applySlashSuggestionItem(selected);
+        }
+        return;
+      }
+
+      if (event.key === "Enter" && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
+        event.preventDefault();
+        const selected = slashSuggestions[slashSelectedIndex] ?? slashSuggestions[0];
+        if (selected) {
+          applySlashSuggestionItem(selected);
+        }
       }
     }
   };

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2735,31 +2735,43 @@ export default function App() {
 
   const applyLoopSlash = useCallback(() => {
     setSlashSelectedIndex(-1);
+    setDismissedSlashQueryKey(null);
     void runtime.setLoopEnabled(true);
-    runtime.setComposer("");
-    composerRichInputRef.current?.insertLoopChip({ clearText: true });
-  }, [runtime]);
+    composerRichInputRef.current?.insertLoopChip({ clearText: false });
+    if (slashQuery) {
+      composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);
+    }
+  }, [runtime, slashQuery]);
 
   const applyPlanSlash = useCallback(() => {
     setSlashSelectedIndex(-1);
+    setDismissedSlashQueryKey(null);
     void runtime.saveSettingsPatch({ agentMode: "plan" });
-    runtime.setComposer("");
-    composerRichInputRef.current?.insertPlanChip({ clearText: true });
-  }, [runtime]);
+    composerRichInputRef.current?.insertPlanChip({ clearText: false });
+    if (slashQuery) {
+      composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);
+    }
+  }, [runtime, slashQuery]);
 
   const applyAskSlash = useCallback(() => {
     setSlashSelectedIndex(-1);
+    setDismissedSlashQueryKey(null);
     void runtime.saveSettingsPatch({ agentMode: "ask" });
-    runtime.setComposer("");
-    composerRichInputRef.current?.insertAskChip({ clearText: true });
-  }, [runtime]);
+    composerRichInputRef.current?.insertAskChip({ clearText: false });
+    if (slashQuery) {
+      composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);
+    }
+  }, [runtime, slashQuery]);
 
   const applyDebugSlash = useCallback(() => {
     setSlashSelectedIndex(-1);
+    setDismissedSlashQueryKey(null);
     void runtime.saveSettingsPatch({ agentMode: "debug" });
-    runtime.setComposer("");
-    composerRichInputRef.current?.insertDebugChip({ clearText: true });
-  }, [runtime]);
+    composerRichInputRef.current?.insertDebugChip({ clearText: false });
+    if (slashQuery) {
+      composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);
+    }
+  }, [runtime, slashQuery]);
 
   const applySlashSuggestionItem = useCallback(
     (suggestion: SkillSlashSuggestion) => {
@@ -2780,8 +2792,11 @@ export default function App() {
         return;
       }
       if (suggestion.kind === "skill") {
-        runtime.setComposer("");
         setSlashSelectedIndex(-1);
+        setDismissedSlashQueryKey(null);
+        if (slashQuery) {
+          composerRichInputRef.current?.removeSkillSlashQuery(slashQuery);
+        }
         queueMicrotask(() => {
           composerRichInputRef.current?.insertSkillChip(suggestion.alias);
         });
@@ -2789,7 +2804,7 @@ export default function App() {
       }
       applySlashSuggestion(`${suggestion.alias} `);
     },
-    [applyLoopSlash, applyPlanSlash, applyAskSlash],
+    [applyAskSlash, applyDebugSlash, applyLoopSlash, applyPlanSlash, slashQuery],
   );
 
   const ensureConversationSurface = useCallback(() => {
@@ -2862,12 +2877,18 @@ export default function App() {
   };
 
   const insertComposerText = (text: string) => {
-    const selectionStart = composerCursorCodeUnits;
-    const selectionEnd = selectionStart;
-    const nextValue = `${runtime.composer.slice(0, selectionStart)}${text}${runtime.composer.slice(selectionEnd)}`;
-    const nextCursorCodeUnits = selectionStart + text.length;
-    runtime.setComposer(nextValue);
-    setComposerCursorCodeUnits(nextCursorCodeUnits);
+    const segments = composerRichInputRef.current?.getSegments() ?? [];
+    const hasRichChips = segments.some((segment) => segment.kind !== "text");
+    if (hasRichChips) {
+      composerRichInputRef.current?.insertPlainTextAtCaret(text);
+    } else {
+      const selectionStart = composerCursorCodeUnits;
+      const selectionEnd = selectionStart;
+      const nextValue = `${runtime.composer.slice(0, selectionStart)}${text}${runtime.composer.slice(selectionEnd)}`;
+      const nextCursorCodeUnits = selectionStart + text.length;
+      runtime.setComposer(nextValue);
+      setComposerCursorCodeUnits(nextCursorCodeUnits);
+    }
     setSlashSelectedIndex(-1);
     setFileReferenceSelectedIndex(-1);
     setFileReferenceSuggestions(null);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2721,8 +2721,13 @@ export default function App() {
   };
 
   const applySlashSuggestion = (replacement: string) => {
-    runtime.setComposer(replacement);
+    if (slashQuery) {
+      composerRichInputRef.current?.replaceSkillSlashQuery(slashQuery, replacement, true);
+    } else {
+      runtime.setComposer(replacement);
+    }
     setSlashSelectedIndex(-1);
+    setDismissedSlashQueryKey(null);
     queueMicrotask(() => {
       composerRichInputRef.current?.focus();
     });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3435,7 +3435,7 @@ export default function App() {
                 settingsDisabled={!runtime.apiReady || runtime.busyAction === "automation"}
                 onAddWorkspace={() => void runtime.pickWorkspaceDirectory?.().then((path) => {
                   if (path) {
-                    void runtime.rememberWorkspaceRoot({ workspaceRoot: path });
+                    void runtime.rememberWorkspaceRoot(path);
                   }
                 })}
               />
@@ -3467,7 +3467,7 @@ export default function App() {
               onSubmit={(request) => void runtime.createAutomation(request)}
               onAddWorkspace={() => void runtime.pickWorkspaceDirectory?.().then((path) => {
                 if (path) {
-                  void runtime.rememberWorkspaceRoot({ workspaceRoot: path });
+                  void runtime.rememberWorkspaceRoot(path);
                 }
               })}
             />

--- a/apps/desktop/src/components/automation-settings-panel.tsx
+++ b/apps/desktop/src/components/automation-settings-panel.tsx
@@ -193,7 +193,7 @@ export function AutomationSettingsPanel({
               if (!patch) {
                 return;
               }
-              void onSave(patch).then(() => {
+              void Promise.resolve(onSave(patch)).then(() => {
                 initializedForAutomationIdRef.current = null;
               });
             }}

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -130,6 +130,7 @@ export type ComposerRichInputHandle = {
     finalize?: boolean,
   ): void;
   removeSkillSlashQuery(query: ActiveSkillSlashQuery): void;
+  insertPlainTextAtCaret(text: string): void;
   /** 发送成功后由宿主调用：恢复 chip（若仍为 plan/ask）并将光标置于 chip 后。 */
   resetAfterSend(agentMode: DesktopAgentMode): void;
   getSegments(): RichSegment[];
@@ -484,18 +485,54 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       [insertAgentModeChip],
     );
 
+    const insertPlainTextAtCaret = useCallback(
+      (text: string) => {
+        if (!text) {
+          return;
+        }
+        const div = divRef.current;
+        if (!div) {
+          return;
+        }
+        div.focus();
+        const current = mergeAdjacentTextSegments(segmentsRef.current);
+        const caret = selectionToCaret(div, current) ?? caretAtEnd(current);
+        const seg = current[caret.segmentIndex];
+        if (seg?.kind === "text") {
+          const before = seg.value.slice(0, caret.offset);
+          const after = seg.value.slice(caret.offset);
+          const next = mergeAdjacentTextSegments([
+            ...current.slice(0, caret.segmentIndex),
+            { kind: "text" as const, value: `${before}${text}${after}` },
+            ...current.slice(caret.segmentIndex + 1),
+          ]);
+          commitSegments(next, {
+            segmentIndex: caret.segmentIndex,
+            offset: caret.offset + text.length,
+          });
+          return;
+        }
+        const { segments: next, caret: nextCaret } = insertSegmentAtCaret(current, caret, {
+          kind: "text",
+          value: text,
+        });
+        commitSegments(next, nextCaret);
+      },
+      [commitSegments],
+    );
+
     const insertSkillChip = useCallback(
       (alias: string) => {
         const div = divRef.current;
         if (div) {
           div.focus();
         }
-        // 始终从空 segments 开始，确保斜杠查询文本不会残留
-        const { segments: next, caret: nextCaret } = insertSegmentAtCaret(
-          emptySegments(),
-          { segmentIndex: 0, offset: 0 },
-          { kind: "skill", alias },
-        );
+        const current = segmentsRef.current;
+        const caret = selectionToCaret(div, current) ?? caretAtEnd(current);
+        const { segments: next, caret: nextCaret } = insertSegmentAtCaret(current, caret, {
+          kind: "skill",
+          alias,
+        });
         commitSegments(next, nextCaret);
       },
       [commitSegments],
@@ -550,6 +587,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         insertSkillChip,
         replaceSkillSlashQuery,
         removeSkillSlashQuery,
+        insertPlainTextAtCaret,
         resetAfterSend,
         getSegments,
         setSegments: (next: RichSegment[]) => applySegments(next),
@@ -559,6 +597,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         insertWorkspaceFileReference,
         replaceSkillSlashQuery,
         removeSkillSlashQuery,
+        insertPlainTextAtCaret,
         insertLoopChip,
         removeLoopChip,
         insertPlanChip,

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -449,6 +449,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         return;
       }
       const next = applyComposerPolicy(removeLoopSegment(segmentsRef.current));
+      loopEnabledRef.current = false;
       hadLoopRef.current = false;
       commitSegments(next, { segmentIndex: 0, offset: 0 }, { syncLoop: false });
       onLoopEnabledChangeRef.current?.(false);
@@ -464,6 +465,8 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         agentModeChipDismissedRef.current = false;
         onAgentModeChipDismissChangeRef.current?.(false);
         const { segments: next, caret } = insertAgentModeSegment(base, mode);
+        // Pin policy to the mode being inserted; host agentMode prop may lag saveSettingsPatch / poll.
+        agentModeRef.current = mode;
         hadAgentModeRef.current = true;
         commitSegments(next, caret, { syncAgentMode: false });
       },
@@ -660,8 +663,17 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       }
 
       const domSegs = domToSegments(div);
+      const domEqual = segmentsEqual(domSegs, segments);
+
       if (skipRenderRef.current) {
         skipRenderRef.current = false;
+        if (!domEqual) {
+          renderSegmentsToElement(div, segments, {
+            loopLabel: loopChipLabel,
+            planLabel: planChipLabel,
+            askLabel: askChipLabel,
+          });
+        }
         if (pendingCaretRef.current) {
           const caret = normalizeCaretForComposer(segments, pendingCaretRef.current);
           caretToDomRange(div, segments, caret);
@@ -671,7 +683,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         return;
       }
 
-      if (segmentsEqual(domSegs, segments)) {
+      if (domEqual) {
         if (pendingCaretRef.current) {
           const caret = normalizeCaretForComposer(segments, pendingCaretRef.current);
           caretToDomRange(div, segments, caret);
@@ -733,12 +745,12 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
 
       // Parent cleared composer after send: 由 resetAfterSend 恢复 chip；此处仅处理 loop shell。
       if (!value && attachmentCount === 0 && (plain || hasElements || hasLoopSegment(current) || hasAgentModeSegment(current))) {
-        if (loopEnabled || loopEnabledRef.current) {
-          const { segments: next, caret } = insertLoopSegment(emptySegments());
-          commitSegments(applyComposerPolicy(next), caret, { syncLoop: false, syncAgentMode: false });
+        if (hasLoopSegment(current) && isComposerPlainEmpty(plain) && !hasElements) {
           return;
         }
-        if (hasLoopSegment(current) && !plain && !hasElements) {
+        if ((loopEnabled || loopEnabledRef.current) && !hasLoopSegment(current)) {
+          const { segments: next, caret } = insertLoopSegment(emptySegments());
+          commitSegments(applyComposerPolicy(next), caret, { syncLoop: false, syncAgentMode: false });
           return;
         }
         // 发消息后 resetAfterSend 已恢复 chip；busy poll 时勿反复 empty→policy 重插（日志 B 根因）。

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -16,7 +16,9 @@ import { caretToDomRange, selectionToCaret } from "@/lib/composer-segment-select
 import {
   caretAtEnd,
   caretToPlainTextOffset,
+  replaceSkillSlashQueryInSegments,
   replaceWorkspaceFileReferenceInSegments,
+  type ActiveSkillSlashQuery,
   type ActiveWorkspaceFileReferenceQuery,
 } from "@/lib/composer-segment-model";
 import {
@@ -122,6 +124,12 @@ export type ComposerRichInputHandle = {
   insertDebugChip(options?: InsertAgentModeChipOptions): void;
   removeAgentModeChip(): void;
   insertSkillChip(alias: string): void;
+  replaceSkillSlashQuery(
+    query: ActiveSkillSlashQuery,
+    replacement: string,
+    finalize?: boolean,
+  ): void;
+  removeSkillSlashQuery(query: ActiveSkillSlashQuery): void;
   /** 发送成功后由宿主调用：恢复 chip（若仍为 plan/ask）并将光标置于 chip 后。 */
   resetAfterSend(agentMode: DesktopAgentMode): void;
   getSegments(): RichSegment[];
@@ -381,6 +389,31 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       [commitSegments],
     );
 
+    const replaceSkillSlashQuery = useCallback(
+      (query: ActiveSkillSlashQuery, replacement: string, finalize = false) => {
+        const div = divRef.current;
+        if (!div) {
+          return;
+        }
+        div.focus();
+        const { segments: next, caret } = replaceSkillSlashQueryInSegments(
+          segmentsRef.current,
+          query,
+          replacement,
+          finalize,
+        );
+        commitSegments(next, caret);
+      },
+      [commitSegments],
+    );
+
+    const removeSkillSlashQuery = useCallback(
+      (query: ActiveSkillSlashQuery) => {
+        replaceSkillSlashQuery(query, "", false);
+      },
+      [replaceSkillSlashQuery],
+    );
+
     const applySegments = useCallback(
       (next: RichSegment[], caret?: SegmentCaret | null, notifyParent = true) => {
         commitSegments(next, caret ?? caretAtEnd(mergeAdjacentTextSegments(next)), {
@@ -515,6 +548,8 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         insertDebugChip,
         removeAgentModeChip,
         insertSkillChip,
+        replaceSkillSlashQuery,
+        removeSkillSlashQuery,
         resetAfterSend,
         getSegments,
         setSegments: (next: RichSegment[]) => applySegments(next),
@@ -522,6 +557,8 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       [
         insertAttachment,
         insertWorkspaceFileReference,
+        replaceSkillSlashQuery,
+        removeSkillSlashQuery,
         insertLoopChip,
         removeLoopChip,
         insertPlanChip,

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -524,9 +524,10 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
     const insertSkillChip = useCallback(
       (alias: string) => {
         const div = divRef.current;
-        if (div) {
-          div.focus();
+        if (!div) {
+          return;
         }
+        div.focus();
         const current = segmentsRef.current;
         const caret = selectionToCaret(div, current) ?? caretAtEnd(current);
         const { segments: next, caret: nextCaret } = insertSegmentAtCaret(current, caret, {

--- a/apps/desktop/src/components/settings-view.tsx
+++ b/apps/desktop/src/components/settings-view.tsx
@@ -3394,7 +3394,7 @@ function ModelsSettingsPanel({
           </DialogHeader>
 
           <div className="grid gap-3 py-1">
-            {providerShowsConnectTransportPicker(selectedProvider) ? (
+            {selectedProvider && providerShowsConnectTransportPicker(selectedProvider) ? (
               <div className="grid gap-2">
                 <Label htmlFor="connect-api-transport">{t('settings.apiType')}</Label>
                 <Select

--- a/apps/desktop/src/components/ui/filtered-overlay-menu.tsx
+++ b/apps/desktop/src/components/ui/filtered-overlay-menu.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 import {
   DropdownMenu,
@@ -82,6 +82,13 @@ export function FilteredOverlayMenu({
       ? DESKTOP_OVERLAY_LIST_WORKSPACE_SCROLL_AREA
       : DESKTOP_OVERLAY_LIST_SCROLL_AREA;
 
+  useEffect(() => {
+    if (!open || !showFilter) {
+      return;
+    }
+    filterInputRef.current?.focus();
+  }, [open, showFilter]);
+
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange}>
       {trigger}
@@ -89,14 +96,6 @@ export function FilteredOverlayMenu({
         align={align}
         side={side}
         className={contentClasses}
-        onOpenAutoFocus={
-          showFilter
-            ? (event) => {
-                event.preventDefault();
-                filterInputRef.current?.focus();
-              }
-            : undefined
-        }
       >
         {showFilter ? (
           <div className={DESKTOP_OVERLAY_LIST_FILTER_HEADER}>

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -509,6 +509,14 @@ export function useDesktopRuntime() {
         turnInFlight && current.agentMode !== configAgentMode
           ? current.agentMode
           : configAgentMode;
+      // saveSettingsPatch 乐观更新后、poll 快照尚未追上时，勿覆盖本地 chip 模式。
+      if (
+        !chipDismissed &&
+        isAgentModeChipKind(current.agentMode) &&
+        current.agentMode !== configAgentMode
+      ) {
+        agentMode = current.agentMode;
+      }
       // 用户 Backspace 去掉 chip 后，poll 不得再把 settings.agentMode 设回 ask/plan（否则 agentMode effect 会重插 chip）。
       if (chipDismissed && isAgentModeChipKind(agentMode)) {
         agentMode = "agent";

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -90,6 +90,7 @@ type BusyAction =
   | "modelsPreview"
   | "mcps"
   | "skills"
+  | "rules"
   | "extensions"
   | "lspInstall"
   | "marketplace"

--- a/apps/desktop/src/lib/composer-agent-mode-policy.ts
+++ b/apps/desktop/src/lib/composer-agent-mode-policy.ts
@@ -58,10 +58,9 @@ const STRUCTURAL_KINDS = new Set(["loop", "plan", "ask", "debug"]);
 
 /** DOM 只驱动正文/附件；loop/plan/ask 以 shell（segments state）为准。 */
 export function synchronizeTextFromDom(shell: RichSegment[], domParsed: RichSegment[]): RichSegment[] {
-  const loopSegs = shell.filter((s) => s.kind === "loop");
-  const modeSegs = shell.filter((s) => s.kind === "plan" || s.kind === "ask" || s.kind === "debug");
+  const shellStructural = shell.filter((s) => STRUCTURAL_KINDS.has(s.kind));
   const domBody = domParsed.filter((s) => !STRUCTURAL_KINDS.has(s.kind));
-  return mergeAdjacentTextSegments([...loopSegs, ...modeSegs, ...domBody]);
+  return mergeAdjacentTextSegments([...shellStructural, ...domBody]);
 }
 
 export function domParsedMissingRequiredAgentChip(

--- a/apps/desktop/src/lib/composer-agent-mode-segments.ts
+++ b/apps/desktop/src/lib/composer-agent-mode-segments.ts
@@ -108,10 +108,11 @@ export function ensureAgentModePinned(
   if (current === agentMode && hasAgentModeSegment(segs)) {
     const modeIndex = agentModeChipIndex(segs);
     const loopIndex = segs.findIndex((s) => s.kind === "loop");
-    if (loopIndex >= 0 && modeIndex >= 0 && modeIndex < loopIndex) {
-      return insertAgentModeSegment(segs, agentMode).segments;
+    if (loopIndex < 0) {
+      return mergeAdjacentTextSegments(segs);
     }
-    if (loopIndex < 0 || modeIndex === loopIndex + 1) {
+    const adjacent = modeIndex === loopIndex + 1 || loopIndex === modeIndex + 1;
+    if (adjacent) {
       return mergeAdjacentTextSegments(segs);
     }
     return insertAgentModeSegment(segs, agentMode).segments;

--- a/apps/desktop/src/lib/composer-loop-segments.ts
+++ b/apps/desktop/src/lib/composer-loop-segments.ts
@@ -1,21 +1,65 @@
 import type { RichSegment, SegmentCaret } from "./composer-segment-model";
 import { emptySegments, mergeAdjacentTextSegments } from "./composer-segment-model";
 
+const AGENT_MODE_KINDS = new Set(["plan", "ask", "debug"]);
+
+function isAgentModeKind(kind: RichSegment["kind"]): boolean {
+  return AGENT_MODE_KINDS.has(kind);
+}
+
+export function loopChipIndex(segs: RichSegment[]): number {
+  return segs.findIndex((s) => s.kind === "loop");
+}
+
 export function hasLoopSegment(segs: RichSegment[]): boolean {
-  return segs.some((s) => s.kind === "loop");
+  return loopChipIndex(segs) >= 0;
 }
 
 export function removeLoopSegment(segs: RichSegment[]): RichSegment[] {
   return mergeAdjacentTextSegments(segs.filter((s) => s.kind !== "loop"));
 }
 
-/** Keep at most one loop chip pinned at index 0. */
-export function ensureLoopPinned(segs: RichSegment[]): RichSegment[] {
-  if (!hasLoopSegment(segs)) {
-    return mergeAdjacentTextSegments(segs);
+/** Insert loop after existing structural chips (plan/ask/debug), before body text. */
+function loopInsertIndex(segs: RichSegment[]): number {
+  let insertAt = 0;
+  for (let i = 0; i < segs.length; i++) {
+    const kind = segs[i]?.kind;
+    if (kind === "plan" || kind === "ask" || kind === "debug") {
+      insertAt = i + 1;
+    } else {
+      break;
+    }
   }
-  const rest = segs.filter((s) => s.kind !== "loop");
-  return mergeAdjacentTextSegments([{ kind: "loop" }, ...rest]);
+  return insertAt;
+}
+
+/** Keep at most one loop chip in the structural prefix; preserve order vs plan/ask/debug. */
+export function ensureLoopPinned(segs: RichSegment[]): RichSegment[] {
+  const merged = mergeAdjacentTextSegments(segs);
+  if (!hasLoopSegment(merged)) {
+    return merged;
+  }
+
+  const firstLoopIndex = loopChipIndex(merged);
+  const agentIndex = merged.findIndex((s) => isAgentModeKind(s.kind));
+  const body = merged.filter((s) => s.kind !== "loop" && !isAgentModeKind(s.kind));
+  const loopSeg = { kind: "loop" as const };
+  const agentSeg = agentIndex >= 0 ? merged[agentIndex] : null;
+
+  const structural: RichSegment[] = [];
+  if (agentSeg && firstLoopIndex >= 0) {
+    if (agentIndex < firstLoopIndex) {
+      structural.push(agentSeg, loopSeg);
+    } else {
+      structural.push(loopSeg, agentSeg);
+    }
+  } else if (firstLoopIndex >= 0) {
+    structural.push(loopSeg);
+  } else if (agentSeg) {
+    structural.push(agentSeg);
+  }
+
+  return mergeAdjacentTextSegments([...structural, ...body]);
 }
 
 /** Match element chip: add a trailing space when nothing follows the chip. */
@@ -35,34 +79,33 @@ export function insertLoopSegment(segs: RichSegment[]): {
   caret: SegmentCaret;
 } {
   const rest = removeLoopSegment(segs);
+  const merged = mergeAdjacentTextSegments(rest);
+  const insertAt = loopInsertIndex(merged);
   const normalized = mergeAdjacentTextSegments([
+    ...merged.slice(0, insertAt),
     { kind: "loop" },
-    ...tailAfterLoopChip(rest),
+    ...tailAfterLoopChip(merged.slice(insertAt)),
   ]);
-  const textIndex = normalized.findIndex((s) => s.kind === "text");
-  const caretSegmentIndex = textIndex >= 0 ? textIndex : normalized.length;
-  const textSeg = textIndex >= 0 ? normalized[textIndex] : undefined;
-  const caretOffset =
-    textSeg?.kind === "text" && textSeg.value.startsWith(" ") ? 1 : 0;
   return {
     segments: normalized,
-    caret: { segmentIndex: caretSegmentIndex, offset: caretOffset },
+    caret: caretAfterLoopChip(normalized),
   };
 }
 
 export function caretAfterLoopChip(segs: RichSegment[]): SegmentCaret {
   const merged = mergeAdjacentTextSegments(segs);
-  if (merged[0]?.kind !== "loop") {
+  const loopIndex = loopChipIndex(merged);
+  if (loopIndex < 0) {
     return { segmentIndex: 0, offset: 0 };
   }
-  const textIndex = merged.findIndex((s, i) => i > 0 && s.kind === "text");
+  const textIndex = merged.findIndex((s, i) => i > loopIndex && s.kind === "text");
   if (textIndex >= 0) {
     const textSeg = merged[textIndex];
     const offset =
       textSeg?.kind === "text" && textSeg.value.startsWith(" ") ? 1 : 0;
     return { segmentIndex: textIndex, offset };
   }
-  return { segmentIndex: 1, offset: 0 };
+  return { segmentIndex: loopIndex + 1, offset: 0 };
 }
 
 /** DOM/selection often reports segment 0 on the chip; snap to the typed position after it. */
@@ -77,10 +120,11 @@ export function normalizeCaretForPinnedLoopChip(
     return caretAfterLoopChip(segs);
   }
   const merged = mergeAdjacentTextSegments(segs);
-  if (merged[0]?.kind !== "loop") {
+  const loopIndex = loopChipIndex(merged);
+  if (loopIndex < 0) {
     return caret;
   }
-  if (caret.segmentIndex <= 0) {
+  if (caret.segmentIndex <= loopIndex) {
     return caretAfterLoopChip(merged);
   }
   return caret;
@@ -92,14 +136,11 @@ export function isCaretAtLoopRemovalPoint(
   caret: SegmentCaret,
 ): boolean {
   const merged = mergeAdjacentTextSegments(segs);
-  if (merged[0]?.kind !== "loop") {
+  const loopIndex = loopChipIndex(merged);
+  if (loopIndex < 0) {
     return false;
   }
-  const at = merged[caret.segmentIndex];
-  if (at?.kind === "text") {
-    return caret.segmentIndex === 1 && caret.offset === 0;
-  }
-  return caret.segmentIndex === 1 && caret.offset === 0;
+  return caret.segmentIndex === loopIndex + 1 && caret.offset === 0;
 }
 
 export function emptySegmentsWithOptionalLoop(loopEnabled: boolean): RichSegment[] {

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -19,6 +19,12 @@ export type ActiveWorkspaceFileReferenceQuery = {
   raw: string;
 };
 
+export type ActiveSkillSlashQuery = {
+  start: number;
+  end: number;
+  raw: string;
+};
+
 export function normalizeWorkspaceFilePath(path: string): string {
   return path.replace(/\\/gu, "/");
 }
@@ -458,6 +464,47 @@ export function replaceWorkspaceFileReferenceInSegments(
   return {
     segments: normalized,
     caret: { segmentIndex: afterIndex, offset: caretOffset },
+  };
+}
+
+export function replaceSkillSlashQueryInSegments(
+  segs: RichSegment[],
+  query: ActiveSkillSlashQuery,
+  replacement: string,
+  finalize = false,
+): { segments: RichSegment[]; caret: SegmentCaret } {
+  const merged = mergeAdjacentTextSegments(segs);
+  const startCaret = plainTextOffsetToCaret(merged, query.start);
+  const endCaret = plainTextOffsetToCaret(merged, query.end);
+  const index = startCaret.segmentIndex;
+  const seg = merged[index];
+
+  if (seg?.kind !== "text" || endCaret.segmentIndex !== index) {
+    return { segments: merged, caret: caretAtEnd(merged) };
+  }
+
+  const before = seg.value.slice(0, startCaret.offset);
+  const after = seg.value.slice(endCaret.offset);
+  let insertText = replacement;
+  if (finalize && insertText.length > 0) {
+    const needsSpace = after.length === 0 || !/^\s/u.test(after.charAt(0));
+    if (needsSpace && !insertText.endsWith(" ")) {
+      insertText += " ";
+    }
+  }
+
+  const combined = `${before}${insertText}${after}`;
+  const next: RichSegment[] = [
+    ...merged.slice(0, index),
+    ...(combined ? [{ kind: "text" as const, value: combined }] : []),
+    ...merged.slice(index + 1),
+  ];
+
+  const normalized = mergeAdjacentTextSegments(next);
+  const caretPlainOffset = query.start + Array.from(insertText).length;
+  return {
+    segments: normalized,
+    caret: plainTextOffsetToCaret(normalized, caretPlainOffset),
   };
 }
 

--- a/apps/desktop/src/lib/composer-segment-selection.ts
+++ b/apps/desktop/src/lib/composer-segment-selection.ts
@@ -457,7 +457,12 @@ export function caretToDomRange(
       placed = true;
       break;
     }
-    if (segIdx === index - 1 && caret.offset === 0) {
+    // Only when the target segment is text at offset 0 (start of text right after this chip).
+    if (
+      segIdx === index - 1 &&
+      caret.offset === 0 &&
+      segments[index]?.kind === "text"
+    ) {
       range.setStartAfter(node);
       range.collapse(true);
       placed = true;

--- a/apps/desktop/src/lib/skill-slash.ts
+++ b/apps/desktop/src/lib/skill-slash.ts
@@ -1,3 +1,8 @@
+import {
+  charCountToCodeUnitIndex,
+  codeUnitIndexToCharCount,
+} from '@spirit-agent/host-internal'
+
 import type { DesktopSkillListItem } from '@/types'
 
 export type SkillSlashSuggestionKind =
@@ -79,8 +84,94 @@ export const STATIC_SLASH_COMMANDS: readonly SkillSlashSuggestion[] = [
   },
 ] as const
 
+export interface ActiveSkillSlashQuery {
+  start: number
+  end: number
+  raw: string
+}
+
+export function skillSlashQueryKey(query: ActiveSkillSlashQuery): string {
+  return `${query.start}\u0000${query.end}\u0000${query.raw}`
+}
+
+function previousCodePointIndex(input: string, fromIndex: number): number {
+  const previousIndex = fromIndex - 1
+  if (previousIndex <= 0) {
+    return 0
+  }
+
+  const codeUnit = input.charCodeAt(previousIndex)
+  if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+    return previousIndex - 1
+  }
+  return previousIndex
+}
+
+function tokenStart(input: string, cursor: number): number {
+  for (let index = cursor; index > 0; ) {
+    const previousIndex = previousCodePointIndex(input, index)
+    const codePoint = input.codePointAt(previousIndex)
+    if (codePoint === undefined) {
+      break
+    }
+
+    const char = String.fromCodePoint(codePoint)
+    if (/\s/u.test(char)) {
+      return index
+    }
+    index = previousIndex
+  }
+
+  return 0
+}
+
+function tokenEnd(input: string, cursor: number): number {
+  for (let index = cursor; index < input.length; ) {
+    const codePoint = input.codePointAt(index)
+    if (codePoint === undefined) {
+      break
+    }
+
+    const char = String.fromCodePoint(codePoint)
+    if (/\s/u.test(char)) {
+      return index
+    }
+    index += codePoint > 0xffff ? 2 : 1
+  }
+
+  return input.length
+}
+
+export function currentSkillSlashQueryAtCursor(
+  input: string,
+  cursorChars: number,
+): ActiveSkillSlashQuery | undefined {
+  if (!input || input.includes('\n')) {
+    return undefined
+  }
+
+  const cursor = charCountToCodeUnitIndex(input, cursorChars)
+  const start = tokenStart(input, cursor)
+  const end = tokenEnd(input, cursor)
+  if (start >= end) {
+    return undefined
+  }
+
+  const token = input.slice(start, end)
+  if (!token.startsWith('/') || /\s/u.test(token.slice(1))) {
+    return undefined
+  }
+
+  return {
+    start: codeUnitIndexToCharCount(input, start),
+    end: codeUnitIndexToCharCount(input, end),
+    raw: token,
+  }
+}
+
+/** Whole-composer slash query when the caret is at the end of trimmed input. */
 export function currentSkillSlashQuery(input: string | undefined): string | undefined {
-  if (!input || !input.startsWith('/') || input.includes('\n')) {
+  if (!input) {
     return undefined
   }
 
@@ -89,11 +180,7 @@ export function currentSkillSlashQuery(input: string | undefined): string | unde
     return undefined
   }
 
-  if (/\s/u.test(trimmedRight.slice(1))) {
-    return undefined
-  }
-
-  return trimmedRight
+  return currentSkillSlashQueryAtCursor(input, Array.from(trimmedRight).length)?.raw
 }
 
 export function buildSkillSlashSuggestions(

--- a/apps/desktop/src/lib/skill-slash.ts
+++ b/apps/desktop/src/lib/skill-slash.ts
@@ -1,7 +1,7 @@
 import {
   charCountToCodeUnitIndex,
   codeUnitIndexToCharCount,
-} from '@spirit-agent/host-internal'
+} from '@spirit-agent/host-internal/workspace-file-reference-query'
 
 import type { DesktopSkillListItem } from '@/types'
 

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -10,6 +10,7 @@ import {
   normalizeComposerPlain,
   messageSegmentSeparator,
   plainTextOffsetToCaret,
+  replaceSkillSlashQueryInSegments,
   replaceWorkspaceFileReferenceInSegments,
   segmentsToMessageText,
   segmentsToPlainText,
@@ -381,6 +382,52 @@ test("plainTextOffsetToCaret roundtrips with workspace file chip", () => {
   const offset = caretToPlainTextOffset(segs, caret);
   const roundtrip = plainTextOffsetToCaret(segs, offset);
   assert.deepEqual(roundtrip, caret);
+});
+
+test("replaceSkillSlashQueryInSegments removes slash token and keeps loop chip", () => {
+  const { segments } = replaceSkillSlashQueryInSegments(
+    [
+      { kind: "loop" },
+      { kind: "text", value: "hi /git" },
+    ],
+    { start: 3, end: 7, raw: "/git" },
+    "",
+  );
+  assert.deepEqual(segments, [
+    { kind: "loop" },
+    { kind: "text", value: "hi " },
+  ]);
+});
+
+test("replaceSkillSlashQueryInSegments replaces mid-text slash token with finalized text", () => {
+  const { segments, caret } = replaceSkillSlashQueryInSegments(
+    [{ kind: "text", value: "see /log" }],
+    { start: 4, end: 8, raw: "/log" },
+    "/log-session",
+    true,
+  );
+  assert.deepEqual(segments, [{ kind: "text", value: "see /log-session " }]);
+  assert.equal(caret.segmentIndex, 0);
+  assert.equal(caret.offset, 17);
+});
+
+test("replaceSkillSlashQueryInSegments keeps inline file chip when replacing nearby slash token", () => {
+  const initial = [
+    { kind: "workspaceFile", path: "src/foo.ts" },
+    { kind: "text", value: " /git" },
+  ];
+  const slashStart = caretToPlainTextOffset(initial, { segmentIndex: 1, offset: 1 });
+  const slashEnd = caretToPlainTextOffset(initial, { segmentIndex: 1, offset: 5 });
+  const { segments } = replaceSkillSlashQueryInSegments(
+    initial,
+    { start: slashStart, end: slashEnd, raw: "/git" },
+    "",
+  );
+  assert.equal(segments.some((s) => s.kind === "workspaceFile"), true);
+  assert.deepEqual(
+    segments.filter((s) => s.kind === "text"),
+    [{ kind: "text", value: " " }],
+  );
 });
 
 test("replaceWorkspaceFileReferenceInSegments inserts chip and caret after finalize space", () => {

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -306,6 +306,22 @@ test("insertAgentModeSegment pins plan after loop", () => {
   assert.equal(segments[2]?.kind === "text" && segments[2].value, "work");
 });
 
+test("insertSegmentAtCaret adds skill inline while preserving loop and plan chips", () => {
+  const base = [
+    { kind: "loop" },
+    { kind: "plan" },
+    { kind: "text", value: "please " },
+  ];
+  const { segments } = insertSegmentAtCaret(base, { segmentIndex: 2, offset: 7 }, {
+    kind: "skill",
+    alias: "/git-commit",
+  });
+  assert.equal(segments[0]?.kind, "loop");
+  assert.equal(segments[1]?.kind, "plan");
+  assert.ok(segments.some((s) => s.kind === "skill" && s.alias === "/git-commit"));
+  assert.ok(segments.some((s) => s.kind === "text" && s.value.includes("please")));
+});
+
 test("insertAgentModeSegment replaces plan with ask", () => {
   const { segments } = insertAgentModeSegment(
     [{ kind: "plan" }, { kind: "text", value: " " }],

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -306,6 +306,41 @@ test("insertAgentModeSegment pins plan after loop", () => {
   assert.equal(segments[2]?.kind === "text" && segments[2].value, "work");
 });
 
+test("replaceSkillSlashQueryInSegments preserves loop plan and skill when removing plan slash token", () => {
+  const initial = [
+    { kind: "loop" },
+    { kind: "plan" },
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: "please /ask" },
+  ];
+  const slashStart = caretToPlainTextOffset(initial, { segmentIndex: 3, offset: 7 });
+  const slashEnd = caretToPlainTextOffset(initial, { segmentIndex: 3, offset: 11 });
+  const { segments } = replaceSkillSlashQueryInSegments(
+    initial,
+    { start: slashStart, end: slashEnd, raw: "/ask" },
+    "",
+  );
+  assert.equal(segments[0]?.kind, "loop");
+  assert.equal(segments[1]?.kind, "plan");
+  assert.ok(segments.some((s) => s.kind === "skill" && s.alias === "/git-commit"));
+  assert.deepEqual(
+    segments.filter((s) => s.kind === "text"),
+    [{ kind: "text", value: "please " }],
+  );
+});
+
+test("insertSegmentAtCaret allows multiple skill chips with different aliases", () => {
+  const base = [
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: " " },
+  ];
+  const { segments } = insertSegmentAtCaret(base, { segmentIndex: 1, offset: 1 }, {
+    kind: "skill",
+    alias: "/create-skill",
+  });
+  assert.equal(segments.filter((s) => s.kind === "skill").length, 2);
+});
+
 test("insertSegmentAtCaret adds skill inline while preserving loop and plan chips", () => {
   const base = [
     { kind: "loop" },
@@ -541,7 +576,7 @@ test("normalizeCaretForInlineAttachmentChips snaps caret on file chip", () => {
     offset: 0,
   });
   assert.equal(snapped.segmentIndex, 1);
-  assert.equal(snapped.offset, 0);
+  assert.equal(snapped.offset, 1);
 });
 
 test("isCaretAtInlineChipRemovalPoint and removeInlineChipAtRemovalPoint", () => {
@@ -553,10 +588,7 @@ test("isCaretAtInlineChipRemovalPoint and removeInlineChipAtRemovalPoint", () =>
   const caret = { segmentIndex: 2, offset: 0 };
   assert.equal(isCaretAtInlineChipRemovalPoint(segs, caret), true);
   const removed = removeInlineChipAtRemovalPoint(segs, caret);
-  assert.deepEqual(removed?.segments, [
-    { kind: "text", value: "see " },
-    { kind: "text", value: " please" },
-  ]);
+  assert.deepEqual(removed?.segments, [{ kind: "text", value: "see  please" }]);
 });
 
 test("normalizeCaretForComposer chains loop and inline chip fixes", () => {

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -250,12 +250,22 @@ test("syncSegmentsFromExternalValue replaces text while keeping elements", () =>
   ]);
 });
 
-test("insertLoopSegment pins loop at index 0", () => {
+test("insertLoopSegment pins loop before body text", () => {
   const { segments } = insertLoopSegment([
     { kind: "text", value: "hello" },
   ]);
   assert.equal(segments[0]?.kind, "loop");
   assert.equal(segments[1]?.kind === "text" && segments[1].value, "hello");
+  assert.equal(hasLoopSegment(segments), true);
+});
+
+test("insertLoopSegment appends loop after existing agent mode chip", () => {
+  const { segments } = insertLoopSegment([
+    { kind: "ask" },
+    { kind: "text", value: " " },
+  ]);
+  assert.equal(segments[0]?.kind, "ask");
+  assert.equal(segments[1]?.kind, "loop");
   assert.equal(hasLoopSegment(segments), true);
 });
 
@@ -269,7 +279,7 @@ test("insertLoopSegment adds trailing space after loop when composer empty", () 
   assert.equal(caret.offset, 1);
 });
 
-test("ensureLoopPinned deduplicates and moves loop to front", () => {
+test("ensureLoopPinned deduplicates and moves misplaced loop before body", () => {
   const pinned = ensureLoopPinned([
     { kind: "text", value: "tail" },
     { kind: "loop" },
@@ -277,6 +287,17 @@ test("ensureLoopPinned deduplicates and moves loop to front", () => {
   ]);
   assert.equal(pinned.filter((s) => s.kind === "loop").length, 1);
   assert.equal(pinned[0]?.kind, "loop");
+});
+
+test("ensureLoopPinned preserves ask then loop order", () => {
+  const pinned = ensureLoopPinned([
+    { kind: "ask" },
+    { kind: "loop" },
+    { kind: "text", value: "work" },
+  ]);
+  assert.equal(pinned[0]?.kind, "ask");
+  assert.equal(pinned[1]?.kind, "loop");
+  assert.equal(pinned[2]?.kind === "text" && pinned[2].value, "work");
 });
 
 test("segmentsToMessageText ignores loop chip", () => {
@@ -551,6 +572,15 @@ test("synchronizeTextFromDom keeps shell chips and adopts dom text", () => {
   assert.equal(merged[1]?.kind === "text" && merged[1].value, "hello");
 });
 
+test("synchronizeTextFromDom preserves ask then loop shell order", () => {
+  const shell = [{ kind: "ask" }, { kind: "loop" }, { kind: "text", value: " " }];
+  const dom = [{ kind: "text", value: "hello" }];
+  const merged = synchronizeTextFromDom(shell, dom);
+  assert.equal(merged[0]?.kind, "ask");
+  assert.equal(merged[1]?.kind, "loop");
+  assert.equal(merged[2]?.kind === "text" && merged[2].value, "hello");
+});
+
 test("normalizeCaretForPinnedLoopChip snaps caret before loop to after chip", () => {
   const segs = [{ kind: "loop" }, { kind: "text", value: " " }];
   const snapped = normalizeCaretForPinnedLoopChip(segs, { segmentIndex: 0, offset: 0 });
@@ -562,6 +592,17 @@ test("normalizeCaretForPinnedLoopChip snaps caret before loop to after chip", ()
   );
   assert.equal(
     isCaretAtLoopRemovalPoint(segs, { segmentIndex: 1, offset: 0 }),
+    true,
+  );
+});
+
+test("normalizeCaretForPinnedLoopChip snaps caret on ask-then-loop chips", () => {
+  const segs = [{ kind: "ask" }, { kind: "loop" }, { kind: "text", value: " " }];
+  const snapped = normalizeCaretForPinnedLoopChip(segs, { segmentIndex: 1, offset: 0 });
+  assert.equal(snapped.segmentIndex, 2);
+  assert.equal(snapped.offset, 1);
+  assert.equal(
+    isCaretAtLoopRemovalPoint(segs, { segmentIndex: 2, offset: 0 }),
     true,
   );
 });

--- a/apps/desktop/test/skill-slash.test.mjs
+++ b/apps/desktop/test/skill-slash.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { currentWorkspaceFileReferenceQuery } from "@spirit-agent/host-internal";
+import { currentWorkspaceFileReferenceQuery } from "@spirit-agent/host-internal/workspace-file-reference-query";
 
 import {
   buildSkillSlashSuggestions,

--- a/apps/desktop/test/skill-slash.test.mjs
+++ b/apps/desktop/test/skill-slash.test.mjs
@@ -3,18 +3,10 @@ import { test } from "node:test";
 
 import {
   buildSkillSlashSuggestions,
-  isCreateRuleSlashInput,
+  currentSkillSlashQuery,
+  currentSkillSlashQueryAtCursor,
+  skillSlashQueryKey,
 } from "../src/lib/skill-slash.ts";
-
-test("buildSkillSlashSuggestions includes create-rule command", () => {
-  const suggestions = buildSkillSlashSuggestions("/create", []);
-  assert.ok(suggestions.some((item) => item.kind === "create-rule" && item.alias === "/create-rule"));
-});
-
-test("isCreateRuleSlashInput matches command with prompt", () => {
-  assert.equal(isCreateRuleSlashInput("/create-rule 使用中文 commit"), true);
-  assert.equal(isCreateRuleSlashInput("/create-skill foo"), false);
-});
 
 test("buildSkillSlashSuggestions excludes start-implementing slash", () => {
   const suggestions = buildSkillSlashSuggestions("/", []);
@@ -42,4 +34,56 @@ test("buildSkillSlashSuggestions filters plan by prefix", () => {
   const suggestions = buildSkillSlashSuggestions("/p", []);
   assert.ok(suggestions.some((item) => item.kind === "plan"));
   assert.equal(buildSkillSlashSuggestions("/ask", []).some((item) => item.kind === "plan"), false);
+});
+
+test("currentSkillSlashQueryAtCursor matches slash token in middle of text", () => {
+  const input = "hello /git";
+  const query = currentSkillSlashQueryAtCursor(input, Array.from(input).length);
+  assert.deepEqual(query, {
+    start: 6,
+    end: 10,
+    raw: "/git",
+  });
+});
+
+test("currentSkillSlashQueryAtCursor matches leading slash token", () => {
+  const input = "/loop";
+  const query = currentSkillSlashQueryAtCursor(input, Array.from(input).length);
+  assert.deepEqual(query, { start: 0, end: 5, raw: "/loop" });
+});
+
+test("currentSkillSlashQueryAtCursor matches mid-text plan token", () => {
+  const input = "please /plan";
+  const query = currentSkillSlashQueryAtCursor(input, Array.from(input).length);
+  assert.deepEqual(query, {
+    start: 7,
+    end: 12,
+    raw: "/plan",
+  });
+});
+
+test("currentSkillSlashQueryAtCursor rejects slash command followed by extra text", () => {
+  assert.equal(
+    currentSkillSlashQueryAtCursor("/loop extra", Array.from("/loop extra").length),
+    undefined,
+  );
+  assert.equal(
+    currentSkillSlashQueryAtCursor("hi /foo bar", Array.from("hi /foo bar").length),
+    undefined,
+  );
+});
+
+test("currentSkillSlashQueryAtCursor returns undefined when caret is outside slash token", () => {
+  assert.equal(currentSkillSlashQueryAtCursor("hello world", 5), undefined);
+});
+
+test("currentSkillSlashQuery delegates to cursor-at-end behavior", () => {
+  assert.equal(currentSkillSlashQuery("/loop"), "/loop");
+  assert.equal(currentSkillSlashQuery("text /git"), "/git");
+  assert.equal(currentSkillSlashQuery("hello world"), undefined);
+});
+
+test("skillSlashQueryKey is stable for the same query", () => {
+  const query = { start: 1, end: 5, raw: "/git" };
+  assert.equal(skillSlashQueryKey(query), "1\u00005\u0000/git");
 });

--- a/apps/desktop/test/skill-slash.test.mjs
+++ b/apps/desktop/test/skill-slash.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { currentWorkspaceFileReferenceQuery } from "@spirit-agent/host-internal";
+
 import {
   buildSkillSlashSuggestions,
   currentSkillSlashQuery,
@@ -86,4 +88,19 @@ test("currentSkillSlashQuery delegates to cursor-at-end behavior", () => {
 test("skillSlashQueryKey is stable for the same query", () => {
   const query = { start: 1, end: 5, raw: "/git" };
   assert.equal(skillSlashQueryKey(query), "1\u00005\u0000/git");
+});
+
+test("slash and file-reference queries target different caret tokens", () => {
+  const input = "see @src/foo.ts then /git";
+  const fileCaret = Array.from("see @").length;
+  const slashCaret = Array.from(input).length;
+  const fileQuery = currentWorkspaceFileReferenceQuery(input, fileCaret);
+  const slashQuery = currentSkillSlashQueryAtCursor(input, slashCaret);
+  assert.ok(fileQuery?.raw.startsWith("@"));
+  assert.equal(slashQuery?.raw, "/git");
+  assert.notEqual(fileQuery?.raw, slashQuery?.raw);
+});
+
+test("buildSkillSlashSuggestions returns empty for undefined query", () => {
+  assert.deepEqual(buildSkillSlashSuggestions(undefined, []), []);
 });


### PR DESCRIPTION
## Summary

- 支持在输入框任意光标位置通过斜杠 token 唤起菜单，选中后仅替换该 token 而非清空整段输入
- Loop / Agent mode / Skill 斜杠应用时保留已有 chip 组合；Skill chip 在光标处插入
- 修复 composer chip 与光标、DOM 同步多项缺陷（含 Ask → Loop 时 Loop 应跟在已有 mode chip 之后）
- 补充斜杠与多 chip 组合的回归测试

## Test plan

- [ ] 输入框中间输入 `/` 唤起菜单，选中 Skill/Loop/Plan/Ask 后仅替换 token
- [ ] 先选 Ask 再选 Loop，chip 顺序为 `[Ask, Loop]` 且光标在正文前
- [ ] 先选 Loop 再选 Ask，chip 顺序为 `[Loop, Ask]`
- [ ] Loop + Ask 组合下 Backspace 删除 Loop 行为正常
- [ ] 发送消息后 chip 状态与设置恢复符合预期
- [x] `npx --yes tsx --test test/composer-segments.test.mjs test/skill-slash.test.mjs`（desktop）