### PR TITLE
feat(agent-core): 压缩前完整消息历史归档

### DIFF
--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -27,9 +27,13 @@ import {
   type LlmToolAgentState,
   type LlmTransportConfig,
 } from '@spirit-agent/core';
-import { resolveWorkspaceFileReferenceAttachmentsFromInput } from '@spirit-agent/host-internal';
+import {
+  persistPreCompactionHistoryArchive,
+  resolveWorkspaceFileReferenceAttachmentsFromInput,
+} from '@spirit-agent/host-internal';
 
 import type { DesktopToolRequest } from './contracts.js';
+import { spiritAgentDataDir } from './storage.js';
 import type { DesktopToolExecutor } from './tool-executor.js';
 
 export type DesktopRuntime = AgentRuntime<
@@ -147,6 +151,10 @@ export function createDesktopRuntime(input: {
       ),
     ...(input.hookRunner ? { hookRunner: input.hookRunner } : {}),
     ...(input.hookSessionContext ? { hookSessionContext: input.hookSessionContext } : {}),
+    persistPreCompactionHistory: async ({ archive, sessionId }) =>
+      persistPreCompactionHistoryArchive(spiritAgentDataDir(), archive, {
+        ...(sessionId !== undefined ? { sessionId } : {}),
+      }),
   }, input.history.map((message) => normalizeStoredLlmMessage(message)));
 }
 

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -29,6 +29,7 @@ import {
 } from '@spirit-agent/core';
 import {
   persistPreCompactionHistoryArchive,
+  removePreCompactionHistoryArchive,
   resolveWorkspaceFileReferenceAttachmentsFromInput,
 } from '@spirit-agent/host-internal';
 
@@ -155,6 +156,8 @@ export function createDesktopRuntime(input: {
       persistPreCompactionHistoryArchive(spiritAgentDataDir(), archive, {
         ...(sessionId !== undefined ? { sessionId } : {}),
       }),
+    removePreCompactionHistoryArchive: async (archivePath) =>
+      removePreCompactionHistoryArchive(archivePath),
   }, input.history.map((message) => normalizeStoredLlmMessage(message)));
 }
 

--- a/packages/acp-server/src/runtime-factory.ts
+++ b/packages/acp-server/src/runtime-factory.ts
@@ -39,6 +39,7 @@ import {
   createNoopMcpAdapter,
   ensureBuiltinAuthoringSkills,
   loadHostInstructionMetadata,
+  persistPreCompactionHistoryArchive,
 } from '@spirit-agent/host-internal';
 
 import { createNoopPeer } from './noop-peer.js';
@@ -215,6 +216,10 @@ export async function createAcpRuntime(
         return saveGeneratedVideo.call(service, saveRequest);
       }),
     resolveWorkspaceFilesFromInput: (text) => pendingWorkspaceFilesFromInput(workspaceRoot, text),
+    persistPreCompactionHistory: async ({ archive, sessionId }) =>
+      persistPreCompactionHistoryArchive(spiritDataDir, archive, {
+        ...(sessionId !== undefined ? { sessionId } : {}),
+      }),
     onEvent,
   });
 

--- a/packages/acp-server/src/runtime-factory.ts
+++ b/packages/acp-server/src/runtime-factory.ts
@@ -40,6 +40,7 @@ import {
   ensureBuiltinAuthoringSkills,
   loadHostInstructionMetadata,
   persistPreCompactionHistoryArchive,
+  removePreCompactionHistoryArchive,
 } from '@spirit-agent/host-internal';
 
 import { createNoopPeer } from './noop-peer.js';
@@ -220,6 +221,8 @@ export async function createAcpRuntime(
       persistPreCompactionHistoryArchive(spiritDataDir, archive, {
         ...(sessionId !== undefined ? { sessionId } : {}),
       }),
+    removePreCompactionHistoryArchive: async (archivePath) =>
+      removePreCompactionHistoryArchive(archivePath),
     onEvent,
   });
 

--- a/packages/agent-core/src/anthropic/ai-sdk-transport.ts
+++ b/packages/agent-core/src/anthropic/ai-sdk-transport.ts
@@ -294,6 +294,7 @@ export class AiSdkAnthropicTransport
     config: AnthropicTransportConfig,
     history: LlmMessage[],
     onProgress?: (message: string) => void,
+    context?: import('../ports.js').CompactHistoryManualContext,
   ): Promise<{
     droppedMessages: number;
     beforeLength: number;
@@ -308,7 +309,13 @@ export class AiSdkAnthropicTransport
       };
     }
 
-    const promptMessages = toolStateMessagesToAiSdkMessages(buildCompactHistoryPromptMessages(history));
+    const promptMessages = toolStateMessagesToAiSdkMessages(
+      buildCompactHistoryPromptMessages(history, {
+        ...(context?.preCompactionArchivePath === undefined
+          ? {}
+          : { preCompactionArchivePath: context.preCompactionArchivePath }),
+      }),
+    );
     const compactConfig: AnthropicTransportConfig = {
       ...config,
       model: config.compactModel ?? config.model,

--- a/packages/agent-core/src/compaction-archive.test.ts
+++ b/packages/agent-core/src/compaction-archive.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   PRE_COMPACTION_ARCHIVE_SECTION_HEADER,
   appendPreCompactionArchiveToCompactSummary,
+  applyPreCompactionArchivePathToCompactHistory,
   buildPreCompactionHistoryArchive,
 } from './compaction-archive.js';
 import { COMPACT_SUMMARY_PREFIX } from './tool-agent.js';
@@ -72,6 +73,22 @@ test('buildCompactHistorySystemPrompt includes archive path guidance when provid
   const prompt = buildCompactHistorySystemPrompt(path);
   assert.match(prompt, /pre-compaction history archive has been saved to: \/data\/compaction-archives\/pre-compact-s1\.json/);
   assert.match(prompt, /\[Pre-compaction Archive\]/);
+});
+
+test('applyPreCompactionArchivePathToCompactHistory updates compact summary message', () => {
+  const history = [
+    {
+      role: 'system' as const,
+      content: createLlmMessageContentFromText(`${COMPACT_SUMMARY_PREFIX}\ncompact summary`),
+    },
+  ];
+  applyPreCompactionArchivePathToCompactHistory(history, '/tmp/archive.json');
+  const text = history[0]?.content
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('');
+  assert.ok(text?.includes('/tmp/archive.json'));
+  assert.ok(text?.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER));
 });
 
 test('buildCompactHistoryPromptMessages forwards archive path into system prompt', () => {

--- a/packages/agent-core/src/compaction-archive.test.ts
+++ b/packages/agent-core/src/compaction-archive.test.ts
@@ -52,11 +52,19 @@ test('buildPreCompactionHistoryArchive keeps user and assistant messages with to
   assert.equal(archive.messages[2]?.toolCalls, undefined);
 });
 
-test('buildCompactHistorySystemPrompt includes archive path when provided', () => {
+test('buildCompactHistorySystemPrompt includes filled archive section example when provided', () => {
   const path = '/data/compaction-archives/pre-compact-s1.json';
   const prompt = buildCompactHistorySystemPrompt(path);
-  assert.match(prompt, /Pre-compaction history archive path \(use this exact path in \[Pre-compaction Archive\]\): \/data\/compaction-archives\/pre-compact-s1\.json/);
-  assert.match(prompt, /\[Pre-compaction Archive\]/);
+  assert.match(prompt, /Example \[Pre-compaction Archive\] section shape/);
+  assert.ok(
+    prompt.includes(
+      '[Pre-compaction Archive]\n/path/to/compaction-archives/pre-compact-session-1234567890.json\nImportant details may be recovered by reading this file with read_file.',
+    ),
+  );
+  assert.ok(prompt.includes(`Archive path for this compression (use this exact path on the archive line): ${path}`));
+  const exampleBlock = prompt.split('Archive path for this compression')[0] ?? '';
+  assert.doesNotMatch(exampleBlock, /\/Users\//);
+  assert.match(prompt, /Do not output only the path/);
 });
 
 test('buildCompactHistoryPromptMessages forwards archive path into system prompt', () => {

--- a/packages/agent-core/src/compaction-archive.test.ts
+++ b/packages/agent-core/src/compaction-archive.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  PRE_COMPACTION_ARCHIVE_SECTION_HEADER,
+  appendPreCompactionArchiveToCompactSummary,
+  buildPreCompactionHistoryArchive,
+} from './compaction-archive.js';
+import { COMPACT_SUMMARY_PREFIX } from './tool-agent.js';
+import {
+  buildCompactHistorySystemPrompt,
+  buildCompactHistoryPromptMessages,
+} from './tool-agent.js';
+import { createLlmMessageContentFromText } from './ports.js';
+
+test('buildPreCompactionHistoryArchive keeps user and assistant messages with toolCalls', () => {
+  const archive = buildPreCompactionHistoryArchive(
+    [
+      {
+        role: 'system',
+        content: createLlmMessageContentFromText(`${COMPACT_SUMMARY_PREFIX}\nold summary`),
+      },
+      {
+        role: 'user',
+        content: createLlmMessageContentFromText('hello'),
+      },
+      {
+        role: 'assistant',
+        content: [],
+        toolCalls: [{ id: 'call-1', name: 'read_file', argumentsJson: '{"path":"a.ts"}' }],
+      },
+      {
+        role: 'tool',
+        toolCallId: 'call-1',
+        content: createLlmMessageContentFromText('file contents'),
+      },
+      {
+        role: 'assistant',
+        content: createLlmMessageContentFromText('done'),
+      },
+    ],
+    1_700_000_000_000,
+  );
+
+  assert.equal(archive.export_version, 1);
+  assert.equal(archive.kind, 'pre_compaction_history');
+  assert.equal(archive.exported_at_unix_ms, 1_700_000_000_000);
+  assert.equal(archive.message_count, 3);
+  assert.equal(archive.messages.length, 3);
+  assert.equal(archive.messages[0]?.role, 'user');
+  assert.equal(archive.messages[1]?.role, 'assistant');
+  assert.deepEqual(archive.messages[1]?.toolCalls, [
+    { id: 'call-1', name: 'read_file', argumentsJson: '{"path":"a.ts"}' },
+  ]);
+  assert.equal(archive.messages[2]?.role, 'assistant');
+  assert.equal(archive.messages[2]?.toolCalls, undefined);
+});
+
+test('appendPreCompactionArchiveToCompactSummary appends archive section once', () => {
+  const path = '/tmp/spirit/compaction-archives/pre-compact-session-1.json';
+  const first = appendPreCompactionArchiveToCompactSummary('summary body', path);
+  assert.match(first, /summary body/);
+  assert.ok(first.includes(`${PRE_COMPACTION_ARCHIVE_SECTION_HEADER}\n${path}`));
+  assert.match(first, /read_file/);
+
+  const second = appendPreCompactionArchiveToCompactSummary(first, path);
+  assert.equal(second, first);
+});
+
+test('buildCompactHistorySystemPrompt includes archive path guidance when provided', () => {
+  const path = '/data/compaction-archives/pre-compact-s1.json';
+  const prompt = buildCompactHistorySystemPrompt(path);
+  assert.match(prompt, /pre-compaction history archive has been saved to: \/data\/compaction-archives\/pre-compact-s1\.json/);
+  assert.match(prompt, /\[Pre-compaction Archive\]/);
+});
+
+test('buildCompactHistoryPromptMessages forwards archive path into system prompt', () => {
+  const messages = buildCompactHistoryPromptMessages(
+    [{ role: 'user', content: createLlmMessageContentFromText('hi') }],
+    { preCompactionArchivePath: '/tmp/archive.json' },
+  );
+
+  assert.equal(messages[0]?.role, 'system');
+  assert.match(messages[0]?.content ?? '', /\/tmp\/archive\.json/);
+  assert.equal(messages[1]?.role, 'user');
+  assert.match(messages[1]?.content ?? '', /USER: hi/);
+});

--- a/packages/agent-core/src/compaction-archive.test.ts
+++ b/packages/agent-core/src/compaction-archive.test.ts
@@ -1,12 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import {
-  PRE_COMPACTION_ARCHIVE_SECTION_HEADER,
-  appendPreCompactionArchiveToCompactSummary,
-  applyPreCompactionArchivePathToCompactHistory,
-  buildPreCompactionHistoryArchive,
-} from './compaction-archive.js';
+import { buildPreCompactionHistoryArchive } from './compaction-archive.js';
 import { COMPACT_SUMMARY_PREFIX } from './tool-agent.js';
 import {
   buildCompactHistorySystemPrompt,
@@ -57,38 +52,11 @@ test('buildPreCompactionHistoryArchive keeps user and assistant messages with to
   assert.equal(archive.messages[2]?.toolCalls, undefined);
 });
 
-test('appendPreCompactionArchiveToCompactSummary appends archive section once', () => {
-  const path = '/tmp/spirit/compaction-archives/pre-compact-session-1.json';
-  const first = appendPreCompactionArchiveToCompactSummary('summary body', path);
-  assert.match(first, /summary body/);
-  assert.ok(first.includes(`${PRE_COMPACTION_ARCHIVE_SECTION_HEADER}\n${path}`));
-  assert.match(first, /read_file/);
-
-  const second = appendPreCompactionArchiveToCompactSummary(first, path);
-  assert.equal(second, first);
-});
-
-test('buildCompactHistorySystemPrompt includes archive path guidance when provided', () => {
+test('buildCompactHistorySystemPrompt includes archive path when provided', () => {
   const path = '/data/compaction-archives/pre-compact-s1.json';
   const prompt = buildCompactHistorySystemPrompt(path);
-  assert.match(prompt, /pre-compaction history archive has been saved to: \/data\/compaction-archives\/pre-compact-s1\.json/);
+  assert.match(prompt, /Pre-compaction history archive path \(use this exact path in \[Pre-compaction Archive\]\): \/data\/compaction-archives\/pre-compact-s1\.json/);
   assert.match(prompt, /\[Pre-compaction Archive\]/);
-});
-
-test('applyPreCompactionArchivePathToCompactHistory updates compact summary message', () => {
-  const history = [
-    {
-      role: 'system' as const,
-      content: createLlmMessageContentFromText(`${COMPACT_SUMMARY_PREFIX}\ncompact summary`),
-    },
-  ];
-  applyPreCompactionArchivePathToCompactHistory(history, '/tmp/archive.json');
-  const text = history[0]?.content
-    .filter((part) => part.type === 'text')
-    .map((part) => part.text)
-    .join('');
-  assert.ok(text?.includes('/tmp/archive.json'));
-  assert.ok(text?.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER));
 });
 
 test('buildCompactHistoryPromptMessages forwards archive path into system prompt', () => {

--- a/packages/agent-core/src/compaction-archive.test.ts
+++ b/packages/agent-core/src/compaction-archive.test.ts
@@ -52,6 +52,13 @@ test('buildPreCompactionHistoryArchive keeps user and assistant messages with to
   assert.equal(archive.messages[2]?.toolCalls, undefined);
 });
 
+test('buildCompactHistorySystemPrompt omits archive section when no path is provided', () => {
+  const prompt = buildCompactHistorySystemPrompt();
+  assert.doesNotMatch(prompt, /\[Pre-compaction Archive\]/);
+  assert.doesNotMatch(prompt, /Do not output only the path/);
+  assert.match(prompt, /\[Open Items\]/);
+});
+
 test('buildCompactHistorySystemPrompt includes filled archive section example when provided', () => {
   const path = '/data/compaction-archives/pre-compact-s1.json';
   const prompt = buildCompactHistorySystemPrompt(path);

--- a/packages/agent-core/src/compaction-archive.ts
+++ b/packages/agent-core/src/compaction-archive.ts
@@ -1,16 +1,12 @@
 import {
   cloneLlmMessageContent,
-  llmMessageTextContent,
   type LlmMessage,
   type LlmMessageContent,
   type LlmToolCall,
   type StoredLlmMessageArchiveEntry,
 } from './ports.js';
-import { COMPACT_SUMMARY_PREFIX } from './tool-agent.js';
 
 export const PRE_COMPACTION_HISTORY_EXPORT_VERSION = 1;
-
-export const PRE_COMPACTION_ARCHIVE_SECTION_HEADER = '[Pre-compaction Archive]';
 
 export interface PreCompactionHistoryArchiveMessage {
   role: 'user' | 'assistant';
@@ -68,56 +64,4 @@ export function toStoredPreCompactionHistoryMessages(
     content: message.content,
     ...(message.toolCalls !== undefined ? { toolCalls: message.toolCalls } : {}),
   }));
-}
-
-export function appendPreCompactionArchiveToCompactSummary(
-  summary: string,
-  archivePath: string,
-): string {
-  const trimmedSummary = summary.trim();
-  const normalizedPath = archivePath.trim();
-  if (!normalizedPath) {
-    return trimmedSummary;
-  }
-
-  const archiveSection = [
-    PRE_COMPACTION_ARCHIVE_SECTION_HEADER,
-    normalizedPath,
-    'Important details may be recovered by reading this file with read_file.',
-  ].join('\n');
-
-  if (trimmedSummary.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER)) {
-    return trimmedSummary;
-  }
-
-  return trimmedSummary.length > 0 ? `${trimmedSummary}\n\n${archiveSection}` : archiveSection;
-}
-
-export function applyPreCompactionArchivePathToCompactHistory(
-  history: LlmMessage[],
-  archivePath: string,
-): void {
-  const normalizedPath = archivePath.trim();
-  if (!normalizedPath) {
-    return;
-  }
-
-  const compactMessage = history.find(
-    (message) =>
-      message.role === 'system' &&
-      llmMessageTextContent(message.content).startsWith(COMPACT_SUMMARY_PREFIX),
-  );
-  if (!compactMessage) {
-    return;
-  }
-
-  const existingText = llmMessageTextContent(compactMessage.content);
-  const summaryBody = existingText.slice(COMPACT_SUMMARY_PREFIX.length).trimStart();
-  const nextSummaryBody = appendPreCompactionArchiveToCompactSummary(summaryBody, normalizedPath);
-  compactMessage.content = [
-    {
-      type: 'text',
-      text: `${COMPACT_SUMMARY_PREFIX}\n${nextSummaryBody}`,
-    },
-  ];
 }

--- a/packages/agent-core/src/compaction-archive.ts
+++ b/packages/agent-core/src/compaction-archive.ts
@@ -1,0 +1,92 @@
+import {
+  cloneLlmMessageContent,
+  type LlmMessage,
+  type LlmMessageContent,
+  type LlmToolCall,
+  type StoredLlmMessageArchiveEntry,
+} from './ports.js';
+
+export const PRE_COMPACTION_HISTORY_EXPORT_VERSION = 1;
+
+export const PRE_COMPACTION_ARCHIVE_SECTION_HEADER = '[Pre-compaction Archive]';
+
+export interface PreCompactionHistoryArchiveMessage {
+  role: 'user' | 'assistant';
+  content: LlmMessageContent;
+  toolCalls?: LlmToolCall[];
+}
+
+export interface PreCompactionHistoryArchive {
+  export_version: typeof PRE_COMPACTION_HISTORY_EXPORT_VERSION;
+  kind: 'pre_compaction_history';
+  exported_at_unix_ms: number;
+  message_count: number;
+  messages: PreCompactionHistoryArchiveMessage[];
+}
+
+export function buildPreCompactionHistoryArchive(
+  history: readonly LlmMessage[],
+  exportedAtUnixMs: number = Date.now(),
+): PreCompactionHistoryArchive {
+  const messages = history.flatMap((message): PreCompactionHistoryArchiveMessage[] => {
+    if (message.role !== 'user' && message.role !== 'assistant') {
+      return [];
+    }
+
+    const entry: PreCompactionHistoryArchiveMessage = {
+      role: message.role,
+      content: cloneLlmMessageContent(message.content),
+    };
+
+    if (message.role === 'assistant' && message.toolCalls !== undefined && message.toolCalls.length > 0) {
+      entry.toolCalls = message.toolCalls.map((toolCall) => ({
+        id: toolCall.id,
+        name: toolCall.name,
+        argumentsJson: toolCall.argumentsJson,
+      }));
+    }
+
+    return [entry];
+  });
+
+  return {
+    export_version: PRE_COMPACTION_HISTORY_EXPORT_VERSION,
+    kind: 'pre_compaction_history',
+    exported_at_unix_ms: exportedAtUnixMs,
+    message_count: messages.length,
+    messages,
+  };
+}
+
+export function toStoredPreCompactionHistoryMessages(
+  archive: PreCompactionHistoryArchive,
+): StoredLlmMessageArchiveEntry[] {
+  return archive.messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+    ...(message.toolCalls !== undefined ? { toolCalls: message.toolCalls } : {}),
+  }));
+}
+
+export function appendPreCompactionArchiveToCompactSummary(
+  summary: string,
+  archivePath: string,
+): string {
+  const trimmedSummary = summary.trim();
+  const normalizedPath = archivePath.trim();
+  if (!normalizedPath) {
+    return trimmedSummary;
+  }
+
+  const archiveSection = [
+    PRE_COMPACTION_ARCHIVE_SECTION_HEADER,
+    normalizedPath,
+    'Important details may be recovered by reading this file with read_file.',
+  ].join('\n');
+
+  if (trimmedSummary.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER)) {
+    return trimmedSummary;
+  }
+
+  return trimmedSummary.length > 0 ? `${trimmedSummary}\n\n${archiveSection}` : archiveSection;
+}

--- a/packages/agent-core/src/compaction-archive.ts
+++ b/packages/agent-core/src/compaction-archive.ts
@@ -1,10 +1,12 @@
 import {
   cloneLlmMessageContent,
+  llmMessageTextContent,
   type LlmMessage,
   type LlmMessageContent,
   type LlmToolCall,
   type StoredLlmMessageArchiveEntry,
 } from './ports.js';
+import { COMPACT_SUMMARY_PREFIX } from './tool-agent.js';
 
 export const PRE_COMPACTION_HISTORY_EXPORT_VERSION = 1;
 
@@ -89,4 +91,33 @@ export function appendPreCompactionArchiveToCompactSummary(
   }
 
   return trimmedSummary.length > 0 ? `${trimmedSummary}\n\n${archiveSection}` : archiveSection;
+}
+
+export function applyPreCompactionArchivePathToCompactHistory(
+  history: LlmMessage[],
+  archivePath: string,
+): void {
+  const normalizedPath = archivePath.trim();
+  if (!normalizedPath) {
+    return;
+  }
+
+  const compactMessage = history.find(
+    (message) =>
+      message.role === 'system' &&
+      llmMessageTextContent(message.content).startsWith(COMPACT_SUMMARY_PREFIX),
+  );
+  if (!compactMessage) {
+    return;
+  }
+
+  const existingText = llmMessageTextContent(compactMessage.content);
+  const summaryBody = existingText.slice(COMPACT_SUMMARY_PREFIX.length).trimStart();
+  const nextSummaryBody = appendPreCompactionArchiveToCompactSummary(summaryBody, normalizedPath);
+  compactMessage.content = [
+    {
+      type: 'text',
+      text: `${COMPACT_SUMMARY_PREFIX}\n${nextSummaryBody}`,
+    },
+  ];
 }

--- a/packages/agent-core/src/compaction-archive.ts
+++ b/packages/agent-core/src/compaction-archive.ts
@@ -3,7 +3,6 @@ import {
   type LlmMessage,
   type LlmMessageContent,
   type LlmToolCall,
-  type StoredLlmMessageArchiveEntry,
 } from './ports.js';
 
 export const PRE_COMPACTION_HISTORY_EXPORT_VERSION = 1;
@@ -54,14 +53,4 @@ export function buildPreCompactionHistoryArchive(
     message_count: messages.length,
     messages,
   };
-}
-
-export function toStoredPreCompactionHistoryMessages(
-  archive: PreCompactionHistoryArchive,
-): StoredLlmMessageArchiveEntry[] {
-  return archive.messages.map((message) => ({
-    role: message.role,
-    content: message.content,
-    ...(message.toolCalls !== undefined ? { toolCalls: message.toolCalls } : {}),
-  }));
 }

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -160,6 +160,7 @@ interface CliHostInternalModule {
     archive: PreCompactionHistoryArchive,
     options?: { sessionId?: string },
   ) => Promise<string>;
+  removePreCompactionHistoryArchive?: (archivePath: string) => Promise<void>;
   loadHostInstructionMetadata: (
     context: { workspaceRoot: string; spiritDataDir: string },
     options?: { planMode?: boolean; agentMode?: SpiritAgentMode; activePlanPath?: string },
@@ -1693,6 +1694,19 @@ async function createRuntime(
         });
       } catch {
         return undefined;
+      }
+    },
+    removePreCompactionHistoryArchive: async (archivePath) => {
+      const hostInternal = await ensureCliHostInternal(workspaceRoot);
+      const remove = hostInternal?.module.removePreCompactionHistoryArchive;
+      if (!hostInternal || typeof remove !== 'function') {
+        return;
+      }
+
+      try {
+        await remove(archivePath);
+      } catch {
+        // Best-effort orphan cleanup.
       }
     },
   }, history);

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -35,6 +35,7 @@ import {
   type LlmToolAgentState,
 } from './llm-tool-agent.js';
 import { buildContributedHostToolDefinitions, buildTodoHostToolDefinitions } from './host-tools.js';
+import type { PreCompactionHistoryArchive } from './compaction-archive.js';
 import { buildTodosSystemMessage } from './tool-agent.js';
 import {
   buildApplyPatchFileToolsPromptSection,
@@ -154,6 +155,11 @@ interface CliHostInternalModule {
     purge(): Promise<void>;
   };
   buildTodoContextText?: (records: unknown[]) => string | undefined;
+  persistPreCompactionHistoryArchive?: (
+    spiritDataDir: string,
+    archive: PreCompactionHistoryArchive,
+    options?: { sessionId?: string },
+  ) => Promise<string>;
   loadHostInstructionMetadata: (
     context: { workspaceRoot: string; spiritDataDir: string },
     options?: { planMode?: boolean; agentMode?: SpiritAgentMode; activePlanPath?: string },
@@ -1674,6 +1680,21 @@ async function createRuntime(
     },
     ...(hookRunner ? { hookRunner } : {}),
     hookSessionContext: buildCliHookSessionContext(config),
+    persistPreCompactionHistory: async ({ archive, sessionId }) => {
+      const hostInternal = await ensureCliHostInternal(workspaceRoot);
+      const persist = hostInternal?.module.persistPreCompactionHistoryArchive;
+      if (!hostInternal || typeof persist !== 'function') {
+        return undefined;
+      }
+
+      try {
+        return await persist(hostInternal.spiritDataDir, archive, {
+          ...(sessionId !== undefined ? { sessionId } : {}),
+        });
+      } catch {
+        return undefined;
+      }
+    },
   }, history);
 }
 

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -1,3 +1,4 @@
+export * from './compaction-archive.js';
 export * from './ports.js';
 export * from './runtime.js';
 export * from './llm-provider-shared.js';

--- a/packages/agent-core/src/open-responses/ai-sdk-transport.ts
+++ b/packages/agent-core/src/open-responses/ai-sdk-transport.ts
@@ -353,6 +353,7 @@ export class AiSdkOpenResponsesTransport
     config: OpenResponsesTransportConfig,
     history: LlmMessage[],
     onProgress?: (message: string) => void,
+    context?: import('../ports.js').CompactHistoryManualContext,
   ): Promise<{
     droppedMessages: number;
     beforeLength: number;
@@ -368,7 +369,11 @@ export class AiSdkOpenResponsesTransport
     }
 
     const promptMessages = openAiMessagesToResponsesAiSdkMessages(
-      buildCompactHistoryPromptMessages(history),
+      buildCompactHistoryPromptMessages(history, {
+        ...(context?.preCompactionArchivePath === undefined
+          ? {}
+          : { preCompactionArchivePath: context.preCompactionArchivePath }),
+      }),
     );
     const compactConfig: OpenResponsesTransportConfig = {
       ...config,

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -461,6 +461,7 @@ export class AiSdkOpenAiCompatibleTransport
     config: OpenAiTransportConfig,
     history: LlmMessage[],
     onProgress?: (message: string) => void,
+    context?: import('../ports.js').CompactHistoryManualContext,
   ): Promise<{
     droppedMessages: number;
     beforeLength: number;
@@ -475,7 +476,13 @@ export class AiSdkOpenAiCompatibleTransport
       };
     }
 
-    const promptMessages = openAiMessagesToAiSdkMessages(buildCompactHistoryPromptMessages(history));
+    const promptMessages = openAiMessagesToAiSdkMessages(
+      buildCompactHistoryPromptMessages(history, {
+        ...(context?.preCompactionArchivePath === undefined
+          ? {}
+          : { preCompactionArchivePath: context.preCompactionArchivePath }),
+      }),
+    );
     const compactConfig: OpenAiTransportConfig = {
       ...config,
       model: config.compactModel ?? config.model,

--- a/packages/agent-core/src/ports.ts
+++ b/packages/agent-core/src/ports.ts
@@ -608,6 +608,10 @@ export interface ToolExecutor<
   getMcpPrompt(name: string, prompt: string, argsJson?: string): Promise<JsonValue>;
 }
 
+export interface CompactHistoryManualContext {
+  preCompactionArchivePath?: string;
+}
+
 export interface LlmTransport<Config, State = JsonValue> {
   startToolAgentRound(
     config: Config,
@@ -623,6 +627,7 @@ export interface LlmTransport<Config, State = JsonValue> {
     config: Config,
     history: LlmMessage[],
     onProgress?: (message: string) => void,
+    context?: CompactHistoryManualContext,
   ): Promise<{
     droppedMessages: number;
     beforeLength: number;

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -83,7 +83,6 @@ import {
 } from './runtime/background-tools.js';
 import {
   compactHistoryImmediate as compactHistoryImmediateInternal,
-  launchHistoryCompaction as launchHistoryCompactionInternal,
   pollPendingHistoryCompaction as pollPendingHistoryCompactionInternal,
   startHistoryCompactionAsync as startHistoryCompactionAsyncInternal,
   startManualHistoryCompactionAsync as startManualHistoryCompactionAsyncInternal,
@@ -2076,17 +2075,6 @@ export class AgentRuntime<
   private startManualHistoryCompactionAsync(): void {
     startManualHistoryCompactionAsyncInternal(
       this as unknown as CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
-    );
-  }
-
-  private launchHistoryCompaction(
-    pending: PendingHistoryCompaction<State, ToolRequest>,
-    history: LlmMessage[],
-  ): void {
-    launchHistoryCompactionInternal(
-      this as unknown as CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
-      pending,
-      history,
     );
   }
 

--- a/packages/agent-core/src/runtime/compaction.runtime.test.ts
+++ b/packages/agent-core/src/runtime/compaction.runtime.test.ts
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { PRE_COMPACTION_ARCHIVE_SECTION_HEADER } from '../compaction-archive.js';
+import { COMPACT_SUMMARY_PREFIX } from '../tool-agent.js';
+import { createLlmMessageContentFromText, type LlmMessage, type LlmTransport } from '../ports.js';
+import { compactHistoryImmediate, type CompactionRuntime } from './compaction.js';
+import type { AgentRuntimeOptions } from './types.js';
+
+type TestState = { messages: LlmMessage[] };
+
+test('compactHistoryImmediate persists archive and appends path to compact summary', async () => {
+  const archivePath = '/tmp/spirit/compaction-archives/pre-compact-s1.json';
+  const history: LlmMessage[] = [
+    { role: 'user', content: createLlmMessageContentFromText('hello') },
+    {
+      role: 'assistant',
+      content: [],
+      toolCalls: [{ id: 'call-1', name: 'read_file', argumentsJson: '{}' }],
+    },
+    {
+      role: 'tool',
+      toolCallId: 'call-1',
+      content: createLlmMessageContentFromText('noise'),
+    },
+  ];
+
+  const llmTransport: LlmTransport<undefined, TestState> = {
+    startToolAgentRound: async () => {
+      throw new Error('not used');
+    },
+    async compactHistoryManual(_config, targetHistory) {
+      targetHistory.splice(0, targetHistory.length, {
+        role: 'system',
+        content: createLlmMessageContentFromText(`${COMPACT_SUMMARY_PREFIX}\ncompact summary`),
+      });
+      return {
+        droppedMessages: targetHistory.length > 0 ? 2 : 0,
+        beforeLength: 3,
+        afterLength: 1,
+      };
+    },
+    compactSummaryText(targetHistory) {
+      const message = targetHistory.find((entry) => entry.role === 'system');
+      if (!message) {
+        return undefined;
+      }
+      const text = message.content
+        .filter((part) => part.type === 'text')
+        .map((part) => part.text)
+        .join('');
+      return text.slice(COMPACT_SUMMARY_PREFIX.length).trim();
+    },
+    isContextOverflowError: () => false,
+    llmHistoryAsApiMessages: () => [],
+    llmSystemPromptsForExport: () => ({}),
+  };
+
+  let persisted = false;
+  const options: AgentRuntimeOptions<undefined, TestState, never> = {
+    config: undefined,
+    llmTransport,
+    toolExecutor: {
+      execute: async () => {
+        throw new Error('not used');
+      },
+    } as unknown as AgentRuntimeOptions<undefined, TestState, never>['toolExecutor'],
+    createToolAgentState: () => ({ messages: [] }),
+    appendToolResultMessage: (state) => state,
+    extractAssistantText: () => undefined,
+    persistPreCompactionHistory: async ({ archive }) => {
+      persisted = true;
+      assert.equal(archive.message_count, 2);
+      assert.equal(archive.messages[1]?.toolCalls?.[0]?.name, 'read_file');
+      return archivePath;
+    },
+  };
+
+  const runtime: CompactionRuntime<undefined, TestState, never> = {
+    options,
+    historyStore: history,
+    compactionTextStore: '',
+    pendingHistoryCompaction: undefined,
+    completedManualHistoryCompactionResultStore: undefined,
+    emitEvent: () => {},
+    completeTurn: () => {},
+    startToolAgentRoundAsync: () => {},
+    startStreamingRound: async () => {},
+    takeCompletedManualHistoryCompactionResult: () => undefined,
+    isBusy: () => false,
+    poll: async () => {},
+  };
+
+  const result = await compactHistoryImmediate(runtime);
+
+  assert.equal(persisted, true);
+  assert.equal(result.preCompactionArchivePath, archivePath);
+  assert.equal(runtime.historyStore.length, 1);
+  const compactText = runtime.historyStore[0]?.content
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text)
+    .join('');
+  assert.ok(compactText?.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER));
+  assert.ok(compactText?.includes(archivePath));
+});

--- a/packages/agent-core/src/runtime/compaction.runtime.test.ts
+++ b/packages/agent-core/src/runtime/compaction.runtime.test.ts
@@ -249,3 +249,59 @@ test('compactHistoryImmediate archives pre-truncation history and compacts post-
   assert.match(compactionToolText, /\[tool output truncated for context retry\]/);
   assert.ok(compactionToolText.length < longToolOutput.length);
 });
+
+test('compactHistoryImmediate removes orphan archive when compaction fails after persist', async () => {
+  const archivePath = '/tmp/spirit/compaction-archives/pre-compact-orphan.json';
+  const history: LlmMessage[] = [
+    { role: 'user', content: createLlmMessageContentFromText('hello') },
+  ];
+
+  const llmTransport: LlmTransport<undefined, TestState> = {
+    startToolAgentRound: async () => {
+      throw new Error('not used');
+    },
+    compactHistoryManual: async () => {
+      throw new Error('llm unavailable');
+    },
+    compactSummaryText: () => undefined,
+    isContextOverflowError: () => false,
+    llmHistoryAsApiMessages: () => [],
+    llmSystemPromptsForExport: () => ({}),
+  };
+
+  const removedPaths: string[] = [];
+  const options: AgentRuntimeOptions<undefined, TestState, never> = {
+    config: undefined,
+    llmTransport,
+    toolExecutor: {
+      execute: async () => {
+        throw new Error('not used');
+      },
+    } as unknown as AgentRuntimeOptions<undefined, TestState, never>['toolExecutor'],
+    createToolAgentState: () => ({ messages: [] }),
+    appendToolResultMessage: (state) => state,
+    extractAssistantText: () => undefined,
+    persistPreCompactionHistory: async () => archivePath,
+    removePreCompactionHistoryArchive: async (path) => {
+      removedPaths.push(path);
+    },
+  };
+
+  const runtime: CompactionRuntime<undefined, TestState, never> = {
+    options,
+    historyStore: history,
+    compactionTextStore: '',
+    pendingHistoryCompaction: undefined,
+    completedManualHistoryCompactionResultStore: undefined,
+    emitEvent: () => {},
+    completeTurn: () => {},
+    startToolAgentRoundAsync: () => {},
+    startStreamingRound: async () => {},
+    takeCompletedManualHistoryCompactionResult: () => undefined,
+    isBusy: () => false,
+    poll: async () => {},
+  };
+
+  await assert.rejects(() => compactHistoryImmediate(runtime), /llm unavailable/);
+  assert.deepEqual(removedPaths, [archivePath]);
+});

--- a/packages/agent-core/src/runtime/compaction.runtime.test.ts
+++ b/packages/agent-core/src/runtime/compaction.runtime.test.ts
@@ -101,3 +101,67 @@ test('compactHistoryImmediate persists archive without post-processing compact s
     .join('');
   assert.equal(compactText, `${COMPACT_SUMMARY_PREFIX}\ncompact summary`);
 });
+
+test('compactHistoryImmediate emits event when pre-compaction archive persist fails', async () => {
+  const history: LlmMessage[] = [
+    { role: 'user', content: createLlmMessageContentFromText('hello') },
+  ];
+
+  const llmTransport: LlmTransport<undefined, TestState> = {
+    startToolAgentRound: async () => {
+      throw new Error('not used');
+    },
+    async compactHistoryManual(_config, targetHistory) {
+      targetHistory.splice(0, targetHistory.length, {
+        role: 'system',
+        content: createLlmMessageContentFromText(`${COMPACT_SUMMARY_PREFIX}\nsummary`),
+      });
+      return { droppedMessages: 0, beforeLength: 1, afterLength: 1 };
+    },
+    compactSummaryText: () => 'summary',
+    isContextOverflowError: () => false,
+    llmHistoryAsApiMessages: () => [],
+    llmSystemPromptsForExport: () => ({}),
+  };
+
+  const events: Array<{ kind: string; error?: string }> = [];
+  const options: AgentRuntimeOptions<undefined, TestState, never> = {
+    config: undefined,
+    llmTransport,
+    toolExecutor: {
+      execute: async () => {
+        throw new Error('not used');
+      },
+    } as unknown as AgentRuntimeOptions<undefined, TestState, never>['toolExecutor'],
+    createToolAgentState: () => ({ messages: [] }),
+    appendToolResultMessage: (state) => state,
+    extractAssistantText: () => undefined,
+    persistPreCompactionHistory: async () => {
+      throw new Error('disk full');
+    },
+  };
+
+  const runtime: CompactionRuntime<undefined, TestState, never> = {
+    options,
+    historyStore: history,
+    compactionTextStore: '',
+    pendingHistoryCompaction: undefined,
+    completedManualHistoryCompactionResultStore: undefined,
+    emitEvent: (event) => {
+      events.push(event);
+    },
+    completeTurn: () => {},
+    startToolAgentRoundAsync: () => {},
+    startStreamingRound: async () => {},
+    takeCompletedManualHistoryCompactionResult: () => undefined,
+    isBusy: () => false,
+    poll: async () => {},
+  };
+
+  const result = await compactHistoryImmediate(runtime);
+
+  assert.equal(result.preCompactionArchivePath, undefined);
+  assert.equal(events.length, 1);
+  assert.equal(events[0]?.kind, 'pre-compaction-archive-persist-failed');
+  assert.match(events[0]?.error ?? '', /disk full/);
+});

--- a/packages/agent-core/src/runtime/compaction.runtime.test.ts
+++ b/packages/agent-core/src/runtime/compaction.runtime.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { PRE_COMPACTION_ARCHIVE_SECTION_HEADER } from '../compaction-archive.js';
 import { COMPACT_SUMMARY_PREFIX } from '../tool-agent.js';
 import { createLlmMessageContentFromText, type LlmMessage, type LlmTransport } from '../ports.js';
 import { compactHistoryImmediate, type CompactionRuntime } from './compaction.js';
@@ -9,7 +8,7 @@ import type { AgentRuntimeOptions } from './types.js';
 
 type TestState = { messages: LlmMessage[] };
 
-test('compactHistoryImmediate persists archive and appends path to compact summary', async () => {
+test('compactHistoryImmediate persists archive without post-processing compact summary', async () => {
   const archivePath = '/tmp/spirit/compaction-archives/pre-compact-s1.json';
   const history: LlmMessage[] = [
     { role: 'user', content: createLlmMessageContentFromText('hello') },
@@ -100,6 +99,5 @@ test('compactHistoryImmediate persists archive and appends path to compact summa
     .filter((part) => part.type === 'text')
     .map((part) => part.text)
     .join('');
-  assert.ok(compactText?.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER));
-  assert.ok(compactText?.includes(archivePath));
+  assert.equal(compactText, `${COMPACT_SUMMARY_PREFIX}\ncompact summary`);
 });

--- a/packages/agent-core/src/runtime/compaction.runtime.test.ts
+++ b/packages/agent-core/src/runtime/compaction.runtime.test.ts
@@ -2,7 +2,13 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { COMPACT_SUMMARY_PREFIX } from '../tool-agent.js';
-import { createLlmMessageContentFromText, type LlmMessage, type LlmTransport } from '../ports.js';
+import { truncateLlmHistoryForCompaction } from '../llm-tool-agent.js';
+import {
+  createLlmMessageContentFromText,
+  llmMessageTextContent,
+  type LlmMessage,
+  type LlmTransport,
+} from '../ports.js';
 import { compactHistoryImmediate, type CompactionRuntime } from './compaction.js';
 import type { AgentRuntimeOptions } from './types.js';
 
@@ -164,4 +170,82 @@ test('compactHistoryImmediate emits event when pre-compaction archive persist fa
   assert.equal(events.length, 1);
   assert.equal(events[0]?.kind, 'pre-compaction-archive-persist-failed');
   assert.match(events[0]?.error ?? '', /disk full/);
+});
+
+test('compactHistoryImmediate archives pre-truncation history and compacts post-truncation history', async () => {
+  const longToolOutput = 'x'.repeat(20_000);
+  const history: LlmMessage[] = [
+    { role: 'user', content: createLlmMessageContentFromText('investigate') },
+    {
+      role: 'assistant',
+      content: [],
+      toolCalls: [{ id: 'call-1', name: 'read_file', argumentsJson: '{}' }],
+    },
+    {
+      role: 'tool',
+      toolCallId: 'call-1',
+      content: createLlmMessageContentFromText(longToolOutput),
+    },
+  ];
+
+  let compactionToolText = '';
+
+  const llmTransport: LlmTransport<undefined, TestState> = {
+    startToolAgentRound: async () => {
+      throw new Error('not used');
+    },
+    async compactHistoryManual(_config, targetHistory) {
+      const toolMessage = targetHistory.find((entry) => entry.role === 'tool');
+      compactionToolText = llmMessageTextContent(toolMessage?.content ?? []);
+      targetHistory.splice(0, targetHistory.length, {
+        role: 'system',
+        content: createLlmMessageContentFromText(`${COMPACT_SUMMARY_PREFIX}\nsummary`),
+      });
+      return { droppedMessages: 2, beforeLength: 3, afterLength: 1 };
+    },
+    compactSummaryText: () => 'summary',
+    isContextOverflowError: () => false,
+    llmHistoryAsApiMessages: () => [],
+    llmSystemPromptsForExport: () => ({}),
+  };
+
+  const options: AgentRuntimeOptions<undefined, TestState, never> = {
+    config: undefined,
+    llmTransport,
+    truncateHistoryForCompaction: truncateLlmHistoryForCompaction,
+    toolExecutor: {
+      execute: async () => {
+        throw new Error('not used');
+      },
+    } as unknown as AgentRuntimeOptions<undefined, TestState, never>['toolExecutor'],
+    createToolAgentState: () => ({ messages: [] }),
+    appendToolResultMessage: (state) => state,
+    extractAssistantText: () => undefined,
+    persistPreCompactionHistory: async ({ archive }) => {
+      assert.equal(archive.message_count, 2);
+      assert.equal(archive.messages[0]?.role, 'user');
+      assert.equal(archive.messages[1]?.toolCalls?.[0]?.name, 'read_file');
+      return '/tmp/archive.json';
+    },
+  };
+
+  const runtime: CompactionRuntime<undefined, TestState, never> = {
+    options,
+    historyStore: history,
+    compactionTextStore: '',
+    pendingHistoryCompaction: undefined,
+    completedManualHistoryCompactionResultStore: undefined,
+    emitEvent: () => {},
+    completeTurn: () => {},
+    startToolAgentRoundAsync: () => {},
+    startStreamingRound: async () => {},
+    takeCompletedManualHistoryCompactionResult: () => undefined,
+    isBusy: () => false,
+    poll: async () => {},
+  };
+
+  await compactHistoryImmediate(runtime);
+
+  assert.match(compactionToolText, /\[tool output truncated for context retry\]/);
+  assert.ok(compactionToolText.length < longToolOutput.length);
 });

--- a/packages/agent-core/src/runtime/compaction.ts
+++ b/packages/agent-core/src/runtime/compaction.ts
@@ -1,6 +1,11 @@
 import { setImmediate as waitForImmediate } from 'node:timers/promises';
 
-import type { LlmMessage } from '../ports.js';
+import {
+  applyPreCompactionArchivePathToCompactHistory,
+  buildPreCompactionHistoryArchive,
+} from '../compaction-archive.js';
+import type { CompactHistoryManualContext, LlmMessage } from '../ports.js';
+import { resolveHookSessionContext } from '../hooks/integration.js';
 
 import { cloneHistory, renderError } from './helpers.js';
 import type {
@@ -47,6 +52,67 @@ export interface CompactionRuntime<
   poll(): Promise<void>;
 }
 
+async function persistPreCompactionArchivePath<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget = string,
+>(
+  runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
+  archiveSourceHistory: LlmMessage[],
+): Promise<string | undefined> {
+  const persist = runtime.options.persistPreCompactionHistory;
+  if (!persist) {
+    return undefined;
+  }
+
+  try {
+    const archive = buildPreCompactionHistoryArchive(archiveSourceHistory);
+    const sessionId = resolveHookSessionContext(runtime.options).sessionId;
+    return await persist({
+      archive,
+      ...(sessionId !== undefined ? { sessionId } : {}),
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function buildCompactionRecord(
+  result: {
+    droppedMessages: number;
+    beforeLength: number;
+    afterLength: number;
+  },
+  summary: string | undefined,
+  preCompactionArchivePath: string | undefined,
+): RuntimeCompactionRecord {
+  return {
+    droppedMessages: result.droppedMessages,
+    beforeLength: result.beforeLength,
+    afterLength: result.afterLength,
+    ...(summary !== undefined ? { summary } : {}),
+    ...(preCompactionArchivePath !== undefined ? { preCompactionArchivePath } : {}),
+  };
+}
+
+function prepareHistoryForCompaction<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget = string,
+>(
+  runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
+  archiveSourceHistory: LlmMessage[],
+): LlmMessage[] {
+  if (!runtime.options.truncateHistoryForCompaction) {
+    return cloneHistory(archiveSourceHistory);
+  }
+
+  const prepared = runtime.options.truncateHistoryForCompaction(archiveSourceHistory);
+  return cloneHistory(prepared.history);
+}
+
 export async function compactHistoryImmediate<
   Config,
   State,
@@ -55,22 +121,30 @@ export async function compactHistoryImmediate<
 >(
   runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
 ): Promise<RuntimeCompactionRecord> {
-  if (runtime.options.truncateHistoryForCompaction) {
-    const prepared = runtime.options.truncateHistoryForCompaction(runtime.historyStore);
-    runtime.historyStore = cloneHistory(prepared.history);
-  }
+  const archiveSourceHistory = cloneHistory(runtime.historyStore);
+  const preCompactionArchivePath = await persistPreCompactionArchivePath(
+    runtime,
+    archiveSourceHistory,
+  );
+  const historyForCompaction = prepareHistoryForCompaction(runtime, archiveSourceHistory);
+  runtime.historyStore = cloneHistory(historyForCompaction);
 
+  const compactionContext: CompactHistoryManualContext | undefined =
+    preCompactionArchivePath !== undefined
+      ? { preCompactionArchivePath }
+      : undefined;
   const result = await runtime.options.llmTransport.compactHistoryManual(
     runtime.options.config,
     runtime.historyStore,
+    undefined,
+    compactionContext,
   );
+  if (preCompactionArchivePath !== undefined) {
+    applyPreCompactionArchivePathToCompactHistory(runtime.historyStore, preCompactionArchivePath);
+  }
+
   const summary = runtime.options.llmTransport.compactSummaryText(runtime.historyStore);
-  return {
-    droppedMessages: result.droppedMessages,
-    beforeLength: result.beforeLength,
-    afterLength: result.afterLength,
-    ...(summary !== undefined ? { summary } : {}),
-  };
+  return buildCompactionRecord(result, summary, preCompactionArchivePath);
 }
 
 export function startHistoryCompactionAsync<
@@ -88,13 +162,11 @@ export function startHistoryCompactionAsync<
   resumeAsStreaming = false,
   streamingEmitBeginResponse = true,
 ): void {
-  if (runtime.options.truncateHistoryForCompaction) {
-    const prepared = runtime.options.truncateHistoryForCompaction(runtime.historyStore);
-    runtime.historyStore = cloneHistory(prepared.history);
-  }
+  const archiveSourceHistory = cloneHistory(runtime.historyStore);
+  const historyForCompaction = prepareHistoryForCompaction(runtime, archiveSourceHistory);
+  runtime.historyStore = cloneHistory(historyForCompaction);
 
   runtime.compactionTextStore = '';
-  const history = cloneHistory(runtime.historyStore);
   const pending: PendingAutoHistoryCompaction<State, ToolRequest> = {
     kind: 'auto-retry',
     pendingUserInput,
@@ -108,7 +180,7 @@ export function startHistoryCompactionAsync<
     result: undefined,
     failure: undefined,
   };
-  launchHistoryCompaction(runtime, pending, history);
+  launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
 }
 
 export function startManualHistoryCompactionAsync<
@@ -119,20 +191,18 @@ export function startManualHistoryCompactionAsync<
 >(
   runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
 ): void {
-  if (runtime.options.truncateHistoryForCompaction) {
-    const prepared = runtime.options.truncateHistoryForCompaction(runtime.historyStore);
-    runtime.historyStore = cloneHistory(prepared.history);
-  }
+  const archiveSourceHistory = cloneHistory(runtime.historyStore);
+  const historyForCompaction = prepareHistoryForCompaction(runtime, archiveSourceHistory);
+  runtime.historyStore = cloneHistory(historyForCompaction);
 
   runtime.compactionTextStore = '';
-  const history = cloneHistory(runtime.historyStore);
   const pending: PendingManualHistoryCompaction = {
     kind: 'manual',
     compactedHistory: undefined,
     result: undefined,
     failure: undefined,
   };
-  launchHistoryCompaction(runtime, pending, history);
+  launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
 }
 
 export function launchHistoryCompaction<
@@ -144,40 +214,55 @@ export function launchHistoryCompaction<
   runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
   pending: PendingHistoryCompaction<State, ToolRequest>,
   history: LlmMessage[],
+  archiveSourceHistory: LlmMessage[],
 ): void {
   runtime.pendingHistoryCompaction = pending;
 
-  void runtime.options.llmTransport
-    .compactHistoryManual(runtime.options.config, history, (chunk) => {
-      if (runtime.pendingHistoryCompaction !== pending || !chunk) {
-        return;
-      }
+  void (async () => {
+    try {
+      const preCompactionArchivePath = await persistPreCompactionArchivePath(
+        runtime,
+        archiveSourceHistory,
+      );
+      const compactionContext: CompactHistoryManualContext | undefined =
+        preCompactionArchivePath !== undefined
+          ? { preCompactionArchivePath }
+          : undefined;
 
-      runtime.compactionTextStore += chunk;
-      runtime.emitEvent({
-        kind: 'update-pending-assistant-compaction',
-        text: runtime.compactionTextStore,
-      });
-    })
-    .then((result) => {
+      const result = await runtime.options.llmTransport.compactHistoryManual(
+        runtime.options.config,
+        history,
+        (chunk) => {
+          if (runtime.pendingHistoryCompaction !== pending || !chunk) {
+            return;
+          }
+
+          runtime.compactionTextStore += chunk;
+          runtime.emitEvent({
+            kind: 'update-pending-assistant-compaction',
+            text: runtime.compactionTextStore,
+          });
+        },
+        compactionContext,
+      );
+
       if (runtime.pendingHistoryCompaction !== pending) {
         return;
       }
 
+      if (preCompactionArchivePath !== undefined) {
+        applyPreCompactionArchivePathToCompactHistory(history, preCompactionArchivePath);
+      }
+
       const summary = runtime.options.llmTransport.compactSummaryText(history);
       pending.compactedHistory = cloneHistory(history);
-      pending.result = {
-        droppedMessages: result.droppedMessages,
-        beforeLength: result.beforeLength,
-        afterLength: result.afterLength,
-        ...(summary !== undefined ? { summary } : {}),
-      };
-    })
-    .catch((error: unknown) => {
+      pending.result = buildCompactionRecord(result, summary, preCompactionArchivePath);
+    } catch (error: unknown) {
       if (runtime.pendingHistoryCompaction === pending) {
         pending.failure = renderError(error);
       }
-    });
+    }
+  })();
 }
 
 export async function pollPendingHistoryCompaction<

--- a/packages/agent-core/src/runtime/compaction.ts
+++ b/packages/agent-core/src/runtime/compaction.ts
@@ -1,9 +1,6 @@
 import { setImmediate as waitForImmediate } from 'node:timers/promises';
 
-import {
-  applyPreCompactionArchivePathToCompactHistory,
-  buildPreCompactionHistoryArchive,
-} from '../compaction-archive.js';
+import { buildPreCompactionHistoryArchive } from '../compaction-archive.js';
 import type { CompactHistoryManualContext, LlmMessage } from '../ports.js';
 import { resolveHookSessionContext } from '../hooks/integration.js';
 
@@ -139,10 +136,6 @@ export async function compactHistoryImmediate<
     undefined,
     compactionContext,
   );
-  if (preCompactionArchivePath !== undefined) {
-    applyPreCompactionArchivePathToCompactHistory(runtime.historyStore, preCompactionArchivePath);
-  }
-
   const summary = runtime.options.llmTransport.compactSummaryText(runtime.historyStore);
   return buildCompactionRecord(result, summary, preCompactionArchivePath);
 }
@@ -248,10 +241,6 @@ export function launchHistoryCompaction<
 
       if (runtime.pendingHistoryCompaction !== pending) {
         return;
-      }
-
-      if (preCompactionArchivePath !== undefined) {
-        applyPreCompactionArchivePathToCompactHistory(history, preCompactionArchivePath);
       }
 
       const summary = runtime.options.llmTransport.compactSummaryText(history);

--- a/packages/agent-core/src/runtime/compaction.ts
+++ b/packages/agent-core/src/runtime/compaction.ts
@@ -70,7 +70,11 @@ async function persistPreCompactionArchivePath<
       archive,
       ...(sessionId !== undefined ? { sessionId } : {}),
     });
-  } catch {
+  } catch (error: unknown) {
+    runtime.emitEvent({
+      kind: 'pre-compaction-archive-persist-failed',
+      error: renderError(error),
+    });
     return undefined;
   }
 }

--- a/packages/agent-core/src/runtime/compaction.ts
+++ b/packages/agent-core/src/runtime/compaction.ts
@@ -49,6 +49,27 @@ export interface CompactionRuntime<
   poll(): Promise<void>;
 }
 
+async function removeOrphanPreCompactionArchive<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget = string,
+>(
+  runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
+  archivePath: string | undefined,
+): Promise<void> {
+  const remove = runtime.options.removePreCompactionHistoryArchive;
+  if (!archivePath || !remove) {
+    return;
+  }
+
+  try {
+    await remove(archivePath);
+  } catch {
+    // Best-effort cleanup when compaction fails after a successful persist.
+  }
+}
+
 async function persistPreCompactionArchivePath<
   Config,
   State,
@@ -134,14 +155,20 @@ export async function compactHistoryImmediate<
     preCompactionArchivePath !== undefined
       ? { preCompactionArchivePath }
       : undefined;
-  const result = await runtime.options.llmTransport.compactHistoryManual(
-    runtime.options.config,
-    runtime.historyStore,
-    undefined,
-    compactionContext,
-  );
-  const summary = runtime.options.llmTransport.compactSummaryText(runtime.historyStore);
-  return buildCompactionRecord(result, summary, preCompactionArchivePath);
+
+  try {
+    const result = await runtime.options.llmTransport.compactHistoryManual(
+      runtime.options.config,
+      runtime.historyStore,
+      undefined,
+      compactionContext,
+    );
+    const summary = runtime.options.llmTransport.compactSummaryText(runtime.historyStore);
+    return buildCompactionRecord(result, summary, preCompactionArchivePath);
+  } catch (error: unknown) {
+    await removeOrphanPreCompactionArchive(runtime, preCompactionArchivePath);
+    throw error;
+  }
 }
 
 export function startHistoryCompactionAsync<
@@ -216,8 +243,9 @@ export function launchHistoryCompaction<
   runtime.pendingHistoryCompaction = pending;
 
   void (async () => {
+    let preCompactionArchivePath: string | undefined;
     try {
-      const preCompactionArchivePath = await persistPreCompactionArchivePath(
+      preCompactionArchivePath = await persistPreCompactionArchivePath(
         runtime,
         archiveSourceHistory,
       );
@@ -252,6 +280,7 @@ export function launchHistoryCompaction<
       pending.result = buildCompactionRecord(result, summary, preCompactionArchivePath);
     } catch (error: unknown) {
       if (runtime.pendingHistoryCompaction === pending) {
+        await removeOrphanPreCompactionArchive(runtime, preCompactionArchivePath);
         pending.failure = renderError(error);
       }
     }

--- a/packages/agent-core/src/runtime/types.ts
+++ b/packages/agent-core/src/runtime/types.ts
@@ -1,3 +1,4 @@
+import type { PreCompactionHistoryArchive } from '../compaction-archive.js';
 import type {
   AskQuestionsRequest,
   ImageGenerationRequest,
@@ -73,6 +74,7 @@ export interface RuntimeCompactionRecord {
   beforeLength: number;
   afterLength: number;
   summary?: string;
+  preCompactionArchivePath?: string;
 }
 
 export interface DeferredUserGuidance {
@@ -402,6 +404,10 @@ export interface AgentRuntimeOptions<
   onEvent?: (event: RuntimeEvent<ToolRequest>) => void;
   hookRunner?: HookRunner;
   hookSessionContext?: HookSessionContext;
+  persistPreCompactionHistory?: (input: {
+    archive: PreCompactionHistoryArchive;
+    sessionId?: string;
+  }) => Promise<string | undefined>;
   resolveWorkspaceFilesFromInput?: (
     userInput: string,
   ) => Promise<PendingWorkspaceFile[]> | PendingWorkspaceFile[];

--- a/packages/agent-core/src/runtime/types.ts
+++ b/packages/agent-core/src/runtime/types.ts
@@ -412,6 +412,7 @@ export interface AgentRuntimeOptions<
     archive: PreCompactionHistoryArchive;
     sessionId?: string;
   }) => Promise<string | undefined>;
+  removePreCompactionHistoryArchive?: (archivePath: string) => Promise<void>;
   resolveWorkspaceFilesFromInput?: (
     userInput: string,
   ) => Promise<PendingWorkspaceFile[]> | PendingWorkspaceFile[];

--- a/packages/agent-core/src/runtime/types.ts
+++ b/packages/agent-core/src/runtime/types.ts
@@ -135,6 +135,10 @@ export type RuntimeEvent<ToolRequest> =
       summaryPreview?: string;
     }
   | {
+      kind: 'pre-compaction-archive-persist-failed';
+      error: string;
+    }
+  | {
       kind: 'approval-requested';
       approval: RuntimePendingApproval<ToolRequest, unknown>;
     }

--- a/packages/agent-core/src/smoke/cases/runtime/parity/compaction.case.ts
+++ b/packages/agent-core/src/smoke/cases/runtime/parity/compaction.case.ts
@@ -1,3 +1,7 @@
+import { PRE_COMPACTION_ARCHIVE_SECTION_HEADER } from '../../../../compaction-archive.js';
+import { llmMessageTextContent } from '../../../../ports.js';
+import { COMPACT_SUMMARY_PREFIX } from '../../../../tool-agent.js';
+
 import {
   AgentRuntime,
   CompactExecutor,
@@ -134,5 +138,81 @@ export async function runCompactionCase(): Promise<RuntimeParityCaseResult> {
     throw new Error('polling compact smoke 缺少 compaction update 事件。');
   }
 
-  return { compactResult, pollingCompactResult };
+  const archivePath = '/tmp/spirit-smoke-pre-compact.json';
+  let persistedMessageCount = 0;
+  const archiveRuntime = new AgentRuntime({
+    config: undefined,
+    llmTransport: new CompactTransport(),
+    toolExecutor: new CompactExecutor(),
+    createToolAgentState: createScriptedState,
+    appendToolResultMessage: appendScriptedToolResult,
+    appendUserMessage: appendScriptedUserMessage,
+    extractAssistantText: extractScriptedAssistantText,
+    truncateStateForContextRetry: truncateScriptedStateForContextRetry,
+    truncateHistoryForCompaction: truncateScriptedHistoryForCompaction,
+    rebuildRetryStateAfterCompaction: rebuildScriptedStateAfterCompaction,
+    hookSessionContext: {
+      sessionId: 'smoke-compact-archive',
+      conversationPath: null,
+      workspaceRoot: '/tmp',
+      model: 'test-model',
+    },
+    persistPreCompactionHistory: async ({ archive }) => {
+      persistedMessageCount = archive.message_count;
+      if (archive.messages.length === 0) {
+        throw new Error('pre-compaction archive smoke 未写入任何消息。');
+      }
+      return archivePath;
+    },
+  }, [
+    {
+      role: 'user',
+      content: createLlmMessageContentFromText('first user turn'),
+    },
+    {
+      role: 'assistant',
+      content: [],
+      toolCalls: [{ id: 'call-archive', name: 'read_file', argumentsJson: '{"path":"a.ts"}' }],
+    },
+    {
+      role: 'tool',
+      toolCallId: 'call-archive',
+      content: createLlmMessageContentFromText('tool output should be omitted from archive'),
+    },
+    {
+      role: 'assistant',
+      content: createLlmMessageContentFromText('assistant follow-up'),
+    },
+  ]);
+
+  const archiveRecord = await archiveRuntime.compactHistory();
+  if (archiveRecord.preCompactionArchivePath !== archivePath) {
+    throw new Error('pre-compaction archive smoke 未记录归档路径。');
+  }
+  if (persistedMessageCount !== 3) {
+    throw new Error(`pre-compaction archive smoke 归档消息数异常: ${persistedMessageCount}`);
+  }
+
+  const compactSummary = archiveRuntime
+    .history()
+    .find(
+      (message) =>
+        message.role === 'system' &&
+        llmMessageTextContent(message.content).startsWith(COMPACT_SUMMARY_PREFIX),
+    );
+  const compactSummaryText = compactSummary
+    ? llmMessageTextContent(compactSummary.content)
+    : '';
+  if (
+    !compactSummaryText.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER) ||
+    !compactSummaryText.includes(archivePath)
+  ) {
+    throw new Error('pre-compaction archive smoke 摘要未包含归档路径段落。');
+  }
+
+  return {
+    compactResult,
+    pollingCompactResult,
+    archiveCompactionResult: archiveRecord,
+  };
 }

--- a/packages/agent-core/src/smoke/cases/runtime/parity/compaction.case.ts
+++ b/packages/agent-core/src/smoke/cases/runtime/parity/compaction.case.ts
@@ -1,7 +1,3 @@
-import { PRE_COMPACTION_ARCHIVE_SECTION_HEADER } from '../../../../compaction-archive.js';
-import { llmMessageTextContent } from '../../../../ports.js';
-import { COMPACT_SUMMARY_PREFIX } from '../../../../tool-agent.js';
-
 import {
   AgentRuntime,
   CompactExecutor,
@@ -191,23 +187,6 @@ export async function runCompactionCase(): Promise<RuntimeParityCaseResult> {
   }
   if (persistedMessageCount !== 3) {
     throw new Error(`pre-compaction archive smoke 归档消息数异常: ${persistedMessageCount}`);
-  }
-
-  const compactSummary = archiveRuntime
-    .history()
-    .find(
-      (message) =>
-        message.role === 'system' &&
-        llmMessageTextContent(message.content).startsWith(COMPACT_SUMMARY_PREFIX),
-    );
-  const compactSummaryText = compactSummary
-    ? llmMessageTextContent(compactSummary.content)
-    : '';
-  if (
-    !compactSummaryText.includes(PRE_COMPACTION_ARCHIVE_SECTION_HEADER) ||
-    !compactSummaryText.includes(archivePath)
-  ) {
-    throw new Error('pre-compaction archive smoke 摘要未包含归档路径段落。');
   }
 
   return {

--- a/packages/agent-core/src/smoke/cases/runtime/runtime-parity-case.ts
+++ b/packages/agent-core/src/smoke/cases/runtime/runtime-parity-case.ts
@@ -27,6 +27,7 @@ export async function runRuntimeParitySmoke(): Promise<void> {
   printSmokeSection('background execution smoke', background.backgroundResult);
   printSmokeSection('polling background smoke', background.pollingBackgroundResult);
   printSmokeSection('polling compact smoke', compaction.pollingCompactResult);
+  printSmokeSection('pre-compaction archive smoke', compaction.archiveCompactionResult);
   printSmokeSection('manual command smoke', manualTools.manualGuidance);
   printSmokeSection('generate image terminal smoke', generateImage.generateImageNonStreamingResult);
   printSmokeSection('generate image streaming terminal smoke events', generateImage.generateImageStreamingEvents);

--- a/packages/agent-core/src/tool-agent.ts
+++ b/packages/agent-core/src/tool-agent.ts
@@ -51,9 +51,13 @@ const COMPACT_HISTORY_OUTPUT_TEMPLATE = `[Session Overview]
 - <Approaches tried but proven infeasible or incorrect, and why>
 
 [Open Items]
-- <Remaining work, questions awaiting user confirmation, blockers>`;
+- <Remaining work, questions awaiting user confirmation, blockers>
 
-export const COMPACT_HISTORY_SYSTEM_PROMPT = [
+[Pre-compaction Archive]
+<Absolute path to the saved pre-compaction history file>
+Important details may be recovered by reading this file with read_file.`;
+
+const COMPACT_HISTORY_SYSTEM_PROMPT_BASE = [
   'Compress the following conversation into a reusable system summary for later turns.',
   '',
   'Hard requirements:',
@@ -70,6 +74,23 @@ export const COMPACT_HISTORY_SYSTEM_PROMPT = [
   COMPACT_HISTORY_OUTPUT_TEMPLATE,
 ].join('\n');
 
+export function buildCompactHistorySystemPrompt(preCompactionArchivePath?: string): string {
+  const normalizedPath = preCompactionArchivePath?.trim();
+  if (!normalizedPath) {
+    return COMPACT_HISTORY_SYSTEM_PROMPT_BASE;
+  }
+
+  return [
+    COMPACT_HISTORY_SYSTEM_PROMPT_BASE,
+    '',
+    `A pre-compaction history archive has been saved to: ${normalizedPath}`,
+    'Important details omitted from this summary may be recovered by reading that file with read_file.',
+    'Include that absolute path in the [Pre-compaction Archive] section of your output.',
+  ].join('\n');
+}
+
+export const COMPACT_HISTORY_SYSTEM_PROMPT = buildCompactHistorySystemPrompt();
+
 export function buildCompactHistoryUserPrompt(history: LlmMessage[]): string {
   return history
     .map((message) => {
@@ -84,11 +105,19 @@ export function buildCompactHistoryUserPrompt(history: LlmMessage[]): string {
     .join('\n\n');
 }
 
+export interface BuildCompactHistoryPromptMessagesOptions {
+  preCompactionArchivePath?: string;
+}
+
 export function buildCompactHistoryPromptMessages(
   history: LlmMessage[],
+  options: BuildCompactHistoryPromptMessagesOptions = {},
 ): Array<{ role: 'system' | 'user'; content: string }> {
   return [
-    { role: 'system', content: COMPACT_HISTORY_SYSTEM_PROMPT },
+    {
+      role: 'system',
+      content: buildCompactHistorySystemPrompt(options.preCompactionArchivePath),
+    },
     { role: 'user', content: buildCompactHistoryUserPrompt(history) },
   ];
 }

--- a/packages/agent-core/src/tool-agent.ts
+++ b/packages/agent-core/src/tool-agent.ts
@@ -35,7 +35,7 @@ export const PRE_COMPACTION_ARCHIVE_READ_FILE_GUIDANCE =
 const PRE_COMPACTION_ARCHIVE_EXAMPLE_PATH =
   '/path/to/compaction-archives/pre-compact-session-1234567890.json';
 
-const COMPACT_HISTORY_OUTPUT_TEMPLATE = `[Session Overview]
+const COMPACT_HISTORY_OUTPUT_TEMPLATE_WITHOUT_ARCHIVE = `[Session Overview]
 <Summarize the current task and overall progress in 1–2 sentences>
 
 [User Messages]
@@ -57,38 +57,52 @@ const COMPACT_HISTORY_OUTPUT_TEMPLATE = `[Session Overview]
 - <Approaches tried but proven infeasible or incorrect, and why>
 
 [Open Items]
-- <Remaining work, questions awaiting user confirmation, blockers>
+- <Remaining work, questions awaiting user confirmation, blockers>`;
 
-[Pre-compaction Archive]
+const COMPACT_HISTORY_ARCHIVE_OUTPUT_SECTION = `[Pre-compaction Archive]
 <the archive absolute path on this line>
 Important details may be recovered by reading this file with read_file.`;
 
-const COMPACT_HISTORY_SYSTEM_PROMPT_BASE = [
-  'Compress the following conversation into a reusable system summary for later turns.',
-  '',
-  'Hard requirements:',
-  '1. Output must strictly follow the section titles, order, and hierarchy in the output template; do not add, remove, or rename sections.',
-  '2. The [User Messages] section must include every user message from the input conversation: one message per line, in order of appearance, preserving original wording; do not omit, merge, paraphrase, or rewrite. You may append [images attached] / [videos attached] annotations only when a message is extremely long.',
-  '3. For sections other than [User Messages], summarize in concise bullet points, preserving decision rationale and verifiable details; avoid vague repetition.',
-  '4. Omit small talk, thanks, repeated explanations, and low-information back-and-forth confirmations.',
-  '5. Output only the summary body; do not wrap it in markdown code fences; do not add explanations, preambles, or closings.',
-  `6. The [Pre-compaction Archive] section must contain exactly three lines: the section title, then the archive absolute path alone on the next line, then this exact guidance sentence on the following line: ${PRE_COMPACTION_ARCHIVE_READ_FILE_GUIDANCE} Do not output only the path.`,
-  '',
-  'When summarizing, preserve: user goals, key constraints, verified conclusions, failed attempts, and open items.',
-  '',
-  'Output template:',
-  '',
-  COMPACT_HISTORY_OUTPUT_TEMPLATE,
-].join('\n');
+const COMPACT_HISTORY_OUTPUT_TEMPLATE = `${COMPACT_HISTORY_OUTPUT_TEMPLATE_WITHOUT_ARCHIVE}
+
+${COMPACT_HISTORY_ARCHIVE_OUTPUT_SECTION}`;
+
+const PRE_COMPACTION_ARCHIVE_HARD_REQUIREMENT = `6. The [Pre-compaction Archive] section must contain exactly three lines: the section title, then the archive absolute path alone on the next line, then this exact guidance sentence on the following line: ${PRE_COMPACTION_ARCHIVE_READ_FILE_GUIDANCE} Do not output only the path.`;
+
+function buildCompactHistorySystemPromptCore(includeArchiveSection: boolean): string {
+  const hardRequirements = [
+    '1. Output must strictly follow the section titles, order, and hierarchy in the output template; do not add, remove, or rename sections.',
+    '2. The [User Messages] section must include every user message from the input conversation: one message per line, in order of appearance, preserving original wording; do not omit, merge, paraphrase, or rewrite. You may append [images attached] / [videos attached] annotations only when a message is extremely long.',
+    '3. For sections other than [User Messages], summarize in concise bullet points, preserving decision rationale and verifiable details; avoid vague repetition.',
+    '4. Omit small talk, thanks, repeated explanations, and low-information back-and-forth confirmations.',
+    '5. Output only the summary body; do not wrap it in markdown code fences; do not add explanations, preambles, or closings.',
+    ...(includeArchiveSection ? [PRE_COMPACTION_ARCHIVE_HARD_REQUIREMENT] : []),
+  ];
+
+  return [
+    'Compress the following conversation into a reusable system summary for later turns.',
+    '',
+    'Hard requirements:',
+    ...hardRequirements,
+    '',
+    'When summarizing, preserve: user goals, key constraints, verified conclusions, failed attempts, and open items.',
+    '',
+    'Output template:',
+    '',
+    includeArchiveSection
+      ? COMPACT_HISTORY_OUTPUT_TEMPLATE
+      : COMPACT_HISTORY_OUTPUT_TEMPLATE_WITHOUT_ARCHIVE,
+  ].join('\n');
+}
 
 export function buildCompactHistorySystemPrompt(preCompactionArchivePath?: string): string {
   const normalizedPath = preCompactionArchivePath?.trim();
   if (!normalizedPath) {
-    return COMPACT_HISTORY_SYSTEM_PROMPT_BASE;
+    return buildCompactHistorySystemPromptCore(false);
   }
 
   return [
-    COMPACT_HISTORY_SYSTEM_PROMPT_BASE,
+    buildCompactHistorySystemPromptCore(true),
     '',
     'Example [Pre-compaction Archive] section shape (use the real archive path from below, not this placeholder path):',
     '',

--- a/packages/agent-core/src/tool-agent.ts
+++ b/packages/agent-core/src/tool-agent.ts
@@ -83,9 +83,7 @@ export function buildCompactHistorySystemPrompt(preCompactionArchivePath?: strin
   return [
     COMPACT_HISTORY_SYSTEM_PROMPT_BASE,
     '',
-    `A pre-compaction history archive has been saved to: ${normalizedPath}`,
-    'Important details omitted from this summary may be recovered by reading that file with read_file.',
-    'Include that absolute path in the [Pre-compaction Archive] section of your output.',
+    `Pre-compaction history archive path (use this exact path in [Pre-compaction Archive]): ${normalizedPath}`,
   ].join('\n');
 }
 

--- a/packages/agent-core/src/tool-agent.ts
+++ b/packages/agent-core/src/tool-agent.ts
@@ -29,6 +29,12 @@ const BASIC_INFO_SECTION_PREFIX = '[SPIRIT_BASIC_INFO]';
 
 export const COMPACT_SUMMARY_PREFIX = '[SPIRIT_COMPACT_SUMMARY]';
 
+export const PRE_COMPACTION_ARCHIVE_READ_FILE_GUIDANCE =
+  'Important details may be recovered by reading this file with read_file.';
+
+const PRE_COMPACTION_ARCHIVE_EXAMPLE_PATH =
+  '/path/to/compaction-archives/pre-compact-session-1234567890.json';
+
 const COMPACT_HISTORY_OUTPUT_TEMPLATE = `[Session Overview]
 <Summarize the current task and overall progress in 1–2 sentences>
 
@@ -54,7 +60,7 @@ const COMPACT_HISTORY_OUTPUT_TEMPLATE = `[Session Overview]
 - <Remaining work, questions awaiting user confirmation, blockers>
 
 [Pre-compaction Archive]
-<Absolute path to the saved pre-compaction history file>
+<the archive absolute path on this line>
 Important details may be recovered by reading this file with read_file.`;
 
 const COMPACT_HISTORY_SYSTEM_PROMPT_BASE = [
@@ -66,6 +72,7 @@ const COMPACT_HISTORY_SYSTEM_PROMPT_BASE = [
   '3. For sections other than [User Messages], summarize in concise bullet points, preserving decision rationale and verifiable details; avoid vague repetition.',
   '4. Omit small talk, thanks, repeated explanations, and low-information back-and-forth confirmations.',
   '5. Output only the summary body; do not wrap it in markdown code fences; do not add explanations, preambles, or closings.',
+  `6. The [Pre-compaction Archive] section must contain exactly three lines: the section title, then the archive absolute path alone on the next line, then this exact guidance sentence on the following line: ${PRE_COMPACTION_ARCHIVE_READ_FILE_GUIDANCE} Do not output only the path.`,
   '',
   'When summarizing, preserve: user goals, key constraints, verified conclusions, failed attempts, and open items.',
   '',
@@ -83,7 +90,13 @@ export function buildCompactHistorySystemPrompt(preCompactionArchivePath?: strin
   return [
     COMPACT_HISTORY_SYSTEM_PROMPT_BASE,
     '',
-    `Pre-compaction history archive path (use this exact path in [Pre-compaction Archive]): ${normalizedPath}`,
+    'Example [Pre-compaction Archive] section shape (use the real archive path from below, not this placeholder path):',
+    '',
+    '[Pre-compaction Archive]',
+    PRE_COMPACTION_ARCHIVE_EXAMPLE_PATH,
+    PRE_COMPACTION_ARCHIVE_READ_FILE_GUIDANCE,
+    '',
+    `Archive path for this compression (use this exact path on the archive line): ${normalizedPath}`,
   ].join('\n');
 }
 

--- a/packages/host-internal/src/compaction-archive.test.ts
+++ b/packages/host-internal/src/compaction-archive.test.ts
@@ -5,9 +5,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
+import { access } from 'node:fs/promises';
+
 import {
   buildPreCompactionArchiveFileName,
   persistPreCompactionHistoryArchive,
+  removePreCompactionHistoryArchive,
   resolveCompactionArchivesDir,
 } from './compaction-archive.js';
 
@@ -35,6 +38,31 @@ test('persistPreCompactionHistoryArchive writes filtered archive JSON under comp
     assert.equal(filePath, join(resolveCompactionArchivesDir(spiritDataDir), buildPreCompactionArchiveFileName('session/1', archive.exported_at_unix_ms)));
     const written = JSON.parse(await readFile(filePath, 'utf8')) as typeof archive;
     assert.deepEqual(written, archive);
+  } finally {
+    await rm(spiritDataDir, { recursive: true, force: true });
+  }
+});
+
+test('removePreCompactionHistoryArchive deletes a persisted archive file', async () => {
+  const spiritDataDir = await mkdtemp(join(tmpdir(), 'spirit-compaction-archive-'));
+
+  try {
+    const archive = {
+      export_version: 1 as const,
+      kind: 'pre_compaction_history' as const,
+      exported_at_unix_ms: 1_700_000_000_001,
+      message_count: 1,
+      messages: [
+        {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: 'hello' }],
+        },
+      ],
+    };
+
+    const filePath = await persistPreCompactionHistoryArchive(spiritDataDir, archive);
+    await removePreCompactionHistoryArchive(filePath);
+    await assert.rejects(() => access(filePath), /ENOENT/);
   } finally {
     await rm(spiritDataDir, { recursive: true, force: true });
   }

--- a/packages/host-internal/src/compaction-archive.test.ts
+++ b/packages/host-internal/src/compaction-archive.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  buildPreCompactionArchiveFileName,
+  persistPreCompactionHistoryArchive,
+  resolveCompactionArchivesDir,
+} from './compaction-archive.js';
+
+test('persistPreCompactionHistoryArchive writes filtered archive JSON under compaction-archives', async () => {
+  const spiritDataDir = await mkdtemp(join(tmpdir(), 'spirit-compaction-archive-'));
+
+  try {
+    const archive = {
+      export_version: 1 as const,
+      kind: 'pre_compaction_history' as const,
+      exported_at_unix_ms: 1_700_000_000_000,
+      message_count: 1,
+      messages: [
+        {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: 'hello' }],
+        },
+      ],
+    };
+
+    const filePath = await persistPreCompactionHistoryArchive(spiritDataDir, archive, {
+      sessionId: 'session/1',
+    });
+
+    assert.equal(filePath, join(resolveCompactionArchivesDir(spiritDataDir), buildPreCompactionArchiveFileName('session/1', archive.exported_at_unix_ms)));
+    const written = JSON.parse(await readFile(filePath, 'utf8')) as typeof archive;
+    assert.deepEqual(written, archive);
+  } finally {
+    await rm(spiritDataDir, { recursive: true, force: true });
+  }
+});

--- a/packages/host-internal/src/compaction-archive.ts
+++ b/packages/host-internal/src/compaction-archive.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { PreCompactionHistoryArchive } from '@spirit-agent/core';
@@ -38,4 +38,8 @@ export async function persistPreCompactionHistoryArchive(
   const filePath = path.join(archivesDir, fileName);
   await writeFile(filePath, `${JSON.stringify(archive, null, 2)}\n`, 'utf8');
   return filePath;
+}
+
+export async function removePreCompactionHistoryArchive(archivePath: string): Promise<void> {
+  await unlink(archivePath);
 }

--- a/packages/host-internal/src/compaction-archive.ts
+++ b/packages/host-internal/src/compaction-archive.ts
@@ -1,0 +1,41 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { PreCompactionHistoryArchive } from '@spirit-agent/core';
+
+export const COMPACTION_ARCHIVES_DIR_NAME = 'compaction-archives';
+
+export function resolveCompactionArchivesDir(spiritDataDir: string): string {
+  return path.join(spiritDataDir, COMPACTION_ARCHIVES_DIR_NAME);
+}
+
+function sanitizeSessionIdForFilename(sessionId: string | undefined): string {
+  const normalized = sessionId?.trim();
+  if (!normalized) {
+    return 'unknown';
+  }
+
+  const sanitized = normalized.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return sanitized.length > 0 ? sanitized : 'unknown';
+}
+
+export function buildPreCompactionArchiveFileName(
+  sessionId: string | undefined,
+  exportedAtUnixMs: number,
+): string {
+  return `pre-compact-${sanitizeSessionIdForFilename(sessionId)}-${exportedAtUnixMs}.json`;
+}
+
+export async function persistPreCompactionHistoryArchive(
+  spiritDataDir: string,
+  archive: PreCompactionHistoryArchive,
+  options: { sessionId?: string } = {},
+): Promise<string> {
+  const archivesDir = resolveCompactionArchivesDir(spiritDataDir);
+  await mkdir(archivesDir, { recursive: true });
+
+  const fileName = buildPreCompactionArchiveFileName(options.sessionId, archive.exported_at_unix_ms);
+  const filePath = path.join(archivesDir, fileName);
+  await writeFile(filePath, `${JSON.stringify(archive, null, 2)}\n`, 'utf8');
+  return filePath;
+}

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -7,6 +7,7 @@ export * from './dreams.js';
 export * from './automations.js';
 export * from './automation-host-tool.js';
 export * from './builtin-skills.js';
+export * from './compaction-archive.js';
 export * from './todos.js';
 export * from './extensions.js';
 export * from './file-rewind.js';


### PR DESCRIPTION
## Summary

- 在上下文压缩（truncate）之前，将完整 `user` / `assistant`（含 `toolCalls`）历史序列化为 `pre_compaction_history` JSON，写入 `{spiritDataDir}/compaction-archives/`。
- 压缩 LLM 仅通过 system 提示获知归档绝对路径与 `read_file` 恢复指引；不再对 `[SPIRIT_COMPACT_SUMMARY]` 做程序化改写。
- 无归档路径时不要求模型输出 `[Pre-compaction Archive]` 章节；持久化失败发出 `pre-compaction-archive-persist-failed` 事件；压缩失败时清理孤儿归档文件。
- Desktop、CLI host-bridge、ACP 均已注入 `persistPreCompactionHistory` / `removePreCompactionHistoryArchive`。

## Test plan

- [x] `packages/agent-core`：`compaction-archive.test.ts`（归档过滤、无/有路径压缩 prompt）
- [x] `packages/agent-core`：`compaction.runtime.test.ts`（即时压缩、持久化失败事件、截断前后历史分离、孤儿归档清理）
- [x] `packages/host-internal`：`compaction-archive.test.ts`（写入与删除归档文件）
- [x] `packages/agent-core`：smoke `runtime/parity/compaction.case.ts` 端到端回归
- [x] `npm run build:agent-core && npm run build:host-internal` 构建通过