### PR TITLE
fix(desktop): 修正接近 100 万 token 的紧凑计数显示

### DIFF
--- a/apps/desktop/src/lib/format-compact-token-count.ts
+++ b/apps/desktop/src/lib/format-compact-token-count.ts
@@ -6,7 +6,8 @@ export function formatCompactTokenCount(value: number): string {
     return `${formatScaledCount(count / 1_000_000)}M`;
   }
   if (count >= 1_000) {
-    return `${formatScaledCount(count / 1_000)}K`;
+    const scaledK = Math.min(Math.round((count / 1_000) * 10) / 10, 999.9);
+    return `${formatScaledCount(scaledK)}K`;
   }
   return String(count);
 }

--- a/apps/desktop/test/lib/format-compact-token-count.test.mjs
+++ b/apps/desktop/test/lib/format-compact-token-count.test.mjs
@@ -8,6 +8,8 @@ test('formatCompactTokenCount abbreviates thousands and millions', () => {
   assert.equal(formatCompactTokenCount(4803), '4.8K');
   assert.equal(formatCompactTokenCount(50_000), '50K');
   assert.equal(formatCompactTokenCount(128_000), '128K');
+  assert.equal(formatCompactTokenCount(999_999), '999.9K');
+  assert.equal(formatCompactTokenCount(999_950), '999.9K');
   assert.equal(formatCompactTokenCount(1_000_000), '1M');
   assert.equal(formatCompactTokenCount(1_050_000), '1.1M');
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

`formatCompactTokenCount` 在 token 数接近 100 万（如 `999_999`、`999_950`）时，K 单位分支的四舍五入会把数值推到 `1000`，显示为 `1000K`，而此时尚未进入 M 单位分支。

## 修复

在 K 单位分支对缩放后的数值上限钳制为 `999.9`，避免显示 `1000K`。

## 测试

- 补充 `999_999`、`999_950` 的单元测试用例
- `format-compact-token-count.test.mjs` 已通过
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aae5785e-39b5-47b3-b760-9cbc084331c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aae5785e-39b5-47b3-b760-9cbc084331c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

