### PR TITLE
feat(desktop): Shell 终端选区 Add to Session 与内联 Terminal Chip

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -549,6 +549,7 @@ export default function App() {
               onActiveWorkspaceToolTabIdChange: workspaceTools.setActiveWorkspaceToolTabId,
               onBrowserElementPicked: composer.handleBrowserElementPicked,
               onPrDiffAddToSession: composer.handlePrDiffAddToSession,
+              onTerminalAddToSession: composer.handleTerminalAddToSession,
               onBrowserOpenInNewTab: workspaceTools.openBrowserUrlInNewTab,
               browserTabEnabled: workspaceTools.browserTabEnabled,
               prTabEnabled: workspaceTools.prTabEnabled,

--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -12,6 +12,7 @@ import {
 
 import type { BrowserElementAttachment } from "@/lib/browser-element-attachment";
 import type { PrDiffAttachment } from "@/lib/pr-diff-attachment";
+import type { TerminalSnippetAttachment } from "@/lib/terminal-snippet-attachment";
 import { hasInlineAttachmentChipSegments } from "@/lib/composer-inline-chip-dom";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
 import { caretToDomRange, selectionToCaret } from "@/lib/composer-segment-selection";
@@ -122,6 +123,7 @@ export type ComposerRichInputHandle = {
   focus(): void;
   insertAttachment(a: BrowserElementAttachment): void;
   insertPrDiffAttachment(attachment: PrDiffAttachment): void;
+  insertTerminalSnippet(attachment: TerminalSnippetAttachment): void;
   insertWorkspaceFileReference(
     path: string,
     query: ActiveWorkspaceFileReferenceQuery,
@@ -402,6 +404,26 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       [commitSegments],
     );
 
+    const insertTerminalSnippet = useCallback(
+      (attachment: TerminalSnippetAttachment) => {
+        const div = divRef.current;
+        if (!div) return;
+        div.focus();
+        const current = segmentsRef.current;
+        const caret =
+          selectionToCaret(div, current) ?? {
+            segmentIndex: current.length - 1,
+            offset: segmentsToPlainText(current).length,
+          };
+        const { segments: next, caret: nextCaret } = insertSegmentAtCaret(current, caret, {
+          kind: "terminalSnippet",
+          attachment,
+        });
+        commitSegments(next, nextCaret);
+      },
+      [commitSegments],
+    );
+
     const insertWorkspaceFileReference = useCallback(
       (path: string, query: ActiveWorkspaceFileReferenceQuery, finalize = true) => {
         const div = divRef.current;
@@ -629,6 +651,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         focus: () => divRef.current?.focus(),
         insertAttachment,
         insertPrDiffAttachment,
+        insertTerminalSnippet,
         insertWorkspaceFileReference,
         insertLoopChip,
         removeLoopChip,
@@ -647,6 +670,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       [
         insertAttachment,
         insertPrDiffAttachment,
+        insertTerminalSnippet,
         insertWorkspaceFileReference,
         replaceSkillSlashQuery,
         removeSkillSlashQuery,

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -140,6 +140,9 @@ export type WorkspaceToolsSectionProps = {
   onPrDiffAddToSession?: NonNullable<
     ComponentProps<typeof WorkspaceToolsDock>["onPrDiffAddToSession"]
   >;
+  onTerminalAddToSession?: NonNullable<
+    ComponentProps<typeof WorkspaceToolsDock>["onTerminalAddToSession"]
+  >;
   onBrowserOpenInNewTab: (rawUrl: string) => void;
   browserTabEnabled: boolean;
   prTabEnabled: boolean;
@@ -378,6 +381,7 @@ export function ConversationView({
           onActiveTabIdChange={workspaceTools.onActiveWorkspaceToolTabIdChange}
           onBrowserElementPicked={workspaceTools.onBrowserElementPicked}
           onPrDiffAddToSession={workspaceTools.onPrDiffAddToSession}
+          onTerminalAddToSession={workspaceTools.onTerminalAddToSession}
           onBrowserOpenInNewTab={workspaceTools.onBrowserOpenInNewTab}
           browserTabEnabled={workspaceTools.browserTabEnabled}
           prTabEnabled={workspaceTools.prTabEnabled}

--- a/apps/desktop/src/components/git-commit-graph.tsx
+++ b/apps/desktop/src/components/git-commit-graph.tsx
@@ -394,43 +394,44 @@ function CommitGraphGutter({
     <svg
       width={graphWidth}
       height={height}
-      className="pointer-events-none absolute left-0 top-0 shrink-0 text-muted-foreground/70"
+      className="pointer-events-none absolute left-0 top-0 shrink-0"
       aria-hidden
     >
-      {verticals.map((d, index) => (
-        d ? (
-          <path
-            key={`v-${index}`}
-            d={d}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={1.5}
-            strokeLinecap="butt"
-            strokeLinejoin="round"
-          />
-        ) : null
-      ))}
-      {curves.map((d, index) => (
-        d ? (
-          <path
-            key={`c-${index}`}
-            d={d}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={1.5}
-            strokeLinecap="butt"
-            strokeLinejoin="round"
-          />
-        ) : null
-      ))}
+      <g className="text-muted-foreground/35">
+        {verticals.map((d, index) => (
+          d ? (
+            <path
+              key={`v-${index}`}
+              d={d}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1}
+              strokeLinecap="butt"
+              strokeLinejoin="round"
+            />
+          ) : null
+        ))}
+        {curves.map((d, index) => (
+          d ? (
+            <path
+              key={`c-${index}`}
+              d={d}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1}
+              strokeLinecap="butt"
+              strokeLinejoin="round"
+            />
+          ) : null
+        ))}
+      </g>
       {rows.map((row, rowIndex) => (
         <circle
           key={row.commit.oid}
           cx={laneCenterX(row.lane)}
           cy={rowCenter(rowIndex)}
           r={NODE_RADIUS_PX}
-          className="fill-foreground stroke-background"
-          strokeWidth={1.5}
+          className="fill-muted-foreground"
         />
       ))}
     </svg>
@@ -519,7 +520,7 @@ function CommitGraphRowWithHover({
 
   return (
     <div
-      className="relative min-w-0 border-b border-border/20 last:border-b-0"
+      className="relative min-w-0"
       style={{ minHeight: ROW_HEIGHT_PX, paddingLeft: textInset }}
     >
       <HoverDetailTooltip.Anchor itemId={row.commit.oid}>

--- a/apps/desktop/src/components/user-message-bubble.tsx
+++ b/apps/desktop/src/components/user-message-bubble.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
-import { GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, PenTool } from "lucide-react";
+import { GitMerge, GitPullRequest, GitPullRequestClosed, GitPullRequestDraft, PenTool, Terminal } from "lucide-react";
 
 import { BROWSER_ELEMENT_CHIP_CLASS } from "@/components/browser-element-card";
 import { ComposerLocalFileStrip } from "@/components/composer-local-file-strip";
@@ -21,6 +21,11 @@ import {
   formatPrDiffChipTitle,
   prDiffChipClassForStatus,
 } from "@/lib/github-pr-diff-chip-styles";
+import {
+  formatTerminalChipLabel,
+  formatTerminalChipTitle,
+  TERMINAL_CHIP_CLASS,
+} from "@/lib/terminal-chip-styles";
 import type { PullRequestChipStatus } from "@/lib/pr-diff-attachment";
 import { workspaceFileBasename } from "@/lib/file-picker-path";
 import { resolveWorkspaceFileChipPresentation } from "@/lib/workspace-file-chip-styles";
@@ -91,10 +96,37 @@ function PrDiffCard({
   );
 }
 
+function TerminalCard({
+  part,
+}: {
+  part: Extract<MessageContentPart, { kind: "terminalSnippet" }>;
+}) {
+  return (
+    <span
+      title={formatTerminalChipTitle({
+        id: "",
+        terminalName: part.terminalName,
+        lineStart: part.lineStart,
+        lineEnd: part.lineEnd,
+        selectedText: part.selectedText,
+      })}
+      className={TERMINAL_CHIP_CLASS}
+    >
+      <Terminal className="size-[10px] shrink-0" aria-hidden />
+      {formatTerminalChipLabel(part.terminalName, part.lineStart, part.lineEnd)}
+    </span>
+  );
+}
+
 function isInlineChipPart(
   part: MessageContentPart | null | undefined,
-): part is Extract<MessageContentPart, { kind: "element" | "workspaceFile" | "prDiff" }> {
-  return part?.kind === "element" || part?.kind === "workspaceFile" || part?.kind === "prDiff";
+): part is Extract<MessageContentPart, { kind: "element" | "workspaceFile" | "prDiff" | "terminalSnippet" }> {
+  return (
+    part?.kind === "element"
+    || part?.kind === "workspaceFile"
+    || part?.kind === "prDiff"
+    || part?.kind === "terminalSnippet"
+  );
 }
 
 type ReadLocalImagePreview = (filePath: string) => Promise<string | null>;
@@ -138,7 +170,11 @@ export function UserMessageBubble({
   const showText =
     (visibleText.trim().length > 0 ||
       contentParts.some(
-        (p) => p.kind === "element" || p.kind === "workspaceFile" || p.kind === "prDiff",
+        (p) =>
+          p.kind === "element"
+          || p.kind === "workspaceFile"
+          || p.kind === "prDiff"
+          || p.kind === "terminalSnippet",
       )) &&
     !isAttachmentOnlyDisplayText(message.content, message.localFileAttachments);
   const hasAttachments = attachmentViews.length > 0;
@@ -182,6 +218,9 @@ export function UserMessageBubble({
               }
               if (part.kind === "prDiff") {
                 return <PrDiffCard key={i} part={part} />;
+              }
+              if (part.kind === "terminalSnippet") {
+                return <TerminalCard key={i} part={part} />;
               }
               const prev = i > 0 ? contentParts[i - 1] : null;
               const next = i < contentParts.length - 1 ? contentParts[i + 1] : null;

--- a/apps/desktop/src/components/workspace-pr-changes-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-changes-view.tsx
@@ -149,7 +149,7 @@ function PrChangesSelectionMenu({
   return (
     <TextSelectionActionMenu open={open} anchor={anchor} onOpenChange={setOpen}>
       <TextSelectionActionMenuItem
-        label={t("workspace.prAddDiffToSession")}
+        label={t("workspace.addSelectionToSession")}
         onSelect={handleAddToSession}
       />
     </TextSelectionActionMenu>

--- a/apps/desktop/src/components/workspace-shell-tab.tsx
+++ b/apps/desktop/src/components/workspace-shell-tab.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import "@xterm/xterm/css/xterm.css";
 
 import { Button } from "@/components/ui/button";
+import { TerminalSelectionMenu } from "@/components/workspace-terminal-selection-menu";
 import { createWorkspaceTerminalSession } from "@/lib/workspace-xterm";
 import { desktopMicaTerminalTintClass } from "@/lib/desktop-mica-surface";
 import { cn } from "@/lib/utils";
@@ -13,6 +14,11 @@ export type WorkspaceShellTabProps = {
   workspaceRoot: string;
   /** 终端标题变化时通知父层（来自 OSC 0/2 序列）；无标题时传 undefined */
   onTitleChange?: (title: string | undefined) => void;
+  /** Chip 与菜单展示用的终端名称（OSC 标题或默认 Terminal 标签）。 */
+  terminalDisplayName?: string;
+  onTerminalAddToSession?: (
+    attachment: import("@/lib/terminal-snippet-attachment").TerminalSnippetAttachment,
+  ) => void;
   /** 侧栏连续拖拽调整宽度时为 true，暂停终端 fit 直至松手。 */
   suspendTerminalResize?: boolean;
   /** Windows 云母 / macOS Vibrancy：终端保留较高不透明度以保证 ANSI 可读性。 */
@@ -22,6 +28,8 @@ export type WorkspaceShellTabProps = {
 export function WorkspaceShellTab({
   workspaceRoot,
   onTitleChange,
+  terminalDisplayName = "Terminal",
+  onTerminalAddToSession,
   suspendTerminalResize = false,
   useMicaBackdrop = false,
 }: WorkspaceShellTabProps) {
@@ -102,7 +110,7 @@ export function WorkspaceShellTab({
   }
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-hidden">
+    <div className="relative flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-hidden">
       {embedError ? (
         <div className="flex shrink-0 flex-col gap-2">
           <p className="text-xs text-destructive">{embedError}</p>
@@ -131,6 +139,12 @@ export function WorkspaceShellTab({
           desktopMicaTerminalTintClass(useMicaBackdrop),
           embedError ? "hidden" : "block",
         )}
+      />
+      <TerminalSelectionMenu
+        containerRef={containerRef}
+        terminalRef={termRef}
+        terminalDisplayName={terminalDisplayName}
+        onTerminalAddToSession={onTerminalAddToSession}
       />
     </div>
   );

--- a/apps/desktop/src/components/workspace-shell-tab.tsx
+++ b/apps/desktop/src/components/workspace-shell-tab.tsx
@@ -35,7 +35,7 @@ export function WorkspaceShellTab({
 }: WorkspaceShellTabProps) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
-  const termRef = useRef<Terminal | null>(null);
+  const [terminal, setTerminal] = useState<Terminal | null>(null);
   const sessionScheduleFitRef = useRef<(() => void) | null>(null);
   const [embedError, setEmbedError] = useState<string | null>(null);
   const [retryNonce, setRetryNonce] = useState(0);
@@ -57,7 +57,7 @@ export function WorkspaceShellTab({
 
   useEffect(() => {
     setEmbedError(null);
-    termRef.current = null;
+    setTerminal(null);
     const b = typeof window !== "undefined" ? window.spiritDesktop : undefined;
     if (!trimmed || !b?.ptyCreate || !b.ptySubscribe) {
       return;
@@ -78,12 +78,12 @@ export function WorkspaceShellTab({
         tRef.current("workspace.shellExited", { exitCode }),
       isResizeSuspended: () => suspendResizeRef.current,
     });
-    termRef.current = session.terminal;
+    setTerminal(session.terminal);
     sessionScheduleFitRef.current = session.scheduleFit;
 
     return () => {
       session.dispose();
-      termRef.current = null;
+      setTerminal(null);
       sessionScheduleFitRef.current = null;
     };
   }, [trimmed, canEmbed, retryNonce]);
@@ -142,7 +142,7 @@ export function WorkspaceShellTab({
       />
       <TerminalSelectionMenu
         containerRef={containerRef}
-        terminalRef={termRef}
+        terminal={terminal}
         terminalDisplayName={terminalDisplayName}
         onTerminalAddToSession={onTerminalAddToSession}
       />

--- a/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
+++ b/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
@@ -61,7 +61,7 @@ function TerminalSelectionMenu({
   return (
     <TextSelectionActionMenu open={open && Boolean(selectionText.trim())} anchor={anchor} onOpenChange={setOpen}>
       <TextSelectionActionMenuItem
-        label={t("workspace.prAddDiffToSession")}
+        label={t("workspace.addSelectionToSession")}
         onSelect={handleAddToSession}
       />
     </TextSelectionActionMenu>

--- a/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
+++ b/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
@@ -41,12 +41,12 @@ function TerminalSelectionMenu({
       return;
     }
 
-    const range = readTerminalSelectionLineRange(term) ?? lineRange ?? { lineStart: 0, lineEnd: 0 };
+    const range = readTerminalSelectionLineRange(term) ?? lineRange;
     const attachment: TerminalSnippetAttachment = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       terminalName: terminalDisplayName,
-      lineStart: range.lineStart,
-      lineEnd: range.lineEnd,
+      lineStart: range?.lineStart ?? 0,
+      lineEnd: range?.lineEnd ?? 0,
       selectedText,
     };
     onTerminalAddToSession(attachment);

--- a/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
+++ b/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
@@ -35,8 +35,8 @@ function TerminalSelectionMenu({
       return;
     }
 
-    const selectedText = term.getSelection();
-    if (!selectedText.trim()) {
+    const selectedText = (selectionText.trim() || term.getSelection()).trim();
+    if (!selectedText) {
       dismiss();
       return;
     }
@@ -52,7 +52,7 @@ function TerminalSelectionMenu({
     onTerminalAddToSession(attachment);
     dismiss();
     term.clearSelection();
-  }, [dismiss, lineRange, onTerminalAddToSession, terminal, terminalDisplayName]);
+  }, [dismiss, lineRange, onTerminalAddToSession, selectionText, terminal, terminalDisplayName]);
 
   if (!enabled) {
     return null;

--- a/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
+++ b/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type RefObject } from "react";
+import { useCallback, type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -11,12 +11,12 @@ import type { Terminal } from "@xterm/xterm";
 
 function TerminalSelectionMenu({
   containerRef,
-  terminalRef,
+  terminal,
   terminalDisplayName,
   onTerminalAddToSession,
 }: {
   containerRef: RefObject<HTMLElement | null>;
-  terminalRef: RefObject<Terminal | null>;
+  terminal: Terminal | null;
   terminalDisplayName: string;
   onTerminalAddToSession?: (attachment: TerminalSnippetAttachment) => void;
 }) {
@@ -25,11 +25,11 @@ function TerminalSelectionMenu({
   const { open, setOpen, anchor, selectionText, lineRange, dismiss } = useTerminalSelectionActionMenu({
     enabled,
     containerRef,
-    terminalRef,
+    terminal,
   });
 
   const handleAddToSession = useCallback(() => {
-    const term = terminalRef.current;
+    const term = terminal;
     if (!term || !onTerminalAddToSession) {
       dismiss();
       return;
@@ -52,7 +52,7 @@ function TerminalSelectionMenu({
     onTerminalAddToSession(attachment);
     dismiss();
     term.clearSelection();
-  }, [dismiss, lineRange, onTerminalAddToSession, terminalDisplayName, terminalRef]);
+  }, [dismiss, lineRange, onTerminalAddToSession, terminal, terminalDisplayName]);
 
   if (!enabled) {
     return null;

--- a/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
+++ b/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
@@ -1,0 +1,71 @@
+import { useCallback, useRef, type RefObject } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  TextSelectionActionMenu,
+  TextSelectionActionMenuItem,
+} from "@/components/text-selection-action-menu";
+import { useTerminalSelectionActionMenu } from "@/hooks/use-terminal-selection-action-menu";
+import type { TerminalSnippetAttachment } from "@/lib/terminal-snippet-attachment";
+import type { Terminal } from "@xterm/xterm";
+
+function TerminalSelectionMenu({
+  containerRef,
+  terminalRef,
+  terminalDisplayName,
+  onTerminalAddToSession,
+}: {
+  containerRef: RefObject<HTMLElement | null>;
+  terminalRef: RefObject<Terminal | null>;
+  terminalDisplayName: string;
+  onTerminalAddToSession?: (attachment: TerminalSnippetAttachment) => void;
+}) {
+  const { t } = useTranslation();
+  const enabled = Boolean(onTerminalAddToSession);
+  const { open, setOpen, anchor, selectionText, lineRange, dismiss } = useTerminalSelectionActionMenu({
+    enabled,
+    containerRef,
+    terminalRef,
+  });
+
+  const handleAddToSession = useCallback(() => {
+    const term = terminalRef.current;
+    if (!term || !onTerminalAddToSession) {
+      dismiss();
+      return;
+    }
+
+    const selectedText = term.getSelection();
+    if (!selectedText.trim()) {
+      dismiss();
+      return;
+    }
+
+    const range = lineRange ?? { lineStart: 0, lineEnd: 0 };
+    const attachment: TerminalSnippetAttachment = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      terminalName: terminalDisplayName,
+      lineStart: range.lineStart,
+      lineEnd: range.lineEnd,
+      selectedText,
+    };
+    onTerminalAddToSession(attachment);
+    dismiss();
+    term.clearSelection();
+  }, [dismiss, lineRange, onTerminalAddToSession, terminalDisplayName, terminalRef]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <TextSelectionActionMenu open={open && Boolean(selectionText.trim())} anchor={anchor} onOpenChange={setOpen}>
+      <TextSelectionActionMenuItem
+        label={t("workspace.prAddDiffToSession")}
+        onSelect={handleAddToSession}
+      />
+    </TextSelectionActionMenu>
+  );
+}
+
+export { TerminalSelectionMenu };

--- a/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
+++ b/apps/desktop/src/components/workspace-terminal-selection-menu.tsx
@@ -5,7 +5,7 @@ import {
   TextSelectionActionMenu,
   TextSelectionActionMenuItem,
 } from "@/components/text-selection-action-menu";
-import { useTerminalSelectionActionMenu } from "@/hooks/use-terminal-selection-action-menu";
+import { useTerminalSelectionActionMenu, readTerminalSelectionLineRange } from "@/hooks/use-terminal-selection-action-menu";
 import type { TerminalSnippetAttachment } from "@/lib/terminal-snippet-attachment";
 import type { Terminal } from "@xterm/xterm";
 
@@ -41,7 +41,7 @@ function TerminalSelectionMenu({
       return;
     }
 
-    const range = lineRange ?? { lineStart: 0, lineEnd: 0 };
+    const range = readTerminalSelectionLineRange(term) ?? lineRange ?? { lineStart: 0, lineEnd: 0 };
     const attachment: TerminalSnippetAttachment = {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       terminalName: terminalDisplayName,

--- a/apps/desktop/src/components/workspace-tools-panel.tsx
+++ b/apps/desktop/src/components/workspace-tools-panel.tsx
@@ -52,6 +52,7 @@ import type {
 import {
   addWorkspaceToolTab,
   closeWorkspaceToolTab,
+  workspaceTerminalChipDisplayName,
   workspaceToolTabLabel,
   type WorkspaceToolTab,
   type WorkspaceToolTabKind,
@@ -121,6 +122,9 @@ export type WorkspaceToolsDockProps = {
   onActiveTabIdChange(id: string): void;
   onBrowserElementPicked?: WorkspaceBrowserTabProps['onElementPicked'];
   onPrDiffAddToSession?: (attachment: import("@/lib/pr-diff-attachment").PrDiffAttachment) => void;
+  onTerminalAddToSession?: (
+    attachment: import("@/lib/terminal-snippet-attachment").TerminalSnippetAttachment,
+  ) => void;
   onBrowserOpenInNewTab?: WorkspaceBrowserTabProps['onOpenUrlInNewTab'];
   /** Electron 桌面版可新建/使用浏览器选项卡；Web 宿主菜单项可见但禁用。 */
   browserTabEnabled?: boolean;
@@ -202,6 +206,7 @@ function WorkspaceToolsDockInner({
   onActiveTabIdChange,
   onBrowserElementPicked,
   onPrDiffAddToSession,
+  onTerminalAddToSession,
   onBrowserOpenInNewTab,
   browserTabEnabled = false,
   prTabEnabled = false,
@@ -666,6 +671,8 @@ function WorkspaceToolsDockInner({
                           workspaceRoot={workspaceRoot}
                           useMicaBackdrop={useMicaBackdrop}
                           onTitleChange={(title) => handleTabTitleChange(item.id, title)}
+                          terminalDisplayName={workspaceTerminalChipDisplayName(item, tabs, t)}
+                          onTerminalAddToSession={onTerminalAddToSession}
                           suspendTerminalResize={isResizing}
                         />
                       </div>

--- a/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
@@ -26,6 +26,16 @@ function pointAnchor(x: number, y: number): SelectionAnchorRect {
   return { x, y, width: 1, height: 1 };
 }
 
+function containerAnchor(container: HTMLElement): SelectionAnchorRect {
+  const rect = container.getBoundingClientRect();
+  return {
+    x: rect.left + rect.width / 2,
+    y: rect.top + rect.height / 2,
+    width: 1,
+    height: 1,
+  };
+}
+
 export function useTerminalSelectionActionMenu({
   enabled = true,
   containerRef,
@@ -65,14 +75,13 @@ export function useTerminalSelectionActionMenu({
 
     const range = readTerminalSelectionLineRange(term);
     const pointer = lastPointerRef.current;
-    if (!pointer) {
-      dismiss();
-      return;
-    }
+    const nextAnchor = pointer
+      ? pointAnchor(pointer.x, pointer.y)
+      : containerAnchor(container);
 
     setSelectionText(text);
     setLineRange(range);
-    setAnchor(pointAnchor(pointer.x, pointer.y));
+    setAnchor(nextAnchor);
     setOpen(true);
   }, [containerRef, dismiss, enabled, terminal]);
 
@@ -102,14 +111,33 @@ export function useTerminalSelectionActionMenu({
     const onSelectionChange = () => {
       if (!term.getSelection().trim() && !openRef.current) {
         dismiss();
+        return;
+      }
+      if (term.getSelection().trim()) {
+        scheduleSync();
+      }
+    };
+
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (
+        event.key === "Shift"
+        || event.key.startsWith("Arrow")
+        || event.key === "Home"
+        || event.key === "End"
+        || event.key === "PageUp"
+        || event.key === "PageDown"
+      ) {
+        scheduleSync();
       }
     };
 
     container.addEventListener("mouseup", onPointerUp);
+    container.addEventListener("keyup", onKeyUp);
     const selectionDisposable = term.onSelectionChange(onSelectionChange);
     return () => {
       cancelAnimationFrame(raf);
       container.removeEventListener("mouseup", onPointerUp);
+      container.removeEventListener("keyup", onKeyUp);
       selectionDisposable.dispose();
     };
   }, [containerRef, dismiss, enabled, syncFromTerminal, terminal]);

--- a/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
@@ -36,6 +36,11 @@ export function useTerminalSelectionActionMenu({
   const [selectionText, setSelectionText] = useState("");
   const [lineRange, setLineRange] = useState<{ lineStart: number; lineEnd: number } | null>(null);
   const lastPointerRef = useRef<{ x: number; y: number } | null>(null);
+  const openRef = useRef(false);
+
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
 
   const dismiss = useCallback(() => {
     setOpen(false);
@@ -95,7 +100,7 @@ export function useTerminalSelectionActionMenu({
     };
 
     const onSelectionChange = () => {
-      if (!term.getSelection().trim()) {
+      if (!term.getSelection().trim() && !openRef.current) {
         dismiss();
       }
     };

--- a/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+
+import type { SelectionAnchorRect } from "@/hooks/use-text-selection-action-menu";
+import type { Terminal } from "@xterm/xterm";
+
+type UseTerminalSelectionActionMenuOptions = {
+  enabled?: boolean;
+  containerRef: RefObject<HTMLElement | null>;
+  terminalRef: RefObject<Terminal | null>;
+};
+
+export function readTerminalSelectionLineRange(
+  term: Terminal,
+): { lineStart: number; lineEnd: number } | null {
+  const position = term.getSelectionPosition();
+  if (!position) {
+    return null;
+  }
+  const lineStart = Math.min(position.start.y, position.end.y) + 1;
+  const lineEnd = Math.max(position.start.y, position.end.y) + 1;
+  return { lineStart, lineEnd };
+}
+
+function pointAnchor(x: number, y: number): SelectionAnchorRect {
+  return { x, y, width: 1, height: 1 };
+}
+
+export function useTerminalSelectionActionMenu({
+  enabled = true,
+  containerRef,
+  terminalRef,
+}: UseTerminalSelectionActionMenuOptions) {
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<SelectionAnchorRect | null>(null);
+  const [selectionText, setSelectionText] = useState("");
+  const [lineRange, setLineRange] = useState<{ lineStart: number; lineEnd: number } | null>(null);
+  const lastPointerRef = useRef<{ x: number; y: number } | null>(null);
+
+  const dismiss = useCallback(() => {
+    setOpen(false);
+    setAnchor(null);
+    setSelectionText("");
+    setLineRange(null);
+  }, []);
+
+  const syncFromTerminal = useCallback(() => {
+    const container = containerRef.current;
+    const term = terminalRef.current;
+    if (!enabled || !container || !term) {
+      dismiss();
+      return;
+    }
+
+    const text = term.getSelection();
+    if (!text.trim()) {
+      dismiss();
+      return;
+    }
+
+    const range = readTerminalSelectionLineRange(term);
+    const pointer = lastPointerRef.current;
+    if (!pointer) {
+      dismiss();
+      return;
+    }
+
+    setSelectionText(text);
+    setLineRange(range);
+    setAnchor(pointAnchor(pointer.x, pointer.y));
+    setOpen(true);
+  }, [containerRef, dismiss, enabled, terminalRef]);
+
+  useEffect(() => {
+    if (!enabled) {
+      dismiss();
+      return;
+    }
+
+    const container = containerRef.current;
+    const term = terminalRef.current;
+    if (!container || !term) {
+      return;
+    }
+
+    let raf = 0;
+    const scheduleSync = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(syncFromTerminal);
+    };
+
+    const onPointerUp = (event: MouseEvent) => {
+      lastPointerRef.current = { x: event.clientX, y: event.clientY };
+      scheduleSync();
+    };
+
+    const onSelectionChange = () => {
+      if (!term.getSelection().trim()) {
+        dismiss();
+      }
+    };
+
+    container.addEventListener("mouseup", onPointerUp);
+    const selectionDisposable = term.onSelectionChange(onSelectionChange);
+    return () => {
+      cancelAnimationFrame(raf);
+      container.removeEventListener("mouseup", onPointerUp);
+      selectionDisposable.dispose();
+    };
+  }, [containerRef, dismiss, enabled, syncFromTerminal, terminalRef]);
+
+  return {
+    open,
+    setOpen,
+    anchor,
+    selectionText,
+    lineRange,
+    dismiss,
+  };
+}

--- a/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
@@ -6,7 +6,8 @@ import type { Terminal } from "@xterm/xterm";
 type UseTerminalSelectionActionMenuOptions = {
   enabled?: boolean;
   containerRef: RefObject<HTMLElement | null>;
-  terminalRef: RefObject<Terminal | null>;
+  /** xterm instance; use state (not ref) so listeners re-bind when terminal becomes ready. */
+  terminal: Terminal | null;
 };
 
 export function readTerminalSelectionLineRange(
@@ -28,7 +29,7 @@ function pointAnchor(x: number, y: number): SelectionAnchorRect {
 export function useTerminalSelectionActionMenu({
   enabled = true,
   containerRef,
-  terminalRef,
+  terminal,
 }: UseTerminalSelectionActionMenuOptions) {
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<SelectionAnchorRect | null>(null);
@@ -45,7 +46,7 @@ export function useTerminalSelectionActionMenu({
 
   const syncFromTerminal = useCallback(() => {
     const container = containerRef.current;
-    const term = terminalRef.current;
+    const term = terminal;
     if (!enabled || !container || !term) {
       dismiss();
       return;
@@ -68,7 +69,7 @@ export function useTerminalSelectionActionMenu({
     setLineRange(range);
     setAnchor(pointAnchor(pointer.x, pointer.y));
     setOpen(true);
-  }, [containerRef, dismiss, enabled, terminalRef]);
+  }, [containerRef, dismiss, enabled, terminal]);
 
   useEffect(() => {
     if (!enabled) {
@@ -77,7 +78,7 @@ export function useTerminalSelectionActionMenu({
     }
 
     const container = containerRef.current;
-    const term = terminalRef.current;
+    const term = terminal;
     if (!container || !term) {
       return;
     }
@@ -106,7 +107,7 @@ export function useTerminalSelectionActionMenu({
       container.removeEventListener("mouseup", onPointerUp);
       selectionDisposable.dispose();
     };
-  }, [containerRef, dismiss, enabled, syncFromTerminal, terminalRef]);
+  }, [containerRef, dismiss, enabled, syncFromTerminal, terminal]);
 
   return {
     open,

--- a/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
+++ b/apps/desktop/src/hooks/use-terminal-selection-action-menu.ts
@@ -131,12 +131,23 @@ export function useTerminalSelectionActionMenu({
       }
     };
 
+    const onTouchEnd = (event: TouchEvent) => {
+      const touch = event.changedTouches[0];
+      if (!touch) {
+        return;
+      }
+      lastPointerRef.current = { x: touch.clientX, y: touch.clientY };
+      scheduleSync();
+    };
+
     container.addEventListener("mouseup", onPointerUp);
+    container.addEventListener("touchend", onTouchEnd);
     container.addEventListener("keyup", onKeyUp);
     const selectionDisposable = term.onSelectionChange(onSelectionChange);
     return () => {
       cancelAnimationFrame(raf);
       container.removeEventListener("mouseup", onPointerUp);
+      container.removeEventListener("touchend", onTouchEnd);
       container.removeEventListener("keyup", onKeyUp);
       selectionDisposable.dispose();
     };

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/composer-direct-media";
 import type { BrowserElementAttachment } from "@/lib/browser-element-attachment";
 import type { PrDiffAttachment } from "@/lib/pr-diff-attachment";
+import type { TerminalSnippetAttachment } from "@/lib/terminal-snippet-attachment";
 import { useLocalFileAttachmentPreviews } from "@/hooks/useLocalFileAttachmentPreviews";
 import { useWorkspaceFileIndex } from "@/hooks/use-workspace-file-index";
 import type { useDesktopRuntime } from "@/hooks/useDesktopRuntime";
@@ -558,6 +559,11 @@ export function useComposerController({
     composerRichInputRef.current?.focus();
   }, []);
 
+  const handleTerminalAddToSession = useCallback((attachment: TerminalSnippetAttachment) => {
+    composerRichInputRef.current?.insertTerminalSnippet(attachment);
+    composerRichInputRef.current?.focus();
+  }, []);
+
   const pickLocalFileFromPalette = useCallback(() => {
     void runtime.pickLocalFile().then((filePath) => {
       if (!filePath) {
@@ -877,6 +883,7 @@ export function useComposerController({
     removeLocalFileAttachment,
     handleBrowserElementPicked,
     handlePrDiffAddToSession,
+    handleTerminalAddToSession,
     pickLocalFileFromPalette,
     handleComposerPaste,
     submitComposerMessage,

--- a/apps/desktop/src/lib/composer-inline-chip-caret.ts
+++ b/apps/desktop/src/lib/composer-inline-chip-caret.ts
@@ -3,10 +3,14 @@ import { emptySegments, mergeAdjacentTextSegments } from "./composer-segment-mod
 
 function isInlineAttachmentChip(
   seg: RichSegment | undefined,
-): seg is Extract<RichSegment, { kind: "element" | "prDiff" | "workspaceFile" | "skill" }> {
+): seg is Extract<
+  RichSegment,
+  { kind: "element" | "prDiff" | "terminalSnippet" | "workspaceFile" | "skill" }
+> {
   return (
     seg?.kind === "element"
     || seg?.kind === "prDiff"
+    || seg?.kind === "terminalSnippet"
     || seg?.kind === "workspaceFile"
     || seg?.kind === "skill"
   );

--- a/apps/desktop/src/lib/composer-inline-chip-dom.ts
+++ b/apps/desktop/src/lib/composer-inline-chip-dom.ts
@@ -1,8 +1,8 @@
 import type { RichSegment } from "./composer-segment-model";
 
-/** DOM markers for inline attachment chips (element / file / PR diff). */
+/** DOM markers for inline attachment chips (element / file / PR diff / terminal). */
 export const COMPOSER_INLINE_ATTACHMENT_CHIP_SELECTOR =
-  "[data-element-chip='true'],[data-file-chip='true'],[data-pr-diff-chip='true']";
+  "[data-element-chip='true'],[data-file-chip='true'],[data-pr-diff-chip='true'],[data-terminal-chip='true']";
 
 /** DOM markers for all non-text composer chips (incl. mode / loop / skill). */
 export const COMPOSER_INLINE_CHIP_SELECTOR = [
@@ -22,6 +22,8 @@ export function isComposerInlineChipElement(el: HTMLElement): boolean {
     || el.getAttribute("data-file-chip") === "true"
     || el.dataset.prDiffChip === "true"
     || el.getAttribute("data-pr-diff-chip") === "true"
+    || el.dataset.terminalChip === "true"
+    || el.getAttribute("data-terminal-chip") === "true"
     || el.dataset.loopChip === "true"
     || el.getAttribute("data-loop-chip") === "true"
     || el.dataset.planChip === "true"
@@ -40,6 +42,7 @@ export function hasInlineAttachmentChipSegments(segs: RichSegment[]): boolean {
     (segment) =>
       segment.kind === "element"
       || segment.kind === "prDiff"
+      || segment.kind === "terminalSnippet"
       || segment.kind === "workspaceFile",
   );
 }

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -168,6 +168,14 @@ export function messageSegmentSeparator(prev: RichSegment, next: RichSegment): s
     return "\n";
   }
 
+  if (
+    (prev.kind === "terminalSnippet" && (next.kind === "element" || next.kind === "prDiff"))
+    || (next.kind === "terminalSnippet" && (prev.kind === "element" || prev.kind === "prDiff"))
+    || (prev.kind === "terminalSnippet" && next.kind === "terminalSnippet")
+  ) {
+    return "\n";
+  }
+
   if (prev.kind === "workspaceFile" || next.kind === "workspaceFile" || prev.kind === "skill" || next.kind === "skill") {
     return "";
   }

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -4,7 +4,7 @@ import type { PrDiffAttachment } from "./pr-diff-attachment.js";
 import { parsePrDiffWireMeta, prDiffContextText, scanPrDiffWireBlocks } from "./pr-diff-wire-text.js";
 import type { TerminalSnippetAttachment } from "./terminal-snippet-attachment.js";
 import {
-  parseTerminalSnippetWireMeta,
+  parseTerminalSnippetLinePart,
   scanTerminalSnippetWireBlocks,
   terminalSnippetContextText,
 } from "./terminal-snippet-wire-text.js";
@@ -685,8 +685,8 @@ function findWireBlocks(content: string): ParsedWireBlock[] {
   }
 
   for (const block of scanTerminalSnippetWireBlocks(content)) {
-    const parsed = parseTerminalSnippetWireMeta(block.meta);
-    if (!parsed) {
+    const lines = parseTerminalSnippetLinePart(block.meta);
+    if (!lines) {
       continue;
     }
     blocks.push({
@@ -694,9 +694,9 @@ function findWireBlocks(content: string): ParsedWireBlock[] {
       length: block.length,
       part: {
         kind: "terminalSnippet",
-        terminalName: parsed.terminalName || block.terminalName,
-        lineStart: parsed.lineStart,
-        lineEnd: parsed.lineEnd,
+        terminalName: block.terminalName,
+        lineStart: lines.lineStart,
+        lineEnd: lines.lineEnd,
         selectedText: block.selectedText,
       },
     });

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -2,14 +2,22 @@ import type { BrowserElementAttachment } from "./browser-element-attachment";
 import { browserElementContextText } from "./browser-element-wire-text.js";
 import type { PrDiffAttachment } from "./pr-diff-attachment.js";
 import { parsePrDiffWireMeta, prDiffContextText, scanPrDiffWireBlocks } from "./pr-diff-wire-text.js";
+import type { TerminalSnippetAttachment } from "./terminal-snippet-attachment.js";
+import {
+  parseTerminalSnippetWireMeta,
+  scanTerminalSnippetWireBlocks,
+  terminalSnippetContextText,
+} from "./terminal-snippet-wire-text.js";
 
 export { browserElementContextText };
 export { prDiffContextText };
+export { terminalSnippetContextText };
 
 export type RichSegment =
   | { kind: "text"; value: string }
   | { kind: "element"; attachment: BrowserElementAttachment }
   | { kind: "prDiff"; attachment: PrDiffAttachment }
+  | { kind: "terminalSnippet"; attachment: TerminalSnippetAttachment }
   | { kind: "workspaceFile"; path: string }
   | { kind: "loop" }
   | { kind: "plan" }
@@ -128,6 +136,14 @@ export function messageSegmentSeparator(prev: RichSegment, next: RichSegment): s
     return "\n";
   }
 
+  if (prev.kind === "text" && next.kind === "terminalSnippet") {
+    const v = prev.value;
+    if (!v) return "\n";
+    if (v.endsWith("\n\n")) return "";
+    if (v.endsWith("\n")) return "\n";
+    return "\n";
+  }
+
   if (prev.kind === "element" && next.kind === "text") {
     const v = next.value;
     if (!v) return "";
@@ -137,6 +153,14 @@ export function messageSegmentSeparator(prev: RichSegment, next: RichSegment): s
   }
 
   if (prev.kind === "prDiff" && next.kind === "text") {
+    const v = next.value;
+    if (!v) return "";
+    if (v.startsWith("\n\n")) return "\n";
+    if (v.startsWith("\n")) return "\n";
+    return "\n";
+  }
+
+  if (prev.kind === "terminalSnippet" && next.kind === "text") {
     const v = next.value;
     if (!v) return "";
     if (v.startsWith("\n\n")) return "\n";
@@ -167,7 +191,9 @@ export function segmentsToMessageText(segs: RichSegment[]): string {
             ? seg.alias
             : seg.kind === "prDiff"
               ? prDiffContextText(seg.attachment)
-              : browserElementContextText(seg.attachment);
+              : seg.kind === "terminalSnippet"
+                ? terminalSnippetContextText(seg.attachment)
+                : browserElementContextText(seg.attachment);
     if (seg.kind === "text" && !piece) continue;
 
     if (!out) {
@@ -209,6 +235,9 @@ export function segmentsEqual(a: RichSegment[], b: RichSegment[]): boolean {
     if (seg.kind === "prDiff" && other.kind === "prDiff") {
       return seg.attachment.id === other.attachment.id;
     }
+    if (seg.kind === "terminalSnippet" && other.kind === "terminalSnippet") {
+      return seg.attachment.id === other.attachment.id;
+    }
     if (seg.kind === "workspaceFile" && other.kind === "workspaceFile") {
       return seg.path === other.path;
     }
@@ -245,8 +274,15 @@ function pinAgentModeChipFromSegments(
 export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string): RichSegment[] {
   const loopPinned = segs.some((s) => s.kind === "loop");
   const inlineChips = segs.filter(
-    (s): s is Extract<RichSegment, { kind: "element" | "prDiff" | "workspaceFile" | "skill" }> =>
-      s.kind === "element" || s.kind === "prDiff" || s.kind === "workspaceFile" || s.kind === "skill",
+    (s): s is Extract<
+      RichSegment,
+      { kind: "element" | "prDiff" | "terminalSnippet" | "workspaceFile" | "skill" }
+    > =>
+      s.kind === "element"
+      || s.kind === "prDiff"
+      || s.kind === "terminalSnippet"
+      || s.kind === "workspaceFile"
+      || s.kind === "skill",
   );
 
   let body: RichSegment[];
@@ -258,7 +294,13 @@ export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string
     const out: RichSegment[] = [];
     let textApplied = false;
     for (const seg of segs) {
-      if (seg.kind === "element" || seg.kind === "prDiff" || seg.kind === "workspaceFile" || seg.kind === "skill") {
+      if (
+        seg.kind === "element"
+        || seg.kind === "prDiff"
+        || seg.kind === "terminalSnippet"
+        || seg.kind === "workspaceFile"
+        || seg.kind === "skill"
+      ) {
         out.push(seg);
       } else if (seg.kind === "text" && !textApplied) {
         out.push({ kind: "text", value });
@@ -289,10 +331,14 @@ function textFollowingChipInsert(after: string): string {
 
 function isInlineChipSegment(
   seg: RichSegment | undefined,
-): seg is Extract<RichSegment, { kind: "element" | "prDiff" | "workspaceFile" | "loop" | "skill" }> {
+): seg is Extract<
+  RichSegment,
+  { kind: "element" | "prDiff" | "terminalSnippet" | "workspaceFile" | "loop" | "skill" }
+> {
   return (
     seg?.kind === "element"
     || seg?.kind === "prDiff"
+    || seg?.kind === "terminalSnippet"
     || seg?.kind === "workspaceFile"
     || seg?.kind === "loop"
     || seg?.kind === "skill"
@@ -365,6 +411,18 @@ export function insertSegmentAtCaret(
     );
     if (diffIndex >= 0) {
       afterIndex = diffIndex + 1;
+      const trailing = normalized[afterIndex];
+      if (trailing?.kind === "text" && trailing.value === " ") {
+        caretOffset = 1;
+      }
+    }
+  } else if (newSegment.kind === "terminalSnippet") {
+    const terminalIndex = normalized.findIndex(
+      (s) =>
+        s.kind === "terminalSnippet" && s.attachment.id === newSegment.attachment.id,
+    );
+    if (terminalIndex >= 0) {
+      afterIndex = terminalIndex + 1;
       const trailing = normalized[afterIndex];
       if (trailing?.kind === "text" && trailing.value === " ") {
         caretOffset = 1;
@@ -572,6 +630,13 @@ export type MessageContentPart =
       status: PrDiffAttachment["status"];
       diffText: string;
     }
+  | {
+      kind: "terminalSnippet";
+      terminalName: string;
+      lineStart: number;
+      lineEnd: number;
+      selectedText: string;
+    }
   | { kind: "workspaceFile"; path: string };
 
 const ELEMENT_BLOCK_RE = /Selected element from ([^\n]*):\n```html\n[\s\S]*?\n```/g;
@@ -615,6 +680,24 @@ function findWireBlocks(content: string): ParsedWireBlock[] {
         lineEnd: parsed.lineEnd,
         status: parsed.status,
         diffText: block.diffText,
+      },
+    });
+  }
+
+  for (const block of scanTerminalSnippetWireBlocks(content)) {
+    const parsed = parseTerminalSnippetWireMeta(block.meta);
+    if (!parsed) {
+      continue;
+    }
+    blocks.push({
+      index: block.index,
+      length: block.length,
+      part: {
+        kind: "terminalSnippet",
+        terminalName: parsed.terminalName || block.terminalName,
+        lineStart: parsed.lineStart,
+        lineEnd: parsed.lineEnd,
+        selectedText: block.selectedText,
       },
     });
   }
@@ -696,6 +779,7 @@ export function messageContentToRichSegments(
   const segments: RichSegment[] = [];
   let elementIndex = 0;
   let prDiffIndex = 0;
+  let terminalSnippetIndex = 0;
 
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]!;
@@ -728,6 +812,18 @@ export function messageContentToRichSegments(
       continue;
     }
 
+    if (part.kind === "terminalSnippet") {
+      const attachment: TerminalSnippetAttachment = {
+        id: `${idPrefix}-term-${terminalSnippetIndex++}`,
+        terminalName: part.terminalName,
+        lineStart: part.lineStart,
+        lineEnd: part.lineEnd,
+        selectedText: part.selectedText,
+      };
+      segments.push({ kind: "terminalSnippet", attachment });
+      continue;
+    }
+
     if (part.kind === "workspaceFile") {
       segments.push({ kind: "workspaceFile", path: part.path });
       continue;
@@ -735,9 +831,15 @@ export function messageContentToRichSegments(
 
     const display = trimMessageTextAroundElements(part.value, {
       afterElement:
-        prev?.kind === "element" || prev?.kind === "prDiff" || prev?.kind === "workspaceFile",
+        prev?.kind === "element"
+        || prev?.kind === "prDiff"
+        || prev?.kind === "terminalSnippet"
+        || prev?.kind === "workspaceFile",
       beforeElement:
-        next?.kind === "element" || next?.kind === "prDiff" || next?.kind === "workspaceFile",
+        next?.kind === "element"
+        || next?.kind === "prDiff"
+        || next?.kind === "terminalSnippet"
+        || next?.kind === "workspaceFile",
     });
     if (display || segments.length === 0) {
       segments.push({ kind: "text", value: display });

--- a/apps/desktop/src/lib/composer-segments.ts
+++ b/apps/desktop/src/lib/composer-segments.ts
@@ -1,5 +1,6 @@
 import { makeChipNode } from "@/lib/browser-element-chip-styles";
 import { makePrDiffChipNode } from "@/lib/github-pr-diff-chip-styles";
+import { makeTerminalChipNode } from "@/lib/terminal-chip-styles";
 import { makeFileChipNode } from "@/lib/workspace-file-chip-styles";
 import type { RichSegment } from "@/lib/composer-segment-model";
 import {
@@ -50,6 +51,7 @@ export { normalizeCaretForComposer } from "@/lib/composer-caret-normalize";
 
 export { makeChipNode } from "@/lib/browser-element-chip-styles";
 export { makePrDiffChipNode } from "@/lib/github-pr-diff-chip-styles";
+export { makeTerminalChipNode } from "@/lib/terminal-chip-styles";
 export { makeFileChipNode } from "@/lib/workspace-file-chip-styles";
 export {
   caretAfterAgentModeChip,
@@ -172,6 +174,26 @@ function appendSegmentFromNode(node: Node, segs: RichSegment[]): void {
     }
     return;
   }
+  if (el.dataset.terminalChip === "true" || el.getAttribute("data-terminal-chip") === "true") {
+    const id = el.dataset.terminalId;
+    const terminalName = el.dataset.terminalName ?? "";
+    const lineStart = Number(el.dataset.terminalLineStart ?? "0");
+    const lineEnd = Number(el.dataset.terminalLineEnd ?? "0");
+    const selectedText = el.dataset.terminalText ?? "";
+    if (id && terminalName) {
+      segs.push({
+        kind: "terminalSnippet",
+        attachment: {
+          id,
+          terminalName,
+          lineStart,
+          lineEnd,
+          selectedText,
+        },
+      });
+    }
+    return;
+  }
   if (el.dataset.skillChip === "true" || el.getAttribute("data-skill-chip") === "true") {
     const alias = el.dataset.skillAlias ?? el.getAttribute("data-skill-alias");
     if (alias) {
@@ -215,6 +237,8 @@ export function segmentsToDom(
       frag.appendChild(makeFileChipNode(seg.path, doc));
     } else if (seg.kind === "prDiff") {
       frag.appendChild(makePrDiffChipNode(seg.attachment, doc));
+    } else if (seg.kind === "terminalSnippet") {
+      frag.appendChild(makeTerminalChipNode(seg.attachment, doc));
     } else if (seg.kind === "skill") {
       frag.appendChild(makeSkillChipNode(seg.alias, doc));
     } else {

--- a/apps/desktop/src/lib/terminal-chip-styles.ts
+++ b/apps/desktop/src/lib/terminal-chip-styles.ts
@@ -1,8 +1,8 @@
 import type { TerminalSnippetAttachment } from "@/lib/terminal-snippet-attachment";
 
-/** 终端选区 chip：灰色底 + 白字，结构参考 Skill Chip。 */
+/** 终端选区 chip：结构对齐元素 chip（圆角/边框/padding），配色保持低透明度中性底。 */
 export const TERMINAL_CHIP_CLASS =
-  "inline-flex items-center gap-1 bg-neutral-600 px-0.5 py-0.5 text-xs font-medium leading-none text-white select-none align-middle mx-0.5 dark:bg-neutral-700";
+  "inline-flex items-center gap-1 rounded-md border border-border/50 bg-foreground/[0.05] px-1.5 py-0.5 text-xs font-medium leading-none text-muted-foreground select-none align-middle mx-0.5 dark:border-white/10 dark:bg-foreground/[0.08]";
 
 const TERMINAL_ICON_PATH =
   '<polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/>';

--- a/apps/desktop/src/lib/terminal-chip-styles.ts
+++ b/apps/desktop/src/lib/terminal-chip-styles.ts
@@ -1,0 +1,65 @@
+import type { TerminalSnippetAttachment } from "@/lib/terminal-snippet-attachment";
+
+/** 终端选区 chip：灰色底 + 白字，结构参考 Skill Chip。 */
+export const TERMINAL_CHIP_CLASS =
+  "inline-flex items-center gap-1 bg-neutral-600 px-0.5 py-0.5 text-xs font-medium leading-none text-white select-none align-middle mx-0.5 dark:bg-neutral-700";
+
+const TERMINAL_ICON_PATH =
+  '<polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/>';
+
+export function formatTerminalChipLabel(
+  terminalName: string,
+  lineStart: number,
+  lineEnd: number,
+): string {
+  const name = terminalName.trim() || "Terminal";
+  if (lineStart > 0 && lineEnd > 0) {
+    return `${name} L${lineStart}-${lineEnd}`;
+  }
+  return name;
+}
+
+export function formatTerminalChipTitle(attachment: TerminalSnippetAttachment): string {
+  const linePart =
+    attachment.lineStart > 0 && attachment.lineEnd > 0
+      ? ` — L${attachment.lineStart}-${attachment.lineEnd}`
+      : "";
+  return `${attachment.terminalName}${linePart}`;
+}
+
+export function makeTerminalChipNode(attachment: TerminalSnippetAttachment, doc: Document): HTMLElement {
+  const span = doc.createElement("span");
+  span.contentEditable = "false";
+  span.dataset.terminalChip = "true";
+  span.setAttribute("data-terminal-chip", "true");
+  span.dataset.terminalId = attachment.id;
+  span.dataset.terminalName = attachment.terminalName;
+  span.dataset.terminalLineStart = String(attachment.lineStart);
+  span.dataset.terminalLineEnd = String(attachment.lineEnd);
+  span.dataset.terminalText = attachment.selectedText;
+  span.className = TERMINAL_CHIP_CLASS;
+  span.title = formatTerminalChipTitle(attachment);
+  span.setAttribute(
+    "aria-label",
+    formatTerminalChipLabel(attachment.terminalName, attachment.lineStart, attachment.lineEnd),
+  );
+
+  const icon = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("width", "10");
+  icon.setAttribute("height", "10");
+  icon.setAttribute("fill", "none");
+  icon.setAttribute("stroke", "currentColor");
+  icon.setAttribute("stroke-width", "2");
+  icon.setAttribute("stroke-linecap", "round");
+  icon.setAttribute("stroke-linejoin", "round");
+  icon.setAttribute("aria-hidden", "true");
+  icon.innerHTML = TERMINAL_ICON_PATH;
+  span.appendChild(icon);
+  span.appendChild(
+    doc.createTextNode(
+      formatTerminalChipLabel(attachment.terminalName, attachment.lineStart, attachment.lineEnd),
+    ),
+  );
+  return span;
+}

--- a/apps/desktop/src/lib/terminal-snippet-attachment.ts
+++ b/apps/desktop/src/lib/terminal-snippet-attachment.ts
@@ -1,0 +1,10 @@
+export interface TerminalSnippetAttachment {
+  id: string;
+  /** Display name frozen at insert time (tab title or default Terminal label). */
+  terminalName: string;
+  /** 1-based buffer line numbers from xterm selection. */
+  lineStart: number;
+  lineEnd: number;
+  /** Raw selected terminal text for the agent. */
+  selectedText: string;
+}

--- a/apps/desktop/src/lib/terminal-snippet-wire-text.ts
+++ b/apps/desktop/src/lib/terminal-snippet-wire-text.ts
@@ -1,16 +1,34 @@
 import type { TerminalSnippetAttachment } from "./terminal-snippet-attachment.js";
 
-function formatTerminalSnippetWireMeta(
-  attachment: Pick<TerminalSnippetAttachment, "terminalName" | "lineStart" | "lineEnd">,
+function formatTerminalSnippetLinePart(
+  attachment: Pick<TerminalSnippetAttachment, "lineStart" | "lineEnd">,
 ): string {
-  const name = attachment.terminalName.trim() || "Terminal";
   const hasLines = attachment.lineStart > 0 && attachment.lineEnd > 0;
-  const linePart = hasLines ? `L${attachment.lineStart}-${attachment.lineEnd}` : "-";
-  return `${name}\t${linePart}`;
+  return hasLines ? `L${attachment.lineStart}-${attachment.lineEnd}` : "-";
 }
 
 const TERMINAL_SNIPPET_HEADER_PREFIX = "Selected terminal output from ";
-const TERMINAL_SNIPPET_HEADER_RE = /^Selected terminal output from ([^\n]+?) \(([^)]*)\):$/u;
+/** Match line-range suffix from the end so terminal names may contain ')'. */
+const TERMINAL_SNIPPET_HEADER_SUFFIX_RE = / \((L\d+-\d+|-)\):$/u;
+
+function parseTerminalSnippetHeaderLine(
+  headerLine: string,
+): { terminalName: string; linePart: string } | null {
+  if (!headerLine.startsWith(TERMINAL_SNIPPET_HEADER_PREFIX)) {
+    return null;
+  }
+  const suffixMatch = TERMINAL_SNIPPET_HEADER_SUFFIX_RE.exec(headerLine);
+  if (!suffixMatch || suffixMatch.index === undefined) {
+    return null;
+  }
+  const terminalName = headerLine
+    .slice(TERMINAL_SNIPPET_HEADER_PREFIX.length, suffixMatch.index)
+    .trim();
+  if (!terminalName) {
+    return null;
+  }
+  return { terminalName, linePart: suffixMatch[1] ?? "-" };
+}
 
 function chooseTextFence(text: string): { open: string; close: string } {
   if (!/^\s*```/m.test(text)) {
@@ -23,9 +41,10 @@ function chooseTextFence(text: string): { open: string; close: string } {
 export function terminalSnippetContextText(
   attachment: Pick<TerminalSnippetAttachment, "terminalName" | "lineStart" | "lineEnd" | "selectedText">,
 ): string {
-  const meta = formatTerminalSnippetWireMeta(attachment);
+  const name = attachment.terminalName.trim() || "Terminal";
+  const linePart = formatTerminalSnippetLinePart(attachment);
   const fence = chooseTextFence(attachment.selectedText);
-  return `Selected terminal output from ${attachment.terminalName.trim() || "Terminal"} (${meta}):\n${fence.open}${attachment.selectedText}${fence.close}`;
+  return `Selected terminal output from ${name} (${linePart}):\n${fence.open}${attachment.selectedText}${fence.close}`;
 }
 
 export type ParsedTerminalSnippetWireBlock = {
@@ -55,8 +74,8 @@ export function scanTerminalSnippetWireBlocks(content: string): ParsedTerminalSn
     }
 
     const headerLine = content.slice(headerIndex, headerLineEnd);
-    const headerMatch = TERMINAL_SNIPPET_HEADER_RE.exec(headerLine);
-    if (!headerMatch) {
+    const parsedHeader = parseTerminalSnippetHeaderLine(headerLine);
+    if (!parsedHeader) {
       searchFrom = headerIndex + 1;
       continue;
     }
@@ -83,8 +102,8 @@ export function scanTerminalSnippetWireBlocks(content: string): ParsedTerminalSn
         blocks.push({
           index: headerIndex,
           length: blockEnd - headerIndex,
-          terminalName: headerMatch[1]?.trim() ?? "",
-          meta: headerMatch[2]?.trim() ?? "",
+          terminalName: parsedHeader.terminalName,
+          meta: parsedHeader.linePart,
           selectedText: bodyLines.join("\n"),
         });
         searchFrom = blockEnd;
@@ -106,6 +125,25 @@ export function scanTerminalSnippetWireBlocks(content: string): ParsedTerminalSn
   return blocks;
 }
 
+export function parseTerminalSnippetLinePart(linePart: string): {
+  lineStart: number;
+  lineEnd: number;
+} | null {
+  const trimmed = linePart.trim();
+  if (trimmed === "-") {
+    return { lineStart: 0, lineEnd: 0 };
+  }
+  const lineMatch = /^L(\d+)-(\d+)$/u.exec(trimmed);
+  if (!lineMatch) {
+    return null;
+  }
+  return {
+    lineStart: Number(lineMatch[1]),
+    lineEnd: Number(lineMatch[2]),
+  };
+}
+
+/** @deprecated Prefer parseTerminalSnippetLinePart; kept for legacy tab-separated meta in tests. */
 export function parseTerminalSnippetWireMeta(meta: string): {
   terminalName: string;
   lineStart: number;
@@ -117,16 +155,9 @@ export function parseTerminalSnippetWireMeta(meta: string): {
     const terminalName = tabParts[0]?.trim() ?? "";
     const linePart = tabParts[1]?.trim() ?? "";
     if (terminalName) {
-      if (linePart === "-") {
-        return { terminalName, lineStart: 0, lineEnd: 0 };
-      }
-      const lineMatch = /^L(\d+)-(\d+)$/u.exec(linePart);
-      if (lineMatch) {
-        return {
-          terminalName,
-          lineStart: Number(lineMatch[1]),
-          lineEnd: Number(lineMatch[2]),
-        };
+      const lines = parseTerminalSnippetLinePart(linePart);
+      if (lines) {
+        return { terminalName, ...lines };
       }
     }
   }

--- a/apps/desktop/src/lib/terminal-snippet-wire-text.ts
+++ b/apps/desktop/src/lib/terminal-snippet-wire-text.ts
@@ -1,0 +1,134 @@
+import type { TerminalSnippetAttachment } from "./terminal-snippet-attachment.js";
+
+function formatTerminalSnippetWireMeta(
+  attachment: Pick<TerminalSnippetAttachment, "terminalName" | "lineStart" | "lineEnd">,
+): string {
+  const name = attachment.terminalName.trim() || "Terminal";
+  const hasLines = attachment.lineStart > 0 && attachment.lineEnd > 0;
+  const linePart = hasLines ? `L${attachment.lineStart}-${attachment.lineEnd}` : "-";
+  return `${name}\t${linePart}`;
+}
+
+const TERMINAL_SNIPPET_HEADER_PREFIX = "Selected terminal output from ";
+const TERMINAL_SNIPPET_HEADER_RE = /^Selected terminal output from ([^\n]+?) \(([^)]*)\):$/u;
+
+function chooseTextFence(text: string): { open: string; close: string } {
+  if (!/^\s*```/m.test(text)) {
+    return { open: "```text\n", close: "\n```" };
+  }
+  return { open: "````text\n", close: "\n````" };
+}
+
+/** Wire-format terminal snippet block (shared by attachment + composer segment model). */
+export function terminalSnippetContextText(
+  attachment: Pick<TerminalSnippetAttachment, "terminalName" | "lineStart" | "lineEnd" | "selectedText">,
+): string {
+  const meta = formatTerminalSnippetWireMeta(attachment);
+  const fence = chooseTextFence(attachment.selectedText);
+  return `Selected terminal output from ${attachment.terminalName.trim() || "Terminal"} (${meta}):\n${fence.open}${attachment.selectedText}${fence.close}`;
+}
+
+export type ParsedTerminalSnippetWireBlock = {
+  index: number;
+  length: number;
+  terminalName: string;
+  meta: string;
+  selectedText: string;
+};
+
+const TERMINAL_SNIPPET_OPEN_FENCE_RE = /^(`{3,})text\n/;
+
+/** Scan wire text for terminal snippet blocks; closing fence must be a standalone line. */
+export function scanTerminalSnippetWireBlocks(content: string): ParsedTerminalSnippetWireBlock[] {
+  const blocks: ParsedTerminalSnippetWireBlock[] = [];
+  let searchFrom = 0;
+
+  while (searchFrom < content.length) {
+    const headerIndex = content.indexOf(TERMINAL_SNIPPET_HEADER_PREFIX, searchFrom);
+    if (headerIndex === -1) {
+      break;
+    }
+
+    const headerLineEnd = content.indexOf("\n", headerIndex);
+    if (headerLineEnd === -1) {
+      break;
+    }
+
+    const headerLine = content.slice(headerIndex, headerLineEnd);
+    const headerMatch = TERMINAL_SNIPPET_HEADER_RE.exec(headerLine);
+    if (!headerMatch) {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+
+    let cursor = headerLineEnd + 1;
+    const fenceTail = content.slice(cursor);
+    const openFenceMatch = TERMINAL_SNIPPET_OPEN_FENCE_RE.exec(fenceTail);
+    if (!openFenceMatch) {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+    const fenceMark = openFenceMatch[1] ?? "```";
+    const closeFence = fenceMark;
+    cursor += openFenceMatch[0].length;
+
+    const bodyLines: string[] = [];
+    let closed = false;
+    while (cursor <= content.length) {
+      const nextLineEnd = content.indexOf("\n", cursor);
+      const lineEnd = nextLineEnd === -1 ? content.length : nextLineEnd;
+      const line = content.slice(cursor, lineEnd);
+      if (line === closeFence) {
+        const blockEnd = nextLineEnd === -1 ? content.length : nextLineEnd + 1;
+        blocks.push({
+          index: headerIndex,
+          length: blockEnd - headerIndex,
+          terminalName: headerMatch[1]?.trim() ?? "",
+          meta: headerMatch[2]?.trim() ?? "",
+          selectedText: bodyLines.join("\n"),
+        });
+        searchFrom = blockEnd;
+        closed = true;
+        break;
+      }
+      bodyLines.push(line);
+      if (nextLineEnd === -1) {
+        break;
+      }
+      cursor = nextLineEnd + 1;
+    }
+
+    if (!closed) {
+      searchFrom = headerIndex + 1;
+    }
+  }
+
+  return blocks;
+}
+
+export function parseTerminalSnippetWireMeta(meta: string): {
+  terminalName: string;
+  lineStart: number;
+  lineEnd: number;
+} | null {
+  const trimmed = meta.trim();
+  const tabParts = trimmed.split("\t");
+  if (tabParts.length === 2) {
+    const terminalName = tabParts[0]?.trim() ?? "";
+    const linePart = tabParts[1]?.trim() ?? "";
+    if (terminalName) {
+      if (linePart === "-") {
+        return { terminalName, lineStart: 0, lineEnd: 0 };
+      }
+      const lineMatch = /^L(\d+)-(\d+)$/u.exec(linePart);
+      if (lineMatch) {
+        return {
+          terminalName,
+          lineStart: Number(lineMatch[1]),
+          lineEnd: Number(lineMatch[2]),
+        };
+      }
+    }
+  }
+  return null;
+}

--- a/apps/desktop/src/lib/workspace-tool-tabs.ts
+++ b/apps/desktop/src/lib/workspace-tool-tabs.ts
@@ -83,6 +83,24 @@ export function workspaceToolTabLabel(
   return `${base} ${index + 1}`;
 }
 
+/** Chip 显示名：优先 OSC 终端标题，否则 i18n 默认 Terminal（多 tab 加序号）。 */
+export function workspaceTerminalChipDisplayName(
+  tab: WorkspaceToolTab,
+  tabs: readonly WorkspaceToolTab[],
+  translate: (key: string) => string,
+): string {
+  const titled = tab.tabTitle?.trim();
+  if (titled) {
+    return titled;
+  }
+  const index = tabs.filter((item) => item.kind === "shell").findIndex((item) => item.id === tab.id);
+  const base = translate("workspace.terminalChipDefaultName");
+  if (index <= 0) {
+    return base;
+  }
+  return `${base} ${index + 1}`;
+}
+
 export function focusFirstTabOfKind(
   tabs: readonly WorkspaceToolTab[],
   kind: WorkspaceToolTabKind,

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -582,6 +582,7 @@
     "openSystemTerminal": "Open System Terminal",
     "files": "Files",
     "shell": "Shell",
+    "terminalChipDefaultName": "Terminal",
     "gitTab": "Git",
     "browser": "Browser",
     "browserPlaceholder": "Browser tab loading…",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -659,7 +659,7 @@
     "prCheckStateInProgress": "In progress",
     "prCheckStatePending": "Not started",
     "prChangesViewOnGitHub": "View on GitHub",
-    "prAddDiffToSession": "Add to Session",
+    "addSelectionToSession": "Add to Session",
     "prFileStatusAdded": "Added",
     "prFileStatusRemoved": "Removed",
     "prFileStatusModified": "Modified",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -657,7 +657,7 @@
     "prCheckStateInProgress": "进行中",
     "prCheckStatePending": "未开始",
     "prChangesViewOnGitHub": "在 GitHub 查看",
-    "prAddDiffToSession": "添加到会话",
+    "addSelectionToSession": "添加到会话",
     "prFileStatusAdded": "新增",
     "prFileStatusRemoved": "删除",
     "prFileStatusModified": "修改",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -580,6 +580,7 @@
     "openSystemTerminal": "打开系统终端",
     "files": "文件",
     "shell": "Shell",
+    "terminalChipDefaultName": "Terminal",
     "gitTab": "Git",
     "browser": "浏览器",
     "browserPlaceholder": "浏览器选项卡加载中…",

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -112,6 +112,39 @@ test("messageSegmentSeparator uses single newline between element and inline tex
   );
 });
 
+const sampleTerminalAttachment = {
+  id: "term-1",
+  terminalName: "Terminal",
+  lineStart: 10,
+  lineEnd: 12,
+  selectedText: "error output",
+};
+
+test("messageSegmentSeparator uses single newline between terminal chip and element", () => {
+  assert.equal(
+    messageSegmentSeparator(
+      { kind: "terminalSnippet", attachment: sampleTerminalAttachment },
+      { kind: "element", attachment: sampleAttachment },
+    ),
+    "\n",
+  );
+  assert.equal(
+    messageSegmentSeparator(
+      { kind: "element", attachment: sampleAttachment },
+      { kind: "terminalSnippet", attachment: sampleTerminalAttachment },
+    ),
+    "\n",
+  );
+});
+
+test("segmentsToMessageText does not double-newline terminal chip after element", () => {
+  const message = segmentsToMessageText([
+    { kind: "element", attachment: sampleAttachment },
+    { kind: "terminalSnippet", attachment: sampleTerminalAttachment },
+  ]);
+  assert.ok(!message.includes("```\n\nSelected terminal"));
+});
+
 test("trimMessageTextAroundElements removes one structural newline after element", () => {
   assert.equal(trimMessageTextAroundElements("\n你好啊", { afterElement: true }), "你好啊");
   assert.equal(trimMessageTextAroundElements("你好啊\n", { beforeElement: true }), "你好啊");

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -832,3 +832,107 @@ test("normalizeCaretForInlineAttachmentChips snaps caret on skill chip", () => {
   assert.equal(snapped.segmentIndex, 1);
   assert.equal(snapped.offset, 1);
 });
+
+test("composerShowsPlaceholder false when terminalSnippet chip present", () => {
+  assert.equal(
+    composerShowsPlaceholder(
+      [
+        {
+          kind: "terminalSnippet",
+          attachment: {
+            id: "term-1",
+            terminalName: "Terminal",
+            lineStart: 10,
+            lineEnd: 12,
+            selectedText: "error output",
+          },
+        },
+        { kind: "text", value: " " },
+      ],
+      { composing: false, attachmentCount: 0 },
+    ),
+    false,
+  );
+});
+
+test("normalizeCaretForInlineAttachmentChips snaps caret on terminalSnippet chip", () => {
+  const segs = [
+    {
+      kind: "terminalSnippet",
+      attachment: {
+        id: "term-1",
+        terminalName: "Terminal",
+        lineStart: 3,
+        lineEnd: 5,
+        selectedText: "log line",
+      },
+    },
+    { kind: "text", value: " tail" },
+  ];
+  const snapped = normalizeCaretForInlineAttachmentChips(segs, {
+    segmentIndex: 0,
+    offset: 0,
+  });
+  assert.equal(snapped.segmentIndex, 1);
+  assert.equal(snapped.offset, 1);
+});
+
+test("isCaretAtInlineChipRemovalPoint detects caret after terminalSnippet chip", () => {
+  const segs = [
+    {
+      kind: "terminalSnippet",
+      attachment: {
+        id: "term-1",
+        terminalName: "npm run dev",
+        lineStart: 1,
+        lineEnd: 1,
+        selectedText: "done",
+      },
+    },
+    { kind: "text", value: " " },
+  ];
+  assert.equal(
+    isCaretAtInlineChipRemovalPoint(segs, { segmentIndex: 1, offset: 0 }),
+    true,
+  );
+});
+
+test("removeInlineChipAtRemovalPoint removes terminalSnippet chip on backspace", () => {
+  const segs = [
+    {
+      kind: "terminalSnippet",
+      attachment: {
+        id: "term-1",
+        terminalName: "Terminal",
+        lineStart: 2,
+        lineEnd: 4,
+        selectedText: "stderr",
+      },
+    },
+    { kind: "text", value: "  " },
+  ];
+  const result = removeInlineChipAtRemovalPoint(segs, { segmentIndex: 1, offset: 0 });
+  assert.ok(result);
+  assert.equal(result.segments.some((s) => s.kind === "terminalSnippet"), false);
+});
+
+test("syncSegmentsFromExternalValue preserves terminalSnippet chip", () => {
+  const synced = syncSegmentsFromExternalValue(
+    [
+      {
+        kind: "terminalSnippet",
+        attachment: {
+          id: "term-1",
+          terminalName: "Terminal",
+          lineStart: 1,
+          lineEnd: 2,
+          selectedText: "x",
+        },
+      },
+      { kind: "text", value: " " },
+    ],
+    "follow up",
+  );
+  assert.equal(synced.some((s) => s.kind === "terminalSnippet"), true);
+  assert.equal(synced.some((s) => s.kind === "text" && s.value === "follow up"), true);
+});

--- a/apps/desktop/test/lib/terminal-snippet-wire-text.test.mjs
+++ b/apps/desktop/test/lib/terminal-snippet-wire-text.test.mjs
@@ -7,6 +7,7 @@ import {
   segmentsToMessageText,
 } from "../../src/lib/composer-segment-model.ts";
 import {
+  parseTerminalSnippetLinePart,
   parseTerminalSnippetWireMeta,
   scanTerminalSnippetWireBlocks,
   terminalSnippetContextText,
@@ -21,12 +22,40 @@ test("terminalSnippetContextText serializes terminal name, line range, and selec
   });
 
   assert.match(wire, /Selected terminal output from Terminal/);
-  assert.match(wire, /Terminal\tL10-15/);
+  assert.match(wire, /\(L10-15\):/);
   assert.match(wire, /```text\n/);
   assert.match(wire, /error: build failed/);
 });
 
-test("parseTerminalSnippetWireMeta round-trips tab-separated meta", () => {
+test("parseTerminalSnippetLinePart parses line range suffix", () => {
+  const parsed = parseTerminalSnippetLinePart("L3-7");
+  assert.deepEqual(parsed, {
+    lineStart: 3,
+    lineEnd: 7,
+  });
+});
+
+test("wire round-trips terminal names containing parentheses", () => {
+  const attachment = {
+    id: "term-paren",
+    terminalName: "bash (main)",
+    lineStart: 5,
+    lineEnd: 8,
+    selectedText: "output line",
+  };
+  const message = segmentsToMessageText([{ kind: "terminalSnippet", attachment }]);
+  const parts = parseMessageContentParts(message);
+  assert.equal(parts.length, 1);
+  assert.equal(parts[0]?.kind, "terminalSnippet");
+  if (parts[0]?.kind !== "terminalSnippet") {
+    return;
+  }
+  assert.equal(parts[0].terminalName, "bash (main)");
+  assert.equal(parts[0].lineStart, 5);
+  assert.equal(parts[0].lineEnd, 8);
+});
+
+test("parseTerminalSnippetWireMeta still parses legacy tab-separated meta", () => {
   const parsed = parseTerminalSnippetWireMeta("npm run dev\tL3-7");
   assert.deepEqual(parsed, {
     terminalName: "npm run dev",

--- a/apps/desktop/test/lib/terminal-snippet-wire-text.test.mjs
+++ b/apps/desktop/test/lib/terminal-snippet-wire-text.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  messageContentToRichSegments,
+  parseMessageContentParts,
+  segmentsToMessageText,
+} from "../../src/lib/composer-segment-model.ts";
+import {
+  parseTerminalSnippetWireMeta,
+  scanTerminalSnippetWireBlocks,
+  terminalSnippetContextText,
+} from "../../src/lib/terminal-snippet-wire-text.ts";
+
+test("terminalSnippetContextText serializes terminal name, line range, and selected text", () => {
+  const wire = terminalSnippetContextText({
+    terminalName: "Terminal",
+    lineStart: 10,
+    lineEnd: 15,
+    selectedText: "error: build failed\nexit code 1",
+  });
+
+  assert.match(wire, /Selected terminal output from Terminal/);
+  assert.match(wire, /Terminal\tL10-15/);
+  assert.match(wire, /```text\n/);
+  assert.match(wire, /error: build failed/);
+});
+
+test("parseTerminalSnippetWireMeta round-trips tab-separated meta", () => {
+  const parsed = parseTerminalSnippetWireMeta("npm run dev\tL3-7");
+  assert.deepEqual(parsed, {
+    terminalName: "npm run dev",
+    lineStart: 3,
+    lineEnd: 7,
+  });
+});
+
+test("segmentsToMessageText and parseMessageContentParts round-trip terminal chips", () => {
+  const attachment = {
+    id: "term-1",
+    terminalName: "Terminal",
+    lineStart: 42,
+    lineEnd: 44,
+    selectedText: "line one\nline two",
+  };
+  const message = segmentsToMessageText([{ kind: "terminalSnippet", attachment }]);
+  const parts = parseMessageContentParts(message);
+  assert.equal(parts.length, 1);
+  assert.equal(parts[0]?.kind, "terminalSnippet");
+  if (parts[0]?.kind !== "terminalSnippet") {
+    return;
+  }
+  assert.equal(parts[0].terminalName, "Terminal");
+  assert.equal(parts[0].lineStart, 42);
+  assert.equal(parts[0].lineEnd, 44);
+  assert.equal(parts[0].selectedText, "line one\nline two");
+
+  const segments = messageContentToRichSegments(message, "rewind");
+  assert.equal(segments.length, 1);
+  assert.equal(segments[0]?.kind, "terminalSnippet");
+});
+
+test("scanTerminalSnippetWireBlocks parses body containing standalone fence lines", () => {
+  const body = ["before", "```", "after"].join("\n");
+  const wire = terminalSnippetContextText({
+    terminalName: "Terminal 2",
+    lineStart: 1,
+    lineEnd: 3,
+    selectedText: body,
+  });
+  const blocks = scanTerminalSnippetWireBlocks(wire);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0]?.selectedText, body);
+});

--- a/apps/desktop/test/lib/terminal-snippet-wire-text.test.mjs
+++ b/apps/desktop/test/lib/terminal-snippet-wire-text.test.mjs
@@ -55,6 +55,26 @@ test("wire round-trips terminal names containing parentheses", () => {
   assert.equal(parts[0].lineEnd, 8);
 });
 
+test("wire round-trips terminal names containing tab characters", () => {
+  const attachment = {
+    id: "term-tab",
+    terminalName: "shell\t1",
+    lineStart: 2,
+    lineEnd: 4,
+    selectedText: "tab name line",
+  };
+  const message = segmentsToMessageText([{ kind: "terminalSnippet", attachment }]);
+  const parts = parseMessageContentParts(message);
+  assert.equal(parts.length, 1);
+  assert.equal(parts[0]?.kind, "terminalSnippet");
+  if (parts[0]?.kind !== "terminalSnippet") {
+    return;
+  }
+  assert.equal(parts[0].terminalName, "shell\t1");
+  assert.equal(parts[0].lineStart, 2);
+  assert.equal(parts[0].lineEnd, 4);
+});
+
 test("parseTerminalSnippetWireMeta still parses legacy tab-separated meta", () => {
   const parsed = parseTerminalSnippetWireMeta("npm run dev\tL3-7");
   assert.deepEqual(parsed, {

--- a/apps/desktop/test/workspace-tool-tabs.test.mjs
+++ b/apps/desktop/test/workspace-tool-tabs.test.mjs
@@ -12,6 +12,7 @@ import {
   focusFirstTabOfKind,
   isBrowserNewTabUrl,
   normalizeWorkspaceToolTabsForHost,
+  workspaceTerminalChipDisplayName,
   workspaceToolTabLabel,
 } from "../src/lib/workspace-tool-tabs.ts";
 
@@ -21,6 +22,7 @@ const t = (key) =>
     "workspace.shell": "Shell",
     "workspace.browser": "浏览器",
     "workspace.prTab": "Pull Request",
+    "workspace.terminalChipDefaultName": "Terminal",
   })[key] ?? key;
 
 test("createDefaultWorkspaceToolTabs has files, shell, and git", () => {
@@ -38,6 +40,15 @@ test("workspaceToolTabLabel numbers duplicate kinds", () => {
   assert.equal(workspaceToolTabLabel("files", tabs, a.id, t), "文件");
   assert.equal(workspaceToolTabLabel("files", tabs, b.id, t), "文件 2");
   assert.equal(workspaceToolTabLabel("shell", tabs, createWorkspaceToolTab("shell").id, t), "Shell");
+});
+
+test("workspaceTerminalChipDisplayName prefers tab title then default label", () => {
+  const shellA = createWorkspaceToolTab("shell");
+  const shellB = createWorkspaceToolTab("shell");
+  shellA.tabTitle = "npm run dev";
+  const tabs = [shellA, shellB];
+  assert.equal(workspaceTerminalChipDisplayName(shellA, tabs, t), "npm run dev");
+  assert.equal(workspaceTerminalChipDisplayName(shellB, tabs, t), "Terminal 2");
 });
 
 test("createWorkspaceToolTab browser defaults to new-tab sentinel", () => {


### PR DESCRIPTION
## Summary

- Shell 终端支持划选输出后通过「添加到会话」插入 Composer 内联 Terminal Chip，发送后消息气泡同步展示
- 新增 `terminalSnippet` segment、wire 文本格式（`Selected terminal output from …`）及 attachment 全链路（composer / caret / DOM / rewind）
- 审查修复：wire 头部支持标题含括号、失焦后保留选区文本、点击时重算行号、键盘/触摸选区、chip 相邻单换行；PR 与终端菜单共用 `workspace.addSelectionToSession`

## Test plan

- [x] Shell 终端鼠标划选 → 弹出「添加到会话」→ Composer 出现 Terminal Chip，可编辑并发送
- [x] 用户消息气泡正确展示 Terminal Chip 标签（`{name} L{start}-{end}`，无行号时省略 `L` 段）
- [x] wire 文本 round-trip：普通名称、含 `)` 的名称（如 `bash (main)`）、含 TAB 的名称、正文含独立 ``` 行
- [x] xterm 晚于 tab mount 就绪后，选区菜单仍能正常弹出（`useState(terminal)` 重绑 listener）
- [x] 菜单打开后 xterm 失焦仍能用缓存选区成功 Add to Session
- [x] 纯键盘选区（Shift+方向键等）可弹出菜单；无指针坐标时使用容器中心锚点
- [x] 触摸设备 `touchend` 可触发选区菜单
- [x] Terminal Chip 与元素 Chip / PR Diff Chip 相邻序列化时不产生双空行
- [x] PR Changes 与终端选区菜单均使用 `workspace.addSelectionToSession` 文案
- [x] `npx --yes tsx --test test/composer-segments.test.mjs test/lib/terminal-snippet-wire-text.test.mjs test/workspace-tool-tabs.test.mjs` 全部通过