### PR TITLE
feat(desktop): 输入框 Shift+Tab 循环切换 Agent 模式

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -21,7 +21,7 @@ import {
   type SessionSidebarChromeApi,
   useSessionSidebarChrome,
 } from "@/contexts/session-sidebar-chrome-context";
-import { type DesktopAgentMode } from "@/lib/agent-mode";
+import { cycleAgentMode, type DesktopAgentMode } from "@/lib/agent-mode";
 import {
   resolveComposerDirectMediaTool,
   type DirectMediaTool,
@@ -3232,6 +3232,19 @@ export default function App() {
   const handleComposerKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     handleComposerSuggestionKeyDown(event);
     if (event.defaultPrevented) {
+      return;
+    }
+    // Shift+Tab — 循环切换 Agent 模式（Agent → Plan → Ask → Debug → Agent）
+    if (
+      event.key === 'Tab' &&
+      event.shiftKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault();
+      const nextMode = cycleAgentMode(runtime.settings.agentMode);
+      handleComposerAgentModeChange(nextMode);
       return;
     }
     if (

--- a/apps/desktop/src/lib/agent-mode.ts
+++ b/apps/desktop/src/lib/agent-mode.ts
@@ -13,6 +13,16 @@ export function resolveDesktopAgentMode(input?: {
   return input?.planMode === true ? 'plan' : 'agent';
 }
 
+/** Cycle to the next agent mode: Agent → Plan → Ask → Debug → Agent (matches CLI Tab order). */
+export function cycleAgentMode(current: DesktopAgentMode): DesktopAgentMode {
+  switch (current) {
+    case 'agent': return 'plan';
+    case 'plan':  return 'ask';
+    case 'ask':   return 'debug';
+    case 'debug': return 'agent';
+  }
+}
+
 export function runModeLabel(mode: DesktopAgentMode): string {
   switch (mode) {
     case 'plan':


### PR DESCRIPTION
## Summary

- 在 Desktop 输入框（composer）聚焦时按 Shift+Tab，按 Agent → Plan → Ask → Debug → Agent 顺序循环切换 Agent 模式，与 CLI Tab 键顺序一致
- 复用现有 `handleComposerAgentModeChange` 处理 chip 增删（Plan / Ask / Debug 各显示对应 Chip，Agent 模式无 Chip）及设置持久化
- 斜杠建议 / 文件引用建议菜单打开时，由 `handleComposerSuggestionKeyDown` 优先消费事件，不触发模式切换
- IME 组合态时不触发切换
- 新增 `cycleAgentMode(current)` 工具函数于 `apps/desktop/src/lib/agent-mode.ts`，统一管理循环顺序

## Test plan

- [ ] 输入框无内容时连续按 Shift+Tab，依次出现 Plan Chip → Ask Chip → Debug Chip → 无 Chip（Agent），循环正确
- [ ] 输入框有文字时按 Shift+Tab，文字保留、模式切换正常
- [ ] 斜杠建议菜单打开时按 Shift+Tab，不触发模式切换（Tab 仍用于确认建议项）
- [ ] 文件引用建议菜单打开时按 Shift+Tab，不触发模式切换
- [ ] IME 组合态（中文输入中途）按 Shift+Tab 不触发切换
- [ ] 切换模式后发送消息，对应模式的系统提示词正确生效（Plan 出方案、Ask 只读、Debug 先列假设）