### PR TITLE
refactor(desktop): 统一默认表单输入框为 shell 样式

### DIFF
--- a/apps/desktop/src/components/font-select.tsx
+++ b/apps/desktop/src/components/font-select.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
+import { DesktopFormInput } from "@/components/ui/desktop-form-field";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   DEFAULT_FONT_ID,
@@ -178,11 +178,10 @@ export function FontSelect({
           className="w-max min-w-[var(--radix-dropdown-menu-trigger-width)] max-w-[min(22rem,calc(100vw-1.25rem))] p-0"
         >
           <div className="border-b border-border/40 p-1.5">
-            <Input
+            <DesktopFormInput
               value={filter}
               onChange={(event) => setFilter(event.target.value)}
               placeholder={t('settings.searchFont')}
-              className="h-8 w-full min-w-0 text-sm"
               onKeyDown={(event) => event.stopPropagation()}
               autoComplete="off"
             />

--- a/apps/desktop/src/components/hooks-settings-panel.tsx
+++ b/apps/desktop/src/components/hooks-settings-panel.tsx
@@ -13,7 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+import { DesktopFormInput } from "@/components/ui/desktop-form-field";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -341,7 +341,7 @@ export function HooksSettingsPanel({
             </div>
             <div className="grid gap-2">
               <Label htmlFor="hook-command">{t("settings.hooksCommand")}</Label>
-              <Input
+              <DesktopFormInput
                 id="hook-command"
                 value={command}
                 onChange={(e) => setCommand(e.target.value)}
@@ -351,7 +351,7 @@ export function HooksSettingsPanel({
             </div>
             <div className="grid gap-2">
               <Label htmlFor="hook-timeout">{t("settings.hooksTimeout")}</Label>
-              <Input
+              <DesktopFormInput
                 id="hook-timeout"
                 value={timeout}
                 onChange={(e) => {
@@ -366,7 +366,7 @@ export function HooksSettingsPanel({
             ) : null}
             <div className="grid gap-2">
               <Label htmlFor="hook-matcher">{t("settings.hooksMatcher")}</Label>
-              <Input
+              <DesktopFormInput
                 id="hook-matcher"
                 value={matcher}
                 onChange={(e) => setMatcher(e.target.value)}

--- a/apps/desktop/src/components/pending-approval-card.tsx
+++ b/apps/desktop/src/components/pending-approval-card.tsx
@@ -5,6 +5,11 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  DESKTOP_FORM_INPUT_SHELL,
+  DESKTOP_FORM_TEXTAREA_INNER,
+} from "@/lib/desktop-chrome";
+import { cn } from "@/lib/utils";
 import type { PendingToolApprovalSnapshot } from "@/types";
 
 type PendingApprovalCardProps = {
@@ -76,12 +81,12 @@ export function PendingApprovalCard({
             {t("app.deny")}
           </Button>
         </div>
-        <div className="flex min-h-9 items-stretch overflow-hidden rounded-md border border-input bg-transparent focus-within:border-ring/60 focus-within:ring-2 focus-within:ring-ring/20">
+        <div className={cn("flex min-h-9 items-stretch", DESKTOP_FORM_INPUT_SHELL)}>
           <Textarea
             value={approvalGuidance}
             onChange={(event) => onApprovalGuidanceChange(event.target.value)}
             placeholder={t("app.approvalGuidancePlaceholder")}
-            className="min-h-9 flex-1 resize-none rounded-none border-0 bg-transparent px-2.5 py-2 text-sm shadow-none focus-visible:ring-0"
+            className={DESKTOP_FORM_TEXTAREA_INNER}
           />
           <Button
             size="icon-sm"

--- a/apps/desktop/src/components/pending-questions-card.tsx
+++ b/apps/desktop/src/components/pending-questions-card.tsx
@@ -4,14 +4,14 @@ import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
+import { DesktopFormInput } from "@/components/ui/desktop-form-field";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { QuestionDraft } from "@/hooks/useDesktopRuntime";
 import {
   DESKTOP_CHROME_TOGGLE_ICON_BTN,
-  DESKTOP_FORM_INPUT_INNER,
   DESKTOP_FORM_INPUT_SHELL,
+  DESKTOP_FORM_TEXTAREA_INNER,
   instantHoverMotionClass,
 } from "@/lib/desktop-chrome";
 import { cn } from "@/lib/utils";
@@ -240,7 +240,7 @@ export function PendingQuestionsCard({
             <Label htmlFor={`${question.id}-text`} className="text-xs">
               {question.customInputLabel ?? t("app.answer")}
             </Label>
-            <div className="overflow-hidden rounded-md border border-input bg-transparent focus-within:border-ring/60 focus-within:ring-2 focus-within:ring-ring/20">
+            <div className={DESKTOP_FORM_INPUT_SHELL}>
               <Textarea
                 id={`${question.id}-text`}
                 value={draft.text}
@@ -251,7 +251,7 @@ export function PendingQuestionsCard({
                   }))
                 }
                 placeholder={question.customInputPlaceholder ?? t("app.enterAnswer")}
-                className="min-h-20 flex-1 resize-none rounded-none border-0 bg-transparent px-2.5 py-2 text-sm shadow-none focus-visible:ring-0"
+                className={cn(DESKTOP_FORM_TEXTAREA_INNER, "min-h-20")}
                 disabled={questionsBusy}
               />
             </div>
@@ -269,21 +269,18 @@ export function PendingQuestionsCard({
             <Label htmlFor={`${question.id}-custom`} className="text-xs">
               {question.customInputLabel ?? t("app.customInput")}
             </Label>
-            <div className={DESKTOP_FORM_INPUT_SHELL}>
-              <Input
-                id={`${question.id}-custom`}
-                value={draft.customInput}
-                onChange={(event) =>
-                  onUpdateDraft(question.id, (current) => ({
-                    ...current,
-                    customInput: event.target.value,
-                  }))
-                }
-                placeholder={question.customInputPlaceholder ?? t("app.supplementOption")}
-                className={DESKTOP_FORM_INPUT_INNER}
-                disabled={questionsBusy}
-              />
-            </div>
+            <DesktopFormInput
+              id={`${question.id}-custom`}
+              value={draft.customInput}
+              onChange={(event) =>
+                onUpdateDraft(question.id, (current) => ({
+                  ...current,
+                  customInput: event.target.value,
+                }))
+              }
+              placeholder={question.customInputPlaceholder ?? t("app.supplementOption")}
+              disabled={questionsBusy}
+            />
           </div>
         ) : null}
 

--- a/apps/desktop/src/components/settings-view.tsx
+++ b/apps/desktop/src/components/settings-view.tsx
@@ -18,10 +18,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { DesktopFormInput } from "@/components/ui/desktop-form-field";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { DesktopFormInput, DesktopFormTextarea } from "@/components/ui/desktop-form-field";
 import {
   Select,
   SelectContent,
@@ -1015,7 +1012,7 @@ function SkillsSettingsPanel({
             </div>
             <div className="grid gap-2">
               <Label htmlFor="new-skill-name">{t('settings.name')}</Label>
-              <Input
+              <DesktopFormInput
                 id="new-skill-name"
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
@@ -1025,7 +1022,7 @@ function SkillsSettingsPanel({
             </div>
             <div className="grid gap-2">
               <Label htmlFor="new-skill-desc">{t('settings.description')}</Label>
-              <Input
+              <DesktopFormInput
                 id="new-skill-desc"
                 value={newDescription}
                 onChange={(e) => setNewDescription(e.target.value)}
@@ -1341,7 +1338,7 @@ function RulesSettingsPanel({
             </div>
             <div className="grid gap-2">
               <Label htmlFor="new-rule-desc">{t('settings.description')}</Label>
-              <Textarea
+              <DesktopFormTextarea
                 id="new-rule-desc"
                 value={newDescription}
                 onChange={(e) => setNewDescription(e.target.value)}
@@ -1533,8 +1530,9 @@ function ExtensionConfigurationPanel({
                 htmlFor={fieldKey}
               >
                 <div className="flex w-full gap-2 sm:max-w-md">
-                  <Input
+                  <DesktopFormInput
                     id={fieldKey}
+                    shellClassName="min-w-0 flex-1"
                     value={currentText}
                     disabled={extensionsBusy}
                     type={setting.type === "number" ? "number" : "text"}
@@ -1583,14 +1581,14 @@ function ExtensionConfigurationPanel({
                   <Badge variant={configured ? "secondary" : "outline"} className="h-9 px-3 text-muted-foreground">
                     {configured ? t('settings.configured') : t('settings.notConfigured')}
                   </Badge>
-                  <Input
+                  <DesktopFormInput
                     id={fieldKey}
+                    shellClassName="min-w-0 flex-1"
                     type="password"
                     value={secretDrafts[fieldKey] ?? ""}
                     disabled={extensionsBusy}
                     placeholder={configured ? t('settings.enterNewValue') : t('settings.enterSecret')}
                     onChange={(event) => updateSecretDraft(item.id, slot.key, event.target.value)}
-                    className="min-w-0 flex-1"
                   />
                   <Button
                     type="button"
@@ -2172,7 +2170,7 @@ function McpsSettingsPanel({
 
             <div className="grid gap-2">
               <Label htmlFor="new-mcp-name">{t('settings.name')}</Label>
-              <Input
+              <DesktopFormInput
                 id="new-mcp-name"
                 value={newName}
                 onChange={(event) => setNewName(event.target.value)}
@@ -2183,7 +2181,7 @@ function McpsSettingsPanel({
 
             <div className="grid gap-2">
               <Label htmlFor="new-mcp-endpoint">{mcpEndpointLabel(transportType)}</Label>
-              <Input
+              <DesktopFormInput
                 id="new-mcp-endpoint"
                 value={newEndpoint}
                 onChange={(event) => setNewEndpoint(event.target.value)}
@@ -2194,7 +2192,7 @@ function McpsSettingsPanel({
 
             <div className="grid gap-2">
               <Label htmlFor="new-mcp-metadata">{mcpMetadataLabel(transportType)}</Label>
-              <Textarea
+              <DesktopFormTextarea
                 id="new-mcp-metadata"
                 value={newMetadata}
                 onChange={(event) => setNewMetadata(event.target.value)}
@@ -3709,7 +3707,7 @@ function NetworksSettingsPanel({
             description={t('settings.listenAddressDescription')}
             htmlFor="settings-web-host-host"
           >
-            <Input
+            <DesktopFormInput
               id="settings-web-host-host"
               className="sm:text-right"
               value={webHostHostDraft}
@@ -3726,7 +3724,7 @@ function NetworksSettingsPanel({
           </SettingsRow>
 
           <SettingsRow label={t('settings.listenPort')} htmlFor="settings-web-host-port">
-            <Input
+            <DesktopFormInput
               id="settings-web-host-port"
               className="sm:text-right"
               type="number"

--- a/apps/desktop/src/components/settings-view.tsx
+++ b/apps/desktop/src/components/settings-view.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DesktopFormInput, DesktopFormTextarea } from "@/components/ui/desktop-form-field";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,

--- a/apps/desktop/src/components/settings-view.tsx
+++ b/apps/desktop/src/components/settings-view.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { DesktopFormInput } from "@/components/ui/desktop-form-field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -51,7 +52,6 @@ import {
 import { modelCapabilityLabel } from "@/lib/model-capability-label";
 import {
   DESKTOP_FORM_FIELD_TRIGGER_INNER,
-  DESKTOP_FORM_INPUT_INNER,
   DESKTOP_FORM_INPUT_SHELL,
 } from "@/lib/desktop-chrome";
 import { desktopMicaTintClass } from "@/lib/desktop-mica-surface";
@@ -477,17 +477,6 @@ function modelDefaultActionLabel(roles: readonly ModelDefaultRole[]): string {
   }
 
   return i18n.t('settings.selectDefaultRole');
-}
-
-function ProviderFormInput({
-  className,
-  ...props
-}: ComponentProps<typeof Input>) {
-  return (
-    <div className={DESKTOP_FORM_INPUT_SHELL}>
-      <Input className={cn(DESKTOP_FORM_INPUT_INNER, className)} {...props} />
-    </div>
-  );
 }
 
 function ModelCapabilitiesCombobox({
@@ -3367,7 +3356,7 @@ function ModelsSettingsPanel({
             <DialogDescription>{t('settings.selectProviderDescription')}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-3 py-1">
-            <ProviderFormInput
+            <DesktopFormInput
               value={providerQuery}
               onChange={(e) => setProviderQuery(e.target.value)}
               placeholder={t('common.search')}
@@ -3487,7 +3476,7 @@ function ModelsSettingsPanel({
             {selectedProvider === "custom" && customConnectMode === "single" ? (
               <div className="grid gap-2">
                 <Label htmlFor="connect-model-name">{t('settings.modelName')}</Label>
-                <ProviderFormInput
+                <DesktopFormInput
                   id="connect-model-name"
                   value={connectName}
                   onChange={(e) => setConnectName(e.target.value)}
@@ -3509,7 +3498,7 @@ function ModelsSettingsPanel({
             {selectedProvider === "custom" && customConnectMode === "single" ? (
               <div className="grid gap-2">
                 <Label htmlFor="connect-context-length">{t('settings.contextLength')}</Label>
-                <ProviderFormInput
+                <DesktopFormInput
                   id="connect-context-length"
                   type="number"
                   min={1}
@@ -3524,7 +3513,7 @@ function ModelsSettingsPanel({
             {selectedProvider === "custom" ? (
               <div className="grid gap-2">
                 <Label htmlFor="connect-api-base">{t('settings.endpoint')}</Label>
-                <ProviderFormInput
+                <DesktopFormInput
                   id="connect-api-base"
                   value={connectApiBase}
                   onChange={(e) => setConnectApiBase(e.target.value)}
@@ -3538,7 +3527,7 @@ function ModelsSettingsPanel({
             ) : null}
             <div className="grid gap-2">
               <Label htmlFor="connect-api-key">API Key</Label>
-              <ProviderFormInput
+              <DesktopFormInput
                 id="connect-api-key"
                 type="password"
                 value={connectApiKey}

--- a/apps/desktop/src/components/ui/desktop-form-field.tsx
+++ b/apps/desktop/src/components/ui/desktop-form-field.tsx
@@ -1,0 +1,38 @@
+import type { ComponentProps } from "react";
+
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  DESKTOP_FORM_INPUT_INNER,
+  DESKTOP_FORM_INPUT_SHELL,
+  DESKTOP_FORM_TEXTAREA_INNER,
+} from "@/lib/desktop-chrome";
+import { cn } from "@/lib/utils";
+
+type DesktopFormFieldShellProps = {
+  shellClassName?: string;
+};
+
+export function DesktopFormInput({
+  className,
+  shellClassName,
+  ...props
+}: ComponentProps<typeof Input> & DesktopFormFieldShellProps) {
+  return (
+    <div className={cn(DESKTOP_FORM_INPUT_SHELL, shellClassName)}>
+      <Input className={cn(DESKTOP_FORM_INPUT_INNER, className)} {...props} />
+    </div>
+  );
+}
+
+export function DesktopFormTextarea({
+  className,
+  shellClassName,
+  ...props
+}: ComponentProps<typeof Textarea> & DesktopFormFieldShellProps) {
+  return (
+    <div className={cn(DESKTOP_FORM_INPUT_SHELL, shellClassName)}>
+      <Textarea className={cn(DESKTOP_FORM_TEXTAREA_INNER, className)} {...props} />
+    </div>
+  );
+}

--- a/apps/desktop/src/components/web-host-pairing-gate.tsx
+++ b/apps/desktop/src/components/web-host-pairing-gate.tsx
@@ -11,7 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
+import { DesktopFormInput } from "@/components/ui/desktop-form-field";
 import { Label } from "@/components/ui/label";
 
 export function WebHostPairingGate({
@@ -50,7 +50,7 @@ export function WebHostPairingGate({
         <CardContent className="space-y-4">
           <div className="grid gap-2">
             <Label htmlFor="web-host-pairing-code">{t('app.pairingCode')}</Label>
-            <Input
+            <DesktopFormInput
               id="web-host-pairing-code"
               value={code}
               inputMode="numeric"

--- a/apps/desktop/src/lib/desktop-chrome.ts
+++ b/apps/desktop/src/lib/desktop-chrome.ts
@@ -108,6 +108,9 @@ export const DESKTOP_FORM_INPUT_SHELL = DESKTOP_OVERLAY_LIST_FILTER_INPUT_SHELL;
 export const DESKTOP_FORM_INPUT_INNER =
   "h-8 w-full min-w-0 rounded-none border-0 bg-transparent px-2.5 py-1 text-sm shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent";
 
+export const DESKTOP_FORM_TEXTAREA_INNER =
+  "min-h-9 w-full min-w-0 flex-1 resize-none rounded-none border-0 bg-transparent px-2.5 py-2 text-sm shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent";
+
 /** 置于 DESKTOP_FORM_INPUT_SHELL 内的 Select / 自定义触发器 */
 export const DESKTOP_FORM_FIELD_TRIGGER_INNER =
   "h-8 min-h-8 w-full rounded-none border-0 bg-transparent px-2.5 shadow-none focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent";


### PR DESCRIPTION
## Summary

- 新增 `DesktopFormInput` / `DesktopFormTextarea` 共享组件与 `DESKTOP_FORM_TEXTAREA_INNER` token，统一 Desktop 默认 shadcn 输入框为审批指引输入框的 shell + 内层无边框样式
- 迁移 Settings（含 Add MCP 对话框）、Hooks 创建、Web Host 配对、字体选择器等表单输入框
- 审批卡与问题卡复用共享 token，不改变现有视觉

## Test plan

- [x] Settings → MCP → Add MCP：Name / Command / Environment Variables 为 `rounded-md` 细边框，focus 为 `ring-2`
- [x] Settings → Provider 连接表单：搜索与字段输入样式与改前一致
- [x] Settings → Extension 行 Input+Save 按钮布局正常
- [x] Settings → Web Host host/port 右对齐仍生效
- [x] Hooks 创建对话框输入框样式一致
- [x] Web Host 首次配对页输入框样式一致
- [x] 字体选择器下拉搜索框样式一致
- [x] Composer 主输入未变
- [x] Marketplace / PR 列表 / 浏览器地址栏等 ghost 输入未变
- [x] `npx tsc --noEmit`（desktop）通过