### PR TITLE
feat(desktop): Shell 流式回显与非阻塞审批

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,11 @@
 
 首次启动 Desktop Host 时，会将 `apps/desktop/builtin-skills/` 下的 `git-commit`、`git-push`、`git-merge` 种子到 `%APPDATA%/SpiritAgent/skills/`（已存在则不覆盖，可自行编辑）。Git 选项卡按钮与输入框斜杠菜单一致（如 `/git-commit`），在当前会话激活对应 Skill；不再使用后台 ephemeral 会话生成提交信息。
 
+## Shell 流式执行
+
+- `run_shell_command` 的 spawn 执行与增量输出契约在 `packages/host-internal`（`shell-execution.ts`）；`agent-core` 通过 `tool-execution-output-chunk` 事件转发增量文本。
+- Desktop 将会话 tool 卡实时投影输出；CLI 经 host-bridge 接收事件但 TUI 暂不渲染 chunk（最终仍一次性展示 `tool-execution-finished` 结果）。
+
 ## Agent / LLM 约定
 
 - 发给 LLM 的模型可见文本默认统一使用英文，包括但不限于系统消息、工具定义概述、工具描述、评估文案等；除非某个机制明确要求其他语言，否则不要混入中文或中英混写，以尽量减少输出质量波动。

--- a/apps/cli/src/ts_bridge.rs
+++ b/apps/cli/src/ts_bridge.rs
@@ -587,6 +587,17 @@ enum BridgeRuntimeEvent {
     },
     #[serde(rename = "tool-execution-finished")]
     ToolExecutionFinished { execution: BridgeToolExecution },
+    /// Incremental shell stdout/stderr while `run_shell_command` runs in the background.
+    /// CLI TUI does not render chunks yet; Desktop projects them into tool cards.
+    #[serde(rename = "tool-execution-output-chunk")]
+    ToolExecutionOutputChunk {
+        #[serde(alias = "toolCallId")]
+        tool_call_id: String,
+        #[serde(alias = "toolName")]
+        tool_name: String,
+        request: Value,
+        chunk: String,
+    },
     #[serde(rename = "context-usage-updated")]
     ContextUsageUpdated { usage: BridgeLlmTokenUsage },
 }
@@ -2504,6 +2515,8 @@ impl TsBridgeRuntime {
                 }
                 BridgeRuntimeEvent::BackgroundToolStatus { .. } => {}
                 BridgeRuntimeEvent::ContextUsageUpdated { .. } => {}
+                // TODO(cli): project tool-execution-output-chunk into TUI shell tool cards.
+                BridgeRuntimeEvent::ToolExecutionOutputChunk { .. } => {}
                 BridgeRuntimeEvent::ToolExecutionFinished { execution } => {
                     if execution.tool_name.starts_with("todo_") {
                         continue;
@@ -3966,6 +3979,36 @@ mod tests {
                     execution.request.get("name").and_then(Value::as_str),
                     Some("run_shell_command")
                 );
+            }
+            other => panic!("unexpected event variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_execution_output_chunk_event_deserializes() {
+        let value = json!({
+            "kind": "tool-execution-output-chunk",
+            "toolCallId": "call_shell",
+            "toolName": "run_shell_command",
+            "request": {
+                "name": "run_shell_command",
+                "command": "npm install"
+            },
+            "chunk": "added 1 package\n"
+        });
+
+        let event: BridgeRuntimeEvent =
+            serde_json::from_value(value).expect("event should deserialize");
+        match event {
+            BridgeRuntimeEvent::ToolExecutionOutputChunk {
+                tool_call_id,
+                tool_name,
+                chunk,
+                ..
+            } => {
+                assert_eq!(tool_call_id, "call_shell");
+                assert_eq!(tool_name, "run_shell_command");
+                assert_eq!(chunk, "added 1 package\n");
             }
             other => panic!("unexpected event variant: {other:?}"),
         }

--- a/apps/desktop/src/components/minimal-tool-call-card.tsx
+++ b/apps/desktop/src/components/minimal-tool-call-card.tsx
@@ -380,6 +380,8 @@ function ShellToolExpandedBody({
   command: string | undefined;
 }) {
   const { t } = useTranslation();
+  const outputPreRef = useRef<HTMLPreElement>(null);
+  const followTail = tool.phase === "running";
   const shellOutput = useMemo(() => {
     const parsed = parseShellToolResult(tool.outputExcerpt);
     if (parsed) {
@@ -393,6 +395,17 @@ function ShellToolExpandedBody({
 
   const commandLine = command?.trim();
   const showShellPanel = Boolean(commandLine || shellOutput);
+
+  useEffect(() => {
+    if (!followTail) {
+      return;
+    }
+    const element = outputPreRef.current;
+    if (!element) {
+      return;
+    }
+    element.scrollTop = element.scrollHeight;
+  }, [followTail, shellOutput?.text]);
 
   return (
     <div className="space-y-2">
@@ -408,7 +421,15 @@ function ShellToolExpandedBody({
             {shellOutput ? (
               <div className={commandLine ? "mt-2" : undefined}>
                 {shellOutput.text.length > 0 ? (
-                  <pre className="overflow-x-auto whitespace-pre-wrap break-words font-mono">{shellOutput.text}</pre>
+                  <pre
+                    ref={outputPreRef}
+                    className={cn(
+                      "overflow-x-auto whitespace-pre-wrap break-words font-mono",
+                      followTail && "max-h-96 overflow-y-auto overscroll-contain",
+                    )}
+                  >
+                    {shellOutput.text}
+                  </pre>
                 ) : (
                   <p className="text-muted-foreground/70">{t("tool.shellOutputEmpty")}</p>
                 )}

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -114,6 +114,7 @@ export class DesktopRuntimeEventOrchestrator {
    * 同一个 Collapsible 实例上收起；本段 completed 时再拆成独立思考行。
    */
   private deferredAfterStreamThinking: string | undefined;
+  private shellOutputSnapshotTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(private readonly options: DesktopRuntimeEventOrchestratorOptions) {}
 
@@ -168,6 +169,20 @@ export class DesktopRuntimeEventOrchestrator {
     this.activeGenerateImageTools.clear();
     this.activeGenerateVideoTools.clear();
     this.deferredAfterStreamThinking = undefined;
+    if (this.shellOutputSnapshotTimer !== undefined) {
+      clearTimeout(this.shellOutputSnapshotTimer);
+      this.shellOutputSnapshotTimer = undefined;
+    }
+  }
+
+  private scheduleLiveSnapshotUpdateForShellOutput(): void {
+    if (this.shellOutputSnapshotTimer !== undefined) {
+      return;
+    }
+    this.shellOutputSnapshotTimer = setTimeout(() => {
+      this.shellOutputSnapshotTimer = undefined;
+      this.options.requestLiveSnapshotUpdate?.();
+    }, 150);
   }
 
   /** 无工具回合里暂挂的 after-stream 思考：在 completed / 空正文收尾时拆成独立思考行。 */
@@ -478,6 +493,26 @@ export class DesktopRuntimeEventOrchestrator {
             request: event.request as JsonObject,
           },
         });
+        if (event.decisionKind === 'allow') {
+          this.options.requestLiveSnapshotUpdate?.();
+        }
+        continue;
+      }
+      if (event.kind === 'tool-execution-output-chunk') {
+        if (this.shouldSuppressMainTimelineChildToolSurface(event.toolName)) {
+          continue;
+        }
+        const existing = this.findExistingToolSnapshot(event.toolCallId);
+        if (!existing) {
+          continue;
+        }
+        const updated: ToolBlockSnapshot = {
+          ...existing,
+          outputExcerpt: `${existing.outputExcerpt ?? ''}${event.chunk}`,
+        };
+        this.options.assistantMessages.upsertToolMessage(event.toolCallId, updated, batchId);
+        this.options.messageTimeline?.()?.upsertToolMessage(event.toolCallId, updated);
+        this.scheduleLiveSnapshotUpdateForShellOutput();
         continue;
       }
       if (event.kind === 'tool-execution-finished') {

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -478,6 +478,7 @@ export async function replyPendingApprovalCommand(
     orchestration.runtimeEvents.consumeCompletedTurnResult();
     orchestration.runtimeEvents.syncPendingToolStates();
     orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
+    ctx.emitLiveSnapshotUpdate();
     await ctx.flushDeferredRuntimeRefreshIfIdle();
     return ctx.buildSnapshot();
   });

--- a/apps/desktop/src/host/tool-executor.ts
+++ b/apps/desktop/src/host/tool-executor.ts
@@ -404,6 +404,10 @@ export class DesktopToolExecutor
     return this.tools.backgroundStatusText?.(request);
   }
 
+  abortRunningShellCommands(): void {
+    this.tools.abortRunningShellCommands();
+  }
+
   startMcpBackgroundRefresh(): void {
     this.mcp.startBackgroundRefreshInBackground(true);
   }

--- a/apps/desktop/src/lib/shell-tool-display.ts
+++ b/apps/desktop/src/lib/shell-tool-display.ts
@@ -74,9 +74,12 @@ export function shellExpandableDetailLines(
 }
 
 export function shellHasExpandableContent(
-  tool: Pick<ToolBlockSnapshot, "argsExcerpt" | "detailLines" | "outputExcerpt">,
+  tool: Pick<ToolBlockSnapshot, "argsExcerpt" | "detailLines" | "outputExcerpt" | "phase">,
   command: string | undefined,
 ): boolean {
+  if (tool.phase === 'running' || tool.phase === 'preview') {
+    return true;
+  }
   if (tool.outputExcerpt?.trim()) {
     return true;
   }

--- a/packages/acp-server/src/event-mapper.ts
+++ b/packages/acp-server/src/event-mapper.ts
@@ -122,6 +122,9 @@ export function mapRuntimeEventToUpdate(
       // represent a full-text replacement. Skip to avoid duplicate content.
       return undefined;
 
+    case 'tool-execution-output-chunk':
+      return undefined;
+
     case 'background-tool-status':
       return {
         sessionId,

--- a/packages/agent-core/src/host-bridge/host-tool-executor.ts
+++ b/packages/agent-core/src/host-bridge/host-tool-executor.ts
@@ -59,6 +59,7 @@ export interface LocalHostToolService {
   saveGeneratedImage?(request: GeneratedImageSaveRequest): Promise<GeneratedImageFile>;
   saveGeneratedVideo?(request: import('../ports.js').GeneratedVideoSaveRequest): Promise<import('../ports.js').GeneratedVideoFile>;
   attachRequestMetadata?(request: JsonValue, metadata: ToolRequestExecutionMetadata): JsonValue;
+  abortRunningShellCommands?(): void;
 }
 
 export class HostToolExecutorProxy implements ToolExecutor<JsonValue, JsonValue> {
@@ -346,6 +347,10 @@ export class HostToolExecutorProxy implements ToolExecutor<JsonValue, JsonValue>
     }
 
     return this.resolveRequestMetadata(request)?.backgroundStatusText;
+  }
+
+  abortRunningShellCommands(): void {
+    this.localHostService?.abortRunningShellCommands?.();
   }
 
   startMcpBackgroundRefresh(): void {

--- a/packages/agent-core/src/host-bridge/protocol.ts
+++ b/packages/agent-core/src/host-bridge/protocol.ts
@@ -75,6 +75,7 @@ export interface BridgeRuntimeSnapshot {
 }
 
 export interface DrainEventsResult {
+  /** Includes `tool-execution-output-chunk` while `run_shell_command` streams; CLI ignores, Desktop projects to UI. */
   events: RuntimeEvent<JsonValue>[];
   snapshot: BridgeRuntimeSnapshot;
 }

--- a/packages/agent-core/src/ports.ts
+++ b/packages/agent-core/src/ports.ts
@@ -593,6 +593,7 @@ export interface ToolExecutor<
   continueAfterQuestions?(request: ToolRequest, result: AskQuestionsResult): Promise<ToolRequest | undefined>;
   shouldExecuteInBackground?(request: ToolRequest): boolean;
   backgroundStatusText?(request: ToolRequest): string | undefined;
+  abortRunningShellCommands?(): void;
   startMcpBackgroundRefresh(): void;
   mcpStatusSnapshot(): McpStatusSnapshot;
   addMcpServer(name: string, config: JsonValue): Promise<string>;

--- a/packages/agent-core/src/ports.ts
+++ b/packages/agent-core/src/ports.ts
@@ -565,6 +565,8 @@ export interface ToolRequestExecutionMetadata {
   subagentSessionId?: string;
   subagentTitle?: string;
   userInitiated?: boolean;
+  /** In-process only; not serialized across host bridge IPC. */
+  onOutputChunk?: (chunk: string) => void;
 }
 
 export interface ToolExecutor<

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -647,6 +647,8 @@ export class AgentRuntime<
       return;
     }
 
+    this.options.toolExecutor.abortRunningShellCommands?.();
+
     const hasPendingAssistantText = this.pendingAssistantTextStore.trim().length > 0;
 
     if (hasPendingAssistantText) {

--- a/packages/agent-core/src/runtime/background-tools.shell-streaming.test.ts
+++ b/packages/agent-core/src/runtime/background-tools.shell-streaming.test.ts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createToolExecutionTextOutput,
+  type AuthorizationDecision,
+  type JsonValue,
+  type ToolExecutionOutput,
+  type ToolExecutor,
+  type ToolRequestExecutionMetadata,
+} from '../ports.js';
+import { startBackgroundToolExecutionAsync, type BackgroundToolsRuntime } from './background-tools.js';
+import type { RuntimeEvent, RuntimeTurnContext } from './types.js';
+
+interface ShellToolRequest {
+  name: 'run_shell_command';
+  command: string;
+}
+
+class StreamingShellExecutor implements ToolExecutor<ShellToolRequest> {
+  toolDefinitionsJson(): JsonValue {
+    return [];
+  }
+
+  async parseCommand(): Promise<ShellToolRequest> {
+    throw new Error('not implemented');
+  }
+
+  async requestFromFunctionCall(): Promise<ShellToolRequest> {
+    throw new Error('not implemented');
+  }
+
+  async authorize(): Promise<AuthorizationDecision> {
+    return { kind: 'allowed' };
+  }
+
+  async trust(): Promise<void> {}
+
+  attachRequestMetadata(
+    request: ShellToolRequest,
+    metadata: ToolRequestExecutionMetadata,
+  ): ShellToolRequest {
+    this.lastMetadata = metadata;
+    return request;
+  }
+
+  lastMetadata: ToolRequestExecutionMetadata | undefined;
+
+  async execute(request: ShellToolRequest): Promise<ToolExecutionOutput> {
+    this.lastMetadata?.onOutputChunk?.('line1\n');
+    this.lastMetadata?.onOutputChunk?.('line2\n');
+    return createToolExecutionTextOutput(`shell done: ${request.command}`);
+  }
+
+  shouldExecuteInBackground(request: ShellToolRequest): boolean {
+    return request.name === 'run_shell_command';
+  }
+
+  backgroundStatusText(request: ShellToolRequest): string | undefined {
+    return `Shell: ${request.command}`;
+  }
+
+  startMcpBackgroundRefresh(): void {}
+
+  mcpStatusSnapshot() {
+    return {
+      revision: 0,
+      state: 'idle' as const,
+      configuredServers: 0,
+      loadedServers: 0,
+      cachedTools: 0,
+    };
+  }
+
+  async addMcpServer(): Promise<string> {
+    throw new Error('not implemented');
+  }
+
+  async listMcpServers(): Promise<never[]> {
+    return [];
+  }
+
+  async inspectMcpServer(): Promise<never> {
+    throw new Error('not implemented');
+  }
+
+  async listMcpTools(): Promise<never[]> {
+    return [];
+  }
+
+  async listMcpResources(): Promise<never[]> {
+    return [];
+  }
+
+  async readMcpResource(): Promise<JsonValue> {
+    throw new Error('not implemented');
+  }
+
+  async listCachedMcpPrompts(): Promise<never[]> {
+    return [];
+  }
+
+  async listMcpPrompts(): Promise<never[]> {
+    return [];
+  }
+
+  async getMcpPrompt(): Promise<JsonValue> {
+    throw new Error('not implemented');
+  }
+}
+
+test('startBackgroundToolExecutionAsync emits tool-execution-output-chunk for shell', async () => {
+  const executor = new StreamingShellExecutor();
+  const events: RuntimeEvent<ShellToolRequest>[] = [];
+  const request: ShellToolRequest = {
+    name: 'run_shell_command',
+    command: 'echo hello',
+  };
+  const turn: RuntimeTurnContext<ShellToolRequest> = {
+    requestTrace: [],
+    toolExecutions: [],
+    compactions: [],
+    autoCompactAttempts: 0,
+    deferredUserGuidances: [],
+  };
+
+  type TestState = { messages: string[] };
+  const runtime = {
+    options: {
+      toolExecutor: executor,
+      appendToolResultMessage: (state: TestState) => state,
+    },
+    pendingBackgroundToolStatusStore: undefined as string | undefined,
+    pendingBackgroundToolExecution: undefined,
+    completedManualToolCommandResultStore: undefined,
+    emitEvent: (event: RuntimeEvent<ShellToolRequest>) => {
+      events.push(event);
+    },
+    persistToolExecutionResult: () => {},
+    startToolAgentRoundAsync: () => {},
+    startStreamingRound: async () => {},
+    queuePendingToolCallContinuation: () => {},
+    processToolCallsAsync: async () => {},
+  } as unknown as BackgroundToolsRuntime<unknown, TestState, ShellToolRequest>;
+
+  startBackgroundToolExecutionAsync(
+    runtime,
+    'run shell',
+    { messages: [] },
+    request,
+    'call_shell_1',
+    'run_shell_command',
+    [],
+    turn,
+  );
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+  const chunkEvents = events.filter(
+    (event): event is Extract<RuntimeEvent<ShellToolRequest>, { kind: 'tool-execution-output-chunk' }> =>
+      event.kind === 'tool-execution-output-chunk',
+  );
+  assert.equal(chunkEvents.length, 2);
+  assert.equal(chunkEvents[0]?.chunk, 'line1\n');
+  assert.equal(chunkEvents[1]?.chunk, 'line2\n');
+  assert.ok(events.some((event) => event.kind === 'background-tool-status' && event.phase === 'started'));
+  const pending = runtime.pendingBackgroundToolExecution;
+  assert.ok(pending && pending.kind === 'tool-call');
+  assert.equal(pending.output?.summaryText, 'shell done: echo hello');
+});

--- a/packages/agent-core/src/runtime/background-tools.ts
+++ b/packages/agent-core/src/runtime/background-tools.ts
@@ -107,8 +107,22 @@ export function startBackgroundToolExecutionAsync<
   };
   runtime.pendingBackgroundToolExecution = pending;
 
+  const requestForExecution = runtime.options.toolExecutor.attachRequestMetadata?.(request, {
+    toolCallId,
+    toolName,
+    onOutputChunk: (chunk) => {
+      runtime.emitEvent({
+        kind: 'tool-execution-output-chunk',
+        toolCallId,
+        toolName,
+        request,
+        chunk,
+      });
+    },
+  }) ?? request;
+
   void runtime.options.toolExecutor
-    .execute(request)
+    .execute(requestForExecution)
     .then((output) => {
       if (runtime.pendingBackgroundToolExecution === pending) {
         pending.output = output;
@@ -153,8 +167,21 @@ export function startManualBackgroundToolExecution<
   };
   runtime.pendingBackgroundToolExecution = pending;
 
+  const requestForExecution = runtime.options.toolExecutor.attachRequestMetadata?.(request, {
+    toolName,
+    onOutputChunk: (chunk) => {
+      runtime.emitEvent({
+        kind: 'tool-execution-output-chunk',
+        toolCallId: `manual:${toolName}`,
+        toolName,
+        request,
+        chunk,
+      });
+    },
+  }) ?? request;
+
   void runtime.options.toolExecutor
-    .execute(request)
+    .execute(requestForExecution)
     .then((output) => {
       if (runtime.pendingBackgroundToolExecution === pending) {
         pending.output = output;

--- a/packages/agent-core/src/runtime/streaming.ts
+++ b/packages/agent-core/src/runtime/streaming.ts
@@ -313,6 +313,16 @@ export function currentAuxKind<
     ) {
       return undefined;
     }
+    if (
+      runtime.pendingBackgroundToolExecution !== undefined &&
+      runtime.pendingStreamingRound === undefined &&
+      runtime.pendingToolAgentRound === undefined &&
+      !runtime.thinkingTextStore.trim() &&
+      !runtime.compactionTextStore.trim() &&
+      !runtime.pendingBackgroundToolStatusStore?.trim()
+    ) {
+      return undefined;
+    }
     return 'thinking';
   }
 

--- a/packages/agent-core/src/runtime/types.ts
+++ b/packages/agent-core/src/runtime/types.ts
@@ -166,6 +166,13 @@ export type RuntimeEvent<ToolRequest> =
       execution: RuntimeToolExecution<ToolRequest>;
     }
   | {
+      kind: 'tool-execution-output-chunk';
+      toolCallId: string;
+      toolName: string;
+      request: ToolRequest;
+      chunk: string;
+    }
+  | {
       kind: 'context-usage-updated';
       usage: LlmTokenUsage;
     };

--- a/packages/host-internal/src/file-rewind.ts
+++ b/packages/host-internal/src/file-rewind.ts
@@ -28,6 +28,8 @@ export interface HostToolRequestMetadata {
   subagentSessionId?: string;
   subagentTitle?: string;
   userInitiated?: boolean;
+  /** In-process only; not serialized across host bridge IPC. */
+  onOutputChunk?: (chunk: string) => void;
 }
 
 export interface HostRecordedFileChange {

--- a/packages/host-internal/src/shell-execution.test.ts
+++ b/packages/host-internal/src/shell-execution.test.ts
@@ -17,7 +17,7 @@ test('runShellCommand streams stdout chunks and returns combined output', async 
   const chunks: string[] = [];
 
   try {
-    const result = await runShellCommand({
+    const { result: resultPromise } = runShellCommand({
       workspaceRoot,
       command: 'printf "line1\\n"; printf "line2\\n"',
       onOutputChunk: (chunk) => {
@@ -25,6 +25,7 @@ test('runShellCommand streams stdout chunks and returns combined output', async 
       },
       chunkThrottleMs: 10,
     });
+    const result = await resultPromise;
 
     assert.equal(result.exitCode, 0);
     assert.equal(combineShellToolOutput(result.stdout, result.stderr), 'line1\nline2\n');
@@ -53,10 +54,11 @@ test('runShellCommand reports non-zero exit code', async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-exec-fail-'));
 
   try {
-    const result = await runShellCommand({
+    const { result: resultPromise } = runShellCommand({
       workspaceRoot,
       command: 'exit 7',
     });
+    const result = await resultPromise;
 
     assert.equal(result.exitCode, 7);
     assert.equal(combineShellToolOutput(result.stdout, result.stderr), '');
@@ -70,7 +72,7 @@ test('runShellCommand merges stderr into streamed chunks', async () => {
   const chunks: string[] = [];
 
   try {
-    const result = await runShellCommand({
+    const { result: resultPromise } = runShellCommand({
       workspaceRoot,
       command: 'printf "out\\n" 1>&2; printf "ok\\n"',
       onOutputChunk: (chunk) => {
@@ -78,12 +80,32 @@ test('runShellCommand merges stderr into streamed chunks', async () => {
       },
       chunkThrottleMs: 10,
     });
+    const result = await resultPromise;
 
     assert.equal(result.exitCode, 0);
     assert.equal(result.stderr, 'out\n');
     assert.equal(result.stdout, 'ok\n');
     assert.ok(chunks.join('').includes('out'));
     assert.ok(chunks.join('').includes('ok'));
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('runShellCommand kill terminates a long-running child', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-exec-kill-'));
+
+  try {
+    const handle = runShellCommand({
+      workspaceRoot,
+      command: 'sleep 30',
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    handle.kill();
+    const result = await handle.result;
+    assert.equal(result.exitCode, -1);
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }

--- a/packages/host-internal/src/shell-execution.test.ts
+++ b/packages/host-internal/src/shell-execution.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  buildRunShellCommandToolResult,
+  combineShellToolOutput,
+  serializeRunShellCommandToolResult,
+} from '@spirit-agent/core';
+
+import { runShellCommand } from './shell-execution.js';
+
+test('runShellCommand streams stdout chunks and returns combined output', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-exec-'));
+  const chunks: string[] = [];
+
+  try {
+    const result = await runShellCommand({
+      workspaceRoot,
+      command: 'printf "line1\\n"; printf "line2\\n"',
+      onOutputChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+      chunkThrottleMs: 10,
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(combineShellToolOutput(result.stdout, result.stderr), 'line1\nline2\n');
+    assert.ok(chunks.length > 0);
+    assert.equal(chunks.join(''), 'line1\nline2\n');
+
+    const serialized = serializeRunShellCommandToolResult(
+      buildRunShellCommandToolResult({
+        terminal: 'test',
+        workspace: workspaceRoot,
+        command: 'printf',
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      }),
+    );
+    const parsed = JSON.parse(serialized) as { output: string; exitCode: number };
+    assert.equal(parsed.exitCode, 0);
+    assert.equal(parsed.output, 'line1\nline2\n');
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('runShellCommand reports non-zero exit code', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-exec-fail-'));
+
+  try {
+    const result = await runShellCommand({
+      workspaceRoot,
+      command: 'exit 7',
+    });
+
+    assert.equal(result.exitCode, 7);
+    assert.equal(combineShellToolOutput(result.stdout, result.stderr), '');
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('runShellCommand merges stderr into streamed chunks', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-exec-err-'));
+  const chunks: string[] = [];
+
+  try {
+    const result = await runShellCommand({
+      workspaceRoot,
+      command: 'printf "out\\n" 1>&2; printf "ok\\n"',
+      onOutputChunk: (chunk) => {
+        chunks.push(chunk);
+      },
+      chunkThrottleMs: 10,
+    });
+
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stderr, 'out\n');
+    assert.equal(result.stdout, 'ok\n');
+    assert.ok(chunks.join('').includes('out'));
+    assert.ok(chunks.join('').includes('ok'));
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/host-internal/src/shell-execution.ts
+++ b/packages/host-internal/src/shell-execution.ts
@@ -1,0 +1,159 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+import {
+  decodeShellHostOutput,
+  defaultShellForPty,
+  isWindowsCmdExecutable,
+  isWindowsPowerShellExecutable,
+  prepareShellCommandForHostExecution,
+} from './default-terminal-shell.js';
+
+const DEFAULT_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+const DEFAULT_CHUNK_THROTTLE_MS = 75;
+
+export interface RunShellCommandOptions {
+  workspaceRoot: string;
+  command: string;
+  onOutputChunk?: (chunk: string) => void;
+  chunkThrottleMs?: number;
+  maxOutputBytes?: number;
+}
+
+export interface RunShellCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function shellSpawnInvocation(shellFile: string, command: string): { file: string; args: string[] } {
+  if (isWindowsPowerShellExecutable(shellFile)) {
+    return {
+      file: shellFile,
+      args: ['-NoProfile', '-NonInteractive', '-Command', command],
+    };
+  }
+  if (isWindowsCmdExecutable(shellFile)) {
+    return {
+      file: shellFile,
+      args: ['/d', '/s', '/c', command],
+    };
+  }
+  const base = path.basename(shellFile).toLowerCase();
+  if (base === 'fish') {
+    return { file: shellFile, args: ['-c', command] };
+  }
+  return { file: shellFile, args: ['-c', command] };
+}
+
+function createChunkThrottle(
+  onOutputChunk: (chunk: string) => void,
+  intervalMs: number,
+): {
+  push: (chunk: string) => void;
+  flush: () => void;
+} {
+  let pending = '';
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const flush = (): void => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    if (pending.length === 0) {
+      return;
+    }
+    const chunk = pending;
+    pending = '';
+    onOutputChunk(chunk);
+  };
+
+  const push = (chunk: string): void => {
+    if (chunk.length === 0) {
+      return;
+    }
+    pending += chunk;
+    if (timer === undefined) {
+      timer = setTimeout(flush, intervalMs);
+    }
+  };
+
+  return { push, flush };
+}
+
+function decodeSpawnChunk(shellFile: string, chunk: Buffer): string {
+  return decodeShellHostOutput(shellFile, chunk);
+}
+
+export function runShellCommand(options: RunShellCommandOptions): Promise<RunShellCommandResult> {
+  const { file: shellExecutable } = defaultShellForPty();
+  const preparedCommand = prepareShellCommandForHostExecution(shellExecutable, options.command);
+  const { file, args } = shellSpawnInvocation(shellExecutable, preparedCommand);
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const throttle = options.onOutputChunk
+    ? createChunkThrottle(options.onOutputChunk, options.chunkThrottleMs ?? DEFAULT_CHUNK_THROTTLE_MS)
+    : undefined;
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let exitCode = 0;
+
+    const appendLimited = (current: string, addition: string): string => {
+      if (addition.length === 0 || Buffer.byteLength(current, 'utf8') >= maxOutputBytes) {
+        return current;
+      }
+      let combined = current + addition;
+      while (Buffer.byteLength(combined, 'utf8') > maxOutputBytes && combined.length > current.length) {
+        combined = combined.slice(0, -1);
+      }
+      return combined;
+    };
+
+    const appendStream = (
+      stream: 'stdout' | 'stderr',
+      decoded: string,
+    ): void => {
+      if (decoded.length === 0) {
+        return;
+      }
+      if (stream === 'stdout') {
+        stdout = appendLimited(stdout, decoded);
+        stdoutBytes = Buffer.byteLength(stdout, 'utf8');
+      } else {
+        stderr = appendLimited(stderr, decoded);
+        stderrBytes = Buffer.byteLength(stderr, 'utf8');
+      }
+      throttle?.push(decoded);
+    };
+
+    const child = spawn(file, args, {
+      cwd: options.workspaceRoot,
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      appendStream('stdout', decodeSpawnChunk(shellExecutable, chunk));
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      appendStream('stderr', decodeSpawnChunk(shellExecutable, chunk));
+    });
+
+    child.on('error', () => {
+      throttle?.flush();
+      resolve({ stdout, stderr, exitCode: -1 });
+    });
+
+    child.on('close', (code) => {
+      throttle?.flush();
+      exitCode = typeof code === 'number' ? code : -1;
+      resolve({ stdout, stderr, exitCode });
+    });
+  });
+}

--- a/packages/host-internal/src/shell-execution.ts
+++ b/packages/host-internal/src/shell-execution.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import path from 'node:path';
 
 import {
@@ -24,6 +24,11 @@ export interface RunShellCommandResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+}
+
+export interface RunShellCommandHandle {
+  result: Promise<RunShellCommandResult>;
+  kill: () => void;
 }
 
 function shellSpawnInvocation(shellFile: string, command: string): { file: string; args: string[] } {
@@ -86,7 +91,7 @@ function decodeSpawnChunk(shellFile: string, chunk: Buffer): string {
   return decodeShellHostOutput(shellFile, chunk);
 }
 
-export function runShellCommand(options: RunShellCommandOptions): Promise<RunShellCommandResult> {
+export function runShellCommand(options: RunShellCommandOptions): RunShellCommandHandle {
   const { file: shellExecutable } = defaultShellForPty();
   const preparedCommand = prepareShellCommandForHostExecution(shellExecutable, options.command);
   const { file, args } = shellSpawnInvocation(shellExecutable, preparedCommand);
@@ -95,7 +100,17 @@ export function runShellCommand(options: RunShellCommandOptions): Promise<RunShe
     ? createChunkThrottle(options.onOutputChunk, options.chunkThrottleMs ?? DEFAULT_CHUNK_THROTTLE_MS)
     : undefined;
 
-  return new Promise((resolve) => {
+  let child: ChildProcess | undefined;
+  let killedByHost = false;
+
+  const kill = (): void => {
+    if (child !== undefined && !child.killed) {
+      killedByHost = true;
+      child.kill();
+    }
+  };
+
+  const result = new Promise<RunShellCommandResult>((resolve) => {
     let stdout = '';
     let stderr = '';
     let stdoutBytes = 0;
@@ -130,7 +145,7 @@ export function runShellCommand(options: RunShellCommandOptions): Promise<RunShe
       throttle?.push(decoded);
     };
 
-    const child = spawn(file, args, {
+    child = spawn(file, args, {
       cwd: options.workspaceRoot,
       windowsHide: true,
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -152,8 +167,10 @@ export function runShellCommand(options: RunShellCommandOptions): Promise<RunShe
 
     child.on('close', (code) => {
       throttle?.flush();
-      exitCode = typeof code === 'number' ? code : -1;
+      exitCode = killedByHost ? -1 : typeof code === 'number' ? code : -1;
       resolve({ stdout, stderr, exitCode });
     });
   });
+
+  return { result, kill };
 }

--- a/packages/host-internal/src/shell-streaming.acceptance.test.ts
+++ b/packages/host-internal/src/shell-streaming.acceptance.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { NodeHostToolService } from './tools.js';
+
+test('NodeHostToolService streams incremental shell output via attachRequestMetadata', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-accept-'));
+  const spiritDataDir = join(workspaceRoot, '.spirit-data');
+  const chunks: string[] = [];
+  const startMs = Date.now();
+  const chunkTimes: number[] = [];
+
+  try {
+    await import('node:fs/promises').then((fs) => fs.mkdir(spiritDataDir, { recursive: true }));
+
+    const service = new NodeHostToolService(
+      { workspaceRoot, spiritDataDir },
+      { getApprovalLevel: () => 'full-approval' },
+    );
+
+    assert.equal(
+      service.shouldExecuteInBackground?.({
+        name: 'run_shell_command',
+        command: 'printf "a\\n"; sleep 0.15; printf "b\\n"',
+        reason: 'acceptance',
+      }),
+      true,
+    );
+
+    const request = {
+      name: 'run_shell_command' as const,
+      command: 'printf "a\\n"; sleep 0.15; printf "b\\n"',
+      reason: 'acceptance',
+    };
+    service.attachRequestMetadata?.(request, {
+      onOutputChunk: (chunk) => {
+        chunks.push(chunk);
+        chunkTimes.push(Date.now() - startMs);
+      },
+    });
+
+    const output = await service.execute(request);
+    assert.equal(typeof output, 'string');
+    assert.ok(chunks.join('').includes('a'));
+    assert.ok(chunks.join('').includes('b'));
+    assert.ok(chunkTimes.length >= 1);
+    if (chunkTimes.length >= 2) {
+      assert.ok(chunkTimes[1]! >= chunkTimes[0]!);
+    }
+    assert.match(String(output), /"exitCode":0/);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/host-internal/src/shell-streaming.acceptance.test.ts
+++ b/packages/host-internal/src/shell-streaming.acceptance.test.ts
@@ -55,3 +55,33 @@ test('NodeHostToolService streams incremental shell output via attachRequestMeta
     await rm(workspaceRoot, { recursive: true, force: true });
   }
 });
+
+test('NodeHostToolService.abortRunningShellCommands kills in-flight shell', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-abort-'));
+  const spiritDataDir = join(workspaceRoot, '.spirit-data');
+
+  try {
+    await import('node:fs/promises').then((fs) => fs.mkdir(spiritDataDir, { recursive: true }));
+
+    const service = new NodeHostToolService(
+      { workspaceRoot, spiritDataDir },
+      { getApprovalLevel: () => 'full-approval' },
+    );
+
+    const request = {
+      name: 'run_shell_command' as const,
+      command: 'sleep 30',
+      reason: 'abort-test',
+    };
+
+    const execution = service.execute(request);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    service.abortRunningShellCommands();
+    const output = await execution;
+    assert.match(String(output), /"exitCode":-1/);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -1,4 +1,3 @@
-import { exec as execCallback } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import {
@@ -12,7 +11,6 @@ import {
 } from 'node:fs/promises';
 import { release as osRelease } from 'node:os';
 import path from 'node:path';
-import { promisify } from 'node:util';
 
 import { glob as globPaths } from 'glob';
 
@@ -25,13 +23,11 @@ import {
 
 import { applyDiff } from './apply-diff.js';
 import {
-  decodeShellHostOutput,
   defaultShellForPty,
-  prepareShellCommandForHostExecution,
   shellCommandParameterDescriptionForResolvedShell,
   shellDisplayNameForResolvedShell,
-  shellHostExecUsesBufferOutput,
 } from './default-terminal-shell.js';
+import { runShellCommand } from './shell-execution.js';
 import {
   readHostFileSnapshot,
   type HostFileChangeKind,
@@ -87,8 +83,6 @@ import {
   buildRunShellCommandToolResult,
   serializeRunShellCommandToolResult,
 } from '@spirit-agent/core';
-
-const exec = promisify(execCallback);
 
 const PERMISSIONS_FILE = 'tool-permissions.json';
 const MAX_READ_LINES_DEFAULT = 200;
@@ -1029,7 +1023,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
       case 'finish_task':
         return createHostToolTextOutput(request.summary?.trim() || 'Task marked complete.');
       case 'run_shell_command':
-        return this.executeShell(request.command);
+        return this.executeShell(request.command, this.requestMetadataFor(request)?.onOutputChunk);
       case 'web_fetch':
         return this.executeWebFetch(request.url);
       case 'list_directory_files':
@@ -1713,57 +1707,25 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
     return out;
   }
 
-  private async executeShell(command: string): Promise<string> {
+  private async executeShell(
+    command: string,
+    onOutputChunk?: (chunk: string) => void,
+  ): Promise<string> {
     const shell = this.toolDefinitionEnvironment();
-    const { file: shellExecutable } = defaultShellForPty();
-    const preparedCommand = prepareShellCommandForHostExecution(shellExecutable, command);
-    const decodeBufferOutput = shellHostExecUsesBufferOutput(shellExecutable);
-    let stdout = '';
-    let stderr = '';
-    let code = 0;
-    try {
-      const result = await exec(preparedCommand, {
-        cwd: this.workspaceRoot,
-        maxBuffer: 8 * 1024 * 1024,
-        windowsHide: true,
-        shell: shellExecutable,
-        encoding: decodeBufferOutput ? 'buffer' : 'utf8',
-      });
-      if (decodeBufferOutput) {
-        const out = result.stdout as Buffer | undefined;
-        const err = result.stderr as Buffer | undefined;
-        stdout = decodeShellHostOutput(shellExecutable, out ?? Buffer.alloc(0));
-        stderr = decodeShellHostOutput(shellExecutable, err ?? Buffer.alloc(0));
-      } else {
-        stdout = (result.stdout as string | undefined) ?? '';
-        stderr = (result.stderr as string | undefined) ?? '';
-      }
-    } catch (error: unknown) {
-      const ex = error as { stdout?: string | Buffer; stderr?: string | Buffer; code?: number };
-      if (decodeBufferOutput) {
-        stdout = decodeShellHostOutput(
-          shellExecutable,
-          Buffer.isBuffer(ex.stdout) ? ex.stdout : Buffer.alloc(0),
-        );
-        stderr = decodeShellHostOutput(
-          shellExecutable,
-          Buffer.isBuffer(ex.stderr) ? ex.stderr : Buffer.alloc(0),
-        );
-      } else {
-        stdout = typeof ex.stdout === 'string' ? ex.stdout : '';
-        stderr = typeof ex.stderr === 'string' ? ex.stderr : '';
-      }
-      code = typeof ex.code === 'number' ? ex.code : -1;
-    }
+    const result = await runShellCommand({
+      workspaceRoot: this.workspaceRoot,
+      command,
+      ...(onOutputChunk ? { onOutputChunk } : {}),
+    });
 
     return serializeRunShellCommandToolResult(
       buildRunShellCommandToolResult({
         terminal: shell.shellDisplayName,
         workspace: this.workspaceRoot,
         command,
-        exitCode: code,
-        stdout,
-        stderr,
+        exitCode: result.exitCode,
+        stdout: result.stdout,
+        stderr: result.stderr,
       }),
     );
   }

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -1178,7 +1178,8 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
 
   backgroundStatusText(request: HostToolRequest<QuestionSpec>): string | undefined {
     if (request.name === 'run_shell_command') {
-      return `Shell: ${request.command}`;
+      // Shell status is shown on the tool card; do not mirror into thinking aux.
+      return undefined;
     }
     if (request.name !== 'extension_tool' || request.execution_mode !== 'background') {
       return undefined;

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -1170,10 +1170,16 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
   }
 
   shouldExecuteInBackground(request: HostToolRequest<QuestionSpec>): boolean {
+    if (request.name === 'run_shell_command') {
+      return true;
+    }
     return request.name === 'extension_tool' && request.execution_mode === 'background';
   }
 
   backgroundStatusText(request: HostToolRequest<QuestionSpec>): string | undefined {
+    if (request.name === 'run_shell_command') {
+      return `Shell: ${request.command}`;
+    }
     if (request.name !== 'extension_tool' || request.execution_mode !== 'background') {
       return undefined;
     }

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -356,6 +356,7 @@ export interface HostBuiltinToolService<QuestionSpec = HostAskQuestionsQuestionS
   ): HostToolRequest<QuestionSpec>;
   shouldExecuteInBackground?(request: HostToolRequest<QuestionSpec>): boolean;
   backgroundStatusText?(request: HostToolRequest<QuestionSpec>): string | undefined;
+  abortRunningShellCommands?(): void;
   startMcpBackgroundRefresh(): void;
   mcpStatusSnapshot(): HostMcpStatusSnapshot;
   addMcpServer(name: string, config: HostJsonValue): Promise<string>;
@@ -520,6 +521,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
   private readonly todoStore: HostTodoStore | undefined;
   private permissionsPromise: Promise<ToolPermissionStore> | undefined;
   private readonly requestMetadata = new WeakMap<object, HostToolRequestMetadata>();
+  private readonly activeShellKills = new Set<() => void>();
   private availableToolDefinitions: (() => JsonValue) | undefined;
 
   constructor(
@@ -1176,6 +1178,13 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
     return request.name === 'extension_tool' && request.execution_mode === 'background';
   }
 
+  abortRunningShellCommands(): void {
+    for (const kill of this.activeShellKills) {
+      kill();
+    }
+    this.activeShellKills.clear();
+  }
+
   backgroundStatusText(request: HostToolRequest<QuestionSpec>): string | undefined {
     if (request.name === 'run_shell_command') {
       // Shell status is shown on the tool card; do not mirror into thinking aux.
@@ -1719,11 +1728,18 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
     onOutputChunk?: (chunk: string) => void,
   ): Promise<string> {
     const shell = this.toolDefinitionEnvironment();
-    const result = await runShellCommand({
+    const handle = runShellCommand({
       workspaceRoot: this.workspaceRoot,
       command,
       ...(onOutputChunk ? { onOutputChunk } : {}),
     });
+    this.activeShellKills.add(handle.kill);
+    let result;
+    try {
+      result = await handle.result;
+    } finally {
+      this.activeShellKills.delete(handle.kill);
+    }
 
     return serializeRunShellCommandToolResult(
       buildRunShellCommandToolResult({


### PR DESCRIPTION
## Summary

- 将 `run_shell_command` 从阻塞式 `exec` 重构为 `spawn` 流式执行，通过 `tool-execution-output-chunk` 事件在 Desktop tool 卡实时回显输出
- shell 改为后台执行，审批通过后立即关闭弹窗并推送 live snapshot，composer 不再被长时间 IPC 阻塞
- 修复后台 shell 状态误投影为 Thought 卡片的问题；中断会话时终止孤儿 shell 子进程

## Test plan

- [x] `shell-execution.test.js` / `shell-streaming.acceptance.test.js` 通过
- [x] `background-tools.shell-streaming.test.js` 通过
- [x] CLI `tool_execution_output_chunk_event_deserializes` 通过
- [x] Desktop 手动验证：`sleep 5` 审批非阻塞、流式输出、无多余 Thought 卡片