### PR TITLE
feat(desktop): 列出目录工具卡工作区内显示相对路径

### DIFF
--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -13,6 +13,8 @@ import {
 } from '@spirit-agent/core';
 
 import { isStandaloneThinkingMessage } from '../lib/conversation-thinking-ui.js';
+import { listDirectoryToolDisplayPath } from '@spirit-agent/host-internal/skill-paths';
+
 import {
   isSkillMarkdownPath,
   parseReadFilePathFromRequest,
@@ -182,6 +184,10 @@ export interface ToolCallSummaryCopy {
   headlineDetail?: string;
 }
 
+export type ToolCallSummaryOptions = {
+  workspaceRoot?: string;
+};
+
 const SUMMARY_DETAIL_MAX = 80;
 const SUBAGENT_TASK_PREVIEW_MAX = 48;
 
@@ -199,6 +205,7 @@ export function toolCallSummaryCopyForRequest(
   toolName: string,
   request: unknown,
   phase?: ToolBlockSnapshot['phase'],
+  options?: ToolCallSummaryOptions,
 ): ToolCallSummaryCopy | undefined {
   if (!request || typeof request !== 'object') {
     return undefined;
@@ -316,7 +323,13 @@ export function toolCallSummaryCopyForRequest(
       const rawPath = typeof record.path === 'string' ? record.path.trim() : '';
       return {
         headline: i18n.t('tool.listDirectory', tOpts),
-        ...(rawPath ? { headlineDetail: truncateSummaryDetail(displayPathForListDirectory(rawPath)) } : {}),
+        ...(rawPath
+          ? {
+              headlineDetail: truncateSummaryDetail(
+                displayPathForListDirectory(rawPath, options?.workspaceRoot),
+              ),
+            }
+          : {}),
       };
     }
     case 'get_diagnostics': {
@@ -423,12 +436,13 @@ export function toolCallSummaryForPhase(
   phase: ToolBlockSnapshot['phase'],
   toolName: string,
   request: unknown,
+  options?: ToolCallSummaryOptions,
 ): ToolCallSummaryCopy {
   if (toolName === 'read_file') {
     return readFileSummaryCopy(request, phase);
   }
 
-  const custom = toolCallSummaryCopyForRequest(toolName, request, phase);
+  const custom = toolCallSummaryCopyForRequest(toolName, request, phase, options);
   if (custom) {
     return custom;
   }
@@ -440,8 +454,9 @@ export function headlineForToolPhase(
   phase: ToolBlockSnapshot['phase'],
   toolName: string,
   request: unknown,
+  options?: ToolCallSummaryOptions,
 ): string {
-  return toolCallSummaryForPhase(phase, toolName, request).headline;
+  return toolCallSummaryForPhase(phase, toolName, request, options).headline;
 }
 
 export function applyToolCallSummaryCopy(
@@ -987,12 +1002,16 @@ export function toolCallSummaryForStreamingPreview(
   toolCallId: string,
   toolName: string,
   request?: unknown,
+  options?: ToolCallSummaryOptions,
 ): ToolCallSummaryCopy {
   if (toolName === 'read_file') {
     return readFileSummaryCopy(request, 'running');
   }
 
-  const custom = request !== undefined ? toolCallSummaryCopyForRequest(toolName, request, 'running') : undefined;
+  const custom =
+    request !== undefined
+      ? toolCallSummaryCopyForRequest(toolName, request, 'running', options)
+      : undefined;
   if (custom) {
     return custom;
   }
@@ -1019,8 +1038,9 @@ export function headlineForStreamingToolPreview(
   toolCallId: string,
   toolName: string,
   request?: unknown,
+  options?: ToolCallSummaryOptions,
 ): string {
-  return toolCallSummaryForStreamingPreview(messages, toolCallId, toolName, request).headline;
+  return toolCallSummaryForStreamingPreview(messages, toolCallId, toolName, request, options).headline;
 }
 
 function readFileSummaryCopy(request: unknown, phase?: ToolBlockSnapshot['phase']): ToolCallSummaryCopy {
@@ -1077,15 +1097,12 @@ function displayBasename(path: string): string {
   return segments[segments.length - 1] || normalized;
 }
 
-function displayPathForListDirectory(path: string): string {
-  const trimmed = path.trim();
-  if (!trimmed) {
-    return i18n.t('tool.directory');
+function displayPathForListDirectory(path: string, workspaceRoot?: string): string {
+  const displayed = listDirectoryToolDisplayPath(path, workspaceRoot, i18n.t('tool.directory'));
+  if (displayed.length <= SUMMARY_DETAIL_MAX) {
+    return displayed;
   }
-  if (trimmed.length <= SUMMARY_DETAIL_MAX) {
-    return trimmed.replace(/\\/g, '/');
-  }
-  return displayPathForReadFile(trimmed);
+  return displayPathForReadFile(displayed);
 }
 
 function displayPathForReadFile(path: string): string {

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -98,6 +98,7 @@ export interface DesktopRuntimeEventOrchestratorOptions {
     usage: { inputTokens: number };
     activeModel: ContextUsageModelProfile;
   }) => void;
+  currentWorkspaceRoot?: () => string;
 }
 
 function isMcpLikeToolName(toolName: string): boolean {
@@ -117,6 +118,11 @@ export class DesktopRuntimeEventOrchestrator {
   private shellOutputSnapshotTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(private readonly options: DesktopRuntimeEventOrchestratorOptions) {}
+
+  private toolSummaryOptions() {
+    const workspaceRoot = this.options.currentWorkspaceRoot?.().trim();
+    return workspaceRoot ? { workspaceRoot } : undefined;
+  }
 
   private shouldSuppressMainTimelineChildToolSurface(toolName: string): boolean {
     if (toolName === 'run_subagent') {
@@ -449,7 +455,7 @@ export class DesktopRuntimeEventOrchestrator {
               ? { headline: i18n.t('tool.generateVideo', { context: 'running' }) }
               : event.toolName === 'get_diagnostics'
                 ? diagnosticsCheckingSummary(event.request)
-                : toolCallSummaryForPhase('running', event.toolName, event.request);
+                : toolCallSummaryForPhase('running', event.toolName, event.request, this.toolSummaryOptions());
         const runningTool: ToolBlockSnapshot = this.attachLineDelta(
           applyToolCallSummaryCopy(
             {
@@ -574,6 +580,7 @@ export class DesktopRuntimeEventOrchestrator {
         event.toolCallId,
         event.toolName,
         previewRequest,
+        this.toolSummaryOptions(),
       );
       const responsesBuiltInPhase = isResponsesBuiltIn
         ? resolveResponsesBuiltInToolStreamPhaseFromArgumentsJson(event.argumentsJson)
@@ -769,6 +776,7 @@ export class DesktopRuntimeEventOrchestrator {
         'pending-approval',
         approval.toolName,
         approval.request,
+        this.toolSummaryOptions(),
       );
       const pendingTool: ToolBlockSnapshot = this.attachLineDelta(
         applyToolCallSummaryCopy(
@@ -871,6 +879,7 @@ export class DesktopRuntimeEventOrchestrator {
               execution.failed ? 'failed' : 'succeeded',
               execution.toolName,
               execution.request,
+              this.toolSummaryOptions(),
             );
       const argsExcerpt = truncateJson(execution.request);
       const fileToolDiffArgumentsJson = FILE_DIFF_TOOL_NAMES.has(execution.toolName)
@@ -972,7 +981,7 @@ export class DesktopRuntimeEventOrchestrator {
       return;
     }
 
-    const runningSummary = toolCallSummaryForPhase('running', event.toolName, event.request);
+    const runningSummary = toolCallSummaryForPhase('running', event.toolName, event.request, this.toolSummaryOptions());
     const runningTool: ToolBlockSnapshot = this.attachLineDelta(
       applyToolCallSummaryCopy(
         {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -848,6 +848,7 @@ class DesktopHostService {
       messageTimeline: () => bundle.messageTimeline,
       takeNextAssistantSegmentKind: () => this.takeNextTimelineAssistantSegmentKind(bundle),
       conversationSnapshotView,
+      currentWorkspaceRoot: () => bundle.workspaceRoot,
       clearCurrentTurnSkills: () => {
         bundle.currentTurnSkills = [];
       },

--- a/apps/desktop/test/host/message-ordering.test.mjs
+++ b/apps/desktop/test/host/message-ordering.test.mjs
@@ -286,6 +286,46 @@ test('toolCallSummaryCopyForRequest: English verbs use past tense in succeeded p
   }
 });
 
+test('toolCallSummaryCopyForRequest: list_directory_files uses relative path within workspace', () => {
+  const workspaceRoot = '/Users/yu/proj';
+  assert.deepEqual(
+    toolCallSummaryCopyForRequest(
+      'list_directory_files',
+      { path: '/Users/yu/proj/apps/cli' },
+      'succeeded',
+      { workspaceRoot },
+    ),
+    { headline: '列出', headlineDetail: 'apps/cli' },
+  );
+  assert.deepEqual(
+    toolCallSummaryCopyForRequest(
+      'list_directory_files',
+      { path: '/Users/yu/proj' },
+      'running',
+      { workspaceRoot },
+    ),
+    { headline: '列出', headlineDetail: '.' },
+  );
+  assert.deepEqual(
+    toolCallSummaryCopyForRequest(
+      'list_directory_files',
+      { path: '/tmp/foo' },
+      'succeeded',
+      { workspaceRoot },
+    ),
+    { headline: '列出', headlineDetail: '/tmp/foo' },
+  );
+  assert.deepEqual(
+    toolCallSummaryCopyForRequest(
+      'list_directory_files',
+      { path: '/Users/yu/proj/apps/' },
+      'succeeded',
+      { workspaceRoot },
+    ),
+    { headline: '列出', headlineDetail: 'apps/' },
+  );
+});
+
 test('toolCallSummaryForPhase: get_diagnostics failed uses checking headline and basename', () => {
   assert.deepEqual(
     toolCallSummaryForPhase('failed', 'get_diagnostics', { path: 'src/App.tsx' }),

--- a/apps/desktop/test/host/message-ordering.test.mjs
+++ b/apps/desktop/test/host/message-ordering.test.mjs
@@ -9,6 +9,7 @@ import {
   stripRedundantThinkingFromMessageAux,
   toolCallSummaryCopyForRequest,
   toolCallSummaryForPhase,
+  toolCallSummaryForStreamingPreview,
 } from '../../dist-electron/src/host/message-ordering.js';
 import i18n from '../../dist-electron/src/lib/i18n-host.js';
 
@@ -323,6 +324,20 @@ test('toolCallSummaryCopyForRequest: list_directory_files uses relative path wit
       { workspaceRoot },
     ),
     { headline: '列出', headlineDetail: 'apps/' },
+  );
+});
+
+test('toolCallSummaryForStreamingPreview: list_directory_files uses relative path within workspace', () => {
+  const workspaceRoot = '/Users/yu/proj';
+  assert.deepEqual(
+    toolCallSummaryForStreamingPreview(
+      [],
+      'tool-1',
+      'list_directory_files',
+      { path: '/Users/yu/proj/apps' },
+      { workspaceRoot },
+    ),
+    { headline: '列出', headlineDetail: 'apps' },
   );
 });
 

--- a/packages/host-internal/src/skill-paths.test.ts
+++ b/packages/host-internal/src/skill-paths.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   SKILL_FILE_NAME,
   isSkillMarkdownPath,
+  listDirectoryToolDisplayPath,
   readFileToolDisplayBase,
   skillFolderBasename,
 } from './skill-paths.js';
@@ -17,6 +18,47 @@ test('isSkillMarkdownPath matches SKILL_FILE_NAME case-sensitively', () => {
 test('skillFolderBasename returns parent directory of SKILL.md', () => {
   assert.equal(skillFolderBasename('skills/git-commit/SKILL.md'), 'git-commit');
   assert.equal(skillFolderBasename(SKILL_FILE_NAME), SKILL_FILE_NAME);
+});
+
+test('listDirectoryToolDisplayPath relativizes paths within workspace root', () => {
+  const root = '/Users/yu/SpiritAgent';
+  assert.equal(
+    listDirectoryToolDisplayPath('/Users/yu/SpiritAgent/apps', root, 'Directory'),
+    'apps',
+  );
+  assert.equal(
+    listDirectoryToolDisplayPath('/Users/yu/SpiritAgent/apps/', root, 'Directory'),
+    'apps/',
+  );
+  assert.equal(
+    listDirectoryToolDisplayPath('/Users/yu/SpiritAgent/apps/cli/src', root, 'Directory'),
+    'apps/cli/src',
+  );
+  assert.equal(listDirectoryToolDisplayPath('/Users/yu/SpiritAgent', root, 'Directory'), '.');
+  assert.equal(listDirectoryToolDisplayPath('/Users/yu/SpiritAgent/', root, 'Directory'), '.');
+});
+
+test('listDirectoryToolDisplayPath keeps absolute paths outside workspace', () => {
+  const root = '/Users/yu/SpiritAgent';
+  assert.equal(
+    listDirectoryToolDisplayPath('/tmp/foo', root, 'Directory'),
+    '/tmp/foo',
+  );
+  assert.equal(listDirectoryToolDisplayPath('', root, 'Directory'), 'Directory');
+});
+
+test('listDirectoryToolDisplayPath without workspace root keeps absolute path', () => {
+  assert.equal(
+    listDirectoryToolDisplayPath('/Users/yu/SpiritAgent/apps', undefined, 'Directory'),
+    '/Users/yu/SpiritAgent/apps',
+  );
+});
+
+test('listDirectoryToolDisplayPath normalizes Windows-style paths', () => {
+  assert.equal(
+    listDirectoryToolDisplayPath('D:\\proj\\apps', 'D:\\proj', 'Directory'),
+    'apps',
+  );
 });
 
 test('readFileToolDisplayBase uses skill folder for SKILL.md paths', () => {

--- a/packages/host-internal/src/skill-paths.ts
+++ b/packages/host-internal/src/skill-paths.ts
@@ -33,6 +33,51 @@ export function skillFolderBasename(path: string): string {
   return segments[segments.length - 2] ?? pathBasename(path);
 }
 
+function workspaceRelativeDirectoryPath(path: string, workspaceRoot: string): string | undefined {
+  const pathSegs = pathSegments(path);
+  const rootSegs = pathSegments(workspaceRoot);
+  if (pathSegs.length < rootSegs.length) {
+    return undefined;
+  }
+  for (let i = 0; i < rootSegs.length; i += 1) {
+    if (pathSegs[i]!.toLowerCase() !== rootSegs[i]!.toLowerCase()) {
+      return undefined;
+    }
+  }
+  const relativeSegs = pathSegs.slice(rootSegs.length);
+  if (relativeSegs.length === 0) {
+    return '.';
+  }
+  let relative = relativeSegs.join('/');
+  if (normalizePath(path).endsWith('/') && relative) {
+    relative += '/';
+  }
+  return relative;
+}
+
+/** list_directory_files 工具卡路径：工作区内显示相对路径，区外显示绝对路径。 */
+export function listDirectoryToolDisplayPath(
+  path: string,
+  workspaceRoot: string | undefined,
+  emptyLabel: string,
+): string {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    return emptyLabel;
+  }
+
+  const normalized = normalizePath(trimmed);
+  const root = workspaceRoot?.trim();
+  if (root) {
+    const relative = workspaceRelativeDirectoryPath(normalized, root);
+    if (relative !== undefined) {
+      return relative;
+    }
+  }
+
+  return normalized;
+}
+
 /** read_file 工具卡右侧详情：SKILL.md 显示上级 Skill 目录名，其它路径与 Desktop 既有规则一致。 */
 export function readFileToolDisplayBase(path: string, emptyLabel: string): string {
   const trimmed = path.trim();


### PR DESCRIPTION
## Summary

- 新增 `listDirectoryToolDisplayPath` helper，工作区内目录转为相对路径展示，区外保持绝对路径。
- Host 侧 `message-ordering` 在生成 `list_directory_files` 的 `headlineDetail` 时注入 `workspaceRoot` 并 relativize。
- `runtime-event-orchestrator` 通过 `currentWorkspaceRoot` 将当前会话工作区根传入所有 tool summary 调用。
- Renderer 透传 `headlineDetail` 不变，不兼容历史绝对路径快照。

## Test plan

- [x] **新触发**的 `list_directory_files` 显示 `列出 apps`（非 `/Users/.../apps`）
- [x] 工作区外目录仍显示完整绝对路径
- [x] 工作区根目录列出显示 `.`
- [x] 旧会话中已有工具卡仍显示当时的绝对路径（预期行为，不修复）
- [x] `npm run test:lib` 通过
- [x] `skill-paths.test.ts` 单测通过
- [x] `message-ordering.test.mjs` 含 streaming preview 回归断言