### PR TITLE
feat(desktop): PR Changes 选区 Add to Session 与内联 Diff Chip

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -532,6 +532,7 @@ export default function App() {
               onWorkspaceToolTabsChange: workspaceTools.setWorkspaceToolTabs,
               onActiveWorkspaceToolTabIdChange: workspaceTools.setActiveWorkspaceToolTabId,
               onBrowserElementPicked: composer.handleBrowserElementPicked,
+              onPrDiffAddToSession: composer.handlePrDiffAddToSession,
               onBrowserOpenInNewTab: workspaceTools.openBrowserUrlInNewTab,
               browserTabEnabled: workspaceTools.browserTabEnabled,
               prTabEnabled: workspaceTools.prTabEnabled,

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -12,6 +12,7 @@ import {
 
 import type { BrowserElementAttachment } from "@/lib/browser-element-attachment";
 import type { PrDiffAttachment } from "@/lib/pr-diff-attachment";
+import { hasInlineAttachmentChipSegments } from "@/lib/composer-inline-chip-dom";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
 import { caretToDomRange, selectionToCaret } from "@/lib/composer-segment-selection";
 import {
@@ -817,6 +818,10 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         // Skill chip 存在时，parent 侧 value 为空（segmentsToPlainText 对 skill 返回 ""），
         // 但 chip 本身应保留，勿清空。
         if (hasSkillSegment(current) && isComposerPlainEmpty(plain)) {
+          return;
+        }
+        // PR diff / 工作区文件 / 元素 chip 不贡献 parent plain；parent value 为空时保留内联 chip。
+        if (hasInlineAttachmentChipSegments(current) && isComposerPlainEmpty(plain)) {
           return;
         }
         commitSegments(emptySegments(), { segmentIndex: 0, offset: 0 });

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 
 import type { BrowserElementAttachment } from "@/lib/browser-element-attachment";
+import type { PrDiffAttachment } from "@/lib/pr-diff-attachment";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
 import { caretToDomRange, selectionToCaret } from "@/lib/composer-segment-selection";
 import {
@@ -119,6 +120,7 @@ export type InsertSkillChipOptions = {
 export type ComposerRichInputHandle = {
   focus(): void;
   insertAttachment(a: BrowserElementAttachment): void;
+  insertPrDiffAttachment(attachment: PrDiffAttachment): void;
   insertWorkspaceFileReference(
     path: string,
     query: ActiveWorkspaceFileReferenceQuery,
@@ -379,6 +381,26 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       [commitSegments],
     );
 
+    const insertPrDiffAttachment = useCallback(
+      (attachment: PrDiffAttachment) => {
+        const div = divRef.current;
+        if (!div) return;
+        div.focus();
+        const current = segmentsRef.current;
+        const caret =
+          selectionToCaret(div, current) ?? {
+            segmentIndex: current.length - 1,
+            offset: segmentsToPlainText(current).length,
+          };
+        const { segments: next, caret: nextCaret } = insertSegmentAtCaret(current, caret, {
+          kind: "prDiff",
+          attachment,
+        });
+        commitSegments(next, nextCaret);
+      },
+      [commitSegments],
+    );
+
     const insertWorkspaceFileReference = useCallback(
       (path: string, query: ActiveWorkspaceFileReferenceQuery, finalize = true) => {
         const div = divRef.current;
@@ -605,6 +627,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       () => ({
         focus: () => divRef.current?.focus(),
         insertAttachment,
+        insertPrDiffAttachment,
         insertWorkspaceFileReference,
         insertLoopChip,
         removeLoopChip,
@@ -622,6 +645,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       }),
       [
         insertAttachment,
+        insertPrDiffAttachment,
         insertWorkspaceFileReference,
         replaceSkillSlashQuery,
         removeSkillSlashQuery,

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -136,6 +136,9 @@ export type WorkspaceToolsSectionProps = {
   onBrowserElementPicked: NonNullable<
     ComponentProps<typeof WorkspaceToolsDock>["onBrowserElementPicked"]
   >;
+  onPrDiffAddToSession?: NonNullable<
+    ComponentProps<typeof WorkspaceToolsDock>["onPrDiffAddToSession"]
+  >;
   onBrowserOpenInNewTab: (rawUrl: string) => void;
   browserTabEnabled: boolean;
   prTabEnabled: boolean;
@@ -371,6 +374,7 @@ export function ConversationView({
           onTabsChange={workspaceTools.onWorkspaceToolTabsChange}
           onActiveTabIdChange={workspaceTools.onActiveWorkspaceToolTabIdChange}
           onBrowserElementPicked={workspaceTools.onBrowserElementPicked}
+          onPrDiffAddToSession={workspaceTools.onPrDiffAddToSession}
           onBrowserOpenInNewTab={workspaceTools.onBrowserOpenInNewTab}
           browserTabEnabled={workspaceTools.browserTabEnabled}
           prTabEnabled={workspaceTools.prTabEnabled}

--- a/apps/desktop/src/components/text-selection-action-menu.tsx
+++ b/apps/desktop/src/components/text-selection-action-menu.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from "react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { SelectionAnchorRect } from "@/hooks/use-text-selection-action-menu";
+
+type TextSelectionActionMenuProps = {
+  open: boolean;
+  anchor: SelectionAnchorRect | null;
+  onOpenChange(open: boolean): void;
+  children: ReactNode;
+};
+
+export function TextSelectionActionMenu({
+  open,
+  anchor,
+  onOpenChange,
+  children,
+}: TextSelectionActionMenuProps) {
+  if (!anchor) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
+      <DropdownMenuTrigger asChild>
+        <span
+          aria-hidden
+          tabIndex={-1}
+          style={{
+            position: "fixed",
+            left: anchor.x,
+            top: anchor.y,
+            width: anchor.width,
+            height: anchor.height,
+            pointerEvents: "none",
+          }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="center"
+        side="top"
+        sideOffset={8}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+type TextSelectionActionMenuItemProps = {
+  label: string;
+  onSelect(): void;
+};
+
+export function TextSelectionActionMenuItem({
+  label,
+  onSelect,
+}: TextSelectionActionMenuItemProps) {
+  return (
+    <DropdownMenuItem
+      onSelect={onSelect}
+      onMouseDown={(event) => event.preventDefault()}
+    >
+      {label}
+    </DropdownMenuItem>
+  );
+}

--- a/apps/desktop/src/components/user-message-bubble.tsx
+++ b/apps/desktop/src/components/user-message-bubble.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
-import { GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, PenTool } from "lucide-react";
+import { GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, PenTool } from "lucide-react";
 
 import { BROWSER_ELEMENT_CHIP_CLASS } from "@/components/browser-element-card";
 import { ComposerLocalFileStrip } from "@/components/composer-local-file-strip";
@@ -60,6 +60,9 @@ function prDiffStatusIcon(status: PullRequestChipStatus) {
       return GitPullRequestClosed;
     case "draft":
       return GitPullRequestDraft;
+    case "merged":
+      return GitMerge;
+    case "open":
     default:
       return GitPullRequest;
   }

--- a/apps/desktop/src/components/user-message-bubble.tsx
+++ b/apps/desktop/src/components/user-message-bubble.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
-import { PenTool } from "lucide-react";
+import { GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, PenTool } from "lucide-react";
 
 import { BROWSER_ELEMENT_CHIP_CLASS } from "@/components/browser-element-card";
 import { ComposerLocalFileStrip } from "@/components/composer-local-file-strip";
@@ -14,7 +14,14 @@ import {
 import {
   parseMessageContentParts,
   trimMessageTextAroundElements,
+  type MessageContentPart,
 } from "@/lib/composer-segment-model";
+import {
+  formatPrDiffChipLabel,
+  formatPrDiffChipTitle,
+  prDiffChipClassForStatus,
+} from "@/lib/github-pr-diff-chip-styles";
+import type { PullRequestChipStatus } from "@/lib/pr-diff-attachment";
 import { workspaceFileBasename } from "@/lib/file-picker-path";
 import {
   WORKSPACE_FILE_CHIP_CLASS,
@@ -47,10 +54,46 @@ function WorkspaceFileCard({ path }: { path: string }) {
   );
 }
 
+function prDiffStatusIcon(status: PullRequestChipStatus) {
+  switch (status) {
+    case "closed":
+      return GitPullRequestClosed;
+    case "draft":
+      return GitPullRequestDraft;
+    default:
+      return GitPullRequest;
+  }
+}
+
+function PrDiffCard({
+  part,
+}: {
+  part: Extract<MessageContentPart, { kind: "prDiff" }>;
+}) {
+  const Icon = prDiffStatusIcon(part.status);
+  return (
+    <span
+      title={formatPrDiffChipTitle({
+        id: "",
+        prUrl: part.prUrl,
+        filename: part.filename,
+        lineStart: part.lineStart,
+        lineEnd: part.lineEnd,
+        diffText: part.diffText,
+        status: part.status,
+      })}
+      className={prDiffChipClassForStatus(part.status)}
+    >
+      <Icon className="size-[10px] shrink-0" aria-hidden />
+      {formatPrDiffChipLabel(part.filename, part.lineStart, part.lineEnd)}
+    </span>
+  );
+}
+
 function isInlineChipPart(
-  part: { kind: string } | null | undefined,
-): part is { kind: "element" | "workspaceFile" } {
-  return part?.kind === "element" || part?.kind === "workspaceFile";
+  part: MessageContentPart | null | undefined,
+): part is Extract<MessageContentPart, { kind: "element" | "workspaceFile" | "prDiff" }> {
+  return part?.kind === "element" || part?.kind === "workspaceFile" || part?.kind === "prDiff";
 }
 
 type ReadLocalImagePreview = (filePath: string) => Promise<string | null>;
@@ -93,7 +136,9 @@ export function UserMessageBubble({
   const visibleText = contentParts.filter((p) => p.kind === 'text').map((p) => p.value).join('');
   const showText =
     (visibleText.trim().length > 0 ||
-      contentParts.some((p) => p.kind === "element" || p.kind === "workspaceFile")) &&
+      contentParts.some(
+        (p) => p.kind === "element" || p.kind === "workspaceFile" || p.kind === "prDiff",
+      )) &&
     !isAttachmentOnlyDisplayText(message.content, message.localFileAttachments);
   const hasAttachments = attachmentViews.length > 0;
 
@@ -133,6 +178,9 @@ export function UserMessageBubble({
               }
               if (part.kind === "workspaceFile") {
                 return <WorkspaceFileCard key={i} path={part.path} />;
+              }
+              if (part.kind === "prDiff") {
+                return <PrDiffCard key={i} part={part} />;
               }
               const prev = i > 0 ? contentParts[i - 1] : null;
               const next = i < contentParts.length - 1 ? contentParts[i + 1] : null;

--- a/apps/desktop/src/components/workspace-pr-changes-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-changes-view.tsx
@@ -16,7 +16,7 @@ import { useTextSelectionActionMenu } from "@/hooks/use-text-selection-action-me
 import { buildPrChangedFilesTree } from "@/lib/pr-changed-files-tree";
 import type { PrDiffAttachment, PullRequestChipStatus } from "@/lib/pr-diff-attachment";
 import { buildPrDiffSnippetFromPatch, buildPrDiffSnippetText } from "@/lib/pr-diff-text";
-import { readDiffSelectionText, resolveDiffSelectionLineRange } from "@/lib/pr-diff-selection";
+import { readDiffSelectionText, resolveChangedFileFromSelection, resolveDiffSelectionLineRange } from "@/lib/pr-diff-selection";
 import {
   PR_CHANGES_TREE_MIN_WIDTH_PX,
   computePrChangesTreeMaxWidthPx,
@@ -29,20 +29,6 @@ import type { GitHubPullRequestChangedFile } from "@/types";
 
 export function prChangedFileAnchorId(filename: string): string {
   return `pr-change-file-${encodeURIComponent(filename)}`;
-}
-
-function findChangedFileFromSelection(node: Node | null, root: HTMLElement): string | null {
-  let current: Node | null = node;
-  while (current && current !== root) {
-    if (current instanceof HTMLElement) {
-      const filename = current.dataset.prChangedFile;
-      if (filename) {
-        return filename;
-      }
-    }
-    current = current.parentNode;
-  }
-  return null;
 }
 
 function findDiffRootFromSelection(node: Node | null, root: HTMLElement): HTMLElement | null {
@@ -77,7 +63,8 @@ function isDiffCodeSelection(selection: Selection, root: HTMLElement): boolean {
     }
     return false;
   };
-  return isInDiffCode(anchor) && isInDiffCode(focus);
+  return isInDiffCode(anchor) && isInDiffCode(focus)
+    && resolveChangedFileFromSelection(selection, root) != null;
 }
 
 function PrChangesSelectionMenu({
@@ -109,7 +96,7 @@ function PrChangesSelectionMenu({
       return;
     }
 
-    const filename = findChangedFileFromSelection(selection.anchorNode, root);
+    const filename = resolveChangedFileFromSelection(selection, root);
     if (!filename) {
       dismiss();
       return;

--- a/apps/desktop/src/components/workspace-pr-changes-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-changes-view.tsx
@@ -16,6 +16,7 @@ import { useTextSelectionActionMenu } from "@/hooks/use-text-selection-action-me
 import { buildPrChangedFilesTree } from "@/lib/pr-changed-files-tree";
 import type { PrDiffAttachment, PullRequestChipStatus } from "@/lib/pr-diff-attachment";
 import { buildPrDiffSnippetFromPatch, buildPrDiffSnippetText } from "@/lib/pr-diff-text";
+import { inferLineRangeFromPatch } from "@/lib/pr-diff-patch-slice";
 import { readDiffSelectionText, resolveChangedFileFromSelection, resolveDiffSelectionLineRange } from "@/lib/pr-diff-selection";
 import {
   PR_CHANGES_TREE_MIN_WIDTH_PX,
@@ -109,8 +110,10 @@ function PrChangesSelectionMenu({
       return;
     }
 
-    const lineRange = diffRoot ? resolveDiffSelectionLineRange(diffRoot, selection) : null;
     const filePatch = files.find((file) => file.filename === filename)?.patch;
+    const lineRange =
+      (diffRoot ? resolveDiffSelectionLineRange(diffRoot, selection) : null)
+      ?? (filePatch ? inferLineRangeFromPatch(filename, filePatch, selectedText) : null);
     const diffText =
       filePatch && lineRange
         ? buildPrDiffSnippetFromPatch(

--- a/apps/desktop/src/components/workspace-pr-changes-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-changes-view.tsx
@@ -3,12 +3,20 @@ import { useTranslation } from "react-i18next";
 import { ChevronRight } from "lucide-react";
 
 import { ReviewCommentHunkView } from "@/components/review-comment-hunk-view";
+import {
+  TextSelectionActionMenu,
+  TextSelectionActionMenuItem,
+} from "@/components/text-selection-action-menu";
 import { EditFileLineDeltaBadge } from "@/components/edit-file-line-delta-badge";
 import { WorkspacePrChangesFileTree } from "@/components/workspace-pr-changes-file-tree";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useCollapsibleChildMount } from "@/hooks/use-collapsible-child-mount";
+import { useTextSelectionActionMenu } from "@/hooks/use-text-selection-action-menu";
 import { buildPrChangedFilesTree } from "@/lib/pr-changed-files-tree";
+import type { PrDiffAttachment, PullRequestChipStatus } from "@/lib/pr-diff-attachment";
+import { buildPrDiffSnippetText } from "@/lib/pr-diff-text";
+import { readDiffSelectionText, resolveDiffSelectionLineRange } from "@/lib/pr-diff-selection";
 import {
   PR_CHANGES_TREE_MIN_WIDTH_PX,
   computePrChangesTreeMaxWidthPx,
@@ -21,6 +29,124 @@ import type { GitHubPullRequestChangedFile } from "@/types";
 
 export function prChangedFileAnchorId(filename: string): string {
   return `pr-change-file-${encodeURIComponent(filename)}`;
+}
+
+function findChangedFileFromSelection(node: Node | null, root: HTMLElement): string | null {
+  let current: Node | null = node;
+  while (current && current !== root) {
+    if (current instanceof HTMLElement) {
+      const filename = current.dataset.prChangedFile;
+      if (filename) {
+        return filename;
+      }
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function findDiffRootFromSelection(node: Node | null, root: HTMLElement): HTMLElement | null {
+  let current: Node | null = node;
+  while (current && current !== root) {
+    if (current instanceof HTMLElement && current.classList.contains("tool-call-diff")) {
+      return current;
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function isDiffCodeSelection(selection: Selection, root: HTMLElement): boolean {
+  const anchor = selection.anchorNode;
+  const focus = selection.focusNode;
+  if (!anchor || !focus) {
+    return false;
+  }
+  const diffRoot =
+    findDiffRootFromSelection(anchor, root) ?? findDiffRootFromSelection(focus, root);
+  if (!diffRoot) {
+    return false;
+  }
+  const isInDiffCode = (node: Node | null): boolean => {
+    let current: Node | null = node;
+    while (current && current !== diffRoot) {
+      if (current instanceof HTMLElement && current.classList.contains("diff-code")) {
+        return true;
+      }
+      current = current.parentNode;
+    }
+    return false;
+  };
+  return isInDiffCode(anchor) && isInDiffCode(focus);
+}
+
+function PrChangesSelectionMenu({
+  rootRef,
+  prUrl,
+  prStatus,
+  onPrDiffAddToSession,
+}: {
+  rootRef: RefObject<HTMLElement | null>;
+  prUrl: string;
+  prStatus: PullRequestChipStatus;
+  onPrDiffAddToSession?: (attachment: PrDiffAttachment) => void;
+}) {
+  const { t } = useTranslation();
+  const enabled = Boolean(onPrDiffAddToSession && prUrl);
+  const { open, setOpen, anchor, dismiss } = useTextSelectionActionMenu({
+    enabled,
+    rootRef,
+    isSelectionAllowed: isDiffCodeSelection,
+  });
+
+  const handleAddToSession = useCallback(() => {
+    const root = rootRef.current;
+    const selection = typeof window !== "undefined" ? window.getSelection() : null;
+    if (!root || !selection || !onPrDiffAddToSession) {
+      dismiss();
+      return;
+    }
+
+    const filename = findChangedFileFromSelection(selection.anchorNode, root);
+    if (!filename) {
+      dismiss();
+      return;
+    }
+
+    const diffRoot = findDiffRootFromSelection(selection.anchorNode, root);
+    const selectedText = readDiffSelectionText(selection);
+    if (!selectedText) {
+      dismiss();
+      return;
+    }
+
+    const lineRange = diffRoot ? resolveDiffSelectionLineRange(diffRoot, selection) : null;
+    const attachment: PrDiffAttachment = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      prUrl,
+      filename,
+      lineStart: lineRange?.lineStart ?? 0,
+      lineEnd: lineRange?.lineEnd ?? 0,
+      diffText: buildPrDiffSnippetText(filename, selectedText),
+      status: prStatus,
+    };
+    onPrDiffAddToSession(attachment);
+    dismiss();
+    selection.removeAllRanges();
+  }, [dismiss, onPrDiffAddToSession, prStatus, prUrl, rootRef]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <TextSelectionActionMenu open={open} anchor={anchor} onOpenChange={setOpen}>
+      <TextSelectionActionMenuItem
+        label={t("workspace.prAddDiffToSession")}
+        onSelect={handleAddToSession}
+      />
+    </TextSelectionActionMenu>
+  );
 }
 
 function scrollAreaViewport(root: ComponentRef<typeof ScrollArea> | null): HTMLElement | null {
@@ -195,6 +321,9 @@ export type WorkspacePrChangesViewProps = {
   files: GitHubPullRequestChangedFile[];
   loading?: boolean;
   hasMore?: boolean;
+  prUrl?: string;
+  prStatus?: PullRequestChipStatus;
+  onPrDiffAddToSession?: (attachment: PrDiffAttachment) => void;
   onOpenExternal?: (url: string) => void;
   className?: string;
 };
@@ -203,6 +332,9 @@ export function WorkspacePrChangesView({
   files,
   loading = false,
   hasMore = false,
+  prUrl = "",
+  prStatus = "open",
+  onPrDiffAddToSession,
   onOpenExternal,
   className,
 }: WorkspacePrChangesViewProps) {
@@ -415,6 +547,12 @@ export function WorkspacePrChangesView({
           ) : null}
         </div>
       </ScrollArea>
+      <PrChangesSelectionMenu
+        rootRef={cardsListRef}
+        prUrl={prUrl}
+        prStatus={prStatus}
+        onPrDiffAddToSession={onPrDiffAddToSession}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/components/workspace-pr-changes-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-changes-view.tsx
@@ -15,7 +15,7 @@ import { useCollapsibleChildMount } from "@/hooks/use-collapsible-child-mount";
 import { useTextSelectionActionMenu } from "@/hooks/use-text-selection-action-menu";
 import { buildPrChangedFilesTree } from "@/lib/pr-changed-files-tree";
 import type { PrDiffAttachment, PullRequestChipStatus } from "@/lib/pr-diff-attachment";
-import { buildPrDiffSnippetText } from "@/lib/pr-diff-text";
+import { buildPrDiffSnippetFromPatch, buildPrDiffSnippetText } from "@/lib/pr-diff-text";
 import { readDiffSelectionText, resolveDiffSelectionLineRange } from "@/lib/pr-diff-selection";
 import {
   PR_CHANGES_TREE_MIN_WIDTH_PX,
@@ -82,11 +82,13 @@ function isDiffCodeSelection(selection: Selection, root: HTMLElement): boolean {
 
 function PrChangesSelectionMenu({
   rootRef,
+  files,
   prUrl,
   prStatus,
   onPrDiffAddToSession,
 }: {
   rootRef: RefObject<HTMLElement | null>;
+  files: GitHubPullRequestChangedFile[];
   prUrl: string;
   prStatus: PullRequestChipStatus;
   onPrDiffAddToSession?: (attachment: PrDiffAttachment) => void;
@@ -121,19 +123,34 @@ function PrChangesSelectionMenu({
     }
 
     const lineRange = diffRoot ? resolveDiffSelectionLineRange(diffRoot, selection) : null;
+    const filePatch = files.find((file) => file.filename === filename)?.patch;
+    const diffText =
+      filePatch && lineRange
+        ? buildPrDiffSnippetFromPatch(
+            filename,
+            filePatch,
+            lineRange.lineStart,
+            lineRange.lineEnd,
+          )
+        : buildPrDiffSnippetText(filename, selectedText);
+    if (!diffText) {
+      dismiss();
+      return;
+    }
+
     const attachment: PrDiffAttachment = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       prUrl,
       filename,
       lineStart: lineRange?.lineStart ?? 0,
       lineEnd: lineRange?.lineEnd ?? 0,
-      diffText: buildPrDiffSnippetText(filename, selectedText),
+      diffText,
       status: prStatus,
     };
     onPrDiffAddToSession(attachment);
     dismiss();
     selection.removeAllRanges();
-  }, [dismiss, onPrDiffAddToSession, prStatus, prUrl, rootRef]);
+  }, [dismiss, files, onPrDiffAddToSession, prStatus, prUrl, rootRef]);
 
   if (!enabled) {
     return null;
@@ -549,6 +566,7 @@ export function WorkspacePrChangesView({
       </ScrollArea>
       <PrChangesSelectionMenu
         rootRef={cardsListRef}
+        files={files}
         prUrl={prUrl}
         prStatus={prStatus}
         onPrDiffAddToSession={onPrDiffAddToSession}

--- a/apps/desktop/src/components/workspace-pr-detail-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-detail-view.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/lib/layout-prefs";
 import { PR_OVERVIEW_SHELL_DIVIDER_ATTR } from "@/lib/workspace-tools-panel-edge";
 import { useWorkspaceToolsShellHorizontalDivider } from "@/lib/use-workspace-tools-shell-horizontal-divider";
+import type { PrDiffAttachment } from "@/lib/pr-diff-attachment";
+import { resolvePullRequestChipStatus } from "@/lib/pr-diff-attachment";
 import { cn } from "@/lib/utils";
 import type {
   GitHubPullRequestCheck,
@@ -56,6 +58,7 @@ export type WorkspacePrDetailViewProps = {
   onOpenExternal: (url: string) => void;
   onMerge?: (method: GitHubPullRequestMergeMethod) => void;
   onMarkReady?: () => void;
+  onPrDiffAddToSession?: (attachment: PrDiffAttachment) => void;
   className?: string;
 };
 
@@ -128,6 +131,7 @@ export function WorkspacePrDetailView({
   onOpenExternal,
   onMerge,
   onMarkReady,
+  onPrDiffAddToSession,
   className,
 }: WorkspacePrDetailViewProps) {
   const { t } = useTranslation();
@@ -401,6 +405,9 @@ export function WorkspacePrDetailView({
             files={changedFiles}
             loading={loadingChanges}
             hasMore={changesHasMore}
+            prUrl={detail.url}
+            prStatus={resolvePullRequestChipStatus(detail)}
+            onPrDiffAddToSession={onPrDiffAddToSession}
             onOpenExternal={onOpenExternal}
             className="h-full min-h-0"
           />

--- a/apps/desktop/src/components/workspace-pr-tab.tsx
+++ b/apps/desktop/src/components/workspace-pr-tab.tsx
@@ -127,6 +127,7 @@ export type WorkspacePrTabProps = {
   prRevealEnabled?: boolean;
   prRevealNonce?: number;
   prRevealRequest?: GitHubPullRequestRevealRequest | null;
+  onPrDiffAddToSession?: (attachment: import("@/lib/pr-diff-attachment").PrDiffAttachment) => void;
   className?: string;
 };
 
@@ -150,6 +151,7 @@ export function WorkspacePrTab({
   prRevealEnabled = false,
   prRevealNonce = 0,
   prRevealRequest = null,
+  onPrDiffAddToSession,
   className,
 }: WorkspacePrTabProps) {
   const { t } = useTranslation();
@@ -777,6 +779,7 @@ export function WorkspacePrTab({
             checks={GITHUB_PR_CHECKS_DEMO.checks}
             checksHasMore={GITHUB_PR_CHECKS_DEMO.hasMore}
             onOpenExternal={openExternalUrl}
+            onPrDiffAddToSession={onPrDiffAddToSession}
             className="min-h-0 flex-1"
           />
         </section>
@@ -854,6 +857,7 @@ export function WorkspacePrTab({
               onOpenExternal={openExternalUrl}
               onMerge={handleMergePullRequest}
               onMarkReady={handleMarkPullRequestReady}
+              onPrDiffAddToSession={onPrDiffAddToSession}
               className="min-h-0 flex-1"
             />
           ) : (

--- a/apps/desktop/src/components/workspace-tools-panel.tsx
+++ b/apps/desktop/src/components/workspace-tools-panel.tsx
@@ -117,6 +117,7 @@ export type WorkspaceToolsDockProps = {
   onTabsChange: Dispatch<SetStateAction<WorkspaceToolTab[]>>;
   onActiveTabIdChange(id: string): void;
   onBrowserElementPicked?: WorkspaceBrowserTabProps['onElementPicked'];
+  onPrDiffAddToSession?: (attachment: import("@/lib/pr-diff-attachment").PrDiffAttachment) => void;
   onBrowserOpenInNewTab?: WorkspaceBrowserTabProps['onOpenUrlInNewTab'];
   /** Electron 桌面版可新建/使用浏览器选项卡；Web 宿主菜单项可见但禁用。 */
   browserTabEnabled?: boolean;
@@ -193,6 +194,7 @@ function WorkspaceToolsDockInner({
   onTabsChange,
   onActiveTabIdChange,
   onBrowserElementPicked,
+  onPrDiffAddToSession,
   onBrowserOpenInNewTab,
   browserTabEnabled = false,
   prTabEnabled = false,
@@ -671,6 +673,7 @@ function WorkspaceToolsDockInner({
                         prRevealEnabled={prRevealEnabled}
                         prRevealNonce={prRevealEnabled ? prRevealNonce : 0}
                         prRevealRequest={prRevealEnabled ? prRevealRequest : null}
+                        onPrDiffAddToSession={onPrDiffAddToSession}
                       />
                     </div>
                   ) : (

--- a/apps/desktop/src/hooks/use-text-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-text-selection-action-menu.ts
@@ -53,7 +53,7 @@ export function useTextSelectionActionMenu({
       return;
     }
 
-    const text = selection.toString().trim();
+    const text = readDiffSelectionText(selection);
     if (!text) {
       setOpen(false);
       setAnchor(null);
@@ -147,7 +147,6 @@ export function useTextSelectionActionMenu({
     setOpen,
     anchor,
     selectionText,
-    selection: selectionRef.current,
     dismiss,
     syncFromSelection,
   };

--- a/apps/desktop/src/hooks/use-text-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-text-selection-action-menu.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 
+import { readDiffSelectionText } from "@/lib/pr-diff-selection";
+
 export type SelectionAnchorRect = {
   x: number;
   y: number;

--- a/apps/desktop/src/hooks/use-text-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-text-selection-action-menu.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
 
 export type SelectionAnchorRect = {
   x: number;
@@ -9,7 +9,7 @@ export type SelectionAnchorRect = {
 
 type UseTextSelectionActionMenuOptions = {
   enabled?: boolean;
-  rootRef: React.RefObject<HTMLElement | null>;
+  rootRef: RefObject<HTMLElement | null>;
   isSelectionAllowed?: (selection: Selection, root: HTMLElement) => boolean;
 };
 

--- a/apps/desktop/src/hooks/use-text-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-text-selection-action-menu.ts
@@ -97,23 +97,41 @@ export function useTextSelectionActionMenu({
       return;
     }
 
+    let raf = 0;
+    const scheduleSync = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(syncFromSelection);
+    };
+
     const onMouseUp = () => {
-      window.requestAnimationFrame(syncFromSelection);
+      scheduleSync();
     };
     const onSelectionChange = () => {
-      if (!open) {
-        return;
+      scheduleSync();
+    };
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (
+        event.key === "Shift"
+        || event.key.startsWith("Arrow")
+        || event.key === "Home"
+        || event.key === "End"
+        || event.key === "PageUp"
+        || event.key === "PageDown"
+      ) {
+        scheduleSync();
       }
-      syncFromSelection();
     };
 
     document.addEventListener("mouseup", onMouseUp);
     document.addEventListener("selectionchange", onSelectionChange);
+    document.addEventListener("keyup", onKeyUp);
     return () => {
+      cancelAnimationFrame(raf);
       document.removeEventListener("mouseup", onMouseUp);
       document.removeEventListener("selectionchange", onSelectionChange);
+      document.removeEventListener("keyup", onKeyUp);
     };
-  }, [enabled, open, syncFromSelection]);
+  }, [enabled, syncFromSelection]);
 
   const dismiss = useCallback(() => {
     setOpen(false);

--- a/apps/desktop/src/hooks/use-text-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-text-selection-action-menu.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type SelectionAnchorRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type UseTextSelectionActionMenuOptions = {
+  enabled?: boolean;
+  rootRef: React.RefObject<HTMLElement | null>;
+  isSelectionAllowed?: (selection: Selection, root: HTMLElement) => boolean;
+};
+
+function readSelectionAnchor(selection: Selection): SelectionAnchorRect | null {
+  if (selection.rangeCount === 0 || selection.isCollapsed) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+  if (rect.width <= 0 && rect.height <= 0) {
+    return null;
+  }
+  return {
+    x: rect.left,
+    y: rect.top,
+    width: Math.max(rect.width, 1),
+    height: Math.max(rect.height, 1),
+  };
+}
+
+export function useTextSelectionActionMenu({
+  enabled = true,
+  rootRef,
+  isSelectionAllowed,
+}: UseTextSelectionActionMenuOptions) {
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<SelectionAnchorRect | null>(null);
+  const [selectionText, setSelectionText] = useState("");
+  const selectionRef = useRef<Selection | null>(null);
+
+  const syncFromSelection = useCallback(() => {
+    const root = rootRef.current;
+    const selection = typeof window !== "undefined" ? window.getSelection() : null;
+    if (!enabled || !root || !selection || selection.isCollapsed) {
+      setOpen(false);
+      setAnchor(null);
+      setSelectionText("");
+      selectionRef.current = null;
+      return;
+    }
+
+    const text = selection.toString().trim();
+    if (!text) {
+      setOpen(false);
+      setAnchor(null);
+      setSelectionText("");
+      selectionRef.current = null;
+      return;
+    }
+
+    if (!root.contains(selection.anchorNode) || !root.contains(selection.focusNode)) {
+      setOpen(false);
+      setAnchor(null);
+      setSelectionText("");
+      selectionRef.current = null;
+      return;
+    }
+
+    if (isSelectionAllowed && !isSelectionAllowed(selection, root)) {
+      setOpen(false);
+      setAnchor(null);
+      setSelectionText("");
+      selectionRef.current = null;
+      return;
+    }
+
+    const nextAnchor = readSelectionAnchor(selection);
+    if (!nextAnchor) {
+      setOpen(false);
+      setAnchor(null);
+      setSelectionText("");
+      selectionRef.current = null;
+      return;
+    }
+
+    selectionRef.current = selection;
+    setSelectionText(text);
+    setAnchor(nextAnchor);
+    setOpen(true);
+  }, [enabled, isSelectionAllowed, rootRef]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setOpen(false);
+      return;
+    }
+
+    const onMouseUp = () => {
+      window.requestAnimationFrame(syncFromSelection);
+    };
+    const onSelectionChange = () => {
+      if (!open) {
+        return;
+      }
+      syncFromSelection();
+    };
+
+    document.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("selectionchange", onSelectionChange);
+    return () => {
+      document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("selectionchange", onSelectionChange);
+    };
+  }, [enabled, open, syncFromSelection]);
+
+  const dismiss = useCallback(() => {
+    setOpen(false);
+    setAnchor(null);
+    setSelectionText("");
+    selectionRef.current = null;
+  }, []);
+
+  return {
+    open,
+    setOpen,
+    anchor,
+    selectionText,
+    selection: selectionRef.current,
+    dismiss,
+    syncFromSelection,
+  };
+}

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -21,6 +21,7 @@ import {
   resolveComposerDirectMediaTool,
 } from "@/lib/composer-direct-media";
 import type { BrowserElementAttachment } from "@/lib/browser-element-attachment";
+import type { PrDiffAttachment } from "@/lib/pr-diff-attachment";
 import { useLocalFileAttachmentPreviews } from "@/hooks/useLocalFileAttachmentPreviews";
 import { useWorkspaceFileIndex } from "@/hooks/use-workspace-file-index";
 import type { useDesktopRuntime } from "@/hooks/useDesktopRuntime";
@@ -552,6 +553,11 @@ export function useComposerController({
     [attachLocalFilePath],
   );
 
+  const handlePrDiffAddToSession = useCallback((attachment: PrDiffAttachment) => {
+    composerRichInputRef.current?.insertPrDiffAttachment(attachment);
+    composerRichInputRef.current?.focus();
+  }, []);
+
   const pickLocalFileFromPalette = useCallback(() => {
     void runtime.pickLocalFile().then((filePath) => {
       if (!filePath) {
@@ -870,6 +876,7 @@ export function useComposerController({
     insertSkillTriggerFromPalette,
     removeLocalFileAttachment,
     handleBrowserElementPicked,
+    handlePrDiffAddToSession,
     pickLocalFileFromPalette,
     handleComposerPaste,
     submitComposerMessage,

--- a/apps/desktop/src/lib/composer-agent-mode-policy.ts
+++ b/apps/desktop/src/lib/composer-agent-mode-policy.ts
@@ -1,6 +1,7 @@
 import type { DesktopAgentMode } from "@/lib/agent-mode";
 import type { RichSegment } from "@/lib/composer-segment-model";
 import { emptySegments, hasSkillSegment, isComposerPlainEmpty, mergeAdjacentTextSegments, segmentsToPlainText } from "@/lib/composer-segment-model";
+import { hasInlineAttachmentChipSegments } from "@/lib/composer-inline-chip-dom";
 import { hasLoopSegment } from "@/lib/composer-loop-segments";
 import {
   hasAgentModeSegment,
@@ -41,7 +42,12 @@ export function composerShowsPlaceholder(
   if (opts.composing || opts.attachmentCount > 0) {
     return false;
   }
-  if (hasLoopSegment(segs) || hasAgentModeSegment(segs) || hasSkillSegment(segs)) {
+  if (
+    hasLoopSegment(segs)
+    || hasAgentModeSegment(segs)
+    || hasSkillSegment(segs)
+    || hasInlineAttachmentChipSegments(segs)
+  ) {
     return false;
   }
   return isComposerPlainEmpty(segmentsToPlainText(segs));

--- a/apps/desktop/src/lib/composer-inline-chip-caret.ts
+++ b/apps/desktop/src/lib/composer-inline-chip-caret.ts
@@ -3,8 +3,13 @@ import { emptySegments, mergeAdjacentTextSegments } from "./composer-segment-mod
 
 function isInlineAttachmentChip(
   seg: RichSegment | undefined,
-): seg is Extract<RichSegment, { kind: "element" | "workspaceFile" | "skill" }> {
-  return seg?.kind === "element" || seg?.kind === "workspaceFile" || seg?.kind === "skill";
+): seg is Extract<RichSegment, { kind: "element" | "prDiff" | "workspaceFile" | "skill" }> {
+  return (
+    seg?.kind === "element"
+    || seg?.kind === "prDiff"
+    || seg?.kind === "workspaceFile"
+    || seg?.kind === "skill"
+  );
 }
 
 function caretAfterInlineChip(segs: RichSegment[], chipIndex: number): SegmentCaret {

--- a/apps/desktop/src/lib/composer-inline-chip-dom.ts
+++ b/apps/desktop/src/lib/composer-inline-chip-dom.ts
@@ -1,0 +1,45 @@
+import type { RichSegment } from "./composer-segment-model";
+
+/** DOM markers for inline attachment chips (element / file / PR diff). */
+export const COMPOSER_INLINE_ATTACHMENT_CHIP_SELECTOR =
+  "[data-element-chip='true'],[data-file-chip='true'],[data-pr-diff-chip='true']";
+
+/** DOM markers for all non-text composer chips (incl. mode / loop / skill). */
+export const COMPOSER_INLINE_CHIP_SELECTOR = [
+  COMPOSER_INLINE_ATTACHMENT_CHIP_SELECTOR,
+  "[data-loop-chip='true']",
+  "[data-plan-chip='true']",
+  "[data-ask-chip='true']",
+  "[data-debug-chip='true']",
+  "[data-skill-chip='true']",
+].join(",");
+
+export function isComposerInlineChipElement(el: HTMLElement): boolean {
+  return (
+    el.dataset.elementChip === "true"
+    || el.getAttribute("data-element-chip") === "true"
+    || el.dataset.fileChip === "true"
+    || el.getAttribute("data-file-chip") === "true"
+    || el.dataset.prDiffChip === "true"
+    || el.getAttribute("data-pr-diff-chip") === "true"
+    || el.dataset.loopChip === "true"
+    || el.getAttribute("data-loop-chip") === "true"
+    || el.dataset.planChip === "true"
+    || el.getAttribute("data-plan-chip") === "true"
+    || el.dataset.askChip === "true"
+    || el.getAttribute("data-ask-chip") === "true"
+    || el.dataset.debugChip === "true"
+    || el.getAttribute("data-debug-chip") === "true"
+    || el.dataset.skillChip === "true"
+    || el.getAttribute("data-skill-chip") === "true"
+  );
+}
+
+export function hasInlineAttachmentChipSegments(segs: RichSegment[]): boolean {
+  return segs.some(
+    (segment) =>
+      segment.kind === "element"
+      || segment.kind === "prDiff"
+      || segment.kind === "workspaceFile",
+  );
+}

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -1,7 +1,7 @@
 import type { BrowserElementAttachment } from "./browser-element-attachment";
 import { browserElementContextText } from "./browser-element-wire-text.js";
 import type { PrDiffAttachment } from "./pr-diff-attachment.js";
-import { PR_DIFF_BLOCK_RE, parsePrDiffWireMeta, prDiffContextText } from "./pr-diff-wire-text.js";
+import { parsePrDiffWireMeta, prDiffContextText, scanPrDiffWireBlocks } from "./pr-diff-wire-text.js";
 
 export { browserElementContextText };
 export { prDiffContextText };
@@ -599,27 +599,22 @@ function findWireBlocks(content: string): ParsedWireBlock[] {
     });
   }
 
-  const prDiffRe = new RegExp(PR_DIFF_BLOCK_RE.source, "g");
-  while ((match = prDiffRe.exec(content)) !== null) {
-    const prUrl = match[1]?.trim() ?? "";
-    const meta = match[2]?.trim() ?? "";
-    const diffMatch = /```diff\n([\s\S]*?)\n```/.exec(match[0]);
-    const diffText = diffMatch?.[1] ?? "";
-    const parsed = parsePrDiffWireMeta(meta);
+  for (const block of scanPrDiffWireBlocks(content)) {
+    const parsed = parsePrDiffWireMeta(block.meta);
     if (!parsed) {
       continue;
     }
     blocks.push({
-      index: match.index,
-      length: match[0].length,
+      index: block.index,
+      length: block.length,
       part: {
         kind: "prDiff",
-        prUrl,
+        prUrl: block.prUrl,
         filename: parsed.filename,
         lineStart: parsed.lineStart,
         lineEnd: parsed.lineEnd,
         status: parsed.status,
-        diffText,
+        diffText: block.diffText,
       },
     });
   }

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -1,11 +1,15 @@
 import type { BrowserElementAttachment } from "./browser-element-attachment";
 import { browserElementContextText } from "./browser-element-wire-text.js";
+import type { PrDiffAttachment } from "./pr-diff-attachment.js";
+import { PR_DIFF_BLOCK_RE, parsePrDiffWireMeta, prDiffContextText } from "./pr-diff-wire-text.js";
 
 export { browserElementContextText };
+export { prDiffContextText };
 
 export type RichSegment =
   | { kind: "text"; value: string }
   | { kind: "element"; attachment: BrowserElementAttachment }
+  | { kind: "prDiff"; attachment: PrDiffAttachment }
   | { kind: "workspaceFile"; path: string }
   | { kind: "loop" }
   | { kind: "plan" }
@@ -116,7 +120,23 @@ export function messageSegmentSeparator(prev: RichSegment, next: RichSegment): s
     return "\n";
   }
 
+  if (prev.kind === "text" && next.kind === "prDiff") {
+    const v = prev.value;
+    if (!v) return "\n";
+    if (v.endsWith("\n\n")) return "";
+    if (v.endsWith("\n")) return "\n";
+    return "\n";
+  }
+
   if (prev.kind === "element" && next.kind === "text") {
+    const v = next.value;
+    if (!v) return "";
+    if (v.startsWith("\n\n")) return "\n";
+    if (v.startsWith("\n")) return "\n";
+    return "\n";
+  }
+
+  if (prev.kind === "prDiff" && next.kind === "text") {
     const v = next.value;
     if (!v) return "";
     if (v.startsWith("\n\n")) return "\n";
@@ -145,7 +165,9 @@ export function segmentsToMessageText(segs: RichSegment[]): string {
           ? workspaceFilePlainToken(seg.path)
           : seg.kind === "skill"
             ? seg.alias
-            : browserElementContextText(seg.attachment);
+            : seg.kind === "prDiff"
+              ? prDiffContextText(seg.attachment)
+              : browserElementContextText(seg.attachment);
     if (seg.kind === "text" && !piece) continue;
 
     if (!out) {
@@ -184,6 +206,9 @@ export function segmentsEqual(a: RichSegment[], b: RichSegment[]): boolean {
     if (seg.kind === "element" && other.kind === "element") {
       return seg.attachment.id === other.attachment.id;
     }
+    if (seg.kind === "prDiff" && other.kind === "prDiff") {
+      return seg.attachment.id === other.attachment.id;
+    }
     if (seg.kind === "workspaceFile" && other.kind === "workspaceFile") {
       return seg.path === other.path;
     }
@@ -220,8 +245,8 @@ function pinAgentModeChipFromSegments(
 export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string): RichSegment[] {
   const loopPinned = segs.some((s) => s.kind === "loop");
   const inlineChips = segs.filter(
-    (s): s is Extract<RichSegment, { kind: "element" | "workspaceFile" | "skill" }> =>
-      s.kind === "element" || s.kind === "workspaceFile" || s.kind === "skill",
+    (s): s is Extract<RichSegment, { kind: "element" | "prDiff" | "workspaceFile" | "skill" }> =>
+      s.kind === "element" || s.kind === "prDiff" || s.kind === "workspaceFile" || s.kind === "skill",
   );
 
   let body: RichSegment[];
@@ -233,7 +258,7 @@ export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string
     const out: RichSegment[] = [];
     let textApplied = false;
     for (const seg of segs) {
-      if (seg.kind === "element" || seg.kind === "workspaceFile" || seg.kind === "skill") {
+      if (seg.kind === "element" || seg.kind === "prDiff" || seg.kind === "workspaceFile" || seg.kind === "skill") {
         out.push(seg);
       } else if (seg.kind === "text" && !textApplied) {
         out.push({ kind: "text", value });
@@ -264,8 +289,14 @@ function textFollowingChipInsert(after: string): string {
 
 function isInlineChipSegment(
   seg: RichSegment | undefined,
-): seg is Extract<RichSegment, { kind: "element" | "workspaceFile" | "loop" | "skill" }> {
-  return seg?.kind === "element" || seg?.kind === "workspaceFile" || seg?.kind === "loop" || seg?.kind === "skill";
+): seg is Extract<RichSegment, { kind: "element" | "prDiff" | "workspaceFile" | "loop" | "skill" }> {
+  return (
+    seg?.kind === "element"
+    || seg?.kind === "prDiff"
+    || seg?.kind === "workspaceFile"
+    || seg?.kind === "loop"
+    || seg?.kind === "skill"
+  );
 }
 
 export function insertSegmentAtCaret(
@@ -323,6 +354,17 @@ export function insertSegmentAtCaret(
     );
     if (elIndex >= 0) {
       afterIndex = elIndex + 1;
+      const trailing = normalized[afterIndex];
+      if (trailing?.kind === "text" && trailing.value === " ") {
+        caretOffset = 1;
+      }
+    }
+  } else if (newSegment.kind === "prDiff") {
+    const diffIndex = normalized.findIndex(
+      (s) => s.kind === "prDiff" && s.attachment.id === newSegment.attachment.id,
+    );
+    if (diffIndex >= 0) {
+      afterIndex = diffIndex + 1;
       const trailing = normalized[afterIndex];
       if (trailing?.kind === "text" && trailing.value === " ") {
         caretOffset = 1;
@@ -521,9 +563,70 @@ export function caretAtEnd(segs: RichSegment[]): SegmentCaret {
 export type MessageContentPart =
   | { kind: "text"; value: string }
   | { kind: "element"; tagName: string; url: string; outerHtml: string }
+  | {
+      kind: "prDiff";
+      prUrl: string;
+      filename: string;
+      lineStart: number;
+      lineEnd: number;
+      status: PrDiffAttachment["status"];
+      diffText: string;
+    }
   | { kind: "workspaceFile"; path: string };
 
 const ELEMENT_BLOCK_RE = /Selected element from ([^\n]*):\n```html\n[\s\S]*?\n```/g;
+
+type ParsedWireBlock = {
+  index: number;
+  length: number;
+  part: MessageContentPart;
+};
+
+function findWireBlocks(content: string): ParsedWireBlock[] {
+  const blocks: ParsedWireBlock[] = [];
+
+  let match: RegExpExecArray | null;
+  const elementRe = new RegExp(ELEMENT_BLOCK_RE.source, "g");
+  while ((match = elementRe.exec(content)) !== null) {
+    const url = match[1]?.trim() ?? "";
+    const htmlMatch = /```html\n([\s\S]*?)\n```/.exec(match[0]);
+    const outerHtml = htmlMatch?.[1] ?? "";
+    const firstTag = outerHtml ? (/<(\w[\w-]*)/.exec(outerHtml)?.[1] ?? "element") : "element";
+    blocks.push({
+      index: match.index,
+      length: match[0].length,
+      part: { kind: "element", tagName: firstTag, url, outerHtml },
+    });
+  }
+
+  const prDiffRe = new RegExp(PR_DIFF_BLOCK_RE.source, "g");
+  while ((match = prDiffRe.exec(content)) !== null) {
+    const prUrl = match[1]?.trim() ?? "";
+    const meta = match[2]?.trim() ?? "";
+    const diffMatch = /```diff\n([\s\S]*?)\n```/.exec(match[0]);
+    const diffText = diffMatch?.[1] ?? "";
+    const parsed = parsePrDiffWireMeta(meta);
+    if (!parsed) {
+      continue;
+    }
+    blocks.push({
+      index: match.index,
+      length: match[0].length,
+      part: {
+        kind: "prDiff",
+        prUrl,
+        filename: parsed.filename,
+        lineStart: parsed.lineStart,
+        lineEnd: parsed.lineEnd,
+        status: parsed.status,
+        diffText,
+      },
+    });
+  }
+
+  blocks.sort((left, right) => left.index - right.index);
+  return blocks;
+}
 const WORKSPACE_FILE_REF_IN_TEXT_RE = /@([^\s@]+)/gu;
 
 function expandTextWithWorkspaceFileRefs(text: string): MessageContentPart[] {
@@ -559,34 +662,30 @@ function pushExpandedTextParts(parts: MessageContentPart[], text: string): void 
   }
 }
 
-/** Parse wire-format user message text into text / element / workspace file blocks. */
+/** Parse wire-format user message text into text / element / PR diff / workspace file blocks. */
 export function parseMessageContentParts(content: string): MessageContentPart[] {
   if (!content) {
     return [];
   }
 
+  const blocks = findWireBlocks(content);
+  if (blocks.length === 0) {
+    return expandTextWithWorkspaceFileRefs(content);
+  }
+
   const parts: MessageContentPart[] = [];
   let last = 0;
-  let m: RegExpExecArray | null;
-  const re = new RegExp(ELEMENT_BLOCK_RE.source, "g");
-  while ((m = re.exec(content)) !== null) {
-    if (m.index > last) {
-      pushExpandedTextParts(parts, content.slice(last, m.index));
+  for (const block of blocks) {
+    if (block.index > last) {
+      pushExpandedTextParts(parts, content.slice(last, block.index));
     }
-    const url = m[1].trim();
-    const htmlMatch = /```html\n([\s\S]*?)\n```/.exec(m[0]);
-    const outerHtml = htmlMatch?.[1] ?? "";
-    const firstTag = outerHtml ? (/<(\w[\w-]*)/.exec(outerHtml)?.[1] ?? "element") : "element";
-    parts.push({ kind: "element", tagName: firstTag, url, outerHtml });
-    last = m.index + m[0].length;
+    parts.push(block.part);
+    last = block.index + block.length;
   }
   if (last < content.length) {
     pushExpandedTextParts(parts, content.slice(last));
   }
-  if (parts.length === 0) {
-    return expandTextWithWorkspaceFileRefs(content);
-  }
-  return parts;
+  return parts.length > 0 ? parts : expandTextWithWorkspaceFileRefs(content);
 }
 
 /** Rebuild composer segments from stored message content (e.g. message rewind). */
@@ -601,6 +700,7 @@ export function messageContentToRichSegments(
 
   const segments: RichSegment[] = [];
   let elementIndex = 0;
+  let prDiffIndex = 0;
 
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]!;
@@ -619,14 +719,30 @@ export function messageContentToRichSegments(
       continue;
     }
 
+    if (part.kind === "prDiff") {
+      const attachment: PrDiffAttachment = {
+        id: `${idPrefix}-pr-${prDiffIndex++}`,
+        prUrl: part.prUrl,
+        filename: part.filename,
+        lineStart: part.lineStart,
+        lineEnd: part.lineEnd,
+        diffText: part.diffText,
+        status: part.status,
+      };
+      segments.push({ kind: "prDiff", attachment });
+      continue;
+    }
+
     if (part.kind === "workspaceFile") {
       segments.push({ kind: "workspaceFile", path: part.path });
       continue;
     }
 
     const display = trimMessageTextAroundElements(part.value, {
-      afterElement: prev?.kind === "element" || prev?.kind === "workspaceFile",
-      beforeElement: next?.kind === "element" || next?.kind === "workspaceFile",
+      afterElement:
+        prev?.kind === "element" || prev?.kind === "prDiff" || prev?.kind === "workspaceFile",
+      beforeElement:
+        next?.kind === "element" || next?.kind === "prDiff" || next?.kind === "workspaceFile",
     });
     if (display || segments.length === 0) {
       segments.push({ kind: "text", value: display });

--- a/apps/desktop/src/lib/composer-segment-selection.ts
+++ b/apps/desktop/src/lib/composer-segment-selection.ts
@@ -1,4 +1,5 @@
 import type { RichSegment, SegmentCaret } from "@/lib/composer-segment-model";
+import { isComposerInlineChipElement } from "@/lib/composer-inline-chip-dom";
 
 type WalkState = {
   segmentIndex: number;
@@ -6,22 +7,7 @@ type WalkState = {
 };
 
 function isChip(el: HTMLElement): boolean {
-  return (
-    el.dataset.elementChip === "true" ||
-    el.getAttribute("data-element-chip") === "true" ||
-    el.dataset.fileChip === "true" ||
-    el.getAttribute("data-file-chip") === "true" ||
-    el.dataset.loopChip === "true" ||
-    el.getAttribute("data-loop-chip") === "true" ||
-    el.dataset.planChip === "true" ||
-    el.getAttribute("data-plan-chip") === "true" ||
-    el.dataset.askChip === "true" ||
-    el.getAttribute("data-ask-chip") === "true" ||
-    el.dataset.debugChip === "true" ||
-    el.getAttribute("data-debug-chip") === "true" ||
-    el.dataset.skillChip === "true" ||
-    el.getAttribute("data-skill-chip") === "true"
-  );
+  return isComposerInlineChipElement(el);
 }
 
 function childIndex(parent: Node, child: Node): number {

--- a/apps/desktop/src/lib/composer-segments.ts
+++ b/apps/desktop/src/lib/composer-segments.ts
@@ -1,4 +1,5 @@
 import { makeChipNode } from "@/lib/browser-element-chip-styles";
+import { makePrDiffChipNode } from "@/lib/github-pr-diff-chip-styles";
 import { makeFileChipNode } from "@/lib/workspace-file-chip-styles";
 import type { RichSegment } from "@/lib/composer-segment-model";
 import {
@@ -48,6 +49,7 @@ export {
 export { normalizeCaretForComposer } from "@/lib/composer-caret-normalize";
 
 export { makeChipNode } from "@/lib/browser-element-chip-styles";
+export { makePrDiffChipNode } from "@/lib/github-pr-diff-chip-styles";
 export { makeFileChipNode } from "@/lib/workspace-file-chip-styles";
 export {
   caretAfterAgentModeChip,
@@ -141,6 +143,35 @@ function appendSegmentFromNode(node: Node, segs: RichSegment[]): void {
     }
     return;
   }
+  if (el.dataset.prDiffChip === "true" || el.getAttribute("data-pr-diff-chip") === "true") {
+    const id = el.dataset.prDiffId;
+    const prUrl = el.dataset.prDiffUrl;
+    const filename = el.dataset.prDiffFilename;
+    const lineStart = Number(el.dataset.prDiffLineStart ?? "0");
+    const lineEnd = Number(el.dataset.prDiffLineEnd ?? "0");
+    const diffText = el.dataset.prDiffText ?? "";
+    const status = el.dataset.prDiffStatus;
+    if (
+      id
+      && prUrl
+      && filename
+      && (status === "open" || status === "merged" || status === "closed" || status === "draft")
+    ) {
+      segs.push({
+        kind: "prDiff",
+        attachment: {
+          id,
+          prUrl,
+          filename,
+          lineStart,
+          lineEnd,
+          diffText,
+          status,
+        },
+      });
+    }
+    return;
+  }
   if (el.dataset.skillChip === "true" || el.getAttribute("data-skill-chip") === "true") {
     const alias = el.dataset.skillAlias ?? el.getAttribute("data-skill-alias");
     if (alias) {
@@ -182,6 +213,8 @@ export function segmentsToDom(
       frag.appendChild(makeDebugChipNode(doc, opts?.debugLabel ?? "Debug"));
     } else if (seg.kind === "workspaceFile") {
       frag.appendChild(makeFileChipNode(seg.path, doc));
+    } else if (seg.kind === "prDiff") {
+      frag.appendChild(makePrDiffChipNode(seg.attachment, doc));
     } else if (seg.kind === "skill") {
       frag.appendChild(makeSkillChipNode(seg.alias, doc));
     } else {

--- a/apps/desktop/src/lib/github-pr-diff-chip-styles.ts
+++ b/apps/desktop/src/lib/github-pr-diff-chip-styles.ts
@@ -1,0 +1,93 @@
+import { workspaceFileBasename } from "@/lib/file-picker-path";
+import { GITHUB_PR_CLOSED_CHIP_CLASS } from "@/lib/github-pr-merged-badge-styles";
+import type { PrDiffAttachment, PullRequestChipStatus } from "@/lib/pr-diff-attachment";
+
+const PR_DIFF_CHIP_BASE =
+  "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-xs font-medium leading-none select-none align-middle mx-0.5";
+
+export function prDiffChipClassForStatus(status: PullRequestChipStatus): string {
+  switch (status) {
+    case "merged":
+      return `${PR_DIFF_CHIP_BASE} border-transparent bg-[#7954dc]/15 text-[#575786] dark:bg-[#855ae8]/22 dark:text-[#7574a6]`;
+    case "closed":
+      return `${PR_DIFF_CHIP_BASE} ${GITHUB_PR_CLOSED_CHIP_CLASS}`;
+    case "draft":
+      return `${PR_DIFF_CHIP_BASE} border-border/50 bg-background text-foreground/75 dark:border-white/10 dark:bg-input/30 dark:text-foreground/70`;
+    case "open":
+    default:
+      return `${PR_DIFF_CHIP_BASE} border-transparent bg-[#1a7f37]/15 text-[#296837] dark:bg-[#238636]/22 dark:text-[#57a773]`;
+  }
+}
+
+export function formatPrDiffChipLabel(
+  filename: string,
+  lineStart: number,
+  lineEnd: number,
+): string {
+  const base = workspaceFileBasename(filename.replace(/\\/gu, "/"));
+  if (lineStart > 0 && lineEnd > 0) {
+    return `${base} L${lineStart}-${lineEnd}`;
+  }
+  return base;
+}
+
+export function formatPrDiffChipTitle(attachment: PrDiffAttachment): string {
+  const normalized = attachment.filename.replace(/\\/gu, "/");
+  const linePart =
+    attachment.lineStart > 0 && attachment.lineEnd > 0
+      ? ` — L${attachment.lineStart}-${attachment.lineEnd}`
+      : "";
+  return `${normalized} — ${attachment.prUrl}${linePart}`;
+}
+
+const GIT_PULL_REQUEST_ICON_PATH =
+  '<circle cx="6" cy="6" r="3"/><path d="M6 9v12"/><path d="M21 3v5a4 4 0 0 1-4 4H6"/>';
+
+const GIT_PULL_REQUEST_CLOSED_ICON_PATH =
+  '<circle cx="6" cy="6" r="3"/><path d="M6 9v12"/><path d="M21 3v5a4 4 0 0 1-4 4H6"/><path d="m18 9-6 6"/><path d="m12 9 6 6"/>';
+
+const GIT_PULL_REQUEST_DRAFT_ICON_PATH =
+  '<circle cx="6" cy="6" r="3"/><path d="M6 9v12"/><path d="M21 3v5a4 4 0 0 1-4 4H6"/><path d="M15 3h2v4"/><path d="M17 5h-4"/>';
+
+function prDiffIconPaths(status: PullRequestChipStatus): string {
+  switch (status) {
+    case "closed":
+      return GIT_PULL_REQUEST_CLOSED_ICON_PATH;
+    case "draft":
+      return GIT_PULL_REQUEST_DRAFT_ICON_PATH;
+    default:
+      return GIT_PULL_REQUEST_ICON_PATH;
+  }
+}
+
+export function makePrDiffChipNode(attachment: PrDiffAttachment, doc: Document): HTMLElement {
+  const span = doc.createElement("span");
+  span.contentEditable = "false";
+  span.dataset.prDiffId = attachment.id;
+  span.dataset.prDiffUrl = attachment.prUrl;
+  span.dataset.prDiffFilename = attachment.filename;
+  span.dataset.prDiffLineStart = String(attachment.lineStart);
+  span.dataset.prDiffLineEnd = String(attachment.lineEnd);
+  span.dataset.prDiffText = attachment.diffText;
+  span.dataset.prDiffStatus = attachment.status;
+  span.setAttribute("data-pr-diff-chip", "true");
+  span.className = prDiffChipClassForStatus(attachment.status);
+  span.title = formatPrDiffChipTitle(attachment);
+
+  const icon = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("width", "10");
+  icon.setAttribute("height", "10");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("aria-hidden", "true");
+  icon.innerHTML = prDiffIconPaths(attachment.status);
+  span.appendChild(icon);
+  span.appendChild(
+    doc.createTextNode(formatPrDiffChipLabel(attachment.filename, attachment.lineStart, attachment.lineEnd)),
+  );
+  return span;
+}

--- a/apps/desktop/src/lib/github-pr-diff-chip-styles.ts
+++ b/apps/desktop/src/lib/github-pr-diff-chip-styles.ts
@@ -49,12 +49,17 @@ const GIT_PULL_REQUEST_CLOSED_ICON_PATH =
 const GIT_PULL_REQUEST_DRAFT_ICON_PATH =
   '<circle cx="6" cy="6" r="3"/><path d="M6 9v12"/><path d="M21 3v5a4 4 0 0 1-4 4H6"/><path d="M15 3h2v4"/><path d="M17 5h-4"/>';
 
+const GIT_PULL_REQUEST_MERGED_ICON_PATH =
+  '<circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M6 21V9a9 9 0 0 0 9 9"/>';
+
 function prDiffIconPaths(status: PullRequestChipStatus): string {
   switch (status) {
     case "closed":
       return GIT_PULL_REQUEST_CLOSED_ICON_PATH;
     case "draft":
       return GIT_PULL_REQUEST_DRAFT_ICON_PATH;
+    case "merged":
+      return GIT_PULL_REQUEST_MERGED_ICON_PATH;
     default:
       return GIT_PULL_REQUEST_ICON_PATH;
   }

--- a/apps/desktop/src/lib/github-pr-diff-chip-styles.ts
+++ b/apps/desktop/src/lib/github-pr-diff-chip-styles.ts
@@ -70,6 +70,7 @@ export function makePrDiffChipNode(attachment: PrDiffAttachment, doc: Document):
   span.dataset.prDiffLineEnd = String(attachment.lineEnd);
   span.dataset.prDiffText = attachment.diffText;
   span.dataset.prDiffStatus = attachment.status;
+  span.dataset.prDiffChip = "true";
   span.setAttribute("data-pr-diff-chip", "true");
   span.className = prDiffChipClassForStatus(attachment.status);
   span.title = formatPrDiffChipTitle(attachment);

--- a/apps/desktop/src/lib/github-pr-merged-badge-styles.ts
+++ b/apps/desktop/src/lib/github-pr-merged-badge-styles.ts
@@ -12,3 +12,7 @@ export const GITHUB_PR_OPEN_BADGE_CLASS =
 /** GitHub draft pull request badge — neutral monochrome. */
 export const GITHUB_PR_DRAFT_BADGE_CLASS =
   "gap-1 border-border/50 bg-background text-foreground/75 dark:border-white/10 dark:bg-input/30 dark:text-foreground/70";
+
+/** Inline PR diff chip when PR is closed — aligned with secondary Badge. */
+export const GITHUB_PR_CLOSED_CHIP_CLASS =
+  "border-border/50 bg-muted text-muted-foreground dark:border-white/10 dark:bg-input/30 dark:text-foreground/70";

--- a/apps/desktop/src/lib/pr-diff-attachment.ts
+++ b/apps/desktop/src/lib/pr-diff-attachment.ts
@@ -1,0 +1,31 @@
+export type PullRequestChipStatus = "open" | "merged" | "closed" | "draft";
+
+export interface PrDiffAttachment {
+  id: string;
+  prUrl: string;
+  filename: string;
+  /** Unified diff new-side line numbers (gutter); frozen at insert time. */
+  lineStart: number;
+  lineEnd: number;
+  /** Git diff-style snippet for the agent. */
+  diffText: string;
+  /** Frozen at insert time; drives chip colors only. */
+  status: PullRequestChipStatus;
+}
+
+export function resolvePullRequestChipStatus(detail: {
+  merged: boolean;
+  state: "open" | "closed";
+  draft: boolean;
+}): PullRequestChipStatus {
+  if (detail.merged) {
+    return "merged";
+  }
+  if (detail.state === "closed") {
+    return "closed";
+  }
+  if (detail.draft) {
+    return "draft";
+  }
+  return "open";
+}

--- a/apps/desktop/src/lib/pr-diff-patch-slice.ts
+++ b/apps/desktop/src/lib/pr-diff-patch-slice.ts
@@ -2,10 +2,18 @@ import {
   parseDiff,
 } from "react-diff-view";
 
+import type { PrDiffLineRange } from "./pr-diff-selection.js";
+
 type ParsedDiffChange = {
   type: "normal" | "insert" | "delete";
   content: string;
 };
+
+type DiffChangeLike = ParsedDiffChange & { lineNumber?: number; newLineNumber?: number };
+
+function asDiffChangeLike(change: unknown): DiffChangeLike {
+  return change as DiffChangeLike;
+}
 
 function normalizeDiffPath(filename: string): string {
   return filename.replace(/\\/gu, "/").trim() || "file";
@@ -25,7 +33,7 @@ function wrapPatchAsUnifiedDiff(filename: string, patch: string): string {
   ].join("\n");
 }
 
-function displayLineNumber(change: ParsedDiffChange & Record<string, unknown>): number {
+function displayLineNumber(change: DiffChangeLike): number {
   if (change.type === "delete") {
     return typeof change.lineNumber === "number" ? change.lineNumber : -1;
   }
@@ -71,7 +79,7 @@ export function extractPatchBodyForLineRange(
   const bodyLines: string[] = [];
   for (const hunk of hunks) {
     const selectedChanges = hunk.changes.filter((change) => {
-      const line = displayLineNumber(change as ParsedDiffChange & Record<string, unknown>);
+      const line = displayLineNumber(asDiffChangeLike(change));
       return line >= lineStart && line <= lineEnd;
     });
     if (selectedChanges.length === 0) {
@@ -79,9 +87,53 @@ export function extractPatchBodyForLineRange(
     }
     bodyLines.push(hunk.content);
     for (const change of selectedChanges) {
-      bodyLines.push(formatUnifiedChangeLine(change as ParsedDiffChange));
+      bodyLines.push(formatUnifiedChangeLine(asDiffChangeLike(change)));
     }
   }
 
   return bodyLines.join("\n");
+}
+
+/** Infer gutter line range by matching selected plain text against patch change lines. */
+export function inferLineRangeFromPatch(
+  filename: string,
+  patch: string,
+  selectedText: string,
+): PrDiffLineRange | null {
+  const needle = selectedText.trim();
+  if (!needle) {
+    return null;
+  }
+
+  const diffText = wrapPatchAsUnifiedDiff(filename, patch);
+  if (!diffText) {
+    return null;
+  }
+
+  let hunks;
+  try {
+    hunks = parseDiff(diffText, { nearbySequences: "zip" })[0]?.hunks ?? [];
+  } catch {
+    return null;
+  }
+
+  const matchedLines: number[] = [];
+  const selectedLines = needle.split("\n");
+  for (const hunk of hunks) {
+    for (const change of hunk.changes) {
+      const content = asDiffChangeLike(change).content;
+      if (selectedLines.some((line) => line === content || line.trim() === content.trim())) {
+        matchedLines.push(displayLineNumber(asDiffChangeLike(change)));
+      }
+    }
+  }
+
+  const valid = matchedLines.filter((line) => line > 0);
+  if (valid.length === 0) {
+    return null;
+  }
+  return {
+    lineStart: Math.min(...valid),
+    lineEnd: Math.max(...valid),
+  };
 }

--- a/apps/desktop/src/lib/pr-diff-patch-slice.ts
+++ b/apps/desktop/src/lib/pr-diff-patch-slice.ts
@@ -1,0 +1,87 @@
+import {
+  parseDiff,
+} from "react-diff-view";
+
+type ParsedDiffChange = {
+  type: "normal" | "insert" | "delete";
+  content: string;
+};
+
+function normalizeDiffPath(filename: string): string {
+  return filename.replace(/\\/gu, "/").trim() || "file";
+}
+
+function wrapPatchAsUnifiedDiff(filename: string, patch: string): string {
+  const normalizedPath = normalizeDiffPath(filename);
+  const hunk = patch.trim();
+  if (!hunk) {
+    return "";
+  }
+  return [
+    `diff --git a/${normalizedPath} b/${normalizedPath}`,
+    `--- a/${normalizedPath}`,
+    `+++ b/${normalizedPath}`,
+    hunk,
+  ].join("\n");
+}
+
+function displayLineNumber(change: ParsedDiffChange & Record<string, unknown>): number {
+  if (change.type === "delete") {
+    return typeof change.lineNumber === "number" ? change.lineNumber : -1;
+  }
+  if (change.type === "insert") {
+    return typeof change.lineNumber === "number" ? change.lineNumber : -1;
+  }
+  return typeof change.newLineNumber === "number" ? change.newLineNumber : -1;
+}
+
+function formatUnifiedChangeLine(change: ParsedDiffChange): string {
+  if (change.type === "insert") {
+    return `+${change.content}`;
+  }
+  if (change.type === "delete") {
+    return `-${change.content}`;
+  }
+  return ` ${change.content}`;
+}
+
+/** Slice GitHub file patch hunks to the gutter line range shown in PR Changes diff view. */
+export function extractPatchBodyForLineRange(
+  filename: string,
+  patch: string,
+  lineStart: number,
+  lineEnd: number,
+): string {
+  if (lineStart <= 0 || lineEnd <= 0 || lineStart > lineEnd) {
+    return "";
+  }
+
+  const diffText = wrapPatchAsUnifiedDiff(filename, patch);
+  if (!diffText) {
+    return "";
+  }
+
+  let hunks;
+  try {
+    hunks = parseDiff(diffText, { nearbySequences: "zip" })[0]?.hunks ?? [];
+  } catch {
+    return "";
+  }
+
+  const bodyLines: string[] = [];
+  for (const hunk of hunks) {
+    const selectedChanges = hunk.changes.filter((change) => {
+      const line = displayLineNumber(change as ParsedDiffChange & Record<string, unknown>);
+      return line >= lineStart && line <= lineEnd;
+    });
+    if (selectedChanges.length === 0) {
+      continue;
+    }
+    bodyLines.push(hunk.content);
+    for (const change of selectedChanges) {
+      bodyLines.push(formatUnifiedChangeLine(change as ParsedDiffChange));
+    }
+  }
+
+  return bodyLines.join("\n");
+}

--- a/apps/desktop/src/lib/pr-diff-selection.ts
+++ b/apps/desktop/src/lib/pr-diff-selection.ts
@@ -126,5 +126,9 @@ export function resolveDiffSelectionLineRange(root: HTMLElement, selection: Sele
 }
 
 export function readDiffSelectionText(selection: Selection | null): string {
-  return selection?.toString().trim() ?? "";
+  if (!selection) {
+    return "";
+  }
+  const text = selection.toString();
+  return /^\s*$/u.test(text) ? "" : text;
 }

--- a/apps/desktop/src/lib/pr-diff-selection.ts
+++ b/apps/desktop/src/lib/pr-diff-selection.ts
@@ -45,12 +45,32 @@ function diffLineFromNode(node: Node | null): HTMLTableRowElement | null {
   return null;
 }
 
-function lineNumberFromDiffRow(row: HTMLTableRowElement): number | null {
-  const gutter = row.querySelector(".diff-gutter");
-  if (!gutter) {
-    return null;
+function collectDiffLinesForSelection(root: HTMLElement, selection: Selection): HTMLTableRowElement[] {
+  const range = selection.getRangeAt(0);
+  const rows = new Set<HTMLTableRowElement>();
+  for (const row of collectDiffLinesInRange(range, root)) {
+    rows.add(row);
   }
-  return parseGutterLineNumber(gutter);
+  const startRow = diffLineFromNode(range.startContainer);
+  const endRow = diffLineFromNode(range.endContainer);
+  if (startRow) {
+    rows.add(startRow);
+  }
+  if (endRow) {
+    rows.add(endRow);
+  }
+  return [...rows];
+}
+
+function lineNumberFromDiffRow(row: HTMLTableRowElement): number | null {
+  const gutters = row.querySelectorAll(".diff-gutter");
+  for (const gutter of gutters) {
+    const parsed = parseGutterLineNumber(gutter);
+    if (parsed != null) {
+      return parsed;
+    }
+  }
+  return null;
 }
 
 function collectDiffLinesInRange(range: Range, root: HTMLElement): HTMLTableRowElement[] {
@@ -76,7 +96,7 @@ export function resolveDiffSelectionLineRange(root: HTMLElement, selection: Sele
     return null;
   }
 
-  const rows = collectDiffLinesInRange(range, root);
+  const rows = collectDiffLinesForSelection(root, selection);
   const lineNumbers = rows
     .map((row) => lineNumberFromDiffRow(row))
     .filter((value): value is number => value != null);

--- a/apps/desktop/src/lib/pr-diff-selection.ts
+++ b/apps/desktop/src/lib/pr-diff-selection.ts
@@ -1,0 +1,85 @@
+export type PrDiffLineRange = {
+  lineStart: number;
+  lineEnd: number;
+};
+
+function parseGutterLineNumber(gutter: Element): number | null {
+  const text = gutter.textContent?.trim() ?? "";
+  if (!text || !/^\d+$/u.test(text)) {
+    return null;
+  }
+  return Number(text);
+}
+
+function diffLineFromNode(node: Node | null): HTMLTableRowElement | null {
+  let current: Node | null = node;
+  while (current) {
+    if (current instanceof HTMLTableRowElement && current.classList.contains("diff-line")) {
+      return current;
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+function lineNumberFromDiffRow(row: HTMLTableRowElement): number | null {
+  const gutter = row.querySelector(".diff-gutter");
+  if (!gutter) {
+    return null;
+  }
+  return parseGutterLineNumber(gutter);
+}
+
+function collectDiffLinesInRange(range: Range, root: HTMLElement): HTMLTableRowElement[] {
+  const rows = Array.from(root.querySelectorAll("tr.diff-line"));
+  return rows.filter((row) => {
+    try {
+      return range.intersectsNode(row);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/** Resolve unified diff gutter line numbers for the current DOM selection. */
+export function resolveDiffSelectionLineRange(root: HTMLElement, selection: Selection | null): PrDiffLineRange | null {
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) {
+    return null;
+  }
+  const range = selection.getRangeAt(0);
+  if (!root.contains(range.commonAncestorContainer)) {
+    return null;
+  }
+
+  const rows = collectDiffLinesInRange(range, root);
+  const lineNumbers = rows
+    .map((row) => lineNumberFromDiffRow(row))
+    .filter((value): value is number => value != null);
+
+  if (lineNumbers.length > 0) {
+    return {
+      lineStart: Math.min(...lineNumbers),
+      lineEnd: Math.max(...lineNumbers),
+    };
+  }
+
+  const startRow = diffLineFromNode(range.startContainer);
+  const endRow = diffLineFromNode(range.endContainer);
+  const fallback = [startRow, endRow]
+    .filter((row): row is HTMLTableRowElement => row != null)
+    .map((row) => lineNumberFromDiffRow(row))
+    .filter((value): value is number => value != null);
+
+  if (fallback.length === 0) {
+    return null;
+  }
+
+  return {
+    lineStart: Math.min(...fallback),
+    lineEnd: Math.max(...fallback),
+  };
+}
+
+export function readDiffSelectionText(selection: Selection | null): string {
+  return selection?.toString().trim() ?? "";
+}

--- a/apps/desktop/src/lib/pr-diff-selection.ts
+++ b/apps/desktop/src/lib/pr-diff-selection.ts
@@ -3,6 +3,29 @@ export type PrDiffLineRange = {
   lineEnd: number;
 };
 
+export function findChangedFileFromNode(node: Node | null, root: HTMLElement): string | null {
+  let current: Node | null = node;
+  while (current && current !== root) {
+    if (current instanceof HTMLElement) {
+      const filename = current.dataset.prChangedFile;
+      if (filename) {
+        return filename;
+      }
+    }
+    current = current.parentNode;
+  }
+  return null;
+}
+
+export function resolveChangedFileFromSelection(selection: Selection, root: HTMLElement): string | null {
+  const anchorFile = findChangedFileFromNode(selection.anchorNode, root);
+  const focusFile = findChangedFileFromNode(selection.focusNode, root);
+  if (!anchorFile || !focusFile || anchorFile !== focusFile) {
+    return null;
+  }
+  return anchorFile;
+}
+
 function parseGutterLineNumber(gutter: Element): number | null {
   const text = gutter.textContent?.trim() ?? "";
   if (!text || !/^\d+$/u.test(text)) {

--- a/apps/desktop/src/lib/pr-diff-selection.ts
+++ b/apps/desktop/src/lib/pr-diff-selection.ts
@@ -31,7 +31,9 @@ function lineNumberFromDiffRow(row: HTMLTableRowElement): number | null {
 }
 
 function collectDiffLinesInRange(range: Range, root: HTMLElement): HTMLTableRowElement[] {
-  const rows = Array.from(root.querySelectorAll("tr.diff-line"));
+  const rows = Array.from(root.querySelectorAll("tr.diff-line")).filter(
+    (row): row is HTMLTableRowElement => row instanceof HTMLTableRowElement,
+  );
   return rows.filter((row) => {
     try {
       return range.intersectsNode(row);

--- a/apps/desktop/src/lib/pr-diff-text.ts
+++ b/apps/desktop/src/lib/pr-diff-text.ts
@@ -1,6 +1,21 @@
-export function buildPrDiffSnippetText(filename: string, selectedText: string): string {
-  const normalizedPath = filename.replace(/\\/gu, "/").trim() || "file";
-  const body = selectedText.trim();
+import { extractPatchBodyForLineRange } from "@/lib/pr-diff-patch-slice";
+
+function normalizeDiffPath(filename: string): string {
+  return filename.replace(/\\/gu, "/").trim() || "file";
+}
+
+type BuildPrDiffSnippetOptions = {
+  /** Body is already unified diff hunk lines (with +/- prefixes). */
+  fromPatchBody?: boolean;
+};
+
+export function buildPrDiffSnippetText(
+  filename: string,
+  selectedText: string,
+  options?: BuildPrDiffSnippetOptions,
+): string {
+  const normalizedPath = normalizeDiffPath(filename);
+  const body = options?.fromPatchBody ? selectedText : selectedText.trim();
   if (!body) {
     return "";
   }
@@ -10,4 +25,17 @@ export function buildPrDiffSnippetText(filename: string, selectedText: string): 
     `+++ b/${normalizedPath}`,
     body,
   ].join("\n");
+}
+
+export function buildPrDiffSnippetFromPatch(
+  filename: string,
+  patch: string,
+  lineStart: number,
+  lineEnd: number,
+): string {
+  const body = extractPatchBodyForLineRange(filename, patch, lineStart, lineEnd);
+  if (!body) {
+    return "";
+  }
+  return buildPrDiffSnippetText(filename, body, { fromPatchBody: true });
 }

--- a/apps/desktop/src/lib/pr-diff-text.ts
+++ b/apps/desktop/src/lib/pr-diff-text.ts
@@ -1,0 +1,13 @@
+export function buildPrDiffSnippetText(filename: string, selectedText: string): string {
+  const normalizedPath = filename.replace(/\\/gu, "/").trim() || "file";
+  const body = selectedText.trim();
+  if (!body) {
+    return "";
+  }
+  return [
+    `diff --git a/${normalizedPath} b/${normalizedPath}`,
+    `--- a/${normalizedPath}`,
+    `+++ b/${normalizedPath}`,
+    body,
+  ].join("\n");
+}

--- a/apps/desktop/src/lib/pr-diff-text.ts
+++ b/apps/desktop/src/lib/pr-diff-text.ts
@@ -15,7 +15,11 @@ export function buildPrDiffSnippetText(
   options?: BuildPrDiffSnippetOptions,
 ): string {
   const normalizedPath = normalizeDiffPath(filename);
-  const body = options?.fromPatchBody ? selectedText : selectedText.trim();
+  const body = options?.fromPatchBody
+    ? selectedText
+    : /^\s*$/u.test(selectedText)
+      ? ""
+      : selectedText;
   if (!body) {
     return "";
   }

--- a/apps/desktop/src/lib/pr-diff-wire-text.ts
+++ b/apps/desktop/src/lib/pr-diff-wire-text.ts
@@ -1,0 +1,48 @@
+import type { PrDiffAttachment } from "./pr-diff-attachment.js";
+
+function formatPrDiffWireMeta(attachment: Pick<PrDiffAttachment, "filename" | "lineStart" | "lineEnd" | "status">): string {
+  const normalized = attachment.filename.replace(/\\/gu, "/").trim() || "file";
+  const hasLines = attachment.lineStart > 0 && attachment.lineEnd > 0;
+  const linePart = hasLines ? `, L${attachment.lineStart}-${attachment.lineEnd}` : "";
+  return `${normalized}${linePart}, status:${attachment.status}`;
+}
+
+/** Wire-format PR diff block (shared by attachment + composer segment model). */
+export function prDiffContextText(attachment: Pick<PrDiffAttachment, "prUrl" | "filename" | "lineStart" | "lineEnd" | "status" | "diffText">): string {
+  const meta = formatPrDiffWireMeta(attachment);
+  return `Selected diff from ${attachment.prUrl} (${meta}):\n\`\`\`diff\n${attachment.diffText}\n\`\`\``;
+}
+
+export const PR_DIFF_BLOCK_RE =
+  /Selected diff from ([^\n]+) \(([^)]*)\):\n```diff\n[\s\S]*?\n```/g;
+
+export function parsePrDiffWireMeta(meta: string): {
+  filename: string;
+  lineStart: number;
+  lineEnd: number;
+  status: PrDiffAttachment["status"];
+} | null {
+  const trimmed = meta.trim();
+  const statusMatch = /,\s*status:(open|merged|closed|draft)\s*$/u.exec(trimmed);
+  if (!statusMatch) {
+    return null;
+  }
+  const status = statusMatch[1] as PrDiffAttachment["status"];
+  const beforeStatus = trimmed.slice(0, statusMatch.index);
+  const lineMatch = /,\s*L(\d+)-(\d+)\s*$/u.exec(beforeStatus);
+  if (lineMatch) {
+    const filename = beforeStatus.slice(0, lineMatch.index).trim();
+    return {
+      filename,
+      lineStart: Number(lineMatch[1]),
+      lineEnd: Number(lineMatch[2]),
+      status,
+    };
+  }
+  return {
+    filename: beforeStatus.trim(),
+    lineStart: 0,
+    lineEnd: 0,
+    status,
+  };
+}

--- a/apps/desktop/src/lib/pr-diff-wire-text.ts
+++ b/apps/desktop/src/lib/pr-diff-wire-text.ts
@@ -3,8 +3,8 @@ import type { PrDiffAttachment } from "./pr-diff-attachment.js";
 function formatPrDiffWireMeta(attachment: Pick<PrDiffAttachment, "filename" | "lineStart" | "lineEnd" | "status">): string {
   const normalized = attachment.filename.replace(/\\/gu, "/").trim() || "file";
   const hasLines = attachment.lineStart > 0 && attachment.lineEnd > 0;
-  const linePart = hasLines ? `, L${attachment.lineStart}-${attachment.lineEnd}` : "";
-  return `${normalized}${linePart}, status:${attachment.status}`;
+  const linePart = hasLines ? `L${attachment.lineStart}-${attachment.lineEnd}` : "-";
+  return `${normalized}\t${linePart}\t${attachment.status}`;
 }
 
 const PR_DIFF_HEADER_PREFIX = "Selected diff from ";
@@ -113,6 +113,30 @@ export function parsePrDiffWireMeta(meta: string): {
   status: PrDiffAttachment["status"];
 } | null {
   const trimmed = meta.trim();
+  const tabParts = trimmed.split("\t");
+  if (tabParts.length === 3) {
+    const filename = tabParts[0]?.trim() ?? "";
+    const linePart = tabParts[1]?.trim() ?? "";
+    const statusRaw = tabParts[2]?.trim() ?? "";
+    if (
+      filename
+      && (statusRaw === "open" || statusRaw === "merged" || statusRaw === "closed" || statusRaw === "draft")
+    ) {
+      if (linePart === "-") {
+        return { filename, lineStart: 0, lineEnd: 0, status: statusRaw };
+      }
+      const lineMatch = /^L(\d+)-(\d+)$/u.exec(linePart);
+      if (lineMatch) {
+        return {
+          filename,
+          lineStart: Number(lineMatch[1]),
+          lineEnd: Number(lineMatch[2]),
+          status: statusRaw,
+        };
+      }
+    }
+  }
+
   const statusMatch = /,\s*status:(open|merged|closed|draft)\s*$/u.exec(trimmed);
   if (!statusMatch) {
     return null;

--- a/apps/desktop/src/lib/pr-diff-wire-text.ts
+++ b/apps/desktop/src/lib/pr-diff-wire-text.ts
@@ -7,12 +7,102 @@ function formatPrDiffWireMeta(attachment: Pick<PrDiffAttachment, "filename" | "l
   return `${normalized}${linePart}, status:${attachment.status}`;
 }
 
+const PR_DIFF_HEADER_PREFIX = "Selected diff from ";
+const PR_DIFF_HEADER_RE = /^Selected diff from ([^\n]+?) \(([^)]*)\):$/u;
+
+function chooseDiffFence(diffText: string): { open: string; close: string } {
+  if (!/^\s*```/m.test(diffText)) {
+    return { open: "```diff\n", close: "\n```" };
+  }
+  return { open: "````diff\n", close: "\n````" };
+}
+
 /** Wire-format PR diff block (shared by attachment + composer segment model). */
 export function prDiffContextText(attachment: Pick<PrDiffAttachment, "prUrl" | "filename" | "lineStart" | "lineEnd" | "status" | "diffText">): string {
   const meta = formatPrDiffWireMeta(attachment);
-  return `Selected diff from ${attachment.prUrl} (${meta}):\n\`\`\`diff\n${attachment.diffText}\n\`\`\``;
+  const fence = chooseDiffFence(attachment.diffText);
+  return `Selected diff from ${attachment.prUrl} (${meta}):\n${fence.open}${attachment.diffText}${fence.close}`;
 }
 
+export type ParsedPrDiffWireBlock = {
+  index: number;
+  length: number;
+  prUrl: string;
+  meta: string;
+  diffText: string;
+};
+
+const PR_DIFF_OPEN_FENCE_RE = /^(`{3,})diff\n/;
+
+/** Scan wire text for PR diff blocks; closing fence must be a standalone line. */
+export function scanPrDiffWireBlocks(content: string): ParsedPrDiffWireBlock[] {
+  const blocks: ParsedPrDiffWireBlock[] = [];
+  let searchFrom = 0;
+
+  while (searchFrom < content.length) {
+    const headerIndex = content.indexOf(PR_DIFF_HEADER_PREFIX, searchFrom);
+    if (headerIndex === -1) {
+      break;
+    }
+
+    const headerLineEnd = content.indexOf("\n", headerIndex);
+    if (headerLineEnd === -1) {
+      break;
+    }
+
+    const headerLine = content.slice(headerIndex, headerLineEnd);
+    const headerMatch = PR_DIFF_HEADER_RE.exec(headerLine);
+    if (!headerMatch) {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+
+    let cursor = headerLineEnd + 1;
+    const fenceTail = content.slice(cursor);
+    const openFenceMatch = PR_DIFF_OPEN_FENCE_RE.exec(fenceTail);
+    if (!openFenceMatch) {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+    const fenceMark = openFenceMatch[1] ?? "```";
+    const closeFence = fenceMark;
+    cursor += openFenceMatch[0].length;
+
+    const diffLines: string[] = [];
+    let closed = false;
+    while (cursor <= content.length) {
+      const nextLineEnd = content.indexOf("\n", cursor);
+      const lineEnd = nextLineEnd === -1 ? content.length : nextLineEnd;
+      const line = content.slice(cursor, lineEnd);
+      if (line === closeFence) {
+        const blockEnd = nextLineEnd === -1 ? content.length : nextLineEnd + 1;
+        blocks.push({
+          index: headerIndex,
+          length: blockEnd - headerIndex,
+          prUrl: headerMatch[1]?.trim() ?? "",
+          meta: headerMatch[2]?.trim() ?? "",
+          diffText: diffLines.join("\n"),
+        });
+        searchFrom = blockEnd;
+        closed = true;
+        break;
+      }
+      diffLines.push(line);
+      if (nextLineEnd === -1) {
+        break;
+      }
+      cursor = nextLineEnd + 1;
+    }
+
+    if (!closed) {
+      searchFrom = headerIndex + 1;
+    }
+  }
+
+  return blocks;
+}
+
+/** @deprecated Prefer scanPrDiffWireBlocks for parsing; kept for tests referencing the pattern. */
 export const PR_DIFF_BLOCK_RE =
   /Selected diff from ([^\n]+) \(([^)]*)\):\n```diff\n[\s\S]*?\n```/g;
 

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -641,6 +641,7 @@
     "prCheckStateInProgress": "In progress",
     "prCheckStatePending": "Not started",
     "prChangesViewOnGitHub": "View on GitHub",
+    "prAddDiffToSession": "Add to session",
     "prFileStatusAdded": "Added",
     "prFileStatusRemoved": "Removed",
     "prFileStatusModified": "Modified",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -641,7 +641,7 @@
     "prCheckStateInProgress": "In progress",
     "prCheckStatePending": "Not started",
     "prChangesViewOnGitHub": "View on GitHub",
-    "prAddDiffToSession": "Add to session",
+    "prAddDiffToSession": "Add to Session",
     "prFileStatusAdded": "Added",
     "prFileStatusRemoved": "Removed",
     "prFileStatusModified": "Modified",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -639,6 +639,7 @@
     "prCheckStateInProgress": "进行中",
     "prCheckStatePending": "未开始",
     "prChangesViewOnGitHub": "在 GitHub 查看",
+    "prAddDiffToSession": "添加到会话",
     "prFileStatusAdded": "新增",
     "prFileStatusRemoved": "删除",
     "prFileStatusModified": "修改",

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -772,6 +772,54 @@ test("composerShowsPlaceholder false when skill chip present", () => {
   );
 });
 
+test("composerShowsPlaceholder false when prDiff chip present", () => {
+  assert.equal(
+    composerShowsPlaceholder(
+      [
+        {
+          kind: "prDiff",
+          attachment: {
+            id: "pr-1",
+            prUrl: "https://github.com/o/r/pull/1",
+            filename: "src/foo.ts",
+            lineStart: 9,
+            lineEnd: 9,
+            diffText: "diff",
+            status: "merged",
+          },
+        },
+        { kind: "text", value: " " },
+      ],
+      { composing: false, attachmentCount: 0 },
+    ),
+    false,
+  );
+});
+
+test("normalizeCaretForInlineAttachmentChips snaps caret on prDiff chip", () => {
+  const segs = [
+    {
+      kind: "prDiff",
+      attachment: {
+        id: "pr-1",
+        prUrl: "https://github.com/o/r/pull/1",
+        filename: "src/foo.ts",
+        lineStart: 9,
+        lineEnd: 9,
+        diffText: "diff",
+        status: "open",
+      },
+    },
+    { kind: "text", value: " tail" },
+  ];
+  const snapped = normalizeCaretForInlineAttachmentChips(segs, {
+    segmentIndex: 0,
+    offset: 0,
+  });
+  assert.equal(snapped.segmentIndex, 1);
+  assert.equal(snapped.offset, 1);
+});
+
 test("normalizeCaretForInlineAttachmentChips snaps caret on skill chip", () => {
   const segs = [
     { kind: "skill", alias: "/git-commit" },

--- a/apps/desktop/test/lib/pr-diff-patch-slice.test.mjs
+++ b/apps/desktop/test/lib/pr-diff-patch-slice.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { buildPrDiffSnippetFromPatch, buildPrDiffSnippetText } from "../../src/lib/pr-diff-text.ts";
-import { extractPatchBodyForLineRange } from "../../src/lib/pr-diff-patch-slice.ts";
+import { extractPatchBodyForLineRange, inferLineRangeFromPatch } from "../../src/lib/pr-diff-patch-slice.ts";
 
 const SAMPLE_PATCH = `@@ -10,6 +10,7 @@
  import foo
@@ -29,4 +29,9 @@ test("buildPrDiffSnippetFromPatch wraps sliced body in unified diff header", () 
   assert.match(snippet, /^\+import bar$/m);
   assert.doesNotMatch(snippet, /^ context$/m);
   assert.doesNotMatch(snippet, /^-deleted$/m);
+});
+
+test("inferLineRangeFromPatch matches selected plain text to gutter lines", () => {
+  const range = inferLineRangeFromPatch("src/foo.ts", SAMPLE_PATCH, "import bar\ncontext");
+  assert.deepEqual(range, { lineStart: 11, lineEnd: 12 });
 });

--- a/apps/desktop/test/lib/pr-diff-patch-slice.test.mjs
+++ b/apps/desktop/test/lib/pr-diff-patch-slice.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildPrDiffSnippetFromPatch, buildPrDiffSnippetText } from "../../src/lib/pr-diff-text.ts";
+import { extractPatchBodyForLineRange } from "../../src/lib/pr-diff-patch-slice.ts";
+
+const SAMPLE_PATCH = `@@ -10,6 +10,7 @@
+ import foo
++import bar
+ context
+-deleted
++added
+ trailing`;
+
+test("extractPatchBodyForLineRange keeps +/- prefixes for selected gutter lines", () => {
+  const body = extractPatchBodyForLineRange("src/foo.ts", SAMPLE_PATCH, 10, 13);
+  assert.match(body, /^@@ -10,6 \+10,7 @@/);
+  assert.match(body, /^ import foo$/m);
+  assert.match(body, /^\+import bar$/m);
+  assert.match(body, /^ context$/m);
+  assert.match(body, /^-deleted$/m);
+  assert.match(body, /^\+added$/m);
+  assert.doesNotMatch(body, /trailing/);
+});
+
+test("buildPrDiffSnippetFromPatch wraps sliced body in unified diff header", () => {
+  const snippet = buildPrDiffSnippetFromPatch("src/foo.ts", SAMPLE_PATCH, 11, 11);
+  assert.match(snippet, /diff --git a\/src\/foo\.ts b\/src\/foo\.ts/);
+  assert.match(snippet, /^\+import bar$/m);
+  assert.doesNotMatch(snippet, /^ context$/m);
+  assert.doesNotMatch(snippet, /^-deleted$/m);
+});

--- a/apps/desktop/test/lib/pr-diff-wire-text.test.mjs
+++ b/apps/desktop/test/lib/pr-diff-wire-text.test.mjs
@@ -24,18 +24,38 @@ test("prDiffContextText serializes PR URL, filename, line range, status, and dif
   });
 
   assert.match(wire, /Selected diff from https:\/\/github\.com\/o\/r\/pull\/42/);
-  assert.match(wire, /src\/foo\.ts, L12-20, status:open/);
+  assert.match(wire, /src\/foo\.ts\tL12-20\topen/);
   assert.match(wire, /```diff\n/);
   assert.match(wire, /diff --git a\/src\/foo\.ts b\/src\/foo\.ts/);
 });
 
-test("parsePrDiffWireMeta round-trips line range and status", () => {
+test("parsePrDiffWireMeta round-trips tab-separated meta", () => {
+  const parsed = parsePrDiffWireMeta("src/foo.ts\tL12-20\tmerged");
+  assert.deepEqual(parsed, {
+    filename: "src/foo.ts",
+    lineStart: 12,
+    lineEnd: 20,
+    status: "merged",
+  });
+});
+
+test("parsePrDiffWireMeta still parses legacy comma meta", () => {
   const parsed = parsePrDiffWireMeta("src/foo.ts, L12-20, status:merged");
   assert.deepEqual(parsed, {
     filename: "src/foo.ts",
     lineStart: 12,
     lineEnd: 20,
     status: "merged",
+  });
+});
+
+test("parsePrDiffWireMeta parses filename containing comma-like segments via tabs", () => {
+  const parsed = parsePrDiffWireMeta("weird, L1-2, status:open.txt\tL3-4\topen");
+  assert.deepEqual(parsed, {
+    filename: "weird, L1-2, status:open.txt",
+    lineStart: 3,
+    lineEnd: 4,
+    status: "open",
   });
 });
 

--- a/apps/desktop/test/lib/pr-diff-wire-text.test.mjs
+++ b/apps/desktop/test/lib/pr-diff-wire-text.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildPrDiffSnippetText } from "../../src/lib/pr-diff-text.ts";
+import {
+  parsePrDiffWireMeta,
+  prDiffContextText,
+} from "../../src/lib/pr-diff-wire-text.ts";
+import {
+  messageContentToRichSegments,
+  parseMessageContentParts,
+  segmentsToMessageText,
+} from "../../src/lib/composer-segment-model.ts";
+
+test("prDiffContextText serializes PR URL, filename, line range, status, and diff body", () => {
+  const wire = prDiffContextText({
+    prUrl: "https://github.com/o/r/pull/42",
+    filename: "src/foo.ts",
+    lineStart: 12,
+    lineEnd: 20,
+    status: "open",
+    diffText: buildPrDiffSnippetText("src/foo.ts", "@@ -1 +1 @@\n+hello"),
+  });
+
+  assert.match(wire, /Selected diff from https:\/\/github\.com\/o\/r\/pull\/42/);
+  assert.match(wire, /src\/foo\.ts, L12-20, status:open/);
+  assert.match(wire, /```diff\n/);
+  assert.match(wire, /diff --git a\/src\/foo\.ts b\/src\/foo\.ts/);
+});
+
+test("parsePrDiffWireMeta round-trips line range and status", () => {
+  const parsed = parsePrDiffWireMeta("src/foo.ts, L12-20, status:merged");
+  assert.deepEqual(parsed, {
+    filename: "src/foo.ts",
+    lineStart: 12,
+    lineEnd: 20,
+    status: "merged",
+  });
+});
+
+test("segmentsToMessageText and parseMessageContentParts round-trip PR diff chips", () => {
+  const attachment = {
+    id: "pr-1",
+    prUrl: "https://github.com/o/r/pull/7",
+    filename: "apps/desktop/src/App.tsx",
+    lineStart: 42,
+    lineEnd: 42,
+    status: "draft",
+    diffText: buildPrDiffSnippetText("apps/desktop/src/App.tsx", "@@ -1 +1 @@\n+change"),
+  };
+  const message = segmentsToMessageText([{ kind: "prDiff", attachment }]);
+  const parts = parseMessageContentParts(message);
+  assert.equal(parts.length, 1);
+  assert.equal(parts[0]?.kind, "prDiff");
+  if (parts[0]?.kind !== "prDiff") {
+    return;
+  }
+  assert.equal(parts[0].filename, "apps/desktop/src/App.tsx");
+  assert.equal(parts[0].lineStart, 42);
+  assert.equal(parts[0].lineEnd, 42);
+  assert.equal(parts[0].status, "draft");
+  assert.match(parts[0].diffText, /App\.tsx/);
+
+  const segments = messageContentToRichSegments(message, "rewind");
+  assert.equal(segments.length, 1);
+  assert.equal(segments[0]?.kind, "prDiff");
+});

--- a/apps/desktop/test/lib/pr-diff-wire-text.test.mjs
+++ b/apps/desktop/test/lib/pr-diff-wire-text.test.mjs
@@ -5,6 +5,7 @@ import { buildPrDiffSnippetText } from "../../src/lib/pr-diff-text.ts";
 import {
   parsePrDiffWireMeta,
   prDiffContextText,
+  scanPrDiffWireBlocks,
 } from "../../src/lib/pr-diff-wire-text.ts";
 import {
   messageContentToRichSegments,
@@ -64,4 +65,19 @@ test("segmentsToMessageText and parseMessageContentParts round-trip PR diff chip
   const segments = messageContentToRichSegments(message, "rewind");
   assert.equal(segments.length, 1);
   assert.equal(segments[0]?.kind, "prDiff");
+});
+
+test("scanPrDiffWireBlocks parses diff body containing standalone fence lines", () => {
+  const diffBody = ["+before", "```", "+after"].join("\n");
+  const wire = prDiffContextText({
+    prUrl: "https://github.com/o/r/pull/9",
+    filename: "docs/readme.md",
+    lineStart: 1,
+    lineEnd: 3,
+    status: "open",
+    diffText: diffBody,
+  });
+  const blocks = scanPrDiffWireBlocks(wire);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0]?.diffText, diffBody);
 });


### PR DESCRIPTION
## Summary

- PR Changes 视图支持框选 diff 并通过 Add to Session 插入 Composer 内联 PR Diff Chip
- 新增 prDiff segment、wire text 格式与消息气泡 Chip 展示
- 修复 Chip 占位符/光标/valueSync 清空等问题；patch 切片生成真实 +/- unified diff

## Test plan

- [x] Changes 框选 diff → Add to Session → Composer 可见 Chip 且可编辑发送
- [x] 验证 merged/open/closed/draft 配色与气泡 round-trip
- [x] 验证含 ``` 的 diff 正文 rewind 不截断
- [x] 对比元素 Chip Add to Session 行为仍正常