### PR TITLE
feat(desktop): 自动化 GitHub 触发器（PR/Issue 创建）

### DIFF
--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -276,6 +276,12 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   listGitHubPullRequests(request: unknown) {
     return ipcRenderer.invoke('desktop:invoke', 'listGitHubPullRequests', { request });
   },
+  listGitHubAutomationRepositories(request: unknown = {}) {
+    return ipcRenderer.invoke('desktop:invoke', 'listGitHubAutomationRepositories', { request });
+  },
+  searchGitHubAutomationRepositories(request: unknown) {
+    return ipcRenderer.invoke('desktop:invoke', 'searchGitHubAutomationRepositories', { request });
+  },
   getGitHubPullRequestTabCounts(request: unknown) {
     return ipcRenderer.invoke('desktop:invoke', 'getGitHubPullRequestTabCounts', { request });
   },

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -389,6 +389,7 @@ export default function App() {
                 snapshot={snapshot}
                 apiReady={runtime.apiReady}
                 busyAction={runtime.busyAction}
+                githubConnected={gitHubAuthConnected === true}
                 onGenerateAutomation={() => void surfaceNav.handleGenerateAutomation()}
                 onCreateAutomation={() => surfaceNav.setCreateAutomationDialogOpen(true)}
                 onOpenAutomation={(automationId) => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -375,6 +375,9 @@ export default function App() {
                 getAutomation={runtime.getAutomation}
                 updateAutomation={(id, patch) => void runtime.updateAutomation(id, patch)}
                 settingsDisabled={!runtime.apiReady || runtime.busyAction === "automation"}
+                githubConnected={gitHubAuthConnected === true}
+                listGitHubRepositories={runtime.listGitHubAutomationRepositories}
+                searchGitHubRepositories={runtime.searchGitHubAutomationRepositories}
                 onAddWorkspace={() => void runtime.pickWorkspaceDirectory?.().then((path) => {
                   if (path) {
                     void runtime.rememberWorkspaceRoot(path);
@@ -406,6 +409,9 @@ export default function App() {
               onOpenChange={surfaceNav.setCreateAutomationDialogOpen}
               snapshot={snapshot}
               disabled={!runtime.apiReady || runtime.busyAction === "automation"}
+              githubConnected={gitHubAuthConnected === true}
+              listGitHubRepositories={runtime.listGitHubAutomationRepositories}
+              searchGitHubRepositories={runtime.searchGitHubAutomationRepositories}
               onSubmit={(request) => void runtime.createAutomation(request)}
               onAddWorkspace={() => void runtime.pickWorkspaceDirectory?.().then((path) => {
                 if (path) {

--- a/apps/desktop/src/adapters/electron.ts
+++ b/apps/desktop/src/adapters/electron.ts
@@ -258,6 +258,12 @@ export async function createElectronHostApi(): Promise<HostApi> {
     listGitHubPullRequests(request) {
       return bridge.listGitHubPullRequests(request);
     },
+    listGitHubAutomationRepositories(request = {}) {
+      return bridge.listGitHubAutomationRepositories(request);
+    },
+    searchGitHubAutomationRepositories(request) {
+      return bridge.searchGitHubAutomationRepositories(request);
+    },
     getGitHubPullRequestTabCounts(request) {
       return bridge.getGitHubPullRequestTabCounts(request);
     },

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -213,6 +213,12 @@ export function createWebHostApi(): HostApi {
     listGitHubPullRequests() {
       return Promise.reject(new Error('GitHub pull requests are only available in the Electron desktop app.'));
     },
+    listGitHubAutomationRepositories() {
+      return Promise.reject(new Error('GitHub repositories are only available in the Electron desktop app.'));
+    },
+    searchGitHubAutomationRepositories() {
+      return Promise.reject(new Error('GitHub repositories are only available in the Electron desktop app.'));
+    },
     getGitHubPullRequestTabCounts() {
       return Promise.reject(new Error('GitHub pull requests are only available in the Electron desktop app.'));
     },

--- a/apps/desktop/src/components/automation-detail-view.tsx
+++ b/apps/desktop/src/components/automation-detail-view.tsx
@@ -8,6 +8,8 @@ import type {
   DesktopAutomationDetail,
   DesktopSnapshot,
   DesktopUpdateAutomationRequest,
+  GitHubAutomationRepositoriesSnapshot,
+  SearchGitHubAutomationRepositoriesSnapshot,
   SessionListItem,
 } from "@/types";
 import { cn } from "@/lib/utils";
@@ -25,6 +27,12 @@ type AutomationDetailViewProps = {
   ): void | Promise<void>;
   onAddWorkspace?(): void | Promise<void>;
   settingsDisabled?: boolean;
+  githubConnected: boolean;
+  listGitHubRepositories(page?: number): Promise<GitHubAutomationRepositoriesSnapshot>;
+  searchGitHubRepositories(
+    query: string,
+    page?: number,
+  ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
 };
 
 type AutomationDetailTab = "kanban" | "settings";
@@ -84,6 +92,9 @@ export function AutomationDetailView({
   updateAutomation,
   onAddWorkspace,
   settingsDisabled,
+  githubConnected,
+  listGitHubRepositories,
+  searchGitHubRepositories,
 }: AutomationDetailViewProps) {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<AutomationDetailTab>("kanban");
@@ -154,7 +165,10 @@ export function AutomationDetailView({
                 definition={definition}
                 snapshot={snapshot}
                 disabled={settingsDisabled}
+                githubConnected={githubConnected}
                 onAddWorkspace={onAddWorkspace}
+                listGitHubRepositories={listGitHubRepositories}
+                searchGitHubRepositories={searchGitHubRepositories}
                 onSave={async (patch) => {
                   await updateAutomation(automationId, patch);
                   await refresh({ silent: true });

--- a/apps/desktop/src/components/automation-schedule-menu.tsx
+++ b/apps/desktop/src/components/automation-schedule-menu.tsx
@@ -73,6 +73,35 @@ type AutomationScheduleMenuProps = {
   onScheduleChange(schedule: DesktopAutomationSchedule): void;
 };
 
+export function AutomationTimeScheduleOptions({
+  schedule,
+  disabled,
+  onScheduleChange,
+}: AutomationScheduleMenuProps) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <DropdownMenuItem
+        disabled={disabled}
+        onSelect={() => onScheduleChange({ kind: "hourly" })}
+      >
+        {t("automations.schedule.hourly")}
+      </DropdownMenuItem>
+      <DailyScheduleSub
+        title={t("automations.schedule.daily")}
+        schedule={schedule}
+        onScheduleChange={onScheduleChange}
+      />
+      <WeeklyScheduleSub
+        title={t("automations.schedule.weekly")}
+        schedule={schedule}
+        onScheduleChange={onScheduleChange}
+      />
+    </>
+  );
+}
+
 export function AutomationScheduleMenu({
   schedule,
   disabled,
@@ -102,17 +131,9 @@ export function AutomationScheduleMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "z-[120]")}>
-        <DropdownMenuItem onSelect={() => onScheduleChange({ kind: "hourly" })}>
-          {t("automations.schedule.hourly")}
-        </DropdownMenuItem>
-        <DailyScheduleSub
-          title={t("automations.schedule.daily")}
+        <AutomationTimeScheduleOptions
           schedule={schedule}
-          onScheduleChange={onScheduleChange}
-        />
-        <WeeklyScheduleSub
-          title={t("automations.schedule.weekly")}
-          schedule={schedule}
+          disabled={disabled}
           onScheduleChange={onScheduleChange}
         />
       </DropdownMenuContent>

--- a/apps/desktop/src/components/automation-settings-panel.tsx
+++ b/apps/desktop/src/components/automation-settings-panel.tsx
@@ -2,11 +2,17 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ApprovalLevelMenu } from "@/components/approval-level-menu";
-import { AutomationScheduleMenu } from "@/components/automation-schedule-menu";
+import {
+  AutomationTriggerMenu,
+  defaultDesktopTimeTrigger,
+} from "@/components/automation-trigger-menu";
 import { ModelPickerMenu } from "@/components/model-picker-menu";
 import { WorkspaceSelectorMenu } from "@/components/workspace-selector-menu";
 import { Button } from "@/components/ui/button";
-import type { DesktopAutomationSchedule } from "@/lib/automation-schedule";
+import {
+  isValidDesktopAutomationTrigger,
+  type DesktopAutomationTrigger,
+} from "@/lib/automation-trigger";
 import { cn } from "@/lib/utils";
 import type {
   ApprovalLevel,
@@ -14,6 +20,8 @@ import type {
   DesktopModelReasoningEffort,
   DesktopSnapshot,
   DesktopUpdateAutomationRequest,
+  GitHubAutomationRepositoriesSnapshot,
+  SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
 
 type AutomationSettingsPanelProps = {
@@ -21,14 +29,17 @@ type AutomationSettingsPanelProps = {
   definition: DesktopAutomationDefinition | undefined;
   snapshot: DesktopSnapshot | null;
   disabled?: boolean;
+  githubConnected: boolean;
   onSave(patch: DesktopUpdateAutomationRequest): void | Promise<void>;
   onAddWorkspace?(): void | Promise<void>;
+  listGitHubRepositories(page?: number): Promise<GitHubAutomationRepositoriesSnapshot>;
+  searchGitHubRepositories(
+    query: string,
+    page?: number,
+  ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
 };
 
-function schedulesEqual(
-  left: DesktopAutomationSchedule,
-  right: DesktopAutomationSchedule,
-): boolean {
+function triggersEqual(left: DesktopAutomationTrigger, right: DesktopAutomationTrigger): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
@@ -41,14 +52,17 @@ export function AutomationSettingsPanel({
   definition,
   snapshot,
   disabled,
+  githubConnected,
   onSave,
   onAddWorkspace,
+  listGitHubRepositories,
+  searchGitHubRepositories,
 }: AutomationSettingsPanelProps) {
   const { t } = useTranslation();
   const initializedForAutomationIdRef = useRef<string | null>(null);
   const [title, setTitle] = useState("");
   const [overview, setOverview] = useState("");
-  const [schedule, setSchedule] = useState<DesktopAutomationSchedule>({ kind: "daily", hour: 20, minute: 0 });
+  const [trigger, setTrigger] = useState<DesktopAutomationTrigger>(defaultDesktopTimeTrigger());
   const [workspaceRoot, setWorkspaceRoot] = useState("");
   const [modelName, setModelName] = useState("");
   const [reasoningEffort, setReasoningEffort] = useState<DesktopModelReasoningEffort | undefined>();
@@ -66,7 +80,7 @@ export function AutomationSettingsPanel({
     initializedForAutomationIdRef.current = automationId;
     setTitle(definition.title);
     setOverview(definition.overview);
-    setSchedule(definition.schedule);
+    setTrigger(definition.trigger);
     setWorkspaceRoot(definition.workspaceRoot);
     setModelName(definition.modelName);
     setReasoningEffort(definition.reasoningEffort);
@@ -88,8 +102,8 @@ export function AutomationSettingsPanel({
     if (trimmedOverview !== definition.overview) {
       next.overview = trimmedOverview;
     }
-    if (!schedulesEqual(schedule, definition.schedule)) {
-      next.schedule = schedule;
+    if (!triggersEqual(trigger, definition.trigger)) {
+      next.trigger = trigger;
     }
     if (workspaceRoot !== definition.workspaceRoot) {
       next.workspaceRoot = workspaceRoot;
@@ -105,13 +119,15 @@ export function AutomationSettingsPanel({
     }
 
     return Object.keys(next).length > 0 ? next : null;
-  }, [approvalLevel, definition, modelName, overview, reasoningEffort, schedule, title, workspaceRoot]);
+  }, [approvalLevel, definition, modelName, overview, reasoningEffort, trigger, title, workspaceRoot]);
 
   const canSave =
     title.trim().length > 0
     && overview.trim().length > 0
     && workspaceRoot.trim().length > 0
     && modelName.trim().length > 0
+    && isValidDesktopAutomationTrigger(trigger)
+    && (trigger.kind !== "github" || githubConnected)
     && patch !== null;
 
   if (!definition) {
@@ -144,10 +160,13 @@ export function AutomationSettingsPanel({
         />
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
-            <AutomationScheduleMenu
-              schedule={schedule}
+            <AutomationTriggerMenu
+              trigger={trigger}
               disabled={disabled}
-              onScheduleChange={setSchedule}
+              githubConnected={githubConnected}
+              onTriggerChange={setTrigger}
+              listGitHubRepositories={listGitHubRepositories}
+              searchGitHubRepositories={searchGitHubRepositories}
             />
             {snapshot ? (
               <>

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -18,9 +18,12 @@ import {
   DESKTOP_OVERLAY_LIST_CONTENT,
   DESKTOP_OVERLAY_LIST_FILTER_HEADER,
   DESKTOP_OVERLAY_LIST_FILTER_INPUT_GHOST,
+  DESKTOP_OVERLAY_LIST_LIST_PADDING,
+  DESKTOP_OVERLAY_LIST_SCROLL_AREA,
   DESKTOP_OVERLAY_LIST_SHELL,
   DESKTOP_OVERLAY_LIST_SUB_TRIGGER,
   DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH,
+  stopOverlayScrollPropagation,
 } from "@/lib/desktop-chrome";
 import {
   defaultDesktopTimeTrigger,
@@ -206,8 +209,13 @@ function AutomationGitHubRepositoryList({
           autoComplete="off"
         />
       </div>
-      <ScrollArea className="max-h-60">
-        <div className="p-1">
+      <ScrollArea
+        type="always"
+        className={DESKTOP_OVERLAY_LIST_SCROLL_AREA}
+        onWheel={stopOverlayScrollPropagation}
+        onTouchMove={stopOverlayScrollPropagation}
+      >
+        <div className={DESKTOP_OVERLAY_LIST_LIST_PADDING}>
           {loading ? (
             <p className="px-2 py-3 text-xs text-muted-foreground">{t("common.loading")}</p>
           ) : items.length === 0 ? (

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -166,7 +166,7 @@ function AutomationGitHubRepositoryList({
   const { t } = useTranslation();
   const scrollAreaRef = useRef<ComponentRef<typeof ScrollArea>>(null);
   const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
-  const { query, setQuery, items, loading, loadingMore, hasMore, loadMore } = useGitHubAutomationRepositories({
+  const { query, setQuery, items, loading, loadingMore, hasMore, loadMore, error } = useGitHubAutomationRepositories({
     open,
     listGitHubRepositories,
     searchGitHubRepositories,
@@ -216,6 +216,8 @@ function AutomationGitHubRepositoryList({
         <div className={DESKTOP_OVERLAY_LIST_LIST_PADDING}>
           {loading ? (
             <p className="px-2 py-3 text-xs text-muted-foreground">{t("common.loading")}</p>
+          ) : error ? (
+            <p className="px-2 py-3 text-xs text-destructive">{t("automations.trigger.repositoryLoadFailed")}</p>
           ) : items.length === 0 ? (
             <p className="px-2 py-3 text-xs text-muted-foreground">{t("automations.trigger.repositoryEmpty")}</p>
           ) : (

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown } from "lucide-react";
+
+import { AutomationTimeScheduleOptions } from "@/components/automation-schedule-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH } from "@/lib/desktop-chrome";
+import {
+  defaultDesktopTimeTrigger,
+  formatDesktopAutomationTriggerLabel,
+  type DesktopAutomationGitHubEvent,
+  type DesktopAutomationSchedule,
+  type DesktopAutomationTrigger,
+} from "@/lib/automation-trigger";
+import type {
+  DesktopGitHubAutomationRepositoryItem,
+  GitHubAutomationRepositoriesSnapshot,
+  SearchGitHubAutomationRepositoriesSnapshot,
+} from "@/types";
+import { cn } from "@/lib/utils";
+
+type AutomationTriggerMenuProps = {
+  trigger: DesktopAutomationTrigger;
+  disabled?: boolean;
+  githubConnected: boolean;
+  onTriggerChange(trigger: DesktopAutomationTrigger): void;
+  listGitHubRepositories(page?: number): Promise<GitHubAutomationRepositoriesSnapshot>;
+  searchGitHubRepositories(
+    query: string,
+    page?: number,
+  ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
+};
+
+function githubRepoSelected(trigger: DesktopAutomationTrigger): trigger is Extract<
+  DesktopAutomationTrigger,
+  { kind: "github" }
+> {
+  return trigger.kind === "github" && Boolean(trigger.owner.trim() && trigger.repo.trim());
+}
+
+export function AutomationTriggerMenu({
+  trigger,
+  disabled,
+  githubConnected,
+  onTriggerChange,
+  listGitHubRepositories,
+  searchGitHubRepositories,
+}: AutomationTriggerMenuProps) {
+  const { t } = useTranslation();
+  const label = formatDesktopAutomationTriggerLabel(trigger, {
+    hourly: t("automations.schedule.hourly"),
+    dailyPrefix: t("automations.schedule.daily"),
+    weeklyPrefix: t("automations.schedule.weekly"),
+    weekdays: [
+      t("automations.schedule.weekday0"),
+      t("automations.schedule.weekday1"),
+      t("automations.schedule.weekday2"),
+      t("automations.schedule.weekday3"),
+      t("automations.schedule.weekday4"),
+      t("automations.schedule.weekday5"),
+      t("automations.schedule.weekday6"),
+    ],
+    formatWeekly: (weekday, time) => t("automations.schedule.weeklyAt", { weekday, time }),
+    githubPrefix: t("automations.trigger.github"),
+    githubPullRequestCreated: t("automations.trigger.pullRequestCreated"),
+    githubIssueCreated: t("automations.trigger.issueCreated"),
+  });
+
+  const timeSchedule: DesktopAutomationSchedule =
+    trigger.kind === "time" ? trigger.schedule : { kind: "daily", hour: 20, minute: 0 };
+
+  const setTimeSchedule = (schedule: DesktopAutomationSchedule) => {
+    onTriggerChange({ kind: "time", schedule });
+  };
+
+  const setGitHubRepo = (repo: DesktopGitHubAutomationRepositoryItem) => {
+    const currentEvent =
+      trigger.kind === "github" ? trigger.event : ("pull_request_created" satisfies DesktopAutomationGitHubEvent);
+    onTriggerChange({
+      kind: "github",
+      owner: repo.owner,
+      repo: repo.repo,
+      event: currentEvent,
+    });
+  };
+
+  const setGitHubEvent = (event: DesktopAutomationGitHubEvent) => {
+    if (trigger.kind !== "github") {
+      return;
+    }
+    onTriggerChange({ ...trigger, event });
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "inline-flex h-7 max-w-full items-center gap-1 rounded-md border-0 bg-transparent px-1 text-xs font-medium text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
+          )}
+        >
+          <span className="min-w-0 truncate">{label}</span>
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground/80" aria-hidden />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "z-[120]")}>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger disabled={disabled}>{t("automations.trigger.github")}</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="z-[130] p-0">
+            {!githubConnected ? (
+              <div className="max-w-56 px-3 py-2 text-xs text-muted-foreground">
+                {t("automations.trigger.connectGitHubHint")}
+              </div>
+            ) : (
+              <>
+                <AutomationGitHubRepositorySub
+                  disabled={disabled}
+                  selected={
+                    trigger.kind === "github"
+                      ? { owner: trigger.owner, repo: trigger.repo }
+                      : undefined
+                  }
+                  listGitHubRepositories={listGitHubRepositories}
+                  searchGitHubRepositories={searchGitHubRepositories}
+                  onSelect={setGitHubRepo}
+                />
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger
+                    disabled={disabled || !githubRepoSelected(trigger)}
+                  >
+                    {t("automations.trigger.event")}
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="z-[140]">
+                    <DropdownMenuItem
+                      disabled={disabled || !githubRepoSelected(trigger)}
+                      onSelect={() => setGitHubEvent("pull_request_created")}
+                    >
+                      {t("automations.trigger.pullRequestCreated")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={disabled || !githubRepoSelected(trigger)}
+                      onSelect={() => setGitHubEvent("issue_created")}
+                    >
+                      {t("automations.trigger.issueCreated")}
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              </>
+            )}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger disabled={disabled}>{t("automations.trigger.time")}</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "z-[130]")}>
+            <AutomationTimeScheduleOptions
+              schedule={timeSchedule}
+              disabled={disabled}
+              onScheduleChange={setTimeSchedule}
+            />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function AutomationGitHubRepositorySub({
+  disabled,
+  selected,
+  listGitHubRepositories,
+  searchGitHubRepositories,
+  onSelect,
+}: {
+  disabled?: boolean;
+  selected?: { owner: string; repo: string };
+  listGitHubRepositories(page?: number): Promise<GitHubAutomationRepositoriesSnapshot>;
+  searchGitHubRepositories(
+    query: string,
+    page?: number,
+  ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
+  onSelect(repo: DesktopGitHubAutomationRepositoryItem): void;
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [items, setItems] = useState<DesktopGitHubAutomationRepositoryItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const selectedLabel = useMemo(() => {
+    if (!selected?.owner || !selected.repo) {
+      return t("automations.trigger.repository");
+    }
+    return `${selected.owner}/${selected.repo}`;
+  }, [selected, t]);
+
+  const loadRepositories = useCallback(async (searchQuery: string) => {
+    setLoading(true);
+    try {
+      const snapshot = searchQuery.trim()
+        ? await searchGitHubRepositories(searchQuery.trim())
+        : await listGitHubRepositories();
+      setItems(snapshot.items);
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [listGitHubRepositories, searchGitHubRepositories]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      void loadRepositories(query);
+    }, query.trim() ? 300 : 0);
+    return () => window.clearTimeout(handle);
+  }, [loadRepositories, open, query]);
+
+  return (
+    <DropdownMenuSub open={open} onOpenChange={setOpen}>
+      <DropdownMenuSubTrigger disabled={disabled}>{selectedLabel}</DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="z-[140] w-72 p-0">
+        <div className="border-b border-border/40 p-2">
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t("automations.trigger.repositorySearchPlaceholder")}
+            className="h-8 border-0 bg-transparent px-2 shadow-none focus-visible:ring-0"
+          />
+        </div>
+        <ScrollArea className="max-h-60">
+          <div className="p-1">
+            {loading ? (
+              <p className="px-2 py-3 text-xs text-muted-foreground">{t("common.loading")}</p>
+            ) : items.length === 0 ? (
+              <p className="px-2 py-3 text-xs text-muted-foreground">{t("automations.trigger.repositoryEmpty")}</p>
+            ) : (
+              items.map((item) => (
+                <DropdownMenuItem
+                  key={item.fullName}
+                  className="text-xs"
+                  onSelect={() => onSelect(item)}
+                >
+                  <span className="truncate">{item.fullName}</span>
+                </DropdownMenuItem>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+}
+
+export { defaultDesktopTimeTrigger };

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Clock } from "lucide-react";
 
 import { AutomationTimeScheduleOptions } from "@/components/automation-schedule-menu";
+import { GitHubMarkIcon } from "@/components/github-mark-icon";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -115,7 +116,10 @@ export function AutomationTriggerMenu({
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "z-[120]")}>
         <DropdownMenuSub open={githubSubOpen} onOpenChange={setGithubSubOpen}>
-          <DropdownMenuSubTrigger disabled={disabled}>{t("automations.trigger.github")}</DropdownMenuSubTrigger>
+          <DropdownMenuSubTrigger disabled={disabled} className="gap-2">
+            <GitHubMarkIcon className="size-3.5 shrink-0 text-muted-foreground/80" />
+            {t("automations.trigger.github")}
+          </DropdownMenuSubTrigger>
           <DropdownMenuSubContent
             className={cn(DESKTOP_OVERLAY_LIST_CONTENT, DESKTOP_OVERLAY_LIST_SHELL, "z-[130] w-72")}
           >
@@ -135,7 +139,10 @@ export function AutomationTriggerMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger disabled={disabled}>{t("automations.trigger.time")}</DropdownMenuSubTrigger>
+          <DropdownMenuSubTrigger disabled={disabled} className="gap-2">
+            <Clock className="size-3.5 shrink-0 text-muted-foreground/80" aria-hidden />
+            {t("automations.trigger.time")}
+          </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "z-[130]")}>
             <AutomationTimeScheduleOptions
               schedule={timeSchedule}

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -33,6 +33,7 @@ import {
   type DesktopAutomationSchedule,
   type DesktopAutomationTrigger,
 } from "@/lib/automation-trigger";
+import { buildAutomationTriggerFormatLabels } from "@/lib/automation-trigger-i18n";
 import type {
   DesktopGitHubAutomationRepositoryItem,
   GitHubAutomationRepositoriesSnapshot,
@@ -62,24 +63,10 @@ export function AutomationTriggerMenu({
 }: AutomationTriggerMenuProps) {
   const { t } = useTranslation();
   const [githubSubOpen, setGithubSubOpen] = useState(false);
-  const label = formatDesktopAutomationTriggerLabel(trigger, {
-    hourly: t("automations.schedule.hourly"),
-    dailyPrefix: t("automations.schedule.daily"),
-    weeklyPrefix: t("automations.schedule.weekly"),
-    weekdays: [
-      t("automations.schedule.weekday0"),
-      t("automations.schedule.weekday1"),
-      t("automations.schedule.weekday2"),
-      t("automations.schedule.weekday3"),
-      t("automations.schedule.weekday4"),
-      t("automations.schedule.weekday5"),
-      t("automations.schedule.weekday6"),
-    ],
-    formatWeekly: (weekday, time) => t("automations.schedule.weeklyAt", { weekday, time }),
-    githubPrefix: t("automations.trigger.github"),
-    githubPullRequestCreated: t("automations.trigger.pullRequestCreated"),
-    githubIssueCreated: t("automations.trigger.issueCreated"),
-  });
+  const label = formatDesktopAutomationTriggerLabel(
+    trigger,
+    buildAutomationTriggerFormatLabels(t),
+  );
 
   const timeSchedule: DesktopAutomationSchedule =
     trigger.kind === "time" ? trigger.schedule : { kind: "daily", hour: 20, minute: 0 };

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown } from "lucide-react";
 
@@ -15,8 +15,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
+  DESKTOP_OVERLAY_LIST_CONTENT,
   DESKTOP_OVERLAY_LIST_FILTER_HEADER,
   DESKTOP_OVERLAY_LIST_FILTER_INPUT_GHOST,
+  DESKTOP_OVERLAY_LIST_SHELL,
+  DESKTOP_OVERLAY_LIST_SUB_TRIGGER,
   DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH,
 } from "@/lib/desktop-chrome";
 import {
@@ -45,13 +48,6 @@ type AutomationTriggerMenuProps = {
   ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
 };
 
-function githubRepoSelected(trigger: DesktopAutomationTrigger): trigger is Extract<
-  DesktopAutomationTrigger,
-  { kind: "github" }
-> {
-  return trigger.kind === "github" && Boolean(trigger.owner.trim() && trigger.repo.trim());
-}
-
 export function AutomationTriggerMenu({
   trigger,
   disabled,
@@ -61,6 +57,7 @@ export function AutomationTriggerMenu({
   searchGitHubRepositories,
 }: AutomationTriggerMenuProps) {
   const { t } = useTranslation();
+  const [githubSubOpen, setGithubSubOpen] = useState(false);
   const label = formatDesktopAutomationTriggerLabel(trigger, {
     hourly: t("automations.schedule.hourly"),
     dailyPrefix: t("automations.schedule.daily"),
@@ -87,22 +84,16 @@ export function AutomationTriggerMenu({
     onTriggerChange({ kind: "time", schedule });
   };
 
-  const setGitHubRepo = (repo: DesktopGitHubAutomationRepositoryItem) => {
-    const currentEvent =
-      trigger.kind === "github" ? trigger.event : ("pull_request_created" satisfies DesktopAutomationGitHubEvent);
+  const setGitHubTrigger = (
+    repo: DesktopGitHubAutomationRepositoryItem,
+    event: DesktopAutomationGitHubEvent,
+  ) => {
     onTriggerChange({
       kind: "github",
       owner: repo.owner,
       repo: repo.repo,
-      event: currentEvent,
+      event,
     });
-  };
-
-  const setGitHubEvent = (event: DesktopAutomationGitHubEvent) => {
-    if (trigger.kind !== "github") {
-      return;
-    }
-    onTriggerChange({ ...trigger, event });
   };
 
   return (
@@ -120,48 +111,23 @@ export function AutomationTriggerMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "z-[120]")}>
-        <DropdownMenuSub>
+        <DropdownMenuSub open={githubSubOpen} onOpenChange={setGithubSubOpen}>
           <DropdownMenuSubTrigger disabled={disabled}>{t("automations.trigger.github")}</DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="z-[130] p-0">
+          <DropdownMenuSubContent
+            className={cn(DESKTOP_OVERLAY_LIST_CONTENT, DESKTOP_OVERLAY_LIST_SHELL, "z-[130] w-72")}
+          >
             {!githubConnected ? (
               <div className="max-w-56 px-3 py-2 text-xs text-muted-foreground">
                 {t("automations.trigger.connectGitHubHint")}
               </div>
             ) : (
-              <>
-                <AutomationGitHubRepositorySub
-                  disabled={disabled}
-                  selected={
-                    trigger.kind === "github"
-                      ? { owner: trigger.owner, repo: trigger.repo }
-                      : undefined
-                  }
-                  listGitHubRepositories={listGitHubRepositories}
-                  searchGitHubRepositories={searchGitHubRepositories}
-                  onSelect={setGitHubRepo}
-                />
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger
-                    disabled={disabled || !githubRepoSelected(trigger)}
-                  >
-                    {t("automations.trigger.event")}
-                  </DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent className="z-[140]">
-                    <DropdownMenuItem
-                      disabled={disabled || !githubRepoSelected(trigger)}
-                      onSelect={() => setGitHubEvent("pull_request_created")}
-                    >
-                      {t("automations.trigger.pullRequestCreated")}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      disabled={disabled || !githubRepoSelected(trigger)}
-                      onSelect={() => setGitHubEvent("issue_created")}
-                    >
-                      {t("automations.trigger.issueCreated")}
-                    </DropdownMenuItem>
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-              </>
+              <AutomationGitHubRepositoryList
+                open={githubSubOpen}
+                disabled={disabled}
+                listGitHubRepositories={listGitHubRepositories}
+                searchGitHubRepositories={searchGitHubRepositories}
+                onSelect={setGitHubTrigger}
+              />
             )}
           </DropdownMenuSubContent>
         </DropdownMenuSub>
@@ -180,34 +146,29 @@ export function AutomationTriggerMenu({
   );
 }
 
-function AutomationGitHubRepositorySub({
+function AutomationGitHubRepositoryList({
+  open,
   disabled,
-  selected,
   listGitHubRepositories,
   searchGitHubRepositories,
   onSelect,
 }: {
+  open: boolean;
   disabled?: boolean;
-  selected?: { owner: string; repo: string };
   listGitHubRepositories(page?: number): Promise<GitHubAutomationRepositoriesSnapshot>;
   searchGitHubRepositories(
     query: string,
     page?: number,
   ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
-  onSelect(repo: DesktopGitHubAutomationRepositoryItem): void;
+  onSelect(
+    repo: DesktopGitHubAutomationRepositoryItem,
+    event: DesktopAutomationGitHubEvent,
+  ): void;
 }) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [items, setItems] = useState<DesktopGitHubAutomationRepositoryItem[]>([]);
   const [loading, setLoading] = useState(false);
-
-  const selectedLabel = useMemo(() => {
-    if (!selected?.owner || !selected.repo) {
-      return t("automations.trigger.repository");
-    }
-    return `${selected.owner}/${selected.repo}`;
-  }, [selected, t]);
 
   const loadRepositories = useCallback(async (searchQuery: string) => {
     setLoading(true);
@@ -234,40 +195,54 @@ function AutomationGitHubRepositorySub({
   }, [loadRepositories, open, query]);
 
   return (
-    <DropdownMenuSub open={open} onOpenChange={setOpen}>
-      <DropdownMenuSubTrigger disabled={disabled}>{selectedLabel}</DropdownMenuSubTrigger>
-      <DropdownMenuSubContent className="z-[140] w-72 p-0">
-        <div className={DESKTOP_OVERLAY_LIST_FILTER_HEADER}>
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder={t("automations.trigger.repositorySearchPlaceholder")}
-            className={DESKTOP_OVERLAY_LIST_FILTER_INPUT_GHOST}
-            onKeyDown={(event) => event.stopPropagation()}
-            autoComplete="off"
-          />
-        </div>
-        <ScrollArea className="max-h-60">
-          <div className="p-1">
-            {loading ? (
-              <p className="px-2 py-3 text-xs text-muted-foreground">{t("common.loading")}</p>
-            ) : items.length === 0 ? (
-              <p className="px-2 py-3 text-xs text-muted-foreground">{t("automations.trigger.repositoryEmpty")}</p>
-            ) : (
-              items.map((item) => (
-                <DropdownMenuItem
-                  key={item.fullName}
-                  className="text-xs"
-                  onSelect={() => onSelect(item)}
+    <>
+      <div className={DESKTOP_OVERLAY_LIST_FILTER_HEADER}>
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={t("automations.trigger.repositorySearchPlaceholder")}
+          className={DESKTOP_OVERLAY_LIST_FILTER_INPUT_GHOST}
+          onKeyDown={(event) => event.stopPropagation()}
+          autoComplete="off"
+        />
+      </div>
+      <ScrollArea className="max-h-60">
+        <div className="p-1">
+          {loading ? (
+            <p className="px-2 py-3 text-xs text-muted-foreground">{t("common.loading")}</p>
+          ) : items.length === 0 ? (
+            <p className="px-2 py-3 text-xs text-muted-foreground">{t("automations.trigger.repositoryEmpty")}</p>
+          ) : (
+            items.map((item) => (
+              <DropdownMenuSub key={item.fullName}>
+                <DropdownMenuSubTrigger
+                  disabled={disabled}
+                  className={DESKTOP_OVERLAY_LIST_SUB_TRIGGER}
                 >
-                  <span className="truncate">{item.fullName}</span>
-                </DropdownMenuItem>
-              ))
-            )}
-          </div>
-        </ScrollArea>
-      </DropdownMenuSubContent>
-    </DropdownMenuSub>
+                  <span className="min-w-0 truncate">{item.fullName}</span>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="z-[140]">
+                  <DropdownMenuItem
+                    disabled={disabled}
+                    className="text-xs"
+                    onSelect={() => onSelect(item, "pull_request_created")}
+                  >
+                    {t("automations.trigger.pullRequestCreated")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={disabled}
+                    className="text-xs"
+                    onSelect={() => onSelect(item, "issue_created")}
+                  >
+                    {t("automations.trigger.issueCreated")}
+                  </DropdownMenuItem>
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+            ))
+          )}
+        </div>
+      </ScrollArea>
+    </>
   );
 }
 

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef, type ComponentRef } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, Clock } from "lucide-react";
 
@@ -164,11 +164,35 @@ function AutomationGitHubRepositoryList({
   ): void;
 }) {
   const { t } = useTranslation();
-  const { query, setQuery, items, loading } = useGitHubAutomationRepositories({
+  const scrollAreaRef = useRef<ComponentRef<typeof ScrollArea>>(null);
+  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
+  const { query, setQuery, items, loading, loadingMore, hasMore, loadMore } = useGitHubAutomationRepositories({
     open,
     listGitHubRepositories,
     searchGitHubRepositories,
   });
+
+  useEffect(() => {
+    if (!open || !hasMore || loadingMore) {
+      return;
+    }
+    const root = scrollAreaRef.current?.querySelector("[data-radix-scroll-area-viewport]");
+    const sentinel = loadMoreSentinelRef.current;
+    if (!root || !sentinel) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) {
+          return;
+        }
+        loadMore();
+      },
+      { root, rootMargin: "160px 0px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, items.length, loadMore, loadingMore, open]);
 
   return (
     <>
@@ -183,6 +207,7 @@ function AutomationGitHubRepositoryList({
         />
       </div>
       <ScrollArea
+        ref={scrollAreaRef}
         type="always"
         className={DESKTOP_OVERLAY_LIST_SCROLL_AREA}
         onWheel={stopOverlayScrollPropagation}
@@ -194,32 +219,39 @@ function AutomationGitHubRepositoryList({
           ) : items.length === 0 ? (
             <p className="px-2 py-3 text-xs text-muted-foreground">{t("automations.trigger.repositoryEmpty")}</p>
           ) : (
-            items.map((item) => (
-              <DropdownMenuSub key={item.fullName}>
-                <DropdownMenuSubTrigger
-                  disabled={disabled}
-                  className={DESKTOP_OVERLAY_LIST_SUB_TRIGGER}
-                >
-                  <span className="min-w-0 truncate">{item.fullName}</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent className="z-[140]">
-                  <DropdownMenuItem
+            <>
+              {items.map((item) => (
+                <DropdownMenuSub key={item.fullName}>
+                  <DropdownMenuSubTrigger
                     disabled={disabled}
-                    className="text-xs"
-                    onSelect={() => onSelect(item, "pull_request_created")}
+                    className={DESKTOP_OVERLAY_LIST_SUB_TRIGGER}
                   >
-                    {t("automations.trigger.pullRequestCreated")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    disabled={disabled}
-                    className="text-xs"
-                    onSelect={() => onSelect(item, "issue_created")}
-                  >
-                    {t("automations.trigger.issueCreated")}
-                  </DropdownMenuItem>
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
-            ))
+                    <span className="min-w-0 truncate">{item.fullName}</span>
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="z-[140]">
+                    <DropdownMenuItem
+                      disabled={disabled}
+                      className="text-xs"
+                      onSelect={() => onSelect(item, "pull_request_created")}
+                    >
+                      {t("automations.trigger.pullRequestCreated")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      disabled={disabled}
+                      className="text-xs"
+                      onSelect={() => onSelect(item, "issue_created")}
+                    >
+                      {t("automations.trigger.issueCreated")}
+                    </DropdownMenuItem>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              ))}
+              {hasMore ? (
+                <div ref={loadMoreSentinelRef} className="px-2 py-2 text-xs text-muted-foreground">
+                  {loadingMore ? t("common.loading") : null}
+                </div>
+              ) : null}
+            </>
           )}
         </div>
       </ScrollArea>

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -14,7 +14,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH } from "@/lib/desktop-chrome";
+import {
+  DESKTOP_OVERLAY_LIST_FILTER_HEADER,
+  DESKTOP_OVERLAY_LIST_FILTER_INPUT_GHOST,
+  DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH,
+} from "@/lib/desktop-chrome";
 import {
   defaultDesktopTimeTrigger,
   formatDesktopAutomationTriggerLabel,
@@ -233,12 +237,14 @@ function AutomationGitHubRepositorySub({
     <DropdownMenuSub open={open} onOpenChange={setOpen}>
       <DropdownMenuSubTrigger disabled={disabled}>{selectedLabel}</DropdownMenuSubTrigger>
       <DropdownMenuSubContent className="z-[140] w-72 p-0">
-        <div className="border-b border-border/40 p-2">
+        <div className={DESKTOP_OVERLAY_LIST_FILTER_HEADER}>
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder={t("automations.trigger.repositorySearchPlaceholder")}
-            className="h-8 border-0 bg-transparent px-2 shadow-none focus-visible:ring-0"
+            className={DESKTOP_OVERLAY_LIST_FILTER_INPUT_GHOST}
+            onKeyDown={(event) => event.stopPropagation()}
+            autoComplete="off"
           />
         </div>
         <ScrollArea className="max-h-60">

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown, Clock } from "lucide-react";
 
 import { AutomationTimeScheduleOptions } from "@/components/automation-schedule-menu";
 import { GitHubMarkIcon } from "@/components/github-mark-icon";
+import { useGitHubAutomationRepositories } from "@/hooks/use-github-automation-repositories";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -163,33 +164,11 @@ function AutomationGitHubRepositoryList({
   ): void;
 }) {
   const { t } = useTranslation();
-  const [query, setQuery] = useState("");
-  const [items, setItems] = useState<DesktopGitHubAutomationRepositoryItem[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  const loadRepositories = useCallback(async (searchQuery: string) => {
-    setLoading(true);
-    try {
-      const snapshot = searchQuery.trim()
-        ? await searchGitHubRepositories(searchQuery.trim())
-        : await listGitHubRepositories();
-      setItems(snapshot.items);
-    } catch {
-      setItems([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [listGitHubRepositories, searchGitHubRepositories]);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    const handle = window.setTimeout(() => {
-      void loadRepositories(query);
-    }, query.trim() ? 300 : 0);
-    return () => window.clearTimeout(handle);
-  }, [loadRepositories, open, query]);
+  const { query, setQuery, items, loading } = useGitHubAutomationRepositories({
+    open,
+    listGitHubRepositories,
+    searchGitHubRepositories,
+  });
 
   return (
     <>

--- a/apps/desktop/src/components/automations-view.tsx
+++ b/apps/desktop/src/components/automations-view.tsx
@@ -293,6 +293,9 @@ function AutomationListRow({
         ) : null}
       </div>
       <p className="text-xs text-muted-foreground">{triggerLabel}</p>
+      {item.githubPollError ? (
+        <p className="text-xs text-destructive">{item.githubPollError}</p>
+      ) : null}
     </button>
   );
 }

--- a/apps/desktop/src/components/automations-view.tsx
+++ b/apps/desktop/src/components/automations-view.tsx
@@ -25,6 +25,7 @@ type AutomationsViewProps = {
   snapshot: DesktopSnapshot | null;
   apiReady: boolean;
   busyAction: string;
+  githubConnected: boolean;
   onCreateAutomation: () => void;
   onGenerateAutomation: () => void;
   onOpenAutomation: (automationId: string) => void;
@@ -35,6 +36,7 @@ export function AutomationsView({
   snapshot,
   apiReady,
   busyAction,
+  githubConnected,
   onCreateAutomation,
   onGenerateAutomation,
   onOpenAutomation,
@@ -145,6 +147,7 @@ export function AutomationsView({
                   <AutomationListRow
                     key={item.id}
                     item={item}
+                    githubConnected={githubConnected}
                     onOpen={() => onOpenAutomation(item.id)}
                   />
                 ))
@@ -264,9 +267,11 @@ function AutomationListNav({
 
 function AutomationListRow({
   item,
+  githubConnected,
   onOpen,
 }: {
   item: DesktopAutomationListItem;
+  githubConnected: boolean;
   onOpen: () => void;
 }) {
   const { t } = useTranslation();
@@ -289,6 +294,11 @@ function AutomationListRow({
         {!item.enabled ? (
           <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
             {t("automations.disabled")}
+          </span>
+        ) : null}
+        {!githubConnected && item.trigger?.kind === "github" ? (
+          <span className="rounded-md bg-destructive/10 px-1.5 py-0.5 text-[10px] text-destructive">
+            {t("automations.githubDisconnectedPause")}
           </span>
         ) : null}
       </div>

--- a/apps/desktop/src/components/automations-view.tsx
+++ b/apps/desktop/src/components/automations-view.tsx
@@ -17,6 +17,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { DesktopAutomationListItem, DesktopSnapshot } from "@/types";
+import { buildAutomationTriggerFormatLabels } from "@/lib/automation-trigger-i18n";
+import { formatDesktopAutomationTriggerLabel } from "@/lib/automation-trigger";
 import { cn } from "@/lib/utils";
 
 type AutomationsViewProps = {
@@ -268,6 +270,9 @@ function AutomationListRow({
   onOpen: () => void;
 }) {
   const { t } = useTranslation();
+  const triggerLabel = item.trigger
+    ? formatDesktopAutomationTriggerLabel(item.trigger, buildAutomationTriggerFormatLabels(t))
+    : item.scheduleLabel;
 
   return (
     <button
@@ -287,7 +292,7 @@ function AutomationListRow({
           </span>
         ) : null}
       </div>
-      <p className="text-xs text-muted-foreground">{item.scheduleLabel}</p>
+      <p className="text-xs text-muted-foreground">{triggerLabel}</p>
     </button>
   );
 }

--- a/apps/desktop/src/components/create-automation-dialog.tsx
+++ b/apps/desktop/src/components/create-automation-dialog.tsx
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ApprovalLevelMenu } from "@/components/approval-level-menu";
-import { AutomationScheduleMenu } from "@/components/automation-schedule-menu";
+import {
+  AutomationTriggerMenu,
+  defaultDesktopTimeTrigger,
+} from "@/components/automation-trigger-menu";
 import { ModelPickerMenu } from "@/components/model-picker-menu";
 import { WorkspaceSelectorMenu } from "@/components/workspace-selector-menu";
 import { Button } from "@/components/ui/button";
@@ -13,12 +16,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  isValidDesktopAutomationTrigger,
+  type DesktopAutomationTrigger,
+} from "@/lib/automation-trigger";
 import type {
   ApprovalLevel,
-  DesktopAutomationSchedule,
   DesktopCreateAutomationRequest,
   DesktopModelReasoningEffort,
   DesktopSnapshot,
+  GitHubAutomationRepositoriesSnapshot,
+  SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
 import { cn } from "@/lib/utils";
 
@@ -27,8 +35,14 @@ type CreateAutomationDialogProps = {
   onOpenChange(open: boolean): void;
   snapshot: DesktopSnapshot | null;
   disabled?: boolean;
+  githubConnected: boolean;
   onSubmit(request: DesktopCreateAutomationRequest): void | Promise<void>;
   onAddWorkspace?(): void | Promise<void>;
+  listGitHubRepositories(page?: number): Promise<GitHubAutomationRepositoriesSnapshot>;
+  searchGitHubRepositories(
+    query: string,
+    page?: number,
+  ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
 };
 
 export function CreateAutomationDialog({
@@ -36,13 +50,16 @@ export function CreateAutomationDialog({
   onOpenChange,
   snapshot,
   disabled,
+  githubConnected,
   onSubmit,
   onAddWorkspace,
+  listGitHubRepositories,
+  searchGitHubRepositories,
 }: CreateAutomationDialogProps) {
   const { t } = useTranslation();
   const [title, setTitle] = useState("");
   const [overview, setOverview] = useState("");
-  const [schedule, setSchedule] = useState<DesktopAutomationSchedule>({ kind: "daily", hour: 20, minute: 0 });
+  const [trigger, setTrigger] = useState<DesktopAutomationTrigger>(defaultDesktopTimeTrigger());
   const [workspaceRoot, setWorkspaceRoot] = useState("");
   const [modelName, setModelName] = useState("");
   const [reasoningEffort, setReasoningEffort] = useState<DesktopModelReasoningEffort | undefined>();
@@ -62,7 +79,7 @@ export function CreateAutomationDialog({
     initializedForOpenRef.current = true;
     setTitle("");
     setOverview("");
-    setSchedule({ kind: "daily", hour: 20, minute: 0 });
+    setTrigger(defaultDesktopTimeTrigger());
     setWorkspaceRoot(snapshot.workspaceRoot);
     setModelName(snapshot.config.activeModel);
     const activeModel = snapshot.config.models.find((model) => model.name === snapshot.config.activeModel);
@@ -74,7 +91,9 @@ export function CreateAutomationDialog({
     title.trim().length > 0
     && overview.trim().length > 0
     && workspaceRoot.trim().length > 0
-    && modelName.trim().length > 0;
+    && modelName.trim().length > 0
+    && isValidDesktopAutomationTrigger(trigger)
+    && (trigger.kind !== "github" || githubConnected);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -103,10 +122,13 @@ export function CreateAutomationDialog({
         </div>
         <DialogFooter className="mx-0 mb-0 flex-col gap-3 border-t border-border/40 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
-            <AutomationScheduleMenu
-              schedule={schedule}
+            <AutomationTriggerMenu
+              trigger={trigger}
               disabled={disabled}
-              onScheduleChange={setSchedule}
+              githubConnected={githubConnected}
+              onTriggerChange={setTrigger}
+              listGitHubRepositories={listGitHubRepositories}
+              searchGitHubRepositories={searchGitHubRepositories}
             />
             {snapshot ? (
               <>
@@ -154,7 +176,7 @@ export function CreateAutomationDialog({
                 void onSubmit({
                   title: title.trim(),
                   overview: overview.trim(),
-                  schedule,
+                  trigger,
                   workspaceRoot,
                   modelName,
                   ...(reasoningEffort ? { reasoningEffort } : {}),

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -145,6 +145,12 @@ declare global {
     listGitHubPullRequests(
       request: import('./types').ListGitHubPullRequestsRequest,
     ): Promise<import('./types').GitHubPullRequestListSnapshot>;
+    listGitHubAutomationRepositories(
+      request?: import('./types').ListGitHubAutomationRepositoriesRequest,
+    ): Promise<import('./types').GitHubAutomationRepositoriesSnapshot>;
+    searchGitHubAutomationRepositories(
+      request: import('./types').SearchGitHubAutomationRepositoriesRequest,
+    ): Promise<import('./types').SearchGitHubAutomationRepositoriesSnapshot>;
     getGitHubPullRequestTabCounts(
       request: import('./types').GetGitHubPullRequestTabCountsRequest,
     ): Promise<import('./types').GitHubPullRequestTabCounts>;

--- a/apps/desktop/src/hooks/use-github-automation-repositories.ts
+++ b/apps/desktop/src/hooks/use-github-automation-repositories.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  readGitHubAutomationRepositoriesListCache,
+  readGitHubAutomationRepositoriesSearchCache,
+  writeGitHubAutomationRepositoriesListCache,
+  writeGitHubAutomationRepositoriesSearchCache,
+} from "@/lib/github-automation-repositories-cache";
+import type {
+  DesktopGitHubAutomationRepositoryItem,
+  GitHubAutomationRepositoriesSnapshot,
+  SearchGitHubAutomationRepositoriesSnapshot,
+} from "@/types";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+type UseGitHubAutomationRepositoriesOptions = {
+  open: boolean;
+  listGitHubRepositories(page?: number): Promise<GitHubAutomationRepositoriesSnapshot>;
+  searchGitHubRepositories(
+    query: string,
+    page?: number,
+  ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
+};
+
+export function useGitHubAutomationRepositories({
+  open,
+  listGitHubRepositories,
+  searchGitHubRepositories,
+}: UseGitHubAutomationRepositoriesOptions) {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [items, setItems] = useState<DesktopGitHubAutomationRepositoryItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const fetchGenerationRef = useRef(0);
+
+  useEffect(() => {
+    const timerId = window.setTimeout(
+      () => setDebouncedQuery(query.trim()),
+      query.trim() ? SEARCH_DEBOUNCE_MS : 0,
+    );
+    return () => window.clearTimeout(timerId);
+  }, [query]);
+
+  const fetchRepositories = useCallback(
+    async (searchQuery: string) => {
+      const generation = fetchGenerationRef.current;
+      setLoading(true);
+      try {
+        if (searchQuery) {
+          const snapshot = await searchGitHubRepositories(searchQuery);
+          if (generation !== fetchGenerationRef.current) {
+            return;
+          }
+          writeGitHubAutomationRepositoriesSearchCache(searchQuery, {
+            items: snapshot.items,
+            totalCount: snapshot.totalCount,
+          });
+          setItems(snapshot.items);
+          return;
+        }
+
+        const snapshot = await listGitHubRepositories();
+        if (generation !== fetchGenerationRef.current) {
+          return;
+        }
+        writeGitHubAutomationRepositoriesListCache({
+          items: snapshot.items,
+          hasNextPage: snapshot.hasNextPage,
+        });
+        setItems(snapshot.items);
+      } catch {
+        if (generation !== fetchGenerationRef.current) {
+          return;
+        }
+        setItems([]);
+      } finally {
+        if (generation === fetchGenerationRef.current) {
+          setLoading(false);
+        }
+      }
+    },
+    [listGitHubRepositories, searchGitHubRepositories],
+  );
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    fetchGenerationRef.current += 1;
+    const searchQuery = debouncedQuery;
+    const cached = searchQuery
+      ? readGitHubAutomationRepositoriesSearchCache(searchQuery)
+      : readGitHubAutomationRepositoriesListCache();
+
+    if (cached) {
+      setItems(cached.items);
+      setLoading(false);
+      return;
+    }
+
+    setItems([]);
+    void fetchRepositories(searchQuery);
+  }, [debouncedQuery, fetchRepositories, open]);
+
+  return {
+    query,
+    setQuery,
+    items,
+    loading,
+  };
+}

--- a/apps/desktop/src/hooks/use-github-automation-repositories.ts
+++ b/apps/desktop/src/hooks/use-github-automation-repositories.ts
@@ -36,6 +36,7 @@ export function useGitHubAutomationRepositories({
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [nextPage, setNextPage] = useState<number | undefined>(undefined);
+  const [error, setError] = useState(false);
   const fetchGenerationRef = useRef(0);
   const loadMoreInFlightRef = useRef(false);
 
@@ -76,6 +77,7 @@ export function useGitHubAutomationRepositories({
             snapshot.items.length >= SEARCH_PAGE_SIZE && nextLength < snapshot.totalCount;
           setHasMore(hasMoreSearch);
           setNextPage(hasMoreSearch ? page + 1 : undefined);
+          setError(false);
           return;
         }
 
@@ -93,6 +95,7 @@ export function useGitHubAutomationRepositories({
         setItems((current) => (append ? [...current, ...snapshot.items] : snapshot.items));
         setHasMore(snapshot.hasNextPage);
         setNextPage(snapshot.hasNextPage ? page + 1 : undefined);
+        setError(false);
       } catch {
         if (generation !== fetchGenerationRef.current) {
           return;
@@ -101,6 +104,7 @@ export function useGitHubAutomationRepositories({
           setItems([]);
           setHasMore(false);
           setNextPage(undefined);
+          setError(true);
         }
       } finally {
         if (generation === fetchGenerationRef.current) {
@@ -131,6 +135,7 @@ export function useGitHubAutomationRepositories({
       setNextPage(listCached.hasNextPage ? 2 : undefined);
       setLoading(false);
       setLoadingMore(false);
+      setError(false);
       return;
     }
 
@@ -144,12 +149,14 @@ export function useGitHubAutomationRepositories({
       setNextPage(hasMoreSearch ? 2 : undefined);
       setLoading(false);
       setLoadingMore(false);
+      setError(false);
       return;
     }
 
     setItems([]);
     setHasMore(false);
     setNextPage(undefined);
+    setError(false);
     void fetchPage(searchQuery, 1, false);
   }, [debouncedQuery, fetchPage, open]);
 
@@ -169,5 +176,6 @@ export function useGitHubAutomationRepositories({
     loadingMore,
     hasMore,
     loadMore,
+    error,
   };
 }

--- a/apps/desktop/src/hooks/use-github-automation-repositories.ts
+++ b/apps/desktop/src/hooks/use-github-automation-repositories.ts
@@ -13,6 +13,7 @@ import type {
 } from "@/types";
 
 const SEARCH_DEBOUNCE_MS = 300;
+const SEARCH_PAGE_SIZE = 30;
 
 type UseGitHubAutomationRepositoriesOptions = {
   open: boolean;
@@ -32,7 +33,11 @@ export function useGitHubAutomationRepositories({
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const [items, setItems] = useState<DesktopGitHubAutomationRepositoryItem[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [nextPage, setNextPage] = useState<number | undefined>(undefined);
   const fetchGenerationRef = useRef(0);
+  const loadMoreInFlightRef = useRef(false);
 
   useEffect(() => {
     const timerId = window.setTimeout(
@@ -42,41 +47,66 @@ export function useGitHubAutomationRepositories({
     return () => window.clearTimeout(timerId);
   }, [query]);
 
-  const fetchRepositories = useCallback(
-    async (searchQuery: string) => {
+  const fetchPage = useCallback(
+    async (searchQuery: string, page: number, append: boolean) => {
       const generation = fetchGenerationRef.current;
-      setLoading(true);
+      if (append) {
+        setLoadingMore(true);
+      } else {
+        setLoading(true);
+      }
+
       try {
         if (searchQuery) {
-          const snapshot = await searchGitHubRepositories(searchQuery);
+          const snapshot = await searchGitHubRepositories(searchQuery, page);
           if (generation !== fetchGenerationRef.current) {
             return;
           }
           writeGitHubAutomationRepositoriesSearchCache(searchQuery, {
             items: snapshot.items,
             totalCount: snapshot.totalCount,
+          }, page);
+          let nextLength = 0;
+          setItems((current) => {
+            const nextItems = append ? [...current, ...snapshot.items] : snapshot.items;
+            nextLength = nextItems.length;
+            return nextItems;
           });
-          setItems(snapshot.items);
+          const hasMoreSearch =
+            snapshot.items.length >= SEARCH_PAGE_SIZE && nextLength < snapshot.totalCount;
+          setHasMore(hasMoreSearch);
+          setNextPage(hasMoreSearch ? page + 1 : undefined);
           return;
         }
 
-        const snapshot = await listGitHubRepositories();
+        const snapshot = await listGitHubRepositories(page);
         if (generation !== fetchGenerationRef.current) {
           return;
         }
-        writeGitHubAutomationRepositoriesListCache({
-          items: snapshot.items,
-          hasNextPage: snapshot.hasNextPage,
-        });
-        setItems(snapshot.items);
+        writeGitHubAutomationRepositoriesListCache(
+          {
+            items: snapshot.items,
+            hasNextPage: snapshot.hasNextPage,
+          },
+          page,
+        );
+        setItems((current) => (append ? [...current, ...snapshot.items] : snapshot.items));
+        setHasMore(snapshot.hasNextPage);
+        setNextPage(snapshot.hasNextPage ? page + 1 : undefined);
       } catch {
         if (generation !== fetchGenerationRef.current) {
           return;
         }
-        setItems([]);
+        if (!append) {
+          setItems([]);
+          setHasMore(false);
+          setNextPage(undefined);
+        }
       } finally {
         if (generation === fetchGenerationRef.current) {
           setLoading(false);
+          setLoadingMore(false);
+          loadMoreInFlightRef.current = false;
         }
       }
     },
@@ -94,20 +124,50 @@ export function useGitHubAutomationRepositories({
       ? readGitHubAutomationRepositoriesSearchCache(searchQuery)
       : readGitHubAutomationRepositoriesListCache();
 
-    if (cached) {
-      setItems(cached.items);
+    if (cached && !searchQuery) {
+      const listCached = cached as { items: DesktopGitHubAutomationRepositoryItem[]; hasNextPage: boolean };
+      setItems(listCached.items);
+      setHasMore(listCached.hasNextPage);
+      setNextPage(listCached.hasNextPage ? 2 : undefined);
       setLoading(false);
+      setLoadingMore(false);
+      return;
+    }
+
+    if (cached && searchQuery) {
+      const searchCached = cached as { items: DesktopGitHubAutomationRepositoryItem[]; totalCount: number };
+      setItems(searchCached.items);
+      const hasMoreSearch =
+        searchCached.items.length >= SEARCH_PAGE_SIZE
+        && searchCached.items.length < searchCached.totalCount;
+      setHasMore(hasMoreSearch);
+      setNextPage(hasMoreSearch ? 2 : undefined);
+      setLoading(false);
+      setLoadingMore(false);
       return;
     }
 
     setItems([]);
-    void fetchRepositories(searchQuery);
-  }, [debouncedQuery, fetchRepositories, open]);
+    setHasMore(false);
+    setNextPage(undefined);
+    void fetchPage(searchQuery, 1, false);
+  }, [debouncedQuery, fetchPage, open]);
+
+  const loadMore = useCallback(() => {
+    if (!hasMore || loadingMore || loading || !nextPage || loadMoreInFlightRef.current) {
+      return;
+    }
+    loadMoreInFlightRef.current = true;
+    void fetchPage(debouncedQuery, nextPage, true);
+  }, [debouncedQuery, fetchPage, hasMore, loading, loadingMore, nextPage]);
 
   return {
     query,
     setQuery,
     items,
     loading,
+    loadingMore,
+    hasMore,
+    loadMore,
   };
 }

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -79,7 +79,9 @@ import type {
   ReadGitHistoryRequest,
   GetGitHubPullRequestDetailRequest,
   GetGitHubPullRequestTabCountsRequest,
+  ListGitHubAutomationRepositoriesRequest,
   ListGitHubPullRequestsRequest,
+  SearchGitHubAutomationRepositoriesRequest,
   MergeGitHubPullRequestRequest,
 } from "@/types";
 
@@ -2669,6 +2671,26 @@ export function useDesktopRuntime() {
     [api],
   );
 
+  const listGitHubAutomationRepositories = useCallback(
+    async (request: ListGitHubAutomationRepositoriesRequest = {}) => {
+      if (!api) {
+        return { items: [], hasNextPage: false };
+      }
+      return api.listGitHubAutomationRepositories(request);
+    },
+    [api],
+  );
+
+  const searchGitHubAutomationRepositories = useCallback(
+    async (query: string, page?: number) => {
+      if (!api) {
+        return { items: [], totalCount: 0 };
+      }
+      return api.searchGitHubAutomationRepositories({ query, ...(page ? { page } : {}) });
+    },
+    [api],
+  );
+
   const getGitHubPullRequestTabCounts = useCallback(
     async (request: GetGitHubPullRequestTabCountsRequest) => {
       if (!api) {
@@ -2924,6 +2946,8 @@ export function useDesktopRuntime() {
     disconnectGitHub,
     getGitHubPullRequestForCurrentBranch,
     listGitHubPullRequests,
+    listGitHubAutomationRepositories,
+    searchGitHubAutomationRepositories,
     getGitHubPullRequestTabCounts,
     getGitHubPullRequestDetail,
     getGitHubPullRequestConversation,

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/skill-slash";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
 import { isAgentModeChipKind } from "@/lib/composer-agent-mode-segments";
+import { clearGitHubAutomationRepositoriesCache } from "@/lib/github-automation-repositories-cache";
 import { isRunSubagentToolCallPending } from "@/lib/subagent-viewer-pending";
 import { useDesktopSystemNotifications } from "@/hooks/useDesktopSystemNotifications";
 import type {
@@ -2581,7 +2582,9 @@ export function useDesktopRuntime() {
     if (!api) {
       return { connected: false };
     }
-    return api.disconnectGitHub();
+    const status = await api.disconnectGitHub();
+    clearGitHubAutomationRepositoriesCache();
+    return status;
   }, [api]);
 
   const getGitHubPullRequestForCurrentBranch = useCallback(async () => {

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -46,9 +46,12 @@ import type {
   ForkSessionRequest,
   GetGitHubPullRequestDetailRequest,
   GetGitHubPullRequestTabCountsRequest,
+  ListGitHubAutomationRepositoriesRequest,
   ListGitHubPullRequestsRequest,
+  SearchGitHubAutomationRepositoriesRequest,
   MergeGitHubPullRequestRequest,
   GitHubAuthStatus,
+  GitHubAutomationRepositoriesSnapshot,
   GitHubDeviceAuthChallenge,
   GitHubPullRequestDetail,
   GitHubPullRequestListSnapshot,
@@ -59,6 +62,7 @@ import type {
   GitHubPullRequestCommitsSnapshot,
   GitHubPullRequestChecksSnapshot,
   GitHubPullRequestForBranchResult,
+  SearchGitHubAutomationRepositoriesSnapshot,
   SubmitUserTurnRequest,
   SessionListItem,
   WorkspaceExplorerListResult,
@@ -134,6 +138,12 @@ export interface HostApi {
   listGitHubPullRequests(
     request: ListGitHubPullRequestsRequest,
   ): Promise<GitHubPullRequestListSnapshot>;
+  listGitHubAutomationRepositories(
+    request?: ListGitHubAutomationRepositoriesRequest,
+  ): Promise<GitHubAutomationRepositoriesSnapshot>;
+  searchGitHubAutomationRepositories(
+    request: SearchGitHubAutomationRepositoriesRequest,
+  ): Promise<SearchGitHubAutomationRepositoriesSnapshot>;
   getGitHubPullRequestTabCounts(
     request: GetGitHubPullRequestTabCountsRequest,
   ): Promise<GitHubPullRequestTabCounts>;

--- a/apps/desktop/src/host/automation-runner.ts
+++ b/apps/desktop/src/host/automation-runner.ts
@@ -13,8 +13,10 @@ import {
   resolveOpenAiTransportReasoningEffortForContext,
 } from '@spirit-agent/core/reasoning-effort';
 import {
+  buildAutomationTriggerMessage,
   createHostAutomationStore,
-  readGitWorkspaceSnapshot,
+  defaultAutomationRunTriggerContext,
+  type AutomationRunTriggerContext,
   type HostAutomationDefinition,
   type HostAutomationRun,
 } from '@spirit-agent/host-internal';
@@ -44,6 +46,7 @@ export const AUTOMATION_RUN_MAX_GUARD_ROUNDS = 200;
 export interface RunDesktopAutomationOnceInput {
   definition: HostAutomationDefinition;
   config: DesktopConfigFile;
+  triggerContext?: AutomationRunTriggerContext;
 }
 
 export interface RunDesktopAutomationOnceDeps {
@@ -120,6 +123,13 @@ export async function runDesktopAutomationOnce(
       workspaceRoot: input.definition.workspaceRoot,
       basicInfo: buildDesktopRuntimeBasicInfo(input.definition.workspaceRoot, toolExecutor),
     });
+    const triggerContext = input.triggerContext ?? defaultAutomationRunTriggerContext(input.definition);
+    const llmUserMessage = buildAutomationTriggerMessage({
+      overview: input.definition.overview,
+      trigger: input.definition.trigger,
+      context: triggerContext,
+    });
+
     const projection = AutomationConversationProjection.create();
     projection.bindRuntime(runtime);
     projection.beginUserTurn(input.definition.overview);
@@ -141,7 +151,7 @@ export async function runDesktopAutomationOnce(
       runtime,
       projection,
       async () => {
-        await runtime.startUserTurnStreaming(input.definition.overview);
+        await runtime.startUserTurnStreaming(llmUserMessage);
       },
     );
 

--- a/apps/desktop/src/host/automation-runner.ts
+++ b/apps/desktop/src/host/automation-runner.ts
@@ -16,6 +16,7 @@ import {
   buildAutomationTriggerMessage,
   createHostAutomationStore,
   defaultAutomationRunTriggerContext,
+  readGitWorkspaceSnapshot,
   type AutomationRunTriggerContext,
   type HostAutomationDefinition,
   type HostAutomationRun,

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -221,7 +221,7 @@ async function tickGitHubAutomationTriggers(
   }
 }
 
-function groupGitHubPollMatchesByAutomation(
+export function groupGitHubPollMatchesByAutomation(
   matches: GitHubAutomationPollMatch[],
 ): Map<string, GitHubAutomationPollMatch[]> {
   const grouped = new Map<string, GitHubAutomationPollMatch[]>();

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -6,10 +6,13 @@ import {
   fetchGitHubAutomationRepoItems,
   githubTriggerNeedsBaseline,
   groupGitHubAutomationsByRepo,
+  mergeGitHubPollWatermarkUpdates,
   resolveGitHubPollWatermark,
   shouldFireNow,
   type AutomationRunTriggerContext,
+  type GitHubAutomationPollMatch,
   type HostAutomationDefinition,
+  type HostAutomationRun,
 } from '@spirit-agent/host-internal';
 
 import { cloneDesktopConfig } from './service-utils.js';
@@ -158,36 +161,66 @@ async function tickGitHubAutomationTriggers(
     }
 
     const matches = computeGitHubPollMatchesForRepoGroup(group, items);
-    for (const match of matches) {
-      if (ctx.runningAutomationIds().has(match.automationId)) {
+    const matchesByAutomation = groupGitHubPollMatchesByAutomation(matches);
+    for (const [automationId, automationMatches] of matchesByAutomation) {
+      if (ctx.runningAutomationIds().has(automationId)) {
         continue;
       }
-      const activeRun = await store.getActiveRun(match.automationId);
+      const activeRun = await store.getActiveRun(automationId);
       if (activeRun) {
         continue;
       }
-      const latestDefinition = refreshed.find((definition) => definition.id === match.automationId);
-      if (!latestDefinition || latestDefinition.trigger.kind !== 'github') {
-        continue;
+
+      const completedMatches: GitHubAutomationPollMatch[] = [];
+      for (const match of automationMatches) {
+        if (ctx.runningAutomationIds().has(automationId)) {
+          break;
+        }
+        const latestDefinition = refreshed.find((definition) => definition.id === match.automationId);
+        if (!latestDefinition || latestDefinition.trigger.kind !== 'github') {
+          break;
+        }
+
+        const run = await launchAutomationRun(ctx, store, {
+          definition: latestDefinition,
+          config,
+          context: {
+            kind: 'github',
+            event: latestDefinition.trigger.event,
+            eventUrl: match.item.htmlUrl,
+          },
+        });
+        if (run?.status !== 'completed') {
+          break;
+        }
+        completedMatches.push(match);
       }
 
-      await store.updateGitHubPollState(match.automationId, match.item.number);
-
-      launchAutomationRun(ctx, store, {
-        definition: latestDefinition,
-        config,
-        context: {
-          kind: 'github',
-          event: latestDefinition.trigger.event,
-          eventUrl: match.item.htmlUrl,
-        },
-        advanceGitHubPollOnSuccess: match.item.number,
-      });
+      const watermarkUpdates = mergeGitHubPollWatermarkUpdates(completedMatches);
+      const nextWatermark = watermarkUpdates.get(automationId);
+      if (nextWatermark !== undefined) {
+        await store.updateGitHubPollState(automationId, nextWatermark);
+      }
     }
   }
 }
 
-function launchAutomationRun(
+function groupGitHubPollMatchesByAutomation(
+  matches: GitHubAutomationPollMatch[],
+): Map<string, GitHubAutomationPollMatch[]> {
+  const grouped = new Map<string, GitHubAutomationPollMatch[]>();
+  for (const match of matches) {
+    const existing = grouped.get(match.automationId);
+    if (existing) {
+      existing.push(match);
+      continue;
+    }
+    grouped.set(match.automationId, [match]);
+  }
+  return grouped;
+}
+
+async function launchAutomationRun(
   ctx: AutomationSchedulerServiceContext,
   store: ReturnType<typeof createHostAutomationStore>,
   input: {
@@ -195,37 +228,32 @@ function launchAutomationRun(
     config: DesktopConfigFile;
     context: AutomationRunTriggerContext;
     markFiredAtUnixMs?: number;
-    advanceGitHubPollOnSuccess?: number;
   },
-): void {
+): Promise<HostAutomationRun | undefined> {
   ctx.markAutomationRunning(input.definition.id, true);
-  void runDesktopAutomationOnce(
-    {
-      definition: input.definition,
-      config: cloneDesktopConfig(input.config),
-      triggerContext: input.context,
-    },
-    {
-      onRunUpdated: (automationId) => ctx.onAutomationUpdated(automationId),
-      notifySessionListUpdated: () => ctx.notifySessionListUpdated(),
-      syncSessionFromDisk: (sessionPath) => ctx.syncSessionFromDisk?.(sessionPath),
-    },
-  )
-    .then(async (run) => {
-      if (run?.status === 'completed' && input.advanceGitHubPollOnSuccess !== undefined) {
-        await store.updateGitHubPollState(input.definition.id, input.advanceGitHubPollOnSuccess);
-      }
-      if (run && input.markFiredAtUnixMs !== undefined) {
-        await store.markFired(input.definition.id, input.markFiredAtUnixMs);
-      }
-    })
-    .catch(() => {
-      /* run status persisted in store */
-    })
-    .finally(() => {
-      ctx.markAutomationRunning(input.definition.id, false);
-      ctx.onAutomationUpdated(input.definition.id);
-    });
+  try {
+    const run = await runDesktopAutomationOnce(
+      {
+        definition: input.definition,
+        config: cloneDesktopConfig(input.config),
+        triggerContext: input.context,
+      },
+      {
+        onRunUpdated: (automationId) => ctx.onAutomationUpdated(automationId),
+        notifySessionListUpdated: () => ctx.notifySessionListUpdated(),
+        syncSessionFromDisk: (sessionPath) => ctx.syncSessionFromDisk?.(sessionPath),
+      },
+    );
+    if (run && input.markFiredAtUnixMs !== undefined) {
+      await store.markFired(input.definition.id, input.markFiredAtUnixMs);
+    }
+    return run;
+  } catch {
+    return undefined;
+  } finally {
+    ctx.markAutomationRunning(input.definition.id, false);
+    ctx.onAutomationUpdated(input.definition.id);
+  }
 }
 
 export function automationDefinitionNeedsApiKey(

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -156,8 +156,24 @@ async function tickGitHubAutomationTriggers(
       items = await fetchGitHubAutomationRepoItems(accessToken, group.owner, group.repo, {
         sinceNumber: Number.isFinite(minWatermark) ? minWatermark : 0,
       });
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      for (const definition of group.automations) {
+        try {
+          await store.setGitHubPollError(definition.id, message);
+        } catch {
+          /* ignore per-automation persistence errors */
+        }
+      }
       continue;
+    }
+
+    for (const definition of group.automations) {
+      try {
+        await store.setGitHubPollError(definition.id, undefined);
+      } catch {
+        /* ignore per-automation persistence errors */
+      }
     }
 
     const matches = computeGitHubPollMatchesForRepoGroup(group, items);

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -59,7 +59,11 @@ export async function tickAutomationScheduler(ctx: AutomationSchedulerServiceCon
   const definitions = await store.listEnabledDefinitions();
   const now = Date.now();
 
-  await tickGitHubAutomationTriggers(ctx, store, definitions, config);
+  try {
+    await tickGitHubAutomationTriggers(ctx, store, definitions, config);
+  } catch {
+    /* GitHub poll failures must not block time triggers in the same tick. */
+  }
   await tickTimeAutomationTriggers(ctx, store, definitions, config, now);
 }
 
@@ -118,12 +122,16 @@ async function tickGitHubAutomationTriggers(
     if (definition.trigger.kind !== 'github') {
       continue;
     }
-    const lastSeenNumber = await baselineGitHubAutomationWatermark(
-      accessToken,
-      definition.trigger.owner,
-      definition.trigger.repo,
-    );
-    await store.ensureGitHubTriggerBaseline(definition.id, lastSeenNumber);
+    try {
+      const lastSeenNumber = await baselineGitHubAutomationWatermark(
+        accessToken,
+        definition.trigger.owner,
+        definition.trigger.repo,
+      );
+      await store.ensureGitHubTriggerBaseline(definition.id, lastSeenNumber);
+    } catch {
+      /* Skip baseline for this automation; do not abort the rest of the tick. */
+    }
   }
 
   const refreshed = await store.listEnabledDefinitions();

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -1,10 +1,18 @@
 import {
+  automationTimeScheduleFromTrigger,
+  baselineGitHubAutomationWatermark,
+  computeGitHubPollMatchesForRepoGroup,
   createHostAutomationStore,
+  fetchGitHubAutomationRepoItems,
+  githubTriggerNeedsBaseline,
+  groupGitHubAutomationsByRepo,
   shouldFireNow,
+  type AutomationRunTriggerContext,
   type HostAutomationDefinition,
 } from '@spirit-agent/host-internal';
 
 import { cloneDesktopConfig } from './service-utils.js';
+import { loadGitHubAccessToken } from './github-auth-storage.js';
 import { spiritAgentDataDir, type DesktopConfigFile } from './storage.js';
 import { runDesktopAutomationOnce } from './automation-runner.js';
 
@@ -51,7 +59,21 @@ export async function tickAutomationScheduler(ctx: AutomationSchedulerServiceCon
   const definitions = await store.listEnabledDefinitions();
   const now = Date.now();
 
+  await tickGitHubAutomationTriggers(ctx, store, definitions, config);
+  await tickTimeAutomationTriggers(ctx, store, definitions, config, now);
+}
+
+async function tickTimeAutomationTriggers(
+  ctx: AutomationSchedulerServiceContext,
+  store: ReturnType<typeof createHostAutomationStore>,
+  definitions: HostAutomationDefinition[],
+  config: DesktopConfigFile,
+  now: number,
+): Promise<void> {
   for (const definition of definitions) {
+    if (definition.trigger.kind !== 'time') {
+      continue;
+    }
     if (ctx.runningAutomationIds().has(definition.id)) {
       continue;
     }
@@ -59,35 +81,128 @@ export async function tickAutomationScheduler(ctx: AutomationSchedulerServiceCon
     if (activeRun) {
       continue;
     }
-    if (!shouldFireNow(definition.schedule, definition.lastFiredAtUnixMs, now)) {
+    const schedule = automationTimeScheduleFromTrigger(definition.trigger);
+    if (!schedule || !shouldFireNow(schedule, definition.lastFiredAtUnixMs, now)) {
       continue;
     }
 
-    ctx.markAutomationRunning(definition.id, true);
-    void runDesktopAutomationOnce(
-      {
-        definition,
-        config: cloneDesktopConfig(config),
-      },
-      {
-        onRunUpdated: (automationId) => ctx.onAutomationUpdated(automationId),
-        notifySessionListUpdated: () => ctx.notifySessionListUpdated(),
-        syncSessionFromDisk: (sessionPath) => ctx.syncSessionFromDisk?.(sessionPath),
-      },
-    )
-      .then(async (run) => {
-        if (run) {
-          await store.markFired(definition.id, now);
-        }
-      })
-      .catch(() => {
-        /* run status persisted in store */
-      })
-      .finally(() => {
-        ctx.markAutomationRunning(definition.id, false);
-        ctx.onAutomationUpdated(definition.id);
-      });
+    void launchAutomationRun(ctx, store, {
+      definition,
+      config,
+      context: { kind: 'time' },
+      markFiredAtUnixMs: now,
+    });
   }
+}
+
+async function tickGitHubAutomationTriggers(
+  ctx: AutomationSchedulerServiceContext,
+  store: ReturnType<typeof createHostAutomationStore>,
+  definitions: HostAutomationDefinition[],
+  config: DesktopConfigFile,
+): Promise<void> {
+  const githubDefinitions = definitions.filter((definition) => definition.trigger.kind === 'github');
+  if (githubDefinitions.length === 0) {
+    return;
+  }
+
+  const accessToken = await loadGitHubAccessToken();
+  if (!accessToken) {
+    return;
+  }
+
+  for (const definition of githubDefinitions) {
+    if (!githubTriggerNeedsBaseline(definition.trigger)) {
+      continue;
+    }
+    if (definition.trigger.kind !== 'github') {
+      continue;
+    }
+    const lastSeenNumber = await baselineGitHubAutomationWatermark(
+      accessToken,
+      definition.trigger.owner,
+      definition.trigger.repo,
+    );
+    await store.ensureGitHubTriggerBaseline(definition.id, lastSeenNumber);
+  }
+
+  const refreshed = await store.listEnabledDefinitions();
+  const groups = groupGitHubAutomationsByRepo(
+    refreshed.filter((definition) => definition.trigger.kind === 'github'),
+  );
+
+  for (const group of groups) {
+    let items;
+    try {
+      items = await fetchGitHubAutomationRepoItems(accessToken, group.owner, group.repo);
+    } catch {
+      continue;
+    }
+
+    const matches = computeGitHubPollMatchesForRepoGroup(group, items);
+    for (const match of matches) {
+      if (ctx.runningAutomationIds().has(match.automationId)) {
+        continue;
+      }
+      const activeRun = await store.getActiveRun(match.automationId);
+      if (activeRun) {
+        continue;
+      }
+      const latestDefinition = refreshed.find((definition) => definition.id === match.automationId);
+      if (!latestDefinition || latestDefinition.trigger.kind !== 'github') {
+        continue;
+      }
+
+      await store.updateGitHubPollState(match.automationId, match.item.number);
+
+      launchAutomationRun(ctx, store, {
+        definition: latestDefinition,
+        config,
+        context: {
+          kind: 'github',
+          event: latestDefinition.trigger.event,
+          eventUrl: match.item.htmlUrl,
+        },
+      });
+    }
+  }
+}
+
+function launchAutomationRun(
+  ctx: AutomationSchedulerServiceContext,
+  store: ReturnType<typeof createHostAutomationStore>,
+  input: {
+    definition: HostAutomationDefinition;
+    config: DesktopConfigFile;
+    context: AutomationRunTriggerContext;
+    markFiredAtUnixMs?: number;
+  },
+): void {
+  ctx.markAutomationRunning(input.definition.id, true);
+  void runDesktopAutomationOnce(
+    {
+      definition: input.definition,
+      config: cloneDesktopConfig(input.config),
+      triggerContext: input.context,
+    },
+    {
+      onRunUpdated: (automationId) => ctx.onAutomationUpdated(automationId),
+      notifySessionListUpdated: () => ctx.notifySessionListUpdated(),
+      syncSessionFromDisk: (sessionPath) => ctx.syncSessionFromDisk?.(sessionPath),
+    },
+  )
+    .then(async (run) => {
+      if (run && input.markFiredAtUnixMs !== undefined) {
+        await store.markFired(input.definition.id, input.markFiredAtUnixMs);
+      }
+    })
+    .catch(() => {
+      /* run status persisted in store */
+    })
+    .finally(() => {
+      ctx.markAutomationRunning(input.definition.id, false);
+      ctx.onAutomationUpdated(input.definition.id);
+    });
 }
 
 export function automationDefinitionNeedsApiKey(

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -6,6 +6,7 @@ import {
   fetchGitHubAutomationRepoItems,
   githubTriggerNeedsBaseline,
   groupGitHubAutomationsByRepo,
+  resolveGitHubPollWatermark,
   shouldFireNow,
   type AutomationRunTriggerContext,
   type HostAutomationDefinition,
@@ -140,9 +141,18 @@ async function tickGitHubAutomationTriggers(
   );
 
   for (const group of groups) {
+    const minWatermark = Math.min(
+      ...group.automations.map((definition) =>
+        definition.trigger.kind === 'github'
+          ? resolveGitHubPollWatermark(definition.trigger)
+          : Number.MAX_SAFE_INTEGER,
+      ),
+    );
     let items;
     try {
-      items = await fetchGitHubAutomationRepoItems(accessToken, group.owner, group.repo);
+      items = await fetchGitHubAutomationRepoItems(accessToken, group.owner, group.repo, {
+        sinceNumber: Number.isFinite(minWatermark) ? minWatermark : 0,
+      });
     } catch {
       continue;
     }

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -181,6 +181,7 @@ async function tickGitHubAutomationTriggers(
           event: latestDefinition.trigger.event,
           eventUrl: match.item.htmlUrl,
         },
+        advanceGitHubPollOnSuccess: match.item.number,
       });
     }
   }
@@ -194,6 +195,7 @@ function launchAutomationRun(
     config: DesktopConfigFile;
     context: AutomationRunTriggerContext;
     markFiredAtUnixMs?: number;
+    advanceGitHubPollOnSuccess?: number;
   },
 ): void {
   ctx.markAutomationRunning(input.definition.id, true);
@@ -210,6 +212,9 @@ function launchAutomationRun(
     },
   )
     .then(async (run) => {
+      if (run?.status === 'completed' && input.advanceGitHubPollOnSuccess !== undefined) {
+        await store.updateGitHubPollState(input.definition.id, input.advanceGitHubPollOnSuccess);
+      }
       if (run && input.markFiredAtUnixMs !== undefined) {
         await store.markFired(input.definition.id, input.markFiredAtUnixMs);
       }

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -65,6 +65,8 @@ export type HostCommandName =
   | 'disconnectGitHub'
   | 'getGitHubPullRequestForCurrentBranch'
   | 'listGitHubPullRequests'
+  | 'listGitHubAutomationRepositories'
+  | 'searchGitHubAutomationRepositories'
   | 'getGitHubPullRequestTabCounts'
   | 'getGitHubPullRequestDetail'
   | 'getGitHubPullRequestConversation'

--- a/apps/desktop/src/host/host-automation-commands.ts
+++ b/apps/desktop/src/host/host-automation-commands.ts
@@ -63,6 +63,7 @@ export function toDesktopAutomationListItem(
     id: definition.id,
     title: definition.title,
     scheduleLabel: formatTriggerLabel(definition.trigger),
+    trigger: definition.trigger,
     enabled: definition.enabled,
     updatedAtUnixMs: definition.updatedAtUnixMs,
     ...(lastRunAtUnixMs !== undefined ? { lastRunAtUnixMs } : {}),

--- a/apps/desktop/src/host/host-automation-commands.ts
+++ b/apps/desktop/src/host/host-automation-commands.ts
@@ -1,6 +1,6 @@
 import {
   createHostAutomationStore,
-  formatScheduleLabel,
+  formatTriggerLabel,
   type HostAutomationCreateInput,
   type HostAutomationDefinition,
   type HostAutomationRun,
@@ -62,7 +62,7 @@ export function toDesktopAutomationListItem(
   return {
     id: definition.id,
     title: definition.title,
-    scheduleLabel: formatScheduleLabel(definition.schedule),
+    scheduleLabel: formatTriggerLabel(definition.trigger),
     enabled: definition.enabled,
     updatedAtUnixMs: definition.updatedAtUnixMs,
     ...(lastRunAtUnixMs !== undefined ? { lastRunAtUnixMs } : {}),

--- a/apps/desktop/src/host/host-automation-commands.ts
+++ b/apps/desktop/src/host/host-automation-commands.ts
@@ -66,6 +66,7 @@ export function toDesktopAutomationListItem(
     trigger: definition.trigger,
     enabled: definition.enabled,
     updatedAtUnixMs: definition.updatedAtUnixMs,
+    ...(definition.githubPollError ? { githubPollError: definition.githubPollError } : {}),
     ...(lastRunAtUnixMs !== undefined ? { lastRunAtUnixMs } : {}),
   };
 }

--- a/apps/desktop/src/host/host-command-payloads.ts
+++ b/apps/desktop/src/host/host-command-payloads.ts
@@ -37,7 +37,9 @@ import type {
   ForkSessionRequest,
   GetGitHubPullRequestDetailRequest,
   GetGitHubPullRequestTabCountsRequest,
+  ListGitHubAutomationRepositoriesRequest,
   ListGitHubPullRequestsRequest,
+  SearchGitHubAutomationRepositoriesRequest,
   MergeGitHubPullRequestRequest,
   RunExtensionRequest,
   SaveHookEntryRequest,
@@ -75,6 +77,8 @@ export type CommandPayloads = {
   disconnectGitHub: undefined;
   getGitHubPullRequestForCurrentBranch: undefined;
   listGitHubPullRequests: { request: ListGitHubPullRequestsRequest };
+  listGitHubAutomationRepositories: { request?: ListGitHubAutomationRepositoriesRequest };
+  searchGitHubAutomationRepositories: { request: SearchGitHubAutomationRepositoriesRequest };
   getGitHubPullRequestTabCounts: { request: GetGitHubPullRequestTabCountsRequest };
   getGitHubPullRequestDetail: { request: GetGitHubPullRequestDetailRequest };
   getGitHubPullRequestConversation: { request: GetGitHubPullRequestDetailRequest };

--- a/apps/desktop/src/host/host-github-commands.ts
+++ b/apps/desktop/src/host/host-github-commands.ts
@@ -13,6 +13,8 @@ import {
   markPullRequestReadyForReview,
   listPullRequests,
   getPullRequestTabCounts,
+  listUserGitHubRepositories,
+  searchGitHubRepositories,
   GitHubOAuthError,
   parseGitHubRemoteUrl,
   type GitHubAuthStatus,
@@ -33,8 +35,12 @@ import type {
   DesktopGitSnapshot,
   GetGitHubPullRequestDetailRequest,
   GetGitHubPullRequestTabCountsRequest,
+  GitHubAutomationRepositoriesSnapshot,
+  ListGitHubAutomationRepositoriesRequest,
   ListGitHubPullRequestsRequest,
   MergeGitHubPullRequestRequest,
+  SearchGitHubAutomationRepositoriesRequest,
+  SearchGitHubAutomationRepositoriesSnapshot,
 } from '../types.js';
 import {
   clearGitHubOAuthCredentials,
@@ -348,6 +354,43 @@ export async function getGitHubPullRequestTabCountsCommand(
   try {
     const accessToken = await requireGitHubAccessToken();
     return await getPullRequestTabCounts(accessToken, repository);
+  } catch (error) {
+    throw await handleGitHubApiError(error);
+  }
+}
+
+export async function listGitHubAutomationRepositoriesCommand(
+  request: ListGitHubAutomationRepositoriesRequest = {},
+): Promise<GitHubAutomationRepositoriesSnapshot> {
+  try {
+    const accessToken = await requireGitHubAccessToken();
+    const page = request.page && request.page > 0 ? request.page : 1;
+    const result = await listUserGitHubRepositories(accessToken, { page });
+    return {
+      items: result.items,
+      hasNextPage: result.hasNextPage,
+    };
+  } catch (error) {
+    throw await handleGitHubApiError(error);
+  }
+}
+
+export async function searchGitHubAutomationRepositoriesCommand(
+  request: SearchGitHubAutomationRepositoriesRequest,
+): Promise<SearchGitHubAutomationRepositoriesSnapshot> {
+  try {
+    const accessToken = await requireGitHubAccessToken();
+    const status = await getGitHubAuthStatusFromStorage();
+    const login = status.login?.trim();
+    if (!login) {
+      throw new GitHubOAuthError('GitHub login is unavailable.', 401);
+    }
+    const page = request.page && request.page > 0 ? request.page : 1;
+    const result = await searchGitHubRepositories(accessToken, request.query ?? '', login, { page });
+    return {
+      items: result.items,
+      totalCount: result.totalCount,
+    };
   } catch (error) {
     throw await handleGitHubApiError(error);
   }

--- a/apps/desktop/src/host/host-invoke-dispatch.ts
+++ b/apps/desktop/src/host/host-invoke-dispatch.ts
@@ -81,6 +81,12 @@ export interface HostCommandDelegate {
   disconnectGitHub(): Promise<unknown>;
   getGitHubPullRequestForCurrentBranch(): Promise<unknown>;
   listGitHubPullRequests(request: CommandPayloads['listGitHubPullRequests']['request']): Promise<unknown>;
+  listGitHubAutomationRepositories(
+    request?: CommandPayloads['listGitHubAutomationRepositories']['request'],
+  ): Promise<unknown>;
+  searchGitHubAutomationRepositories(
+    request: CommandPayloads['searchGitHubAutomationRepositories']['request'],
+  ): Promise<unknown>;
   getGitHubPullRequestTabCounts(
     request: CommandPayloads['getGitHubPullRequestTabCounts']['request'],
   ): Promise<unknown>;
@@ -186,6 +192,10 @@ const hostCommandDispatch = {
   disconnectGitHub: (host) => host.disconnectGitHub(),
   getGitHubPullRequestForCurrentBranch: (host) => host.getGitHubPullRequestForCurrentBranch(),
   listGitHubPullRequests: (host, payload) => host.listGitHubPullRequests(payload.request),
+  listGitHubAutomationRepositories: (host, payload) =>
+    host.listGitHubAutomationRepositories(payload.request),
+  searchGitHubAutomationRepositories: (host, payload) =>
+    host.searchGitHubAutomationRepositories(payload.request),
   getGitHubPullRequestTabCounts: (host, payload) => host.getGitHubPullRequestTabCounts(payload.request),
   getGitHubPullRequestDetail: (host, payload) => host.getGitHubPullRequestDetail(payload.request),
   getGitHubPullRequestConversation: (host, payload) =>

--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -1,4 +1,4 @@
-import { formatScheduleLabel, normalizeAutomationSchedule } from '@spirit-agent/host-internal';
+import { formatTriggerLabel, normalizeAutomationTrigger } from '@spirit-agent/host-internal';
 
 import i18n from '../lib/i18n-host.js';
 import type {
@@ -251,9 +251,13 @@ export function toolCallSummaryCopyForRequest(
     }
     case 'create_automation': {
       const title = typeof record.title === 'string' ? record.title.trim() : '';
-      const schedule = normalizeAutomationSchedule(record.schedule);
-      const scheduleLabel = schedule ? formatScheduleLabel(schedule) : '';
-      const detail = [title, scheduleLabel].filter((part) => part.length > 0).join(' · ');
+      const trigger =
+        normalizeAutomationTrigger(record.trigger)
+        ?? (record.schedule !== undefined
+          ? normalizeAutomationTrigger({ kind: 'time', schedule: record.schedule })
+          : undefined);
+      const triggerLabel = trigger ? formatTriggerLabel(trigger) : '';
+      const detail = [title, triggerLabel].filter((part) => part.length > 0).join(' · ');
       return {
         headline: i18n.t('automations.create', tOpts),
         headlineDetail: truncateSummaryDetail(detail || 'automation'),

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -87,7 +87,9 @@ import type {
   DesktopGitSnapshot,
   GetGitHubPullRequestDetailRequest,
   GetGitHubPullRequestTabCountsRequest,
+  ListGitHubAutomationRepositoriesRequest,
   ListGitHubPullRequestsRequest,
+  SearchGitHubAutomationRepositoriesRequest,
   MergeGitHubPullRequestRequest,
   GitHistorySnapshot,
   GitWorkingTreeSnapshot,
@@ -197,7 +199,9 @@ import {
   getGitHubPullRequestCommitsCommand,
   getGitHubPullRequestChecksCommand,
   getGitHubPullRequestForCurrentBranchCommand,
+  listGitHubAutomationRepositoriesCommand,
   listGitHubPullRequestsCommand,
+  searchGitHubAutomationRepositoriesCommand,
   getGitHubPullRequestTabCountsCommand,
   markGitHubPullRequestReadyCommand,
   mergeGitHubPullRequestCommand,
@@ -1735,6 +1739,14 @@ class DesktopHostService {
 
   async listGitHubPullRequests(request: ListGitHubPullRequestsRequest) {
     return listGitHubPullRequestsCommand(request);
+  }
+
+  async listGitHubAutomationRepositories(request: ListGitHubAutomationRepositoriesRequest = {}) {
+    return listGitHubAutomationRepositoriesCommand(request);
+  }
+
+  async searchGitHubAutomationRepositories(request: SearchGitHubAutomationRepositoriesRequest) {
+    return searchGitHubAutomationRepositoriesCommand(request);
   }
 
   async getGitHubPullRequestTabCounts(request: GetGitHubPullRequestTabCountsRequest) {

--- a/apps/desktop/src/lib/automation-schedule.ts
+++ b/apps/desktop/src/lib/automation-schedule.ts
@@ -36,3 +36,29 @@ export function formatDesktopAutomationScheduleLabel(
   }
   return `${labels.weeklyPrefix} ${weekday} ${time}`;
 }
+
+function isValidHour(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 23;
+}
+
+function isValidMinute(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 59;
+}
+
+function isValidWeekday(value: unknown): value is DesktopAutomationWeekday {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 6;
+}
+
+export function isValidDesktopAutomationSchedule(schedule: DesktopAutomationSchedule): boolean {
+  if (schedule.kind === 'hourly') {
+    return true;
+  }
+  if (schedule.kind === 'daily') {
+    return isValidHour(schedule.hour) && isValidMinute(schedule.minute);
+  }
+  return (
+    isValidWeekday(schedule.weekday)
+    && isValidHour(schedule.hour)
+    && isValidMinute(schedule.minute)
+  );
+}

--- a/apps/desktop/src/lib/automation-trigger-i18n.ts
+++ b/apps/desktop/src/lib/automation-trigger-i18n.ts
@@ -1,0 +1,26 @@
+import type { TFunction } from "i18next";
+
+import type { DesktopAutomationTriggerFormatLabels } from "@/lib/automation-trigger";
+
+export function buildAutomationTriggerFormatLabels(
+  t: TFunction,
+): DesktopAutomationTriggerFormatLabels {
+  return {
+    hourly: t("automations.schedule.hourly"),
+    dailyPrefix: t("automations.schedule.daily"),
+    weeklyPrefix: t("automations.schedule.weekly"),
+    weekdays: [
+      t("automations.schedule.weekday0"),
+      t("automations.schedule.weekday1"),
+      t("automations.schedule.weekday2"),
+      t("automations.schedule.weekday3"),
+      t("automations.schedule.weekday4"),
+      t("automations.schedule.weekday5"),
+      t("automations.schedule.weekday6"),
+    ],
+    formatWeekly: (weekday, time) => t("automations.schedule.weeklyAt", { weekday, time }),
+    githubPrefix: t("automations.trigger.github"),
+    githubPullRequestCreated: t("automations.trigger.pullRequestCreated"),
+    githubIssueCreated: t("automations.trigger.issueCreated"),
+  };
+}

--- a/apps/desktop/src/lib/automation-trigger.ts
+++ b/apps/desktop/src/lib/automation-trigger.ts
@@ -43,3 +43,10 @@ export function defaultDesktopTimeTrigger(
 ): DesktopAutomationTrigger {
   return { kind: 'time', schedule };
 }
+
+export function isValidDesktopAutomationTrigger(trigger: DesktopAutomationTrigger): boolean {
+  if (trigger.kind === 'time') {
+    return true;
+  }
+  return Boolean(trigger.owner.trim() && trigger.repo.trim());
+}

--- a/apps/desktop/src/lib/automation-trigger.ts
+++ b/apps/desktop/src/lib/automation-trigger.ts
@@ -4,7 +4,10 @@ import type {
   DesktopAutomationSchedule,
   DesktopAutomationScheduleFormatLabels,
 } from './automation-schedule.js';
-import { formatDesktopAutomationScheduleLabel } from './automation-schedule.js';
+import {
+  formatDesktopAutomationScheduleLabel,
+  isValidDesktopAutomationSchedule,
+} from './automation-schedule.js';
 
 export type DesktopAutomationGitHubEvent = 'pull_request_created' | 'issue_created';
 
@@ -46,7 +49,7 @@ export function defaultDesktopTimeTrigger(
 
 export function isValidDesktopAutomationTrigger(trigger: DesktopAutomationTrigger): boolean {
   if (trigger.kind === 'time') {
-    return true;
+    return isValidDesktopAutomationSchedule(trigger.schedule);
   }
   return Boolean(trigger.owner.trim() && trigger.repo.trim());
 }

--- a/apps/desktop/src/lib/automation-trigger.ts
+++ b/apps/desktop/src/lib/automation-trigger.ts
@@ -1,0 +1,45 @@
+/** Renderer-safe automation trigger types and labels. Do not import host-internal here. */
+
+import type {
+  DesktopAutomationSchedule,
+  DesktopAutomationScheduleFormatLabels,
+} from './automation-schedule.js';
+import { formatDesktopAutomationScheduleLabel } from './automation-schedule.js';
+
+export type DesktopAutomationGitHubEvent = 'pull_request_created' | 'issue_created';
+
+export type DesktopAutomationTrigger =
+  | { kind: 'time'; schedule: DesktopAutomationSchedule }
+  | {
+      kind: 'github';
+      owner: string;
+      repo: string;
+      event: DesktopAutomationGitHubEvent;
+      poll?: { lastSeenNumber: number };
+    };
+
+export interface DesktopAutomationTriggerFormatLabels extends DesktopAutomationScheduleFormatLabels {
+  githubPrefix: string;
+  githubPullRequestCreated: string;
+  githubIssueCreated: string;
+}
+
+export function formatDesktopAutomationTriggerLabel(
+  trigger: DesktopAutomationTrigger,
+  labels: DesktopAutomationTriggerFormatLabels,
+): string {
+  if (trigger.kind === 'time') {
+    return formatDesktopAutomationScheduleLabel(trigger.schedule, labels);
+  }
+  const eventLabel =
+    trigger.event === 'pull_request_created'
+      ? labels.githubPullRequestCreated
+      : labels.githubIssueCreated;
+  return `${labels.githubPrefix} · ${trigger.owner}/${trigger.repo} · ${eventLabel}`;
+}
+
+export function defaultDesktopTimeTrigger(
+  schedule: DesktopAutomationSchedule = { kind: 'daily', hour: 20, minute: 0 },
+): DesktopAutomationTrigger {
+  return { kind: 'time', schedule };
+}

--- a/apps/desktop/src/lib/github-automation-repositories-cache.ts
+++ b/apps/desktop/src/lib/github-automation-repositories-cache.ts
@@ -1,0 +1,55 @@
+import type { DesktopGitHubAutomationRepositoryItem } from "@/types";
+
+type ListCacheEntry = {
+  items: DesktopGitHubAutomationRepositoryItem[];
+  hasNextPage: boolean;
+};
+
+type SearchCacheEntry = {
+  items: DesktopGitHubAutomationRepositoryItem[];
+  totalCount: number;
+};
+
+const listCache = new Map<string, ListCacheEntry>();
+const searchCache = new Map<string, SearchCacheEntry>();
+
+function listCacheKey(page = 1): string {
+  return String(page);
+}
+
+function searchCacheKey(query: string, page = 1): string {
+  return `${query}\0${page}`;
+}
+
+export function readGitHubAutomationRepositoriesListCache(
+  page = 1,
+): ListCacheEntry | undefined {
+  return listCache.get(listCacheKey(page));
+}
+
+export function writeGitHubAutomationRepositoriesListCache(
+  entry: ListCacheEntry,
+  page = 1,
+): void {
+  listCache.set(listCacheKey(page), entry);
+}
+
+export function readGitHubAutomationRepositoriesSearchCache(
+  query: string,
+  page = 1,
+): SearchCacheEntry | undefined {
+  return searchCache.get(searchCacheKey(query, page));
+}
+
+export function writeGitHubAutomationRepositoriesSearchCache(
+  query: string,
+  entry: SearchCacheEntry,
+  page = 1,
+): void {
+  searchCache.set(searchCacheKey(query, page), entry);
+}
+
+export function clearGitHubAutomationRepositoriesCache(): void {
+  listCache.clear();
+  searchCache.clear();
+}

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -122,7 +122,7 @@
     "fontDescription": "Defaults to Geist.",
     "selectTheme": "Select Theme",
     "themeDescription": "Applied immediately.",
-    "blurEffectDescription": "Mica on Windows, system vibrancy on macOS. Solid background when off.",
+    "blurEffectDescription": "When enabled, the main UI uses a translucent blurred background.",
     "llmHttpVersion": "LLM HTTP Version",
     "llmHttpVersionDescription": "Protocol for outbound LLM API requests",
     "llmHttpVersionHttp11": "HTTP/1.1",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -406,6 +406,7 @@
       "repository": "Repository",
       "repositorySearchPlaceholder": "Search repositories…",
       "repositoryEmpty": "No repositories found",
+      "repositoryLoadFailed": "Failed to load repositories. Try again.",
       "connectGitHubHint": "Connect GitHub in Settings → Integrations to use repository triggers.",
       "pullRequestCreated": "Pull request created",
       "issueCreated": "Issue created"

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -383,6 +383,7 @@
     "create": "Create automation",
     "empty": "No automations configured",
     "disabled": "Disabled",
+    "githubDisconnectedPause": "GitHub disconnected; repository triggers paused",
     "detailBack": "Automations",
     "detailTabsAria": "Automation detail",
     "tabKanban": "Kanban",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -398,6 +398,17 @@
     "dialogTitlePlaceholder": "Automation title",
     "dialogOverviewPlaceholder": "Briefly explain what this automation should do",
     "dialogEvent": "Event",
+    "trigger": {
+      "github": "GitHub",
+      "time": "Time",
+      "event": "Event",
+      "repository": "Repository",
+      "repositorySearchPlaceholder": "Search repositories…",
+      "repositoryEmpty": "No repositories found",
+      "connectGitHubHint": "Connect GitHub in Settings → Integrations to use repository triggers.",
+      "pullRequestCreated": "Pull request created",
+      "issueCreated": "Issue created"
+    },
     "schedule": {
       "hourly": "Hourly",
       "daily": "Daily",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -122,7 +122,7 @@
     "fontDescription": "默认 Geist。",
     "selectTheme": "选择主题",
     "themeDescription": "立即生效。",
-    "blurEffectDescription": "Windows 为 Mica，macOS 为系统模糊；关闭后为实色背景。",
+    "blurEffectDescription": "开启后主界面背景半透明模糊，可透出桌面。",
     "llmHttpVersion": "LLM HTTP 版本",
     "llmHttpVersionDescription": "LLM API 出站请求使用的协议",
     "llmHttpVersionHttp11": "HTTP/1.1",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -381,6 +381,7 @@
     "create": "创建自动化",
     "empty": "未配置自动化",
     "disabled": "已禁用",
+    "githubDisconnectedPause": "GitHub 未连接，仓库触发已暂停",
     "detailBack": "自动化",
     "detailTabsAria": "自动化详情",
     "tabKanban": "看板",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -396,6 +396,17 @@
     "dialogTitlePlaceholder": "自动化标题",
     "dialogOverviewPlaceholder": "简要说明这个自动化该做什么",
     "dialogEvent": "事件",
+    "trigger": {
+      "github": "GitHub",
+      "time": "时间",
+      "event": "事件",
+      "repository": "仓库",
+      "repositorySearchPlaceholder": "搜索仓库…",
+      "repositoryEmpty": "未找到仓库",
+      "connectGitHubHint": "请先在设置 → 集成 中连接 GitHub，才能使用仓库触发器。",
+      "pullRequestCreated": "Pull Request 创建",
+      "issueCreated": "Issue 创建"
+    },
     "schedule": {
       "hourly": "每小时",
       "daily": "每天",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -404,6 +404,7 @@
       "repository": "仓库",
       "repositorySearchPlaceholder": "搜索仓库…",
       "repositoryEmpty": "未找到仓库",
+      "repositoryLoadFailed": "加载仓库失败，请稍后重试",
       "connectGitHubHint": "请先在设置 → 集成 中连接 GitHub，才能使用仓库触发器。",
       "pullRequestCreated": "Pull Request 创建",
       "issueCreated": "Issue 创建"

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -790,6 +790,38 @@ export type {
   DesktopAutomationSchedule,
   DesktopAutomationWeekday,
 } from './lib/automation-schedule.js';
+export type {
+  DesktopAutomationGitHubEvent,
+  DesktopAutomationTrigger,
+} from './lib/automation-trigger.js';
+
+export interface DesktopGitHubAutomationRepositoryItem {
+  owner: string;
+  repo: string;
+  fullName: string;
+  htmlUrl: string;
+  private: boolean;
+  updatedAt: string;
+}
+
+export interface ListGitHubAutomationRepositoriesRequest {
+  page?: number;
+}
+
+export interface SearchGitHubAutomationRepositoriesRequest {
+  query: string;
+  page?: number;
+}
+
+export interface GitHubAutomationRepositoriesSnapshot {
+  items: DesktopGitHubAutomationRepositoryItem[];
+  hasNextPage: boolean;
+}
+
+export interface SearchGitHubAutomationRepositoriesSnapshot {
+  items: DesktopGitHubAutomationRepositoryItem[];
+  totalCount: number;
+}
 
 export type DesktopAutomationRunStatus = 'running' | 'blocked' | 'completed' | 'failed';
 
@@ -807,7 +839,7 @@ export interface DesktopAutomationDefinition {
   id: string;
   title: string;
   overview: string;
-  schedule: import('./lib/automation-schedule.js').DesktopAutomationSchedule;
+  trigger: import('./lib/automation-trigger.js').DesktopAutomationTrigger;
   workspaceRoot: string;
   modelName: string;
   reasoningEffort?: DesktopModelReasoningEffort;
@@ -826,7 +858,7 @@ export interface DesktopAutomationDetail {
 export interface DesktopCreateAutomationRequest {
   title: string;
   overview: string;
-  schedule: import('./lib/automation-schedule.js').DesktopAutomationSchedule;
+  trigger: import('./lib/automation-trigger.js').DesktopAutomationTrigger;
   workspaceRoot: string;
   modelName: string;
   reasoningEffort?: DesktopModelReasoningEffort;
@@ -837,7 +869,7 @@ export interface DesktopCreateAutomationRequest {
 export interface DesktopUpdateAutomationRequest {
   title?: string;
   overview?: string;
-  schedule?: import('./lib/automation-schedule.js').DesktopAutomationSchedule;
+  trigger?: import('./lib/automation-trigger.js').DesktopAutomationTrigger;
   workspaceRoot?: string;
   modelName?: string;
   reasoningEffort?: DesktopModelReasoningEffort;

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -784,6 +784,7 @@ export interface DesktopAutomationListItem {
   scheduleLabel: string;
   trigger: DesktopAutomationTrigger;
   enabled: boolean;
+  githubPollError?: string;
   lastRunAtUnixMs?: number;
   updatedAtUnixMs: number;
 }

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -3,6 +3,7 @@ import type { ModelReasoningEffort } from '@spirit-agent/core/reasoning-effort';
 import type { LspWriteDiagnosticsUi } from '@spirit-agent/core';
 
 import type { DesktopAgentMode } from './lib/agent-mode.js';
+import type { DesktopAutomationTrigger } from './lib/automation-trigger.js';
 
 export type { DesktopAgentMode };
 import type { WorkspaceFileReferenceSuggestionsResult as HostWorkspaceFileReferenceSuggestionsResult, ApprovalLevel, GitHubPullRequestCommit } from '@spirit-agent/host-internal';
@@ -781,6 +782,7 @@ export interface DesktopAutomationListItem {
   id: string;
   title: string;
   scheduleLabel: string;
+  trigger: DesktopAutomationTrigger;
   enabled: boolean;
   lastRunAtUnixMs?: number;
   updatedAtUnixMs: number;

--- a/apps/desktop/test/host/automation-scheduler-service.test.mjs
+++ b/apps/desktop/test/host/automation-scheduler-service.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { groupGitHubPollMatchesByAutomation } from '../../dist-electron/src/host/automation-scheduler-service.js';
+
+test('groupGitHubPollMatchesByAutomation groups matches by automation id', () => {
+  const definitionA = {
+    id: 'a',
+    title: 'A',
+    overview: 'A',
+    trigger: { kind: 'github', owner: 'o', repo: 'r', event: 'issue_created' },
+    workspaceRoot: '/tmp',
+    modelName: 'm',
+    approvalLevel: 'default',
+    enabled: true,
+    createdAtUnixMs: 1,
+    updatedAtUnixMs: 1,
+  };
+  const definitionB = { ...definitionA, id: 'b', title: 'B', overview: 'B' };
+  const grouped = groupGitHubPollMatchesByAutomation([
+    {
+      automationId: 'a',
+      definition: definitionA,
+      item: { number: 1, htmlUrl: 'https://example/1', isPullRequest: false, createdAt: '' },
+      nextLastSeenNumber: 2,
+    },
+    {
+      automationId: 'b',
+      definition: definitionB,
+      item: { number: 3, htmlUrl: 'https://example/3', isPullRequest: false, createdAt: '' },
+      nextLastSeenNumber: 3,
+    },
+    {
+      automationId: 'a',
+      definition: definitionA,
+      item: { number: 2, htmlUrl: 'https://example/2', isPullRequest: false, createdAt: '' },
+      nextLastSeenNumber: 2,
+    },
+  ]);
+
+  assert.equal(grouped.size, 2);
+  assert.equal(grouped.get('a')?.length, 2);
+  assert.equal(grouped.get('b')?.length, 1);
+});

--- a/apps/desktop/test/host/message-ordering.test.mjs
+++ b/apps/desktop/test/host/message-ordering.test.mjs
@@ -28,12 +28,12 @@ test('toolCallSummaryCopyForRequest: write tools use verb headline + basename de
   );
 });
 
-test('toolCallSummaryCopyForRequest: create_automation uses title and schedule detail', () => {
+test('toolCallSummaryCopyForRequest: create_automation uses title and trigger detail', () => {
   assert.deepEqual(
     toolCallSummaryCopyForRequest('create_automation', {
       title: 'CI check',
       overview: 'Summarize CI failures.',
-      schedule: { kind: 'weekly', weekday: 1, hour: 9, minute: 0 },
+      trigger: { kind: 'time', schedule: { kind: 'weekly', weekday: 1, hour: 9, minute: 0 } },
     }),
     { headline: '创建自动化', headlineDetail: 'CI check · 每周一 09:00' },
   );

--- a/apps/desktop/test/lib/automation-trigger.test.mjs
+++ b/apps/desktop/test/lib/automation-trigger.test.mjs
@@ -36,6 +36,27 @@ test('isValidDesktopAutomationTrigger requires github owner and repo', () => {
   assert.equal(isValidDesktopAutomationTrigger({ kind: 'time', schedule: { kind: 'hourly' } }), true);
   assert.equal(
     isValidDesktopAutomationTrigger({
+      kind: 'time',
+      schedule: { kind: 'daily', hour: 9, minute: 30 },
+    }),
+    true,
+  );
+  assert.equal(
+    isValidDesktopAutomationTrigger({
+      kind: 'time',
+      schedule: { kind: 'daily', hour: 25, minute: 0 },
+    }),
+    false,
+  );
+  assert.equal(
+    isValidDesktopAutomationTrigger({
+      kind: 'time',
+      schedule: { kind: 'weekly', weekday: 1, hour: 9, minute: 60 },
+    }),
+    false,
+  );
+  assert.equal(
+    isValidDesktopAutomationTrigger({
       kind: 'github',
       owner: 'acme',
       repo: 'app',

--- a/apps/desktop/test/lib/automation-trigger.test.mjs
+++ b/apps/desktop/test/lib/automation-trigger.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  formatDesktopAutomationTriggerLabel,
+  isValidDesktopAutomationTrigger,
+} from '../../src/lib/automation-trigger.ts';
+
+const labels = {
+  hourly: 'Hourly',
+  dailyPrefix: 'Daily',
+  weeklyPrefix: 'Weekly',
+  weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+  formatWeekly: (weekday, time) => `Weekly ${weekday} ${time}`,
+  githubPrefix: 'GitHub',
+  githubPullRequestCreated: 'PR created',
+  githubIssueCreated: 'Issue created',
+};
+
+test('formatDesktopAutomationTriggerLabel renders github trigger', () => {
+  assert.equal(
+    formatDesktopAutomationTriggerLabel(
+      {
+        kind: 'github',
+        owner: 'acme',
+        repo: 'app',
+        event: 'pull_request_created',
+      },
+      labels,
+    ),
+    'GitHub · acme/app · PR created',
+  );
+});
+
+test('isValidDesktopAutomationTrigger requires github owner and repo', () => {
+  assert.equal(isValidDesktopAutomationTrigger({ kind: 'time', schedule: { kind: 'hourly' } }), true);
+  assert.equal(
+    isValidDesktopAutomationTrigger({
+      kind: 'github',
+      owner: 'acme',
+      repo: 'app',
+      event: 'issue_created',
+    }),
+    true,
+  );
+  assert.equal(
+    isValidDesktopAutomationTrigger({
+      kind: 'github',
+      owner: '',
+      repo: 'app',
+      event: 'issue_created',
+    }),
+    false,
+  );
+});

--- a/packages/host-internal/src/automation-host-tool.test.ts
+++ b/packages/host-internal/src/automation-host-tool.test.ts
@@ -8,16 +8,18 @@ import {
   deriveAutomationTitle,
   parseCreateAutomationApprovalLevel,
   parseCreateAutomationSchedule,
+  parseCreateAutomationTrigger,
+  parseCreateAutomationTriggerInput,
 } from './automation-host-tool.js';
 
-test('CREATE_AUTOMATION_CONTRIBUTED_TOOL exposes required overview and schedule', () => {
+test('CREATE_AUTOMATION_CONTRIBUTED_TOOL exposes required overview', () => {
   assert.equal(CREATE_AUTOMATION_CONTRIBUTED_TOOL.name, CREATE_AUTOMATION_TOOL_NAME);
   const schema = CREATE_AUTOMATION_CONTRIBUTED_TOOL.inputSchema;
-  assert.deepEqual(schema.required, ['overview', 'schedule']);
+  assert.deepEqual(schema.required, ['overview']);
   const properties = schema.properties;
   assert.ok(properties && typeof properties === 'object' && !Array.isArray(properties));
-  const schedule = properties.schedule;
-  assert.equal(schedule && typeof schedule === 'object' && !Array.isArray(schedule) ? schedule.type : undefined, 'object');
+  const trigger = properties.trigger;
+  assert.equal(trigger && typeof trigger === 'object' && !Array.isArray(trigger) ? trigger.type : undefined, 'object');
 });
 
 test('buildAutomationHostToolDefinitions returns one function tool', () => {
@@ -52,6 +54,51 @@ test('parseCreateAutomationSchedule accepts hourly daily weekly', () => {
 
 test('parseCreateAutomationSchedule rejects invalid input', () => {
   assert.throws(() => parseCreateAutomationSchedule({ kind: 'monthly' }), /Invalid automation schedule/);
+});
+
+test('parseCreateAutomationTrigger accepts github trigger', () => {
+  assert.deepEqual(
+    parseCreateAutomationTrigger({
+      kind: 'github',
+      owner: 'acme',
+      repo: 'app',
+      event: 'issue_created',
+    }),
+    {
+      kind: 'github',
+      owner: 'acme',
+      repo: 'app',
+      event: 'issue_created',
+    },
+  );
+});
+
+test('parseCreateAutomationTriggerInput prefers trigger and falls back to legacy schedule', () => {
+  assert.deepEqual(
+    parseCreateAutomationTriggerInput({
+      trigger: {
+        kind: 'github',
+        owner: 'acme',
+        repo: 'app',
+        event: 'pull_request_created',
+      },
+    }),
+    {
+      kind: 'github',
+      owner: 'acme',
+      repo: 'app',
+      event: 'pull_request_created',
+    },
+  );
+  assert.deepEqual(
+    parseCreateAutomationTriggerInput({
+      schedule: { kind: 'daily', hour: 8, minute: 15 },
+    }),
+    {
+      kind: 'time',
+      schedule: { kind: 'daily', hour: 8, minute: 15 },
+    },
+  );
 });
 
 test('parseCreateAutomationApprovalLevel defaults to default and accepts full-approval', () => {

--- a/packages/host-internal/src/automation-host-tool.ts
+++ b/packages/host-internal/src/automation-host-tool.ts
@@ -5,8 +5,8 @@ import {
   type JsonValue,
 } from '@spirit-agent/core';
 
-import type { HostAutomationSchedule } from './automations.js';
-import { normalizeAutomationSchedule } from './automations.js';
+import type { HostAutomationSchedule, HostAutomationTrigger } from './automations.js';
+import { normalizeAutomationSchedule, normalizeAutomationTrigger } from './automations.js';
 
 export type CreateAutomationApprovalLevel = 'default' | 'full-approval';
 
@@ -54,21 +54,40 @@ export function parseCreateAutomationSchedule(value: unknown): HostAutomationSch
   return schedule;
 }
 
+export function parseCreateAutomationTrigger(value: unknown): HostAutomationTrigger {
+  const trigger = normalizeAutomationTrigger(value);
+  if (!trigger) {
+    throw new Error('Invalid automation trigger.');
+  }
+  return trigger;
+}
+
+export function parseCreateAutomationTriggerInput(parsed: Record<string, unknown>): HostAutomationTrigger {
+  if (parsed.trigger !== undefined) {
+    return parseCreateAutomationTrigger(parsed.trigger);
+  }
+  const scheduleValue = parsed.schedule;
+  if (scheduleValue === undefined) {
+    throw new Error('create_automation 缺少 trigger 或 schedule。');
+  }
+  return parseCreateAutomationTrigger({ kind: 'time', schedule: parseCreateAutomationSchedule(scheduleValue) });
+}
+
 export const CREATE_AUTOMATION_CONTRIBUTED_TOOL: ContributedHostToolDefinition = {
   name: CREATE_AUTOMATION_TOOL_NAME,
   excludeFromAskMode: true,
   agentModeExposure: 'agent',
   description:
-    'Create a scheduled Desktop automation that runs an agent turn with your prompt on the current workspace. ' +
-    'Use when the user asks to automate recurring work (daily reports, weekly checks, hourly monitoring). ' +
-    'Schedule times use the host local timezone.',
+    'Create a Desktop automation that runs an agent turn with your prompt on the current workspace. ' +
+    'Triggers may be time-based (hourly/daily/weekly local time) or GitHub repository events (new pull request or issue). ' +
+    'Use when the user asks to automate recurring work or react to GitHub activity.',
   inputSchema: {
     type: 'object',
     properties: {
       overview: {
         type: 'string',
         description:
-          'Agent prompt executed on each scheduled run. Write a self-contained instruction the automation agent can follow without extra context.',
+          'Agent prompt executed on each run. Write a self-contained instruction the automation agent can follow without extra context.',
       },
       title: {
         type: 'string',
@@ -81,10 +100,42 @@ export const CREATE_AUTOMATION_CONTRIBUTED_TOOL: ContributedHostToolDefinition =
         description:
           'Approval policy when the automation runs. default: normal tool approval prompts; full-approval: skip high-risk approval prompts for that automation run. Omit to use default.',
       },
+      trigger: {
+        type: 'object',
+        description:
+          'Preferred trigger definition. kind=time uses schedule; kind=github listens for new pull requests or issues in a repository.',
+        properties: {
+          kind: {
+            type: 'string',
+            enum: ['time', 'github'],
+          },
+          schedule: {
+            type: 'object',
+            description: 'Required when kind=time.',
+            properties: {
+              kind: { type: 'string', enum: ['hourly', 'daily', 'weekly'] },
+              hour: { type: 'integer', minimum: 0, maximum: 23 },
+              minute: { type: 'integer', minimum: 0, maximum: 59 },
+              weekday: { type: 'integer', minimum: 0, maximum: 6 },
+            },
+            required: ['kind'],
+            additionalProperties: false,
+          },
+          owner: { type: 'string', description: 'GitHub owner/org. Required when kind=github.' },
+          repo: { type: 'string', description: 'GitHub repository name. Required when kind=github.' },
+          event: {
+            type: 'string',
+            enum: ['pull_request_created', 'issue_created'],
+            description: 'GitHub event to watch when kind=github.',
+          },
+        },
+        required: ['kind'],
+        additionalProperties: false,
+      },
       schedule: {
         type: 'object',
         description:
-          'When to fire the automation (host local time). kind=hourly ignores hour/minute/weekday; kind=weekly requires weekday.',
+          'Legacy time-only trigger. Prefer trigger instead. When provided alone, treated as { kind: "time", schedule }.',
         properties: {
           kind: {
             type: 'string',
@@ -114,7 +165,7 @@ export const CREATE_AUTOMATION_CONTRIBUTED_TOOL: ContributedHostToolDefinition =
         additionalProperties: false,
       },
     },
-    required: ['overview', 'schedule'],
+    required: ['overview'],
     additionalProperties: false,
   } satisfies JsonObject,
 };

--- a/packages/host-internal/src/automation-trigger-message.test.ts
+++ b/packages/host-internal/src/automation-trigger-message.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  AUTOMATION_TRIGGER_CLOSE,
+  AUTOMATION_TRIGGER_OPEN,
+  buildAutomationTriggerMessage,
+  formatGitHubAutomationEventLabel,
+} from './automation-trigger-message.js';
+
+test('buildAutomationTriggerMessage wraps GitHub event with meta block', () => {
+  const message = buildAutomationTriggerMessage({
+    overview: 'Summarize the PR.',
+    trigger: {
+      kind: 'github',
+      owner: 'o',
+      repo: 'r',
+      event: 'pull_request_created',
+    },
+    context: {
+      kind: 'github',
+      event: 'pull_request_created',
+      eventUrl: 'https://github.com/o/r/pull/12',
+    },
+  });
+  assert.match(message, new RegExp(`^${AUTOMATION_TRIGGER_OPEN}`));
+  assert.match(message, /Event: Pull request created \(https:\/\/github\.com\/o\/r\/pull\/12\)\./);
+  assert.match(message, new RegExp(`${AUTOMATION_TRIGGER_CLOSE}\\n\\nSummarize the PR\\.$`));
+});
+
+test('buildAutomationTriggerMessage wraps scheduled time trigger', () => {
+  const message = buildAutomationTriggerMessage({
+    overview: 'Daily digest',
+    trigger: { kind: 'time', schedule: { kind: 'daily', hour: 20, minute: 0 } },
+    context: { kind: 'time' },
+  });
+  assert.match(message, /Event: Scheduled run \(daily 20:00\)\./);
+  assert.match(message, /Daily digest$/);
+});
+
+test('formatGitHubAutomationEventLabel covers issue events', () => {
+  assert.equal(formatGitHubAutomationEventLabel('issue_created'), 'Issue created');
+});

--- a/packages/host-internal/src/automation-trigger-message.ts
+++ b/packages/host-internal/src/automation-trigger-message.ts
@@ -1,0 +1,74 @@
+import {
+  formatScheduleLabel,
+  type HostAutomationDefinition,
+  type HostAutomationGitHubEvent,
+  type HostAutomationTrigger,
+} from './automations.js';
+
+export const AUTOMATION_TRIGGER_OPEN = '<automation_trigger>';
+export const AUTOMATION_TRIGGER_CLOSE = '</automation_trigger>';
+
+export type AutomationRunTriggerContext =
+  | { kind: 'time' }
+  | {
+      kind: 'github';
+      event: HostAutomationGitHubEvent;
+      eventUrl: string;
+    };
+
+export function formatGitHubAutomationEventLabel(event: HostAutomationGitHubEvent): string {
+  if (event === 'pull_request_created') {
+    return 'Pull request created';
+  }
+  return 'Issue created';
+}
+
+export function formatTimeAutomationEventLabel(
+  trigger: Extract<HostAutomationTrigger, { kind: 'time' }>,
+): string {
+  return `Scheduled run (${formatScheduleLabel(trigger.schedule, {
+    hourly: 'hourly',
+    dailyPrefix: 'daily',
+    weeklyPrefix: 'weekly',
+    weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    formatWeekly: (weekday, time) => `weekly ${weekday} ${time}`,
+  })})`;
+}
+
+export function buildAutomationTriggerEventLine(
+  trigger: HostAutomationTrigger,
+  context: AutomationRunTriggerContext,
+): string {
+  if (context.kind === 'github' && trigger.kind === 'github') {
+    return `${formatGitHubAutomationEventLabel(context.event)} (${context.eventUrl}).`;
+  }
+  if (trigger.kind === 'time') {
+    return `${formatTimeAutomationEventLabel(trigger)}.`;
+  }
+  return 'Automation activated.';
+}
+
+export function buildAutomationTriggerMessage(input: {
+  overview: string;
+  trigger: HostAutomationTrigger;
+  context: AutomationRunTriggerContext;
+}): string {
+  const overview = input.overview.trim();
+  const eventLine = buildAutomationTriggerEventLine(input.trigger, input.context);
+  const metaBlock = [
+    AUTOMATION_TRIGGER_OPEN,
+    'Automation activated.',
+    `Event: ${eventLine}`,
+    AUTOMATION_TRIGGER_CLOSE,
+  ].join('\n');
+  return overview ? `${metaBlock}\n\n${overview}` : metaBlock;
+}
+
+export function defaultAutomationRunTriggerContext(
+  definition: HostAutomationDefinition,
+): AutomationRunTriggerContext {
+  if (definition.trigger.kind === 'github') {
+    throw new Error('GitHub automation runs require an event URL context.');
+  }
+  return { kind: 'time' };
+}

--- a/packages/host-internal/src/automations.test.ts
+++ b/packages/host-internal/src/automations.test.ts
@@ -10,6 +10,7 @@ import {
   formatScheduleLabel,
   formatTriggerLabel,
   normalizeAutomationTrigger,
+  reconcileGitHubTriggerPollState,
   shouldFireNow,
 } from './automations.js';
 
@@ -147,6 +148,29 @@ test('normalizeAutomationTrigger accepts legacy bare schedule', () => {
   assert.deepEqual(normalizeAutomationTrigger({ kind: 'daily', hour: 9, minute: 0 }), {
     kind: 'time',
     schedule: { kind: 'daily', hour: 9, minute: 0 },
+  });
+});
+
+test('reconcileGitHubTriggerPollState clears poll when repo identity changes', () => {
+  const previous = {
+    kind: 'github' as const,
+    owner: 'a',
+    repo: 'b',
+    event: 'issue_created' as const,
+    poll: { lastSeenNumber: 42 },
+  };
+  const next = {
+    kind: 'github' as const,
+    owner: 'c',
+    repo: 'd',
+    event: 'issue_created' as const,
+    poll: { lastSeenNumber: 99 },
+  };
+  assert.deepEqual(reconcileGitHubTriggerPollState(previous, next), {
+    kind: 'github',
+    owner: 'c',
+    repo: 'd',
+    event: 'issue_created',
   });
 });
 

--- a/packages/host-internal/src/automations.test.ts
+++ b/packages/host-internal/src/automations.test.ts
@@ -8,6 +8,8 @@ import {
   computeNextRunAt,
   createHostAutomationStore,
   formatScheduleLabel,
+  formatTriggerLabel,
+  normalizeAutomationTrigger,
   shouldFireNow,
 } from './automations.js';
 
@@ -19,13 +21,13 @@ test('automation store create list get update delete', async () => {
     const created = await store.create({
       title: 'GitHub 日报',
       overview: '收集 GitHub 新闻',
-      schedule: { kind: 'daily', hour: 20, minute: 0 },
+      trigger: { kind: 'time', schedule: { kind: 'daily', hour: 20, minute: 0 } },
       workspaceRoot: spiritDataDir,
       modelName: 'gpt-test',
       approvalLevel: 'default',
     });
     assert.equal(created.enabled, true);
-    assert.equal(created.schedule.kind, 'daily');
+    assert.equal(created.trigger.kind, 'time');
 
     const summaries = await store.listSummaries();
     assert.equal(summaries.length, 1);
@@ -55,7 +57,7 @@ test('automation store tracks runs and active run', async () => {
     const created = await store.create({
       title: 'Hourly task',
       overview: 'Do work',
-      schedule: { kind: 'hourly' },
+      trigger: { kind: 'time', schedule: { kind: 'hourly' } },
       workspaceRoot: spiritDataDir,
       modelName: 'gpt-test',
       approvalLevel: 'full-approval',
@@ -127,4 +129,62 @@ test('formatScheduleLabel renders weekly label', () => {
     '每周一 09:00',
   );
   assert.equal(formatScheduleLabel({ kind: 'hourly' }), '每小时');
+});
+
+test('formatTriggerLabel renders GitHub trigger', () => {
+  assert.equal(
+    formatTriggerLabel({
+      kind: 'github',
+      owner: 'spirit',
+      repo: 'agent',
+      event: 'pull_request_created',
+    }),
+    'GitHub · spirit/agent · PR created',
+  );
+});
+
+test('normalizeAutomationTrigger accepts legacy bare schedule', () => {
+  assert.deepEqual(normalizeAutomationTrigger({ kind: 'daily', hour: 9, minute: 0 }), {
+    kind: 'time',
+    schedule: { kind: 'daily', hour: 9, minute: 0 },
+  });
+});
+
+test('automation store migrates legacy schedule field on load', async () => {
+  const spiritDataDir = await mkdtemp(join(tmpdir(), 'spirit-host-automations-legacy-'));
+  const { mkdir, writeFile } = await import('node:fs/promises');
+  const { automationsDirPath } = await import('./automations.js');
+
+  try {
+    const automationId = '00000000-0000-4000-8000-000000000001';
+    const dir = automationsDirPath(spiritDataDir);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, `${automationId}.json`),
+      `${JSON.stringify({
+        version: 1,
+        definition: {
+          id: automationId,
+          title: 'Legacy',
+          overview: 'Legacy overview',
+          schedule: { kind: 'hourly' },
+          workspaceRoot: spiritDataDir,
+          modelName: 'gpt-test',
+          approvalLevel: 'default',
+          enabled: true,
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 1,
+        },
+        runs: [],
+      }, null, 2)}\n`,
+      'utf8',
+    );
+
+    const store = createHostAutomationStore(spiritDataDir);
+    const loaded = await store.get(automationId);
+    assert.ok(loaded);
+    assert.deepEqual(loaded!.definition.trigger, { kind: 'time', schedule: { kind: 'hourly' } });
+  } finally {
+    await rm(spiritDataDir, { recursive: true, force: true });
+  }
 });

--- a/packages/host-internal/src/automations.test.ts
+++ b/packages/host-internal/src/automations.test.ts
@@ -32,7 +32,7 @@ test('automation store create list get update delete', async () => {
     const summaries = await store.listSummaries();
     assert.equal(summaries.length, 1);
     assert.equal(summaries[0]?.title, 'GitHub 日报');
-    assert.equal(summaries[0]?.scheduleLabel, '每天 20:00');
+    assert.equal(summaries[0]?.scheduleLabel, 'Daily 20:00');
 
     const loaded = await store.get(created.id);
     assert.ok(loaded);
@@ -126,9 +126,9 @@ test('computeNextRunAt advances schedule', () => {
 test('formatScheduleLabel renders weekly label', () => {
   assert.equal(
     formatScheduleLabel({ kind: 'weekly', weekday: 1, hour: 9, minute: 0 }),
-    '每周一 09:00',
+    'Weekly Mon 09:00',
   );
-  assert.equal(formatScheduleLabel({ kind: 'hourly' }), '每小时');
+  assert.equal(formatScheduleLabel({ kind: 'hourly' }), 'Hourly');
 });
 
 test('formatTriggerLabel renders GitHub trigger', () => {

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -230,6 +230,7 @@ export interface ScheduleFormatLabels {
   dailyPrefix: string;
   weeklyPrefix: string;
   weekdays: readonly string[];
+  formatWeekly?(weekday: string, time: string): string;
 }
 
 function defaultScheduleFormatLabels(): ScheduleFormatLabels {

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -8,16 +8,31 @@ import { normalizeApprovalLevel, type ApprovalLevel } from './tools.js';
 
 export type HostAutomationWeekday = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
+/** @deprecated Use HostAutomationTimeSchedule via HostAutomationTrigger.kind === 'time'. */
 export type HostAutomationSchedule =
   | { kind: 'hourly' }
   | { kind: 'daily'; hour: number; minute: number }
   | { kind: 'weekly'; weekday: HostAutomationWeekday; hour: number; minute: number };
 
+export type HostAutomationTimeSchedule = HostAutomationSchedule;
+
+export type HostAutomationGitHubEvent = 'pull_request_created' | 'issue_created';
+
+export type HostAutomationTrigger =
+  | { kind: 'time'; schedule: HostAutomationTimeSchedule }
+  | {
+      kind: 'github';
+      owner: string;
+      repo: string;
+      event: HostAutomationGitHubEvent;
+      poll?: { lastSeenNumber: number };
+    };
+
 export interface HostAutomationDefinition {
   id: string;
   title: string;
   overview: string;
-  schedule: HostAutomationSchedule;
+  trigger: HostAutomationTrigger;
   workspaceRoot: string;
   modelName: string;
   reasoningEffort?: ModelReasoningEffort;
@@ -52,7 +67,7 @@ export interface HostAutomationListItem {
 export interface HostAutomationCreateInput {
   title: string;
   overview: string;
-  schedule: HostAutomationSchedule;
+  trigger: HostAutomationTrigger;
   workspaceRoot: string;
   modelName: string;
   reasoningEffort?: ModelReasoningEffort;
@@ -63,7 +78,7 @@ export interface HostAutomationCreateInput {
 export interface HostAutomationUpdateInput {
   title?: string;
   overview?: string;
-  schedule?: HostAutomationSchedule;
+  trigger?: HostAutomationTrigger;
   workspaceRoot?: string;
   modelName?: string;
   reasoningEffort?: ModelReasoningEffort;
@@ -91,11 +106,11 @@ export function createHostAutomationStore(spiritDataDir: string): HostAutomation
   return new HostAutomationStore(spiritDataDir);
 }
 
-export function normalizeAutomationSchedule(value: unknown): HostAutomationSchedule | undefined {
+export function normalizeAutomationSchedule(value: unknown): HostAutomationTimeSchedule | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
   }
-  const schedule = value as Partial<HostAutomationSchedule>;
+  const schedule = value as Partial<HostAutomationTimeSchedule>;
   if (schedule.kind === 'hourly') {
     return { kind: 'hourly' };
   }
@@ -119,8 +134,83 @@ export function normalizeAutomationSchedule(value: unknown): HostAutomationSched
   return undefined;
 }
 
+export function normalizeAutomationTrigger(value: unknown): HostAutomationTrigger | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Partial<HostAutomationTrigger> & { schedule?: unknown };
+  if (record.kind === 'time') {
+    const schedule = normalizeAutomationSchedule(record.schedule);
+    if (!schedule) {
+      return undefined;
+    }
+    return { kind: 'time', schedule };
+  }
+  if (record.kind === 'github') {
+    const owner = typeof record.owner === 'string' ? record.owner.trim() : '';
+    const repo = typeof record.repo === 'string' ? record.repo.trim() : '';
+    if (!owner || !repo) {
+      return undefined;
+    }
+    const event = normalizeGitHubEvent(record.event);
+    if (!event) {
+      return undefined;
+    }
+    const poll = normalizeGitHubPoll(record.poll);
+    return {
+      kind: 'github',
+      owner,
+      repo,
+      event,
+      ...(poll ? { poll } : {}),
+    };
+  }
+  // Legacy bare time schedule object.
+  const legacySchedule = normalizeAutomationSchedule(value);
+  if (legacySchedule) {
+    return { kind: 'time', schedule: legacySchedule };
+  }
+  return undefined;
+}
+
+export function automationTimeScheduleFromTrigger(
+  trigger: HostAutomationTrigger,
+): HostAutomationTimeSchedule | undefined {
+  return trigger.kind === 'time' ? trigger.schedule : undefined;
+}
+
+export interface TriggerFormatLabels extends ScheduleFormatLabels {
+  githubPrefix: string;
+  githubPullRequestCreated: string;
+  githubIssueCreated: string;
+}
+
+function defaultTriggerFormatLabels(): TriggerFormatLabels {
+  return {
+    ...defaultScheduleFormatLabels(),
+    githubPrefix: 'GitHub',
+    githubPullRequestCreated: 'PR created',
+    githubIssueCreated: 'Issue created',
+  };
+}
+
+export function formatTriggerLabel(
+  trigger: HostAutomationTrigger,
+  labels?: Partial<TriggerFormatLabels>,
+): string {
+  const l = { ...defaultTriggerFormatLabels(), ...labels };
+  if (trigger.kind === 'time') {
+    return formatScheduleLabel(trigger.schedule, l);
+  }
+  const eventLabel =
+    trigger.event === 'pull_request_created'
+      ? l.githubPullRequestCreated
+      : l.githubIssueCreated;
+  return `${l.githubPrefix} · ${trigger.owner}/${trigger.repo} · ${eventLabel}`;
+}
+
 export function formatScheduleLabel(
-  schedule: HostAutomationSchedule,
+  schedule: HostAutomationTimeSchedule,
   labels?: Partial<ScheduleFormatLabels>,
 ): string {
   const l = { ...defaultScheduleFormatLabels(), ...labels };
@@ -151,7 +241,7 @@ function defaultScheduleFormatLabels(): ScheduleFormatLabels {
   };
 }
 
-export function computeNextRunAt(schedule: HostAutomationSchedule, afterMs: number): number {
+export function computeNextRunAt(schedule: HostAutomationTimeSchedule, afterMs: number): number {
   const after = new Date(afterMs);
   if (schedule.kind === 'hourly') {
     const next = new Date(after);
@@ -167,7 +257,7 @@ export function computeNextRunAt(schedule: HostAutomationSchedule, afterMs: numb
 }
 
 export function shouldFireNow(
-  schedule: HostAutomationSchedule,
+  schedule: HostAutomationTimeSchedule,
   lastFiredMs: number | undefined,
   nowMs: number,
 ): boolean {
@@ -206,7 +296,7 @@ export class HostAutomationStore {
       summaries.push({
         id: file.definition.id,
         title: file.definition.title,
-        scheduleLabel: formatScheduleLabel(file.definition.schedule),
+        scheduleLabel: formatTriggerLabel(file.definition.trigger),
         enabled: file.definition.enabled,
         ...(lastRun ? { lastRunAtUnixMs: lastRun.startedAtUnixMs } : {}),
         updatedAtUnixMs: file.definition.updatedAtUnixMs,
@@ -228,15 +318,15 @@ export class HostAutomationStore {
 
   async create(input: HostAutomationCreateInput): Promise<HostAutomationDefinition> {
     const now = Date.now();
-    const schedule = normalizeAutomationSchedule(input.schedule);
-    if (!schedule) {
-      throw new Error('Invalid automation schedule.');
+    const trigger = normalizeAutomationTrigger(input.trigger);
+    if (!trigger) {
+      throw new Error('Invalid automation trigger.');
     }
     const definition: HostAutomationDefinition = {
       id: randomUUID(),
       title: normalizeNonEmpty(input.title, 'title'),
       overview: normalizeNonEmpty(input.overview, 'overview'),
-      schedule,
+      trigger,
       workspaceRoot: path.resolve(normalizeNonEmpty(input.workspaceRoot, 'workspaceRoot')),
       modelName: normalizeNonEmpty(input.modelName, 'modelName'),
       ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
@@ -259,12 +349,12 @@ export class HostAutomationStore {
     if (patch.overview !== undefined) {
       file.definition.overview = normalizeNonEmpty(patch.overview, 'overview');
     }
-    if (patch.schedule !== undefined) {
-      const schedule = normalizeAutomationSchedule(patch.schedule);
-      if (!schedule) {
-        throw new Error('Invalid automation schedule.');
+    if (patch.trigger !== undefined) {
+      const trigger = normalizeAutomationTrigger(patch.trigger);
+      if (!trigger) {
+        throw new Error('Invalid automation trigger.');
       }
-      file.definition.schedule = schedule;
+      file.definition.trigger = trigger;
     }
     if (patch.workspaceRoot !== undefined) {
       file.definition.workspaceRoot = path.resolve(normalizeNonEmpty(patch.workspaceRoot, 'workspaceRoot'));
@@ -307,6 +397,23 @@ export class HostAutomationStore {
       }
     }
     return definitions;
+  }
+
+  async updateGitHubPollState(
+    automationId: string,
+    lastSeenNumber: number,
+  ): Promise<HostAutomationDefinition> {
+    const file = await this.requireFile(automationId);
+    if (file.definition.trigger.kind !== 'github') {
+      throw new Error('Automation trigger is not GitHub.');
+    }
+    file.definition.trigger = {
+      ...file.definition.trigger,
+      poll: { lastSeenNumber },
+    };
+    file.definition.updatedAtUnixMs = Date.now();
+    await this.saveFile(automationId, file);
+    return { ...file.definition };
   }
 
   async markFired(automationId: string, firedAtUnixMs: number): Promise<void> {
@@ -420,12 +527,15 @@ function normalizeAutomationDefinition(value: unknown): HostAutomationDefinition
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return undefined;
   }
-  const record = value as Partial<HostAutomationDefinition>;
+  const record = value as Partial<HostAutomationDefinition> & { schedule?: unknown };
   if (typeof record.id !== 'string' || !record.id.trim()) {
     return undefined;
   }
-  const schedule = normalizeAutomationSchedule(record.schedule);
-  if (!schedule) {
+  const trigger =
+    normalizeAutomationTrigger(record.trigger)
+    ?? (record.schedule !== undefined ? normalizeAutomationTrigger({ kind: 'time', schedule: record.schedule }) : undefined)
+    ?? normalizeAutomationTrigger(record.schedule);
+  if (!trigger) {
     return undefined;
   }
   if (typeof record.title !== 'string' || !record.title.trim()) {
@@ -448,7 +558,7 @@ function normalizeAutomationDefinition(value: unknown): HostAutomationDefinition
     id: record.id.trim(),
     title: record.title.trim(),
     overview: record.overview.trim(),
-    schedule,
+    trigger,
     workspaceRoot: path.resolve(record.workspaceRoot.trim()),
     modelName: record.modelName.trim(),
     ...(record.reasoningEffort ? { reasoningEffort: record.reasoningEffort } : {}),
@@ -531,6 +641,28 @@ function normalizeWeekday(value: unknown): HostAutomationWeekday | undefined {
     return undefined;
   }
   return value as HostAutomationWeekday;
+}
+
+function normalizeGitHubEvent(value: unknown): HostAutomationGitHubEvent | undefined {
+  if (value === 'pull_request_created' || value === 'issue_created') {
+    return value;
+  }
+  return undefined;
+}
+
+function normalizeGitHubPoll(value: unknown): { lastSeenNumber: number } | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as { lastSeenNumber?: unknown };
+  if (
+    typeof record.lastSeenNumber !== 'number'
+    || !Number.isInteger(record.lastSeenNumber)
+    || record.lastSeenNumber < 0
+  ) {
+    return undefined;
+  }
+  return { lastSeenNumber: record.lastSeenNumber };
 }
 
 function formatTimeOfDay(hour: number, minute: number): string {

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -41,6 +41,8 @@ export interface HostAutomationDefinition {
   createdAtUnixMs: number;
   updatedAtUnixMs: number;
   lastFiredAtUnixMs?: number;
+  /** Set when GitHub issue/PR polling fails for this automation's repository. */
+  githubPollError?: string;
 }
 
 export type HostAutomationRunStatus = 'running' | 'blocked' | 'completed' | 'failed';
@@ -61,6 +63,7 @@ export interface HostAutomationListItem {
   scheduleLabel: string;
   trigger: HostAutomationTrigger;
   enabled: boolean;
+  githubPollError?: string;
   lastRunAtUnixMs?: number;
   updatedAtUnixMs: number;
 }
@@ -305,6 +308,9 @@ export class HostAutomationStore {
         scheduleLabel: formatTriggerLabel(file.definition.trigger),
         trigger: file.definition.trigger,
         enabled: file.definition.enabled,
+        ...(file.definition.githubPollError
+          ? { githubPollError: file.definition.githubPollError }
+          : {}),
         ...(lastRun ? { lastRunAtUnixMs: lastRun.startedAtUnixMs } : {}),
         updatedAtUnixMs: file.definition.updatedAtUnixMs,
       });
@@ -435,6 +441,25 @@ export class HostAutomationStore {
       ...file.definition.trigger,
       poll: { lastSeenNumber },
     };
+    delete file.definition.githubPollError;
+    file.definition.updatedAtUnixMs = Date.now();
+    await this.saveFile(automationId, file);
+    return { ...file.definition };
+  }
+
+  async setGitHubPollError(
+    automationId: string,
+    error: string | undefined,
+  ): Promise<HostAutomationDefinition> {
+    const file = await this.requireFile(automationId);
+    if (file.definition.trigger.kind !== 'github') {
+      throw new Error('Automation trigger is not GitHub.');
+    }
+    if (error?.trim()) {
+      file.definition.githubPollError = error.trim();
+    } else {
+      delete file.definition.githubPollError;
+    }
     file.definition.updatedAtUnixMs = Date.now();
     await this.saveFile(automationId, file);
     return { ...file.definition };
@@ -592,6 +617,9 @@ function normalizeAutomationDefinition(value: unknown): HostAutomationDefinition
     updatedAtUnixMs,
     ...(typeof record.lastFiredAtUnixMs === 'number'
       ? { lastFiredAtUnixMs: record.lastFiredAtUnixMs }
+      : {}),
+    ...(typeof record.githubPollError === 'string' && record.githubPollError.trim()
+      ? { githubPollError: record.githubPollError.trim() }
       : {}),
   };
 }

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -177,6 +177,36 @@ export function normalizeAutomationTrigger(value: unknown): HostAutomationTrigge
   return undefined;
 }
 
+export function reconcileGitHubTriggerPollState(
+  previous: HostAutomationTrigger,
+  next: HostAutomationTrigger,
+): HostAutomationTrigger {
+  if (next.kind !== 'github') {
+    return next;
+  }
+  if (previous.kind !== 'github') {
+    return {
+      kind: 'github',
+      owner: next.owner,
+      repo: next.repo,
+      event: next.event,
+    };
+  }
+  if (
+    previous.owner !== next.owner
+    || previous.repo !== next.repo
+    || previous.event !== next.event
+  ) {
+    return {
+      kind: 'github',
+      owner: next.owner,
+      repo: next.repo,
+      event: next.event,
+    };
+  }
+  return next;
+}
+
 export function automationTimeScheduleFromTrigger(
   trigger: HostAutomationTrigger,
 ): HostAutomationTimeSchedule | undefined {
@@ -384,7 +414,7 @@ export class HostAutomationStore {
       if (!trigger) {
         throw new Error('Invalid automation trigger.');
       }
-      file.definition.trigger = trigger;
+      file.definition.trigger = reconcileGitHubTriggerPollState(file.definition.trigger, trigger);
     }
     if (patch.workspaceRoot !== undefined) {
       file.definition.workspaceRoot = path.resolve(normalizeNonEmpty(patch.workspaceRoot, 'workspaceRoot'));

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -223,7 +223,10 @@ export function formatScheduleLabel(
     return `${l.dailyPrefix} ${time}`;
   }
   const weekday = l.weekdays[schedule.weekday] ?? String(schedule.weekday);
-  return `每${weekday} ${time}`;
+  if (l.formatWeekly) {
+    return l.formatWeekly(weekday, time);
+  }
+  return `${l.weeklyPrefix} ${weekday} ${time}`;
 }
 
 export interface ScheduleFormatLabels {
@@ -236,10 +239,11 @@ export interface ScheduleFormatLabels {
 
 function defaultScheduleFormatLabels(): ScheduleFormatLabels {
   return {
-    hourly: '每小时',
-    dailyPrefix: '每天',
-    weeklyPrefix: '每周',
-    weekdays: ['周日', '周一', '周二', '周三', '周四', '周五', '周六'],
+    hourly: 'Hourly',
+    dailyPrefix: 'Daily',
+    weeklyPrefix: 'Weekly',
+    weekdays: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    formatWeekly: (weekday, time) => `Weekly ${weekday} ${time}`,
   };
 }
 

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -59,6 +59,7 @@ export interface HostAutomationListItem {
   id: string;
   title: string;
   scheduleLabel: string;
+  trigger: HostAutomationTrigger;
   enabled: boolean;
   lastRunAtUnixMs?: number;
   updatedAtUnixMs: number;
@@ -298,6 +299,7 @@ export class HostAutomationStore {
         id: file.definition.id,
         title: file.definition.title,
         scheduleLabel: formatTriggerLabel(file.definition.trigger),
+        trigger: file.definition.trigger,
         enabled: file.definition.enabled,
         ...(lastRun ? { lastRunAtUnixMs: lastRun.startedAtUnixMs } : {}),
         updatedAtUnixMs: file.definition.updatedAtUnixMs,

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -340,6 +340,23 @@ export class HostAutomationStore {
     return { ...definition };
   }
 
+  async ensureGitHubTriggerBaseline(
+    automationId: string,
+    lastSeenNumber: number,
+  ): Promise<HostAutomationDefinition> {
+    const file = await this.requireFile(automationId);
+    if (file.definition.trigger.kind !== 'github') {
+      throw new Error('Automation trigger is not GitHub.');
+    }
+    file.definition.trigger = {
+      ...file.definition.trigger,
+      poll: { lastSeenNumber },
+    };
+    file.definition.updatedAtUnixMs = Date.now();
+    await this.saveFile(automationId, file);
+    return { ...file.definition };
+  }
+
   async update(automationId: string, patch: HostAutomationUpdateInput): Promise<HostAutomationDefinition> {
     const file = await this.requireFile(automationId);
     const now = Date.now();

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -554,7 +554,8 @@ export class HostAutomationStore {
     if (!definition) {
       return undefined;
     }
-    return {
+    const needsTriggerMigration = automationDefinitionNeedsTriggerMigration(parsed.definition);
+    const file: HostAutomationFile = {
       version: 1,
       definition,
       runs: Array.isArray(parsed.runs)
@@ -563,6 +564,10 @@ export class HostAutomationStore {
             .filter((run): run is HostAutomationRun => run !== undefined)
         : [],
     };
+    if (needsTriggerMigration) {
+      await this.saveFile(definition.id, file);
+    }
+    return file;
   }
 
   private async saveFile(automationId: string, file: HostAutomationFile): Promise<void> {
@@ -570,6 +575,14 @@ export class HostAutomationStore {
     await mkdir(path.dirname(filePath), { recursive: true });
     await writeFile(filePath, `${JSON.stringify(file, null, 2)}\n`, 'utf8');
   }
+}
+
+function automationDefinitionNeedsTriggerMigration(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return record.schedule !== undefined && record.trigger === undefined;
 }
 
 function normalizeAutomationDefinition(value: unknown): HostAutomationDefinition | undefined {

--- a/packages/host-internal/src/github/automation-events.test.ts
+++ b/packages/host-internal/src/github/automation-events.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  filterNewGitHubAutomationEvents,
+  matchesGitHubAutomationEvent,
+} from './automation-events.js';
+
+const prItem = {
+  number: 10,
+  htmlUrl: 'https://github.com/o/r/pull/10',
+  isPullRequest: true,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const issueItem = {
+  number: 11,
+  htmlUrl: 'https://github.com/o/r/issues/11',
+  isPullRequest: false,
+  createdAt: '2026-06-01T01:00:00Z',
+};
+
+test('matchesGitHubAutomationEvent distinguishes PR and issue', () => {
+  assert.equal(matchesGitHubAutomationEvent(prItem, 'pull_request_created'), true);
+  assert.equal(matchesGitHubAutomationEvent(prItem, 'issue_created'), false);
+  assert.equal(matchesGitHubAutomationEvent(issueItem, 'issue_created'), true);
+  assert.equal(matchesGitHubAutomationEvent(issueItem, 'pull_request_created'), false);
+});
+
+test('filterNewGitHubAutomationEvents returns ascending items above watermark', () => {
+  const items = [
+    issueItem,
+    prItem,
+    { ...prItem, number: 12, htmlUrl: 'https://github.com/o/r/pull/12' },
+  ];
+  const prEvents = filterNewGitHubAutomationEvents(items, 'pull_request_created', 9);
+  assert.deepEqual(prEvents.map((item) => item.number), [10, 12]);
+
+  const issueEvents = filterNewGitHubAutomationEvents(items, 'issue_created', 10);
+  assert.deepEqual(issueEvents.map((item) => item.number), [11]);
+});
+
+test('filterNewGitHubAutomationEvents ignores numbers at or below watermark', () => {
+  const events = filterNewGitHubAutomationEvents([prItem, issueItem], 'pull_request_created', 10);
+  assert.equal(events.length, 0);
+});

--- a/packages/host-internal/src/github/automation-events.test.ts
+++ b/packages/host-internal/src/github/automation-events.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   filterNewGitHubAutomationEvents,
   matchesGitHubAutomationEvent,
+  shouldFetchNextIssuePage,
 } from './automation-events.js';
 
 const prItem = {
@@ -43,4 +44,14 @@ test('filterNewGitHubAutomationEvents returns ascending items above watermark', 
 test('filterNewGitHubAutomationEvents ignores numbers at or below watermark', () => {
   const events = filterNewGitHubAutomationEvents([prItem, issueItem], 'pull_request_created', 10);
   assert.equal(events.length, 0);
+});
+
+test('shouldFetchNextIssuePage stops when watermark is covered or page is short', () => {
+  const fullPage = Array.from({ length: 100 }, (_, index) => ({
+    ...issueItem,
+    number: 200 - index,
+  }));
+  assert.equal(shouldFetchNextIssuePage(fullPage, 100, 100), true);
+  assert.equal(shouldFetchNextIssuePage(fullPage, 150, 100), false);
+  assert.equal(shouldFetchNextIssuePage([fullPage[0]!], 100, 100), false);
 });

--- a/packages/host-internal/src/github/automation-events.ts
+++ b/packages/host-internal/src/github/automation-events.ts
@@ -36,18 +36,48 @@ export async function listRepositoryIssuesForAutomation(
   accessToken: string,
   owner: string,
   repo: string,
+  options?: { sinceNumber?: number; perPage?: number; maxPages?: number },
 ): Promise<GitHubAutomationIssueItem[]> {
-  const url = new URL(`${GITHUB_API_BASE_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`);
-  url.searchParams.set('state', 'all');
-  url.searchParams.set('sort', 'created');
-  url.searchParams.set('direction', 'desc');
-  url.searchParams.set('per_page', '100');
+  const sinceNumber = options?.sinceNumber ?? 0;
+  const perPage = options?.perPage ?? 100;
+  const maxPages = options?.maxPages ?? 10;
+  const allItems: GitHubAutomationIssueItem[] = [];
 
-  const response = await fetch(url, { headers: githubApiHeaders(accessToken) });
-  const payload = await readGitHubJson<GitHubIssueApiItem[]>(response);
-  return payload
-    .map((item) => mapIssueItem(item))
-    .filter((item): item is GitHubAutomationIssueItem => item !== undefined);
+  for (let page = 1; page <= maxPages; page += 1) {
+    const url = new URL(`${GITHUB_API_BASE_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`);
+    url.searchParams.set('state', 'all');
+    url.searchParams.set('sort', 'created');
+    url.searchParams.set('direction', 'desc');
+    url.searchParams.set('per_page', String(perPage));
+    url.searchParams.set('page', String(page));
+
+    const response = await fetch(url, { headers: githubApiHeaders(accessToken) });
+    const payload = await readGitHubJson<GitHubIssueApiItem[]>(response);
+    const pageItems = payload
+      .map((item) => mapIssueItem(item))
+      .filter((item): item is GitHubAutomationIssueItem => item !== undefined);
+    if (pageItems.length === 0) {
+      break;
+    }
+    allItems.push(...pageItems);
+    if (!shouldFetchNextIssuePage(pageItems, sinceNumber, perPage)) {
+      break;
+    }
+  }
+
+  return allItems;
+}
+
+export function shouldFetchNextIssuePage(
+  pageItems: GitHubAutomationIssueItem[],
+  sinceNumber: number,
+  perPage: number,
+): boolean {
+  if (pageItems.length === 0) {
+    return false;
+  }
+  const minNumber = Math.min(...pageItems.map((item) => item.number));
+  return minNumber > sinceNumber && pageItems.length >= perPage;
 }
 
 export async function fetchRepositoryMaxIssueNumber(

--- a/packages/host-internal/src/github/automation-events.ts
+++ b/packages/host-internal/src/github/automation-events.ts
@@ -1,7 +1,6 @@
 import { githubApiHeaders, readGitHubJson } from './github-api.js';
 import { GITHUB_API_BASE_URL } from './oauth-config.js';
-
-export type HostAutomationGitHubEvent = 'pull_request_created' | 'issue_created';
+import type { HostAutomationGitHubEvent } from '../automations.js';
 
 export interface GitHubAutomationIssueItem {
   number: number;

--- a/packages/host-internal/src/github/automation-events.ts
+++ b/packages/host-internal/src/github/automation-events.ts
@@ -1,0 +1,96 @@
+import { githubApiHeaders, readGitHubJson } from './github-api.js';
+import { GITHUB_API_BASE_URL } from './oauth-config.js';
+
+export type HostAutomationGitHubEvent = 'pull_request_created' | 'issue_created';
+
+export interface GitHubAutomationIssueItem {
+  number: number;
+  htmlUrl: string;
+  isPullRequest: boolean;
+  createdAt: string;
+}
+
+interface GitHubIssueApiItem {
+  number: number;
+  html_url: string;
+  created_at?: string | null;
+  pull_request?: { url?: string | null } | null;
+}
+
+function mapIssueItem(item: GitHubIssueApiItem): GitHubAutomationIssueItem | undefined {
+  if (typeof item.number !== 'number' || !Number.isInteger(item.number) || item.number <= 0) {
+    return undefined;
+  }
+  const htmlUrl = item.html_url?.trim();
+  if (!htmlUrl) {
+    return undefined;
+  }
+  return {
+    number: item.number,
+    htmlUrl,
+    isPullRequest: Boolean(item.pull_request),
+    createdAt: item.created_at?.trim() || new Date(0).toISOString(),
+  };
+}
+
+export async function listRepositoryIssuesForAutomation(
+  accessToken: string,
+  owner: string,
+  repo: string,
+): Promise<GitHubAutomationIssueItem[]> {
+  const url = new URL(`${GITHUB_API_BASE_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`);
+  url.searchParams.set('state', 'all');
+  url.searchParams.set('sort', 'created');
+  url.searchParams.set('direction', 'desc');
+  url.searchParams.set('per_page', '100');
+
+  const response = await fetch(url, { headers: githubApiHeaders(accessToken) });
+  const payload = await readGitHubJson<GitHubIssueApiItem[]>(response);
+  return payload
+    .map((item) => mapIssueItem(item))
+    .filter((item): item is GitHubAutomationIssueItem => item !== undefined);
+}
+
+export async function fetchRepositoryMaxIssueNumber(
+  accessToken: string,
+  owner: string,
+  repo: string,
+): Promise<number> {
+  const url = new URL(`${GITHUB_API_BASE_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues`);
+  url.searchParams.set('state', 'all');
+  url.searchParams.set('sort', 'created');
+  url.searchParams.set('direction', 'desc');
+  url.searchParams.set('per_page', '1');
+
+  const response = await fetch(url, { headers: githubApiHeaders(accessToken) });
+  const payload = await readGitHubJson<GitHubIssueApiItem[]>(response);
+  const first = payload[0];
+  if (!first || typeof first.number !== 'number') {
+    return 0;
+  }
+  return first.number;
+}
+
+export function matchesGitHubAutomationEvent(
+  item: GitHubAutomationIssueItem,
+  event: HostAutomationGitHubEvent,
+): boolean {
+  if (event === 'pull_request_created') {
+    return item.isPullRequest;
+  }
+  return !item.isPullRequest;
+}
+
+export function filterNewGitHubAutomationEvents(
+  items: GitHubAutomationIssueItem[],
+  event: HostAutomationGitHubEvent,
+  lastSeenNumber: number,
+): GitHubAutomationIssueItem[] {
+  return items
+    .filter((item) => item.number > lastSeenNumber && matchesGitHubAutomationEvent(item, event))
+    .sort((left, right) => left.number - right.number);
+}
+
+export function githubAutomationRepoKey(owner: string, repo: string): string {
+  return `${owner}/${repo}`;
+}

--- a/packages/host-internal/src/github/automation-poller.test.ts
+++ b/packages/host-internal/src/github/automation-poller.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  baselineGitHubAutomationWatermark,
+  computeGitHubPollMatchesForAutomation,
+  computeGitHubPollMatchesForRepoGroup,
+  githubTriggerNeedsBaseline,
+  groupGitHubAutomationsByRepo,
+  mergeGitHubPollWatermarkUpdates,
+} from './automation-poller.js';
+
+const baseDefinition = {
+  title: 'Test',
+  overview: 'Do work',
+  workspaceRoot: '/tmp',
+  modelName: 'gpt-test',
+  approvalLevel: 'default' as const,
+  enabled: true,
+  createdAtUnixMs: 1,
+  updatedAtUnixMs: 1,
+};
+
+test('groupGitHubAutomationsByRepo deduplicates repo fetch targets', () => {
+  const groups = groupGitHubAutomationsByRepo([
+    {
+      ...baseDefinition,
+      id: 'a1',
+      trigger: {
+        kind: 'github',
+        owner: 'o',
+        repo: 'r',
+        event: 'pull_request_created',
+        poll: { lastSeenNumber: 1 },
+      },
+    },
+    {
+      ...baseDefinition,
+      id: 'a2',
+      trigger: {
+        kind: 'github',
+        owner: 'o',
+        repo: 'r',
+        event: 'issue_created',
+        poll: { lastSeenNumber: 2 },
+      },
+    },
+    {
+      ...baseDefinition,
+      id: 'a3',
+      trigger: { kind: 'time', schedule: { kind: 'hourly' } },
+    },
+  ]);
+  assert.equal(groups.length, 1);
+  assert.equal(groups[0]?.automations.length, 2);
+});
+
+test('computeGitHubPollMatchesForAutomation avoids replaying historical items', () => {
+  const definition = {
+    ...baseDefinition,
+    id: 'a1',
+    trigger: {
+      kind: 'github' as const,
+      owner: 'o',
+      repo: 'r',
+      event: 'pull_request_created' as const,
+      poll: { lastSeenNumber: 10 },
+    },
+  };
+  const items = [
+    { number: 9, htmlUrl: 'https://github.com/o/r/pull/9', isPullRequest: true, createdAt: '1' },
+    { number: 11, htmlUrl: 'https://github.com/o/r/pull/11', isPullRequest: true, createdAt: '2' },
+    { number: 12, htmlUrl: 'https://github.com/o/r/issues/12', isPullRequest: false, createdAt: '3' },
+  ];
+  const matches = computeGitHubPollMatchesForAutomation(definition, items);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0]?.item.number, 11);
+  assert.equal(matches[0]?.nextLastSeenNumber, 11);
+});
+
+test('computeGitHubPollMatchesForRepoGroup emits one match per new item', () => {
+  const group = {
+    repoKey: 'o/r',
+    owner: 'o',
+    repo: 'r',
+    automations: [
+      {
+        ...baseDefinition,
+        id: 'a1',
+        trigger: {
+          kind: 'github' as const,
+          owner: 'o',
+          repo: 'r',
+          event: 'pull_request_created' as const,
+          poll: { lastSeenNumber: 0 },
+        },
+      },
+    ],
+  };
+  const items = [
+    { number: 1, htmlUrl: 'https://github.com/o/r/pull/1', isPullRequest: true, createdAt: '1' },
+    { number: 2, htmlUrl: 'https://github.com/o/r/pull/2', isPullRequest: true, createdAt: '2' },
+  ];
+  const matches = computeGitHubPollMatchesForRepoGroup(group, items);
+  assert.deepEqual(matches.map((match) => match.item.number), [1, 2]);
+});
+
+test('mergeGitHubPollWatermarkUpdates keeps highest seen number per automation', () => {
+  const updates = mergeGitHubPollWatermarkUpdates([
+    {
+      automationId: 'a1',
+      definition: {
+        ...baseDefinition,
+        id: 'a1',
+        trigger: { kind: 'github', owner: 'o', repo: 'r', event: 'pull_request_created' },
+      },
+      item: { number: 3, htmlUrl: 'u', isPullRequest: true, createdAt: '1' },
+      nextLastSeenNumber: 3,
+    },
+    {
+      automationId: 'a1',
+      definition: {
+        ...baseDefinition,
+        id: 'a1',
+        trigger: { kind: 'github', owner: 'o', repo: 'r', event: 'pull_request_created' },
+      },
+      item: { number: 5, htmlUrl: 'u2', isPullRequest: true, createdAt: '2' },
+      nextLastSeenNumber: 5,
+    },
+  ]);
+  assert.equal(updates.get('a1'), 5);
+});
+
+test('githubTriggerNeedsBaseline detects missing poll state', () => {
+  assert.equal(
+    githubTriggerNeedsBaseline({
+      kind: 'github',
+      owner: 'o',
+      repo: 'r',
+      event: 'issue_created',
+    }),
+    true,
+  );
+  assert.equal(
+    githubTriggerNeedsBaseline({
+      kind: 'github',
+      owner: 'o',
+      repo: 'r',
+      event: 'issue_created',
+      poll: { lastSeenNumber: 0 },
+    }),
+    false,
+  );
+});
+
+test('baselineGitHubAutomationWatermark uses fetch helper', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify([{ number: 42, html_url: 'https://github.com/o/r/issues/42' }]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  try {
+    const watermark = await baselineGitHubAutomationWatermark('token', 'o', 'r');
+    assert.equal(watermark, 42);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/host-internal/src/github/automation-poller.ts
+++ b/packages/host-internal/src/github/automation-poller.ts
@@ -91,8 +91,9 @@ export async function fetchGitHubAutomationRepoItems(
   accessToken: string,
   owner: string,
   repo: string,
+  options?: { sinceNumber?: number },
 ): Promise<GitHubAutomationIssueItem[]> {
-  return listRepositoryIssuesForAutomation(accessToken, owner, repo);
+  return listRepositoryIssuesForAutomation(accessToken, owner, repo, options);
 }
 
 export async function baselineGitHubAutomationWatermark(

--- a/packages/host-internal/src/github/automation-poller.ts
+++ b/packages/host-internal/src/github/automation-poller.ts
@@ -1,0 +1,117 @@
+import type { HostAutomationDefinition, HostAutomationTrigger } from '../automations.js';
+import {
+  fetchRepositoryMaxIssueNumber,
+  filterNewGitHubAutomationEvents,
+  githubAutomationRepoKey,
+  listRepositoryIssuesForAutomation,
+  type GitHubAutomationIssueItem,
+} from './automation-events.js';
+
+export interface GitHubAutomationPollMatch {
+  automationId: string;
+  definition: HostAutomationDefinition;
+  item: GitHubAutomationIssueItem;
+  nextLastSeenNumber: number;
+}
+
+export interface GitHubAutomationRepoPollGroup {
+  repoKey: string;
+  owner: string;
+  repo: string;
+  automations: HostAutomationDefinition[];
+}
+
+export function groupGitHubAutomationsByRepo(
+  definitions: HostAutomationDefinition[],
+): GitHubAutomationRepoPollGroup[] {
+  const groups = new Map<string, GitHubAutomationRepoPollGroup>();
+  for (const definition of definitions) {
+    if (definition.trigger.kind !== 'github') {
+      continue;
+    }
+    const { owner, repo } = definition.trigger;
+    const repoKey = githubAutomationRepoKey(owner, repo);
+    const existing = groups.get(repoKey);
+    if (existing) {
+      existing.automations.push(definition);
+      continue;
+    }
+    groups.set(repoKey, {
+      repoKey,
+      owner,
+      repo,
+      automations: [definition],
+    });
+  }
+  return [...groups.values()];
+}
+
+export function githubTriggerNeedsBaseline(trigger: HostAutomationTrigger): boolean {
+  return trigger.kind === 'github' && trigger.poll?.lastSeenNumber === undefined;
+}
+
+export function resolveGitHubPollWatermark(trigger: Extract<HostAutomationTrigger, { kind: 'github' }>): number {
+  return trigger.poll?.lastSeenNumber ?? 0;
+}
+
+export function computeGitHubPollMatchesForAutomation(
+  definition: HostAutomationDefinition,
+  items: GitHubAutomationIssueItem[],
+): GitHubAutomationPollMatch[] {
+  if (definition.trigger.kind !== 'github') {
+    return [];
+  }
+  const trigger = definition.trigger;
+  const watermark = resolveGitHubPollWatermark(trigger);
+  const matches = filterNewGitHubAutomationEvents(items, trigger.event, watermark);
+  if (matches.length === 0) {
+    return [];
+  }
+  const nextLastSeenNumber = Math.max(...matches.map((item) => item.number));
+  return matches.map((item) => ({
+    automationId: definition.id,
+    definition,
+    item,
+    nextLastSeenNumber,
+  }));
+}
+
+export function computeGitHubPollMatchesForRepoGroup(
+  group: GitHubAutomationRepoPollGroup,
+  items: GitHubAutomationIssueItem[],
+): GitHubAutomationPollMatch[] {
+  const allMatches: GitHubAutomationPollMatch[] = [];
+  for (const definition of group.automations) {
+    allMatches.push(...computeGitHubPollMatchesForAutomation(definition, items));
+  }
+  return allMatches.sort((left, right) => left.item.number - right.item.number);
+}
+
+export async function fetchGitHubAutomationRepoItems(
+  accessToken: string,
+  owner: string,
+  repo: string,
+): Promise<GitHubAutomationIssueItem[]> {
+  return listRepositoryIssuesForAutomation(accessToken, owner, repo);
+}
+
+export async function baselineGitHubAutomationWatermark(
+  accessToken: string,
+  owner: string,
+  repo: string,
+): Promise<number> {
+  return fetchRepositoryMaxIssueNumber(accessToken, owner, repo);
+}
+
+export function mergeGitHubPollWatermarkUpdates(
+  matches: GitHubAutomationPollMatch[],
+): Map<string, number> {
+  const updates = new Map<string, number>();
+  for (const match of matches) {
+    const current = updates.get(match.automationId);
+    if (current === undefined || match.nextLastSeenNumber > current) {
+      updates.set(match.automationId, match.nextLastSeenNumber);
+    }
+  }
+  return updates;
+}

--- a/packages/host-internal/src/github/automation-repositories.test.ts
+++ b/packages/host-internal/src/github/automation-repositories.test.ts
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildAutomationRepositorySearchQuery } from './automation-repositories.js';
+
+test('buildAutomationRepositorySearchQuery falls back to current user when query is empty', () => {
+  assert.equal(buildAutomationRepositorySearchQuery('', 'octocat'), 'user:octocat');
+  assert.equal(buildAutomationRepositorySearchQuery('   ', 'octocat'), 'user:octocat');
+});
+
+test('buildAutomationRepositorySearchQuery uses repo qualifier for owner/repo input', () => {
+  assert.equal(
+    buildAutomationRepositorySearchQuery('microsoft/vscode', 'octocat'),
+    'repo:microsoft/vscode',
+  );
+});
+
+test('buildAutomationRepositorySearchQuery uses global search for free-text input', () => {
+  assert.equal(buildAutomationRepositorySearchQuery('spirit agent', 'octocat'), 'spirit agent');
+});

--- a/packages/host-internal/src/github/automation-repositories.ts
+++ b/packages/host-internal/src/github/automation-repositories.ts
@@ -1,0 +1,98 @@
+import { githubApiHeaders, githubHasNextPage, readGitHubJson } from './github-api.js';
+import { GITHUB_API_BASE_URL } from './oauth-config.js';
+
+export interface GitHubAutomationRepositoryItem {
+  owner: string;
+  repo: string;
+  fullName: string;
+  htmlUrl: string;
+  private: boolean;
+  updatedAt: string;
+}
+
+interface GitHubUserRepoApiItem {
+  name: string;
+  full_name: string;
+  html_url: string;
+  private?: boolean;
+  updated_at?: string | null;
+  owner?: { login?: string | null } | null;
+}
+
+interface GitHubSearchRepositoriesResponse {
+  total_count: number;
+  items: GitHubUserRepoApiItem[];
+}
+
+function mapRepositoryItem(item: GitHubUserRepoApiItem): GitHubAutomationRepositoryItem | undefined {
+  const fullName = item.full_name?.trim();
+  const name = item.name?.trim();
+  const owner = item.owner?.login?.trim() ?? fullName?.split('/')[0]?.trim();
+  if (!owner || !name || !fullName) {
+    return undefined;
+  }
+  return {
+    owner,
+    repo: name,
+    fullName,
+    htmlUrl: item.html_url?.trim() || `https://github.com/${fullName}`,
+    private: item.private === true,
+    updatedAt: item.updated_at?.trim() || new Date(0).toISOString(),
+  };
+}
+
+export async function listUserGitHubRepositories(
+  accessToken: string,
+  options?: { page?: number; perPage?: number },
+): Promise<{ items: GitHubAutomationRepositoryItem[]; hasNextPage: boolean }> {
+  const page = options?.page ?? 1;
+  const perPage = options?.perPage ?? 100;
+  const url = new URL(`${GITHUB_API_BASE_URL}/user/repos`);
+  url.searchParams.set('affiliation', 'owner,collaborator,organization_member');
+  url.searchParams.set('sort', 'updated');
+  url.searchParams.set('direction', 'desc');
+  url.searchParams.set('per_page', String(perPage));
+  url.searchParams.set('page', String(page));
+
+  const response = await fetch(url, { headers: githubApiHeaders(accessToken) });
+  const payload = await readGitHubJson<GitHubUserRepoApiItem[]>(response);
+  const items = payload
+    .map((item) => mapRepositoryItem(item))
+    .filter((item): item is GitHubAutomationRepositoryItem => item !== undefined);
+
+  return {
+    items,
+    hasNextPage: githubHasNextPage(response),
+  };
+}
+
+export async function searchGitHubRepositories(
+  accessToken: string,
+  query: string,
+  login: string,
+  options?: { page?: number; perPage?: number },
+): Promise<{ items: GitHubAutomationRepositoryItem[]; totalCount: number }> {
+  const trimmedQuery = query.trim();
+  const page = options?.page ?? 1;
+  const perPage = options?.perPage ?? 30;
+  const url = new URL(`${GITHUB_API_BASE_URL}/search/repositories`);
+  const q = trimmedQuery
+    ? `${trimmedQuery} in:name user:${login}`
+    : `user:${login}`;
+  url.searchParams.set('q', q);
+  url.searchParams.set('sort', 'updated');
+  url.searchParams.set('order', 'desc');
+  url.searchParams.set('per_page', String(perPage));
+  url.searchParams.set('page', String(page));
+
+  const response = await fetch(url, { headers: githubApiHeaders(accessToken) });
+  const payload = await readGitHubJson<GitHubSearchRepositoriesResponse>(response);
+  const items = payload.items
+    .map((item) => mapRepositoryItem(item))
+    .filter((item): item is GitHubAutomationRepositoryItem => item !== undefined);
+
+  return {
+    items,
+    totalCount: payload.total_count,
+  };
+}

--- a/packages/host-internal/src/github/automation-repositories.ts
+++ b/packages/host-internal/src/github/automation-repositories.ts
@@ -41,6 +41,18 @@ function mapRepositoryItem(item: GitHubUserRepoApiItem): GitHubAutomationReposit
   };
 }
 
+/** owner/repo（如 microsoft/vscode）走 repo: 限定；否则全局搜索。空串回退当前用户仓库。 */
+export function buildAutomationRepositorySearchQuery(query: string, login: string): string {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return `user:${login}`;
+  }
+  if (/^[^/\s]+\/[^/\s]+$/.test(trimmed)) {
+    return `repo:${trimmed}`;
+  }
+  return trimmed;
+}
+
 export async function listUserGitHubRepositories(
   accessToken: string,
   options?: { page?: number; perPage?: number },
@@ -76,11 +88,9 @@ export async function searchGitHubRepositories(
   const page = options?.page ?? 1;
   const perPage = options?.perPage ?? 30;
   const url = new URL(`${GITHUB_API_BASE_URL}/search/repositories`);
-  const q = trimmedQuery
-    ? `${trimmedQuery} in:name user:${login}`
-    : `user:${login}`;
+  const q = buildAutomationRepositorySearchQuery(trimmedQuery, login);
   url.searchParams.set('q', q);
-  url.searchParams.set('sort', 'updated');
+  url.searchParams.set('sort', trimmedQuery ? 'stars' : 'updated');
   url.searchParams.set('order', 'desc');
   url.searchParams.set('per_page', String(perPage));
   url.searchParams.set('page', String(page));

--- a/packages/host-internal/src/github/index.ts
+++ b/packages/host-internal/src/github/index.ts
@@ -26,3 +26,4 @@ export * from './conversation.js';
 export * from './github-api.js';
 export * from './automation-repositories.js';
 export * from './automation-events.js';
+export * from './automation-poller.js';

--- a/packages/host-internal/src/github/index.ts
+++ b/packages/host-internal/src/github/index.ts
@@ -24,3 +24,5 @@ export * from './repository-permissions.js';
 export * from './github-graphql.js';
 export * from './conversation.js';
 export * from './github-api.js';
+export * from './automation-repositories.js';
+export * from './automation-events.js';

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -6,6 +6,7 @@ export * from './git-log-graph.js';
 export * from './github/index.js';
 export * from './dreams.js';
 export * from './automations.js';
+export * from './automation-trigger-message.js';
 export * from './automation-host-tool.js';
 export * from './builtin-skills.js';
 export * from './compaction-archive.js';

--- a/packages/host-internal/src/tools.test.ts
+++ b/packages/host-internal/src/tools.test.ts
@@ -749,7 +749,10 @@ test('create_automation writes automation file when defaults are provided', asyn
 
     assert.equal(request.name, 'create_automation');
     assert.equal(request.title, 'Check CI status and summarize failures.');
-    assert.deepEqual(request.schedule, { kind: 'weekly', weekday: 1, hour: 9, minute: 0 });
+    assert.deepEqual(request.trigger, {
+      kind: 'time',
+      schedule: { kind: 'weekly', weekday: 1, hour: 9, minute: 0 },
+    });
     assert.equal(request.approval_level, 'default');
 
     const output = await service.execute(request);

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -50,9 +50,8 @@ import {
 } from './automation-host-tool.js';
 import {
   createHostAutomationStore,
-  formatScheduleLabel,
-  type HostAutomationDefinition,
-  type HostAutomationSchedule,
+  formatTriggerLabel,
+  type HostAutomationTrigger,
 } from './automations.js';
 import type { ModelReasoningEffort } from './reasoning-effort.js';
 import { resolveInstructionPaths, type InstructionDiscoveryContext } from './storage.js';
@@ -305,7 +304,7 @@ export type HostToolRequest<QuestionSpec = HostAskQuestionsQuestionSpec> =
       name: typeof CREATE_AUTOMATION_TOOL_NAME;
       title: string;
       overview: string;
-      schedule: HostAutomationSchedule;
+      trigger: HostAutomationTrigger;
       approval_level: ApprovalLevel;
     };
 
@@ -764,7 +763,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
           name: CREATE_AUTOMATION_TOOL_NAME,
           title: deriveAutomationTitle(overview, explicitTitle),
           overview,
-          schedule: parseCreateAutomationSchedule(scheduleValue),
+          trigger: { kind: 'time', schedule: parseCreateAutomationSchedule(scheduleValue) },
           approval_level: parseCreateAutomationApprovalLevel(parsed.approval_level),
         };
       }
@@ -956,7 +955,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
           prompt:
             `高风险工具调用: 创建自动化\n` +
             `标题: ${request.title}\n` +
-            `调度: ${formatScheduleLabel(request.schedule)}\n` +
+            `调度: ${formatTriggerLabel(request.trigger)}\n` +
             `运行审批: ${formatCreateAutomationApprovalLabel(request.approval_level)}\n` +
             `概述长度: ${[...request.overview].length} 字符`,
         };
@@ -1972,7 +1971,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
     const definition = await store.create({
       title: request.title,
       overview: request.overview,
-      schedule: request.schedule,
+      trigger: request.trigger,
       workspaceRoot: defaults.workspaceRoot,
       modelName: defaults.modelName,
       ...(defaults.reasoningEffort ? { reasoningEffort: defaults.reasoningEffort } : {}),
@@ -1985,7 +1984,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
       `action: create_automation\n` +
       `id: ${definition.id}\n` +
       `title: ${definition.title}\n` +
-      `schedule: ${formatScheduleLabel(definition.schedule)}\n` +
+      `trigger: ${formatTriggerLabel(definition.trigger)}\n` +
       `workspace: ${definition.workspaceRoot}`
     );
   }

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -46,7 +46,7 @@ import {
   deriveAutomationTitle,
   formatCreateAutomationApprovalLabel,
   parseCreateAutomationApprovalLevel,
-  parseCreateAutomationSchedule,
+  parseCreateAutomationTriggerInput,
 } from './automation-host-tool.js';
 import {
   createHostAutomationStore,
@@ -756,15 +756,11 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
       case CREATE_AUTOMATION_TOOL_NAME: {
         const overview = requiredString(parsed, 'overview');
         const explicitTitle = optionalStringStrict(parsed, 'title');
-        const scheduleValue = parsed.schedule;
-        if (scheduleValue === undefined) {
-          throw new Error('create_automation 缺少 schedule。');
-        }
         return {
           name: CREATE_AUTOMATION_TOOL_NAME,
           title: deriveAutomationTitle(overview, explicitTitle),
           overview,
-          trigger: { kind: 'time', schedule: parseCreateAutomationSchedule(scheduleValue) },
+          trigger: parseCreateAutomationTriggerInput(parsed),
           approval_level: parseCreateAutomationApprovalLevel(parsed.approval_level),
         };
       }

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -51,6 +51,7 @@ import {
 import {
   createHostAutomationStore,
   formatTriggerLabel,
+  type HostAutomationDefinition,
   type HostAutomationTrigger,
 } from './automations.js';
 import type { ModelReasoningEffort } from './reasoning-effort.js';


### PR DESCRIPTION
## Summary

- 自动化 `schedule` 扩展为 `trigger` union（`time` / `github`），旧 JSON 加载时自动迁移并写回磁盘
- GitHub 触发器：60s 轮询 PR/Issue 创建事件，按 `owner/repo` 去重 fetch，number watermark 防误报；触发消息统一为 `<automation_trigger>` meta + overview（UI 仅展示 overview）
- Desktop：AutomationTriggerMenu（GitHub 仓库搜索/分页 + PR/Issue 事件；Time 保留 hourly/daily/weekly）、创建/设置弹窗、列表 i18n、IPC 仓库列表与搜索
- `create_automation` 工具支持 `trigger`（兼容旧 `schedule` 参数）
- 审查修复：GitHub 异常不阻断 time tick、轮询分页、run 成功后合并 watermark、schedule 英文默认、poll 失败展示、未连接 GitHub badge、搜索失败与空结果分离、time schedule 校验等

## Test plan

- [x] legacy 仅含 `schedule` 的自动化加载后迁移为 `{ kind: 'time', schedule }` 并持久化
- [x] 时间触发器 hourly/daily/weekly 仍按 60s tick 正常触发；GitHub 轮询异常不阻断同 tick 时间触发
- [x] GitHub PR/Issue 创建事件经轮询匹配后启动自动化 run；watermark 在 run 成功后再推进
- [x] 轮询分页可覆盖 watermark 以上超过 100 条的历史事件；同 tick 多 match 按 automation 串行 run 并合并 watermark
- [x] 修改 GitHub trigger 的 owner/repo/event 后 poll watermark 清除；poll 失败时列表展示错误且成功时清除
- [x] 设置 → 集成连接 GitHub 后，创建/编辑自动化可选 GitHub 触发器：仓库 DropDown Menu 搜索（含全局如 `microsoft/vscode`）、分页加载、选 PR/Issue 事件
- [x] GitHub 未连接时 GitHub 触发器自动化列表显示「仓库触发已暂停」；仓库加载失败与「未找到仓库」文案区分
- [x] 自动化列表与 DropDown Menu 触发器文案 i18n 一致（Issue Created 等不再英文硬编码）
- [x] Agent `create_automation` 可创建 time / github trigger；工具摘要显示 trigger 标签
- [x] 触发会话 LLM 收到 `<automation_trigger>` meta，UI 消息气泡仅展示 overview
- [x] `packages/host-internal`：`npm run build` + automations / automation-poller / automation-events / automation-host-tool 单测通过
- [x] `apps/desktop`：`npm run build:electron` + `npm run test:host`（含 scheduler 分组单测）通过