### PR TITLE
fix(desktop): IME 组合态下按 Enter 误触发消息发送

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -985,7 +985,9 @@ function ComposerSurface({
             e.key === 'Enter' &&
             !e.shiftKey &&
             !e.ctrlKey &&
-            !e.metaKey
+            !e.metaKey &&
+            // React synthetic event 的 isComposing 不可靠，必须用 nativeEvent 检测 IME 组合态
+            !e.nativeEvent.isComposing
           ) {
             e.preventDefault();
             if (canSend) onSubmit();
@@ -3238,6 +3240,8 @@ export default function App() {
       !event.shiftKey &&
       !event.ctrlKey &&
       !event.metaKey &&
+      // React synthetic event 的 isComposing 不可靠，必须用 nativeEvent 检测 IME 组合态
+      !event.nativeEvent.isComposing &&
       runtime.busyAction !== "approve"
     ) {
       event.preventDefault();


### PR DESCRIPTION
## Summary

- ComposerSurface 的 Enter keydown 处理器未检查 `nativeEvent.isComposing`，中文输入法下按 Enter 确认英文字符时抢先触发 `onSubmit`，导致消息携带未完成的文本被发出
- 在两处 Enter 处理逻辑（主 composer 发送 + pendingApproval 确认）添加 `isComposing` 守卫
- 注释说明必须使用 `nativeEvent.isComposing` 而非 React 合成事件的 `isComposing`（后者不可靠）

## Test plan

- [ ] 切换至中文输入法，在 composer 输入英文字符（如 debug）按 Enter，确认文本正常提交到输入框而非发送消息
- [ ] 再次按 Enter，确认消息正常发送
- [ ] 非 IME 状态下 Enter 发送行为不受影响
- [ ] Shift+Enter 换行行为不受影响
- [ ] pendingApproval 场景下 IME 组合态按 Enter 不误触发审批提交