### PR TITLE
feat(desktop): 左侧边栏展开收起快捷键 Cmd/Ctrl+B

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2351,6 +2351,21 @@ export default function App() {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, []);
 
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      if (!(event.ctrlKey || event.metaKey) || event.key.toLowerCase() !== "b") {
+        return;
+      }
+      event.preventDefault();
+      sessionSidebarChromeApiRef.current?.toggle();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   const [composerCursorCodeUnits, setComposerCursorCodeUnits] = useState(0);
   const [slashSelectedIndex, setSlashSelectedIndex] = useState(-1);
   const [fileReferenceSuggestions, setFileReferenceSuggestions] =

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -93,11 +93,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AgentMarkdownMessage } from "@/components/agent-markdown-message";
 import { AutomationsView } from "@/components/automations-view";
 import { AutomationDetailView } from "@/components/automation-detail-view";
@@ -230,7 +232,14 @@ import {
 import { cn } from "@/lib/utils";
 import { DesktopTitleBar } from "@/components/desktop-title-bar";
 import { desktopMicaTintClass, desktopMicaTintInnerClass } from "@/lib/desktop-mica-surface";
-import { desktopShellPlatform, isElectronChrome, isNativeBackdropBlurSupported, resolveUseMicaBackdrop } from "@/lib/desktop-shell";
+import {
+  desktopShellPlatform,
+  isElectronChrome,
+  isMacDesktopPlatform,
+  isNativeBackdropBlurSupported,
+  modLetterShortcutKbdKeys,
+  resolveUseMicaBackdrop,
+} from "@/lib/desktop-shell";
 import { LaunchSplash } from "@/components/launch-splash";
 import { SessionSidebar, type SettingsSidebarTab } from "@/components/session-sidebar";
 import { SessionSidebarShell } from "@/components/session-sidebar-shell";
@@ -1739,6 +1748,24 @@ function WebHostPairingGate({
   );
 }
 
+function SessionSidebarShortcutKbd() {
+  const keys = modLetterShortcutKbdKeys("B");
+
+  return (
+    <KbdGroup>
+      {isMacDesktopPlatform() ? (
+        keys.map((key) => <Kbd key={key}>{key}</Kbd>)
+      ) : (
+        <>
+          <Kbd>Ctrl</Kbd>
+          <span>+</span>
+          <Kbd>B</Kbd>
+        </>
+      )}
+    </KbdGroup>
+  );
+}
+
 function DesktopLayoutChromeBar({
   useMicaBackdrop,
   showWorkspaceToggle,
@@ -1777,18 +1804,26 @@ function DesktopLayoutChromeBar({
       )}
     >
       <div className="flex min-w-0 items-center">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className={cn(DESKTOP_CHROME_TOGGLE_ICON_BTN, "mr-1")}
-          onClick={onToggleSessionSidebar}
-          aria-label={sessionSidebarOpen ? t('app.hideSidebar') : t('app.showSidebar')}
-          aria-expanded={sessionSidebarOpen}
-          {...(sessionSidebarOpen ? { "aria-controls": "session-sidebar-panel" } : {})}
-        >
-          {sessionSidebarOpen ? <PanelLeftClose className="size-3.5" aria-hidden /> : <PanelLeftOpen className="size-3.5" aria-hidden />}
-        </Button>
+        <Tooltip delayDuration={300}>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className={cn(DESKTOP_CHROME_TOGGLE_ICON_BTN, "mr-1")}
+              onClick={onToggleSessionSidebar}
+              aria-label={sessionSidebarOpen ? t('app.hideSidebar') : t('app.showSidebar')}
+              aria-expanded={sessionSidebarOpen}
+              {...(sessionSidebarOpen ? { "aria-controls": "session-sidebar-panel" } : {})}
+            >
+              {sessionSidebarOpen ? <PanelLeftClose className="size-3.5" aria-hidden /> : <PanelLeftOpen className="size-3.5" aria-hidden />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {sessionSidebarOpen ? t("app.hideSidebar") : t("app.showSidebar")}{" "}
+            <SessionSidebarShortcutKbd />
+          </TooltipContent>
+        </Tooltip>
         {onNewSession ? (
           <div
             className={cn(

--- a/apps/desktop/src/lib/desktop-shell.ts
+++ b/apps/desktop/src/lib/desktop-shell.ts
@@ -72,6 +72,12 @@ export function shortcutLabel(key: string): string {
   return isMacDesktopPlatform() ? `⌘${letter}` : `Ctrl+${letter}`;
 }
 
+/** Cmd/Ctrl + letter shortcut keys for tooltip Kbd chips. */
+export function modLetterShortcutKbdKeys(key: string): readonly string[] {
+  const letter = key.toUpperCase();
+  return isMacDesktopPlatform() ? ["⌘", letter] : ["Ctrl", letter];
+}
+
 /** Cmd/Ctrl + / shortcut keys for tooltip Kbd chips. */
 export function modSlashShortcutKbdKeys(): readonly string[] {
   return isMacDesktopPlatform() ? ["⌘", "/"] : ["Ctrl", "/"];

--- a/apps/desktop/test/lib/desktop-shell.test.mjs
+++ b/apps/desktop/test/lib/desktop-shell.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  modLetterShortcutKbdKeys,
   modSlashShortcutKbdKeys,
   modSlashShortcutLabel,
   shortcutLabel,
@@ -25,6 +26,18 @@ test("shortcutLabel formats letter shortcuts per platform", () => {
   });
   withDesktopPlatform("win32", () => {
     assert.equal(shortcutLabel("n"), "Ctrl+N");
+  });
+});
+
+test("modLetterShortcutKbdKeys returns letter shortcut chips per platform", () => {
+  withDesktopPlatform("darwin", () => {
+    assert.deepEqual(modLetterShortcutKbdKeys("b"), ["⌘", "B"]);
+  });
+  withDesktopPlatform("win32", () => {
+    assert.deepEqual(modLetterShortcutKbdKeys("b"), ["Ctrl", "B"]);
+  });
+  withDesktopPlatform("linux", () => {
+    assert.deepEqual(modLetterShortcutKbdKeys("b"), ["Ctrl", "B"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- 新增 `modLetterShortcutKbdKeys` helper，为 Tooltip 提供与模型选择器一致的平台化 Kbd 芯片数据源。
- 注册全局 `Cmd/Ctrl+B` 快捷键，通过 `sessionSidebarChromeApiRef` 复用既有侧栏 `toggle()` 逻辑。
- 在 `DesktopLayoutChromeBar` 侧栏切换按钮上增加 Tooltip，展示「隐藏/展开侧栏」文案与快捷键提示。

## Test plan

- [x] macOS：Tooltip 显示 `⌘` + `B` 芯片；按 `Cmd+B` 切换侧栏
- [x] Windows/Linux：Tooltip 显示 `Ctrl` + `+` + `B`；按 `Ctrl+B` 切换侧栏
- [x] 侧栏收起/展开时 Tooltip 文案在「隐藏侧栏」/「展开侧栏」间切换
- [x] 设置页、Automations、Marketplace、会话页顶栏按钮均可见且行为一致
- [x] 在 composer 输入框聚焦时快捷键仍可切换侧栏
- [x] `npm run test:lib` 通过