### PR TITLE
feat(agent-core, desktop): run_subagent worktree 隔离

### DIFF
--- a/apps/desktop/src/host/git.ts
+++ b/apps/desktop/src/host/git.ts
@@ -15,6 +15,7 @@ import {
   readGitWorkingTreeChanges,
   readGitWorkspaceSnapshot,
   readWorktreeContext,
+  removeGitWorktree as removeGitWorktreeInternal,
   resolveDefaultBranch,
   resolvePrimaryRepoRoot,
   type GitCheckoutOptions,
@@ -151,6 +152,13 @@ export async function createWorkspaceGitWorktree(
     worktreePath,
     branchName: names.branchName,
   };
+}
+
+export async function removeWorkspaceGitWorktree(
+  repoRoot: string,
+  worktreePath: string,
+): Promise<void> {
+  await removeGitWorktreeInternal(repoRoot, worktreePath, { force: true });
 }
 
 export async function pushWorkspaceGitBranch(workspaceRoot: string): Promise<void> {

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -62,7 +62,7 @@ export function createDesktopRuntime(input: {
   getLoopEnabled?: () => boolean;
   hookRunner?: HookRunner;
   hookSessionContext?: HookSessionContext;
-  bootstrapSubagentWorkspace?: SubagentWorkspaceBootstrap;
+  bootstrapSubagentWorkspace?: SubagentWorkspaceBootstrap<DesktopToolRequest, string>;
 }): DesktopRuntime {
   const resolveLoopEnabled = () => input.getLoopEnabled?.() === true;
   const applyPatchFileToolsPromptSection = resolveApplyPatchFileToolsPromptSection(
@@ -73,7 +73,12 @@ export function createDesktopRuntime(input: {
     input.transportConfig,
   );
 
-  return new AgentRuntime({
+  return new AgentRuntime<
+    LlmTransportConfig,
+    LlmToolAgentState,
+    DesktopToolRequest,
+    string
+  >({
     config: input.transportConfig,
     llmTransport: input.llmTransport,
     toolExecutor: input.toolExecutor,
@@ -165,7 +170,7 @@ export function createDesktopRuntime(input: {
       }),
     removePreCompactionHistoryArchive: async (archivePath) =>
       removePreCompactionHistoryArchive(archivePath),
-  }, input.history.map((message) => normalizeStoredLlmMessage(message))) as DesktopRuntime;
+  }, input.history.map((message) => normalizeStoredLlmMessage(message)));
 }
 
 export function buildDesktopRuntimeBasicInfo(

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -1,23 +1,22 @@
 import {
   AgentRuntime,
   assistantToolCallMessageFromLlmState,
-  appendLlmUserLlmMessage,
-  normalizeStoredLlmMessage,
-  type HookRunner,
-  type HookSessionContext,
-  type SpiritLlmTransport,
   appendLlmToolResultMessage,
+  appendLlmUserLlmMessage,
   appendLlmUserMessage,
   buildApplyPatchFileToolsPromptSection,
   buildProviderWebSearchPromptSection,
   continueLlmToolAgentState,
   extractLastLlmAssistantText,
+  normalizeStoredLlmMessage,
   rebuildLlmToolAgentStateAfterCompaction,
   shouldUseApplyPatchFileTools,
   startLlmToolAgentState,
   truncateLlmHistoryForCompaction,
   truncateLlmToolAgentStateForContextRetry,
   type ChatArchive,
+  type HookRunner,
+  type HookSessionContext,
   type LlmActiveSkill,
   type LlmEnabledRule,
   type LlmEnabledSkillCatalogEntry,
@@ -26,6 +25,8 @@ import {
   type LlmToolAgentBasicInfo,
   type LlmToolAgentState,
   type LlmTransportConfig,
+  type SpiritLlmTransport,
+  type SubagentWorkspaceBootstrap,
 } from '@spirit-agent/core';
 import {
   persistPreCompactionHistoryArchive,
@@ -61,6 +62,7 @@ export function createDesktopRuntime(input: {
   getLoopEnabled?: () => boolean;
   hookRunner?: HookRunner;
   hookSessionContext?: HookSessionContext;
+  bootstrapSubagentWorkspace?: SubagentWorkspaceBootstrap;
 }): DesktopRuntime {
   const resolveLoopEnabled = () => input.getLoopEnabled?.() === true;
   const applyPatchFileToolsPromptSection = resolveApplyPatchFileToolsPromptSection(
@@ -152,13 +154,16 @@ export function createDesktopRuntime(input: {
       ),
     ...(input.hookRunner ? { hookRunner: input.hookRunner } : {}),
     ...(input.hookSessionContext ? { hookSessionContext: input.hookSessionContext } : {}),
+    ...(input.bootstrapSubagentWorkspace
+      ? { bootstrapSubagentWorkspace: input.bootstrapSubagentWorkspace }
+      : {}),
     persistPreCompactionHistory: async ({ archive, sessionId }) =>
       persistPreCompactionHistoryArchive(spiritAgentDataDir(), archive, {
         ...(sessionId !== undefined ? { sessionId } : {}),
       }),
     removePreCompactionHistoryArchive: async (archivePath) =>
       removePreCompactionHistoryArchive(archivePath),
-  }, input.history.map((message) => normalizeStoredLlmMessage(message)));
+  }, input.history.map((message) => normalizeStoredLlmMessage(message))) as DesktopRuntime;
 }
 
 export function buildDesktopRuntimeBasicInfo(

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -140,6 +140,8 @@ export function createDesktopRuntime(input: {
       ),
     resolveWorkspaceFilesFromInput: (userInput) =>
       resolveWorkspaceFileReferenceAttachmentsFromInput(input.workspaceRoot, userInput),
+    resolveWorkspaceFilesForRoot: (workspaceRoot, userInput) =>
+      resolveWorkspaceFileReferenceAttachmentsFromInput(workspaceRoot, userInput),
     generateImage: (request) =>
       input.llmTransport.generateImage(
         input.transportConfig,

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2181,7 +2181,6 @@ class DesktopHostService {
     const state = this.requireState();
     return createDesktopSubagentWorkspaceBootstrap({
       parentWorkspaceRoot: state.workspaceRoot,
-      parentToolExecutor: parentExecutor,
       isGitRepository: state.git.isRepository,
       resolveBaseBranch: () => {
         const bundle = this.activeBundle();

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -352,6 +352,7 @@ import {
   createDesktopRuntime,
   type DesktopRuntime,
 } from './runtime.js';
+import { createDesktopSubagentWorkspaceBootstrap } from './subagent-worktree-bootstrap.js';
 import {
   buildDreamContextText,
   clearDreamCollectorIssue,
@@ -2150,6 +2151,47 @@ class DesktopHostService {
     });
   }
 
+  private async buildScopedSubagentToolExecutor(
+    workspaceRoot: string,
+    transportConfig: LlmTransportConfig | undefined,
+  ): Promise<DesktopToolExecutor> {
+    const state = this.requireState();
+    const extensions = await this.extensionManager().list();
+    const lsp = await ensureLspServiceReady(this.sharedLspServiceForWorkspace(workspaceRoot));
+    const scoped = new DesktopToolExecutor(workspaceRoot, {
+      mcp: this.sharedMcpServiceForWorkspace(workspaceRoot, state.workspaceBinding),
+      ...(lsp ? { lsp } : {}),
+      extensionToolDefinitions: buildDesktopExtensionToolDefinitions(extensions),
+      hostContributedToolsEnabled: true,
+    });
+    scoped.setAgentModeToolExposure(resolveDesktopAgentMode(state.config));
+    scoped.setLoopToolExposure(this.activeBundle().loopEnabled);
+    if (transportConfig) {
+      scoped.setActiveTransportConfig(transportConfig);
+    }
+    return scoped;
+  }
+
+  private createSubagentWorkspaceBootstrap(
+    parentExecutor: DesktopToolExecutor,
+    transportConfig: LlmTransportConfig,
+  ) {
+    const state = this.requireState();
+    return createDesktopSubagentWorkspaceBootstrap({
+      parentWorkspaceRoot: state.workspaceRoot,
+      parentToolExecutor: parentExecutor,
+      isGitRepository: state.git.isRepository,
+      resolveBaseBranch: () => {
+        const bundle = this.activeBundle();
+        return bundle.pendingGitBranch ?? state.git.branch;
+      },
+      generateWorktreeNames: (task, baseBranch, repoRoot) =>
+        this.generateWorktreeNamesFromModel(task, baseBranch, repoRoot),
+      buildScopedToolExecutor: (workspaceRoot) =>
+        this.buildScopedSubagentToolExecutor(workspaceRoot, transportConfig),
+    });
+  }
+
   private buildClientGitSnapshot(): DesktopGitSnapshot {
     const state = this.requireState();
     const bundle = this.activeBundle();
@@ -2558,6 +2600,7 @@ class DesktopHostService {
       getLoopEnabled: () => bundle.loopEnabled,
       hookRunner,
       hookSessionContext,
+      bootstrapSubagentWorkspace: this.createSubagentWorkspaceBootstrap(toolExecutor, transportConfig),
     });
   }
 

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2154,6 +2154,7 @@ class DesktopHostService {
   private async buildScopedSubagentToolExecutor(
     workspaceRoot: string,
     transportConfig: LlmTransportConfig | undefined,
+    parentExecutor: DesktopToolExecutor,
   ): Promise<DesktopToolExecutor> {
     const state = this.requireState();
     const extensions = await this.extensionManager().list();
@@ -2164,6 +2165,7 @@ class DesktopHostService {
       extensionToolDefinitions: buildDesktopExtensionToolDefinitions(extensions),
       hostContributedToolsEnabled: true,
     });
+    scoped.setApprovalLevel(parentExecutor.approvalLevelSnapshot());
     scoped.setAgentModeToolExposure(resolveDesktopAgentMode(state.config));
     scoped.setLoopToolExposure(this.activeBundle().loopEnabled);
     if (transportConfig) {
@@ -2188,7 +2190,7 @@ class DesktopHostService {
       generateWorktreeNames: (task, baseBranch, repoRoot) =>
         this.generateWorktreeNamesFromModel(task, baseBranch, repoRoot),
       buildScopedToolExecutor: (workspaceRoot) =>
-        this.buildScopedSubagentToolExecutor(workspaceRoot, transportConfig),
+        this.buildScopedSubagentToolExecutor(workspaceRoot, transportConfig, parentExecutor),
     });
   }
 

--- a/apps/desktop/src/host/subagent-worktree-bootstrap.ts
+++ b/apps/desktop/src/host/subagent-worktree-bootstrap.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import type { SubagentWorkspaceBootstrap } from '@spirit-agent/core';
 
+import type { DesktopToolRequest } from './contracts.js';
 import type { DesktopToolExecutor } from './tool-executor.js';
 import {
   createWorkspaceGitWorktree,
@@ -23,7 +24,7 @@ export type DesktopSubagentWorktreeBootstrapDeps = {
 
 export function createDesktopSubagentWorkspaceBootstrap(
   deps: DesktopSubagentWorktreeBootstrapDeps,
-): SubagentWorkspaceBootstrap {
+): SubagentWorkspaceBootstrap<DesktopToolRequest, string> {
   return async (input) => {
     if (!input.worktree) {
       return { workspaceRoot: input.parentWorkspaceRoot || deps.parentWorkspaceRoot };

--- a/apps/desktop/src/host/subagent-worktree-bootstrap.ts
+++ b/apps/desktop/src/host/subagent-worktree-bootstrap.ts
@@ -7,6 +7,7 @@ import {
   createWorkspaceGitWorktree,
   readPrimaryRepoRoot,
   readWorkspaceGitSnapshot,
+  removeWorkspaceGitWorktree,
 } from './git.js';
 
 export type DesktopSubagentWorktreeBootstrapDeps = {
@@ -33,9 +34,11 @@ export function createDesktopSubagentWorkspaceBootstrap(
       return { error: 'worktree subagents require a git repository' };
     }
 
+    let repoRoot: string | undefined;
+    let createdWorktreePath: string | undefined;
     try {
       const parentRoot = input.parentWorkspaceRoot.trim() || deps.parentWorkspaceRoot;
-      const repoRoot = await readPrimaryRepoRoot(parentRoot);
+      repoRoot = await readPrimaryRepoRoot(parentRoot);
       const worktreeContext = await readWorkspaceGitSnapshot(parentRoot);
       if (worktreeContext.isWorktreeSession) {
         return { error: 'worktree subagents cannot start from inside an existing worktree session' };
@@ -48,6 +51,7 @@ export function createDesktopSubagentWorkspaceBootstrap(
 
       const names = await deps.generateWorktreeNames(input.task, baseBranch, repoRoot);
       const created = await createWorkspaceGitWorktree(repoRoot, names, baseBranch);
+      createdWorktreePath = created.worktreePath;
       const scopedExecutor = await deps.buildScopedToolExecutor(created.worktreePath);
 
       return {
@@ -57,6 +61,13 @@ export function createDesktopSubagentWorkspaceBootstrap(
         toolExecutor: scopedExecutor,
       };
     } catch (error) {
+      if (repoRoot && createdWorktreePath) {
+        try {
+          await removeWorkspaceGitWorktree(repoRoot, createdWorktreePath);
+        } catch {
+          // bootstrap 失败时的 best-effort 回滚；残留 worktree 由用户设置页清理兜底。
+        }
+      }
       const message = error instanceof Error ? error.message : String(error);
       return { error: message };
     }

--- a/apps/desktop/src/host/subagent-worktree-bootstrap.ts
+++ b/apps/desktop/src/host/subagent-worktree-bootstrap.ts
@@ -17,7 +17,6 @@ export type DesktopSubagentWorktreeBootstrapDeps = {
     branchName: string;
   }>;
   buildScopedToolExecutor: (workspaceRoot: string) => Promise<DesktopToolExecutor>;
-  parentToolExecutor: DesktopToolExecutor;
   resolveBaseBranch: () => string | undefined;
   isGitRepository: boolean;
 };

--- a/apps/desktop/src/host/subagent-worktree-bootstrap.ts
+++ b/apps/desktop/src/host/subagent-worktree-bootstrap.ts
@@ -1,0 +1,91 @@
+import path from 'node:path';
+
+import type { SubagentWorkspaceBootstrap } from '@spirit-agent/core';
+
+import type { DesktopToolExecutor } from './tool-executor.js';
+import {
+  createWorkspaceGitWorktree,
+  readPrimaryRepoRoot,
+  readWorkspaceGitSnapshot,
+} from './git.js';
+
+export type DesktopSubagentWorktreeBootstrapDeps = {
+  parentWorkspaceRoot: string;
+  generateWorktreeNames: (task: string, baseBranch: string, repoRoot: string) => Promise<{
+    worktreeName: string;
+    branchName: string;
+  }>;
+  buildScopedToolExecutor: (workspaceRoot: string) => Promise<DesktopToolExecutor>;
+  parentToolExecutor: DesktopToolExecutor;
+  resolveBaseBranch: () => string | undefined;
+  isGitRepository: boolean;
+};
+
+export function createDesktopSubagentWorkspaceBootstrap(
+  deps: DesktopSubagentWorktreeBootstrapDeps,
+): SubagentWorkspaceBootstrap {
+  return async (input) => {
+    if (!input.worktree) {
+      return { workspaceRoot: input.parentWorkspaceRoot || deps.parentWorkspaceRoot };
+    }
+
+    if (!deps.isGitRepository) {
+      return { error: 'worktree subagents require a git repository' };
+    }
+
+    try {
+      const parentRoot = input.parentWorkspaceRoot.trim() || deps.parentWorkspaceRoot;
+      const repoRoot = await readPrimaryRepoRoot(parentRoot);
+      const worktreeContext = await readWorkspaceGitSnapshot(parentRoot);
+      if (worktreeContext.isWorktreeSession) {
+        return { error: 'worktree subagents cannot start from inside an existing worktree session' };
+      }
+
+      const baseBranch = deps.resolveBaseBranch();
+      if (!baseBranch) {
+        return { error: 'cannot determine base branch for subagent worktree' };
+      }
+
+      const names = await deps.generateWorktreeNames(input.task, baseBranch, repoRoot);
+      const created = await createWorkspaceGitWorktree(repoRoot, names, baseBranch);
+      const scopedExecutor = await deps.buildScopedToolExecutor(created.worktreePath);
+
+      return {
+        workspaceRoot: created.worktreePath,
+        worktreePath: created.worktreePath,
+        branchName: created.branchName,
+        toolExecutor: scopedExecutor,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { error: message };
+    }
+  };
+}
+
+export function normalizeSubagentWorktreeSlug(sessionId: string): string {
+  const slug = sessionId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/gu, '-')
+    .replace(/^-+|-+$/gu, '');
+  return slug.length > 0 ? slug : 'subagent';
+}
+
+export function buildDeterministicSubagentWorktreeNames(sessionId: string): {
+  worktreeName: string;
+  branchName: string;
+} {
+  const slug = normalizeSubagentWorktreeSlug(sessionId).slice(0, 48);
+  return {
+    worktreeName: `spirit-subagent-${slug}`,
+    branchName: `spirit/subagent-${slug}`,
+  };
+}
+
+export function resolveSubagentBootstrapParentRoot(
+  parentWorkspaceRoot: string,
+  fallbackRoot: string,
+): string {
+  const trimmed = parentWorkspaceRoot.trim();
+  return trimmed.length > 0 ? path.resolve(trimmed) : path.resolve(fallbackRoot);
+}

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -1,5 +1,6 @@
 import { stdin, stdout } from 'node:process';
 import { release as osRelease } from 'node:os';
+import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import {
@@ -60,6 +61,7 @@ import type {
   JsonValue,
   LlmMessage,
   McpStatusSnapshot,
+  ToolExecutor,
 } from './ports.js';
 import {
   AgentRuntime,
@@ -69,6 +71,8 @@ import {
   type RuntimeApprovalDecision,
   type RuntimeEvent,
   type RuntimePendingApproval,
+  type SubagentWorkspaceBootstrapInput,
+  type SubagentWorkspaceBootstrapResult,
 } from './runtime.js';
 import {
   runSessionEndHook,
@@ -890,6 +894,80 @@ async function ensureCliHostInternal(workspaceRoot: string): Promise<CliHostInte
   return cliHostInternal;
 }
 
+async function bootstrapCliSubagentWorkspace(
+  input: SubagentWorkspaceBootstrapInput,
+): Promise<SubagentWorkspaceBootstrapResult> {
+  if (!input.worktree) {
+    return { workspaceRoot: input.parentWorkspaceRoot || currentWorkspaceRoot() };
+  }
+
+  const host = cliHostInternal;
+  const modulePath = process.env[ENV_HOST_INTERNAL_MODULE_PATH]?.trim();
+  if (!host || !modulePath) {
+    return { error: 'CLI host-internal is not available for worktree subagents' };
+  }
+
+  try {
+    const gitModulePath = path.join(path.dirname(modulePath), 'git-workspace.js');
+    const git = await import(pathToFileURL(gitModulePath).href) as {
+      resolvePrimaryRepoRoot: (root: string) => Promise<string>;
+      resolveDefaultBranch: (root: string) => Promise<string | undefined>;
+      buildWorktreeRootPath: (repoRoot: string, worktreeName: string) => string;
+      addGitWorktree: (
+        repoRoot: string,
+        input: { worktreePath: string; branchName: string; baseBranch: string },
+      ) => Promise<void>;
+    };
+
+    const parentRoot = input.parentWorkspaceRoot.trim() || currentWorkspaceRoot();
+    const repoRoot = await git.resolvePrimaryRepoRoot(parentRoot);
+    const baseBranch = await git.resolveDefaultBranch(repoRoot);
+    if (!baseBranch) {
+      return { error: 'cannot determine base branch for subagent worktree' };
+    }
+
+    const slug = input.subagentSessionId
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/gu, '-')
+      .replace(/^-+|-+$/gu, '')
+      .slice(0, 48) || 'subagent';
+    const worktreeName = `spirit-subagent-${slug}`;
+    const branchName = `spirit/subagent-${slug}`;
+    const worktreePath = git.buildWorktreeRootPath(repoRoot, worktreeName);
+    await git.addGitWorktree(repoRoot, {
+      worktreePath,
+      branchName,
+      baseBranch,
+    });
+
+    const scopedProxy = new HostToolExecutorProxy(peer);
+    const serviceOptions = buildCliHostToolServiceOptions(host.module, host.extensionManager);
+    const service = new host.module.NodeHostToolService(
+      { workspaceRoot: worktreePath, spiritDataDir: host.spiritDataDir },
+      Object.keys(serviceOptions).length > 0 ? serviceOptions : undefined,
+    );
+    scopedProxy.setLocalHostService(service);
+    scopedProxy.setAgentModeToolExposure(
+      readSpiritAgentModeFromTransportConfig(
+        transportConfig as { spiritAgentMode?: SpiritAgentMode; planMode?: boolean },
+      ),
+    );
+    scopedProxy.setLoopToolExposure(bridgeLoopEnabled);
+    scopedProxy.setTodoToolDefinitions(currentTodoSessionKey ? buildTodoHostToolDefinitions() : []);
+    applyCliLspHostBindings(host.module);
+    await scopedProxy.setLspWorkspaceRoot(worktreePath);
+
+    return {
+      workspaceRoot: worktreePath,
+      worktreePath,
+      branchName,
+      toolExecutor: scopedProxy,
+    } as SubagentWorkspaceBootstrapResult;
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
 function transportUsesApplyPatchFileTools(
   config: LlmTransportConfig | undefined,
   agentMode?: SpiritAgentMode,
@@ -1681,6 +1759,7 @@ async function createRuntime(
     },
     ...(hookRunner ? { hookRunner } : {}),
     hookSessionContext: buildCliHookSessionContext(config),
+    bootstrapSubagentWorkspace: bootstrapCliSubagentWorkspace,
     persistPreCompactionHistory: async ({ archive, sessionId }) => {
       const hostInternal = await ensureCliHostInternal(workspaceRoot);
       const persist = hostInternal?.module.persistPreCompactionHistoryArchive;
@@ -1709,7 +1788,7 @@ async function createRuntime(
         // Best-effort orphan cleanup.
       }
     },
-  }, history);
+  }, history) as HostRuntime;
 }
 
 function buildSnapshot(target: HostRuntime): BridgeRuntimeSnapshot {

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -1757,6 +1757,13 @@ async function createRuntime(
       }
       return pendingWorkspaceFilesFromInput(workspaceRoot, text);
     },
+    resolveWorkspaceFilesForRoot: (root, text) => {
+      const resolveFromHostInternal = cliHostInternal?.module.resolveWorkspaceFileReferenceAttachmentsFromInput;
+      if (resolveFromHostInternal) {
+        return resolveFromHostInternal(root, text);
+      }
+      return pendingWorkspaceFilesFromInput(root, text);
+    },
     ...(hookRunner ? { hookRunner } : {}),
     hookSessionContext: buildCliHookSessionContext(config),
     bootstrapSubagentWorkspace: bootstrapCliSubagentWorkspace,

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -912,6 +912,7 @@ async function bootstrapCliSubagentWorkspace(
     const git = await import(pathToFileURL(gitModulePath).href) as {
       resolvePrimaryRepoRoot: (root: string) => Promise<string>;
       resolveDefaultBranch: (root: string) => Promise<string | undefined>;
+      readWorktreeContext: (root: string) => Promise<{ isWorktree: boolean }>;
       buildWorktreeRootPath: (repoRoot: string, worktreeName: string) => string;
       addGitWorktree: (
         repoRoot: string,
@@ -920,6 +921,10 @@ async function bootstrapCliSubagentWorkspace(
     };
 
     const parentRoot = input.parentWorkspaceRoot.trim() || currentWorkspaceRoot();
+    const worktreeContext = await git.readWorktreeContext(parentRoot);
+    if (worktreeContext.isWorktree) {
+      return { error: 'worktree subagents cannot start from inside an existing worktree session' };
+    }
     const repoRoot = await git.resolvePrimaryRepoRoot(parentRoot);
     const baseBranch = await git.resolveDefaultBranch(repoRoot);
     if (!baseBranch) {

--- a/packages/agent-core/src/host-tools.ts
+++ b/packages/agent-core/src/host-tools.ts
@@ -259,6 +259,11 @@ export function buildBuiltinHostToolDefinitions(
             items: { type: 'string' },
           },
           expected_output: { type: 'string' },
+          worktree: {
+            type: 'boolean',
+            description:
+              'When true, run the subagent in an isolated git worktree so parallel subagents can edit files without conflicting. Use when the subagent will modify workspace files and other subagents may edit at the same time; omit for read-only tasks.',
+          },
         },
         required: ['task'],
         additionalProperties: false,

--- a/packages/agent-core/src/ports.ts
+++ b/packages/agent-core/src/ports.ts
@@ -316,6 +316,8 @@ export interface SubagentSessionSummary {
   latestMessage?: string;
   finalOutput?: string;
   error?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
 }
 
 export interface SubagentSessionArchiveEntry {
@@ -553,6 +555,7 @@ export interface RunSubagentRequest {
   contextSummary?: string;
   filesToInspect?: string[];
   expectedOutput?: string;
+  worktree?: boolean;
 }
 
 export type AuthorizationDecision<TrustTarget = string> =

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -49,6 +49,7 @@ import {
 } from './runtime/helpers.js';
 import { formatUserMessageContentForLlm } from './runtime/user-turn-timestamp.js';
 import { prependSubagentWorktreeMeta } from './runtime/subagent-worktree-meta.js';
+import { scopeAgentRuntimeOptionsForSubagentWorkspace } from './runtime/subagent-workspace-scope.js';
 import { prepareSubmittedUserTurn as prepareSubmittedUserTurnInternal } from './runtime/context.js';
 import {
   appendHookAdditionalContexts,
@@ -2782,6 +2783,7 @@ export class AgentRuntime<
 
     let childToolExecutor: AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget>['toolExecutor']
       | undefined;
+    let childWorkspaceRoot: string | undefined;
     if (request.worktree === true) {
       const bootstrap = this.options.bootstrapSubagentWorkspace;
       const parentWorkspaceRoot = resolveHookSessionContext(this.options).workspaceRoot?.trim() ?? '';
@@ -2808,12 +2810,14 @@ export class AgentRuntime<
         record.summary.worktreeBranch = boot.branchName;
       }
       childToolExecutor = boot.toolExecutor ?? this.options.toolExecutor;
+      childWorkspaceRoot = boot.workspaceRoot;
     }
 
     const childRuntime = this.createChildRuntime(
       record.summary.sessionId,
       record.summary.title,
       childToolExecutor,
+      childWorkspaceRoot,
     );
     this.childSessionsStore.push(record);
 
@@ -3143,11 +3147,15 @@ export class AgentRuntime<
     subagentSessionId: string,
     subagentTitle: string,
     childToolExecutor?: AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget>['toolExecutor'],
+    childWorkspaceRoot?: string,
   ): AgentRuntime<Config, State, ToolRequest, TrustTarget> {
     const baseExecutor = childToolExecutor ?? this.options.toolExecutor;
+    const scopedOptions = childWorkspaceRoot?.trim()
+      ? scopeAgentRuntimeOptionsForSubagentWorkspace(this.options, childWorkspaceRoot)
+      : this.options;
     return new AgentRuntime<Config, State, ToolRequest, TrustTarget>(
       {
-        ...this.options,
+        ...scopedOptions,
         toolExecutor: createSubagentToolExecutor(
           baseExecutor,
           subagentSessionId,

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -48,6 +48,7 @@ import {
   toolNameFromRequest,
 } from './runtime/helpers.js';
 import { formatUserMessageContentForLlm } from './runtime/user-turn-timestamp.js';
+import { prependSubagentWorktreeMeta } from './runtime/subagent-worktree-meta.js';
 import { prepareSubmittedUserTurn as prepareSubmittedUserTurnInternal } from './runtime/context.js';
 import {
   appendHookAdditionalContexts,
@@ -169,6 +170,9 @@ export type {
   RuntimeStatePreparationResult,
   RuntimeToolExecution,
   RuntimeTurnResult,
+  SubagentWorkspaceBootstrap,
+  SubagentWorkspaceBootstrapInput,
+  SubagentWorkspaceBootstrapResult,
 } from './runtime/types.js';
 
 interface PendingSubagentExecution<Config, State, ToolRequest, TrustTarget> {
@@ -2775,9 +2779,41 @@ export class AgentRuntime<
       },
       llmHistory: [],
     };
+
+    let childToolExecutor: AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget>['toolExecutor']
+      | undefined;
+    if (request.worktree === true) {
+      const bootstrap = this.options.bootstrapSubagentWorkspace;
+      const parentWorkspaceRoot = resolveHookSessionContext(this.options).workspaceRoot?.trim() ?? '';
+      if (!bootstrap) {
+        return {
+          kind: 'completed',
+          text: '[subagent failed] worktree subagents are not supported on this host.',
+          failed: true,
+        };
+      }
+      const boot = await bootstrap({
+        subagentSessionId: sessionId,
+        task: request.task,
+        worktree: true,
+        parentWorkspaceRoot,
+      });
+      if ('error' in boot) {
+        return { kind: 'completed', text: `[subagent failed] ${boot.error}`, failed: true };
+      }
+      if (boot.worktreePath) {
+        record.summary.worktreePath = boot.worktreePath;
+      }
+      if (boot.branchName) {
+        record.summary.worktreeBranch = boot.branchName;
+      }
+      childToolExecutor = boot.toolExecutor ?? this.options.toolExecutor;
+    }
+
     const childRuntime = this.createChildRuntime(
       record.summary.sessionId,
       record.summary.title,
+      childToolExecutor,
     );
     this.childSessionsStore.push(record);
 
@@ -3015,11 +3051,15 @@ export class AgentRuntime<
           ),
           failed: true,
         };
-    const parentToolResultText = buildParentSubagentToolResultText(
-      pending.childRecord.summary.title,
-      output.text,
-      output.failed,
-      pending.childRecord.summary.sessionId,
+    const parentToolResultText = prependSubagentWorktreeMeta(
+      buildParentSubagentToolResultText(
+        pending.childRecord.summary.title,
+        output.text,
+        output.failed,
+        pending.childRecord.summary.sessionId,
+      ),
+      pending.childRecord.summary.worktreePath,
+      pending.childRecord.summary.worktreeBranch,
     );
 
     pending.childRecord.summary.status = output.failed ? 'failed' : 'completed';
@@ -3102,12 +3142,14 @@ export class AgentRuntime<
   private createChildRuntime(
     subagentSessionId: string,
     subagentTitle: string,
+    childToolExecutor?: AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget>['toolExecutor'],
   ): AgentRuntime<Config, State, ToolRequest, TrustTarget> {
+    const baseExecutor = childToolExecutor ?? this.options.toolExecutor;
     return new AgentRuntime<Config, State, ToolRequest, TrustTarget>(
       {
         ...this.options,
         toolExecutor: createSubagentToolExecutor(
-          this.options.toolExecutor,
+          baseExecutor,
           subagentSessionId,
           subagentTitle,
         ),
@@ -3353,6 +3395,7 @@ function extractRunSubagentRequest<ToolRequest>(request: ToolRequest): RunSubage
   const filesToInspect = readOptionalStringArrayField(value, 'files_to_inspect', 'filesToInspect');
   const expectedOutput = readOptionalStringField(value, 'expected_output', 'expectedOutput');
   const subagentType = readOptionalStringField(value, 'subagent_type', 'subagentType');
+  const worktree = value.worktree === true ? true : undefined;
 
   return {
     task,
@@ -3361,6 +3404,7 @@ function extractRunSubagentRequest<ToolRequest>(request: ToolRequest): RunSubage
     ...(contextSummary !== undefined ? { contextSummary } : {}),
     ...(filesToInspect !== undefined ? { filesToInspect } : {}),
     ...(expectedOutput !== undefined ? { expectedOutput } : {}),
+    ...(worktree !== undefined ? { worktree } : {}),
   };
 }
 

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -2821,7 +2821,11 @@ export class AgentRuntime<
     );
     this.childSessionsStore.push(record);
 
-    const subagentStartDenied = await this.runSubagentStartHook(sessionId, request);
+    const subagentStartDenied = await this.runSubagentStartHook(
+      sessionId,
+      request,
+      childWorkspaceRoot,
+    );
     if (subagentStartDenied) {
       record.summary.status = 'failed';
       record.summary.updatedAtUnixMs = Date.now();
@@ -3078,7 +3082,11 @@ export class AgentRuntime<
       delete pending.childRecord.summary.error;
     }
 
-    await this.runSubagentEndHook(pending, output);
+    await this.runSubagentEndHook(
+      pending,
+      output,
+      pending.childRecord.summary.worktreePath,
+    );
 
     const finishedExecution = {
       toolCallId: pending.parentToolCallId,
@@ -3175,6 +3183,7 @@ export class AgentRuntime<
   private async runSubagentStartHook(
     subagentSessionId: string,
     request: RunSubagentRequest,
+    hookWorkspaceRoot?: string,
   ): Promise<string | undefined> {
     const hookRunner = resolveHookRunner(this.options);
     if (!hookRunner) {
@@ -3182,10 +3191,11 @@ export class AgentRuntime<
     }
 
     const context = resolveHookSessionContext(this.options);
+    const workspaceRoot = hookWorkspaceRoot?.trim() || context.workspaceRoot;
     const result = await hookRunner.runSubagentStart({
       sessionId: context.sessionId,
       conversationPath: context.conversationPath,
-      workspaceRoot: context.workspaceRoot,
+      workspaceRoot,
       model: context.model,
       subagentSessionId,
       subagentType: request.subagentType ?? 'generalPurpose',
@@ -3208,6 +3218,7 @@ export class AgentRuntime<
   >(
     pending: Pending,
     output: { text: string; failed: boolean },
+    hookWorkspaceRoot?: string,
   ): Promise<void> {
     const hookRunner = resolveHookRunner(this.options);
     if (!hookRunner) {
@@ -3216,10 +3227,11 @@ export class AgentRuntime<
 
     const subagentRequest = extractRunSubagentRequest(pending.parentRequest);
     const context = resolveHookSessionContext(this.options);
+    const workspaceRoot = hookWorkspaceRoot?.trim() || context.workspaceRoot;
     const result = await hookRunner.runSubagentEnd({
       sessionId: context.sessionId,
       conversationPath: context.conversationPath,
-      workspaceRoot: context.workspaceRoot,
+      workspaceRoot,
       model: context.model,
       subagentSessionId: pending.childRecord.summary.sessionId,
       subagentType: subagentRequest?.subagentType ?? 'generalPurpose',

--- a/packages/agent-core/src/runtime/subagent-workspace-scope.test.ts
+++ b/packages/agent-core/src/runtime/subagent-workspace-scope.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { scopeAgentRuntimeOptionsForSubagentWorkspace } from './subagent-workspace-scope.js';
+import type { AgentRuntimeOptions, PendingWorkspaceFile } from './types.js';
+
+type TestState = { messages: unknown[]; steps: number };
+
+function baseOptions(
+  overrides: Partial<AgentRuntimeOptions<undefined, TestState, unknown>> = {},
+): AgentRuntimeOptions<undefined, TestState, unknown> {
+  return {
+    config: undefined,
+    llmTransport: {} as AgentRuntimeOptions<undefined, TestState, unknown>['llmTransport'],
+    toolExecutor: {} as AgentRuntimeOptions<undefined, TestState, unknown>['toolExecutor'],
+    createToolAgentState: () => ({ messages: [], steps: 0 }),
+    appendToolResultMessage: (state) => state,
+    extractAssistantText: () => undefined,
+    ...overrides,
+  };
+}
+
+test('scopeAgentRuntimeOptionsForSubagentWorkspace rebinds appendUserLlmMessage workspace root', () => {
+  let parentCalled = false;
+  const options = baseOptions({
+    appendUserLlmMessage: () => {
+      parentCalled = true;
+      return { messages: [], steps: 0 };
+    },
+  });
+
+  const scoped = scopeAgentRuntimeOptionsForSubagentWorkspace(
+    options,
+    'D:\\repo.worktrees\\spirit-a',
+  );
+  scoped.appendUserLlmMessage?.(
+    { messages: [], steps: 0 },
+    { role: 'user', content: 'hi' },
+  );
+  assert.equal(parentCalled, false);
+});
+
+test('scopeAgentRuntimeOptionsForSubagentWorkspace uses resolveWorkspaceFilesForRoot when provided', async () => {
+  const sampleFile: PendingWorkspaceFile = {
+    kind: 'text',
+    path: 'scoped/README.md',
+    totalChars: 4,
+    truncated: false,
+    attachedAtUnixMs: 1,
+    content: 'body',
+  };
+  const options = baseOptions({
+    resolveWorkspaceFilesForRoot: (workspaceRoot, userInput) => [
+      { ...sampleFile, path: `${workspaceRoot}/${userInput}` },
+    ],
+    resolveWorkspaceFilesFromInput: () => [{ ...sampleFile, path: 'parent/wrong' }],
+  });
+
+  const scoped = scopeAgentRuntimeOptionsForSubagentWorkspace(
+    options,
+    'D:\\repo.worktrees\\spirit-a',
+  );
+  const files = await scoped.resolveWorkspaceFilesFromInput?.('README.md');
+  assert.deepEqual(files, [{ ...sampleFile, path: 'D:\\repo.worktrees\\spirit-a/README.md' }]);
+});

--- a/packages/agent-core/src/runtime/subagent-workspace-scope.test.ts
+++ b/packages/agent-core/src/runtime/subagent-workspace-scope.test.ts
@@ -20,24 +20,17 @@ function baseOptions(
   };
 }
 
-test('scopeAgentRuntimeOptionsForSubagentWorkspace rebinds appendUserLlmMessage workspace root', () => {
-  let parentCalled = false;
+test('scopeAgentRuntimeOptionsForSubagentWorkspace replaces appendUserLlmMessage callback', () => {
   const options = baseOptions({
-    appendUserLlmMessage: () => {
-      parentCalled = true;
-      return { messages: [], steps: 0 };
-    },
+    appendUserLlmMessage: (state) => state,
   });
 
   const scoped = scopeAgentRuntimeOptionsForSubagentWorkspace(
     options,
     'D:\\repo.worktrees\\spirit-a',
   );
-  scoped.appendUserLlmMessage?.(
-    { messages: [], steps: 0 },
-    { role: 'user', content: 'hi' },
-  );
-  assert.equal(parentCalled, false);
+  assert.notEqual(scoped.appendUserLlmMessage, options.appendUserLlmMessage);
+  assert.equal(typeof scoped.appendUserLlmMessage, 'function');
 });
 
 test('scopeAgentRuntimeOptionsForSubagentWorkspace uses resolveWorkspaceFilesForRoot when provided', async () => {

--- a/packages/agent-core/src/runtime/subagent-workspace-scope.ts
+++ b/packages/agent-core/src/runtime/subagent-workspace-scope.ts
@@ -1,0 +1,66 @@
+import {
+  patchBasicInfoWorkspaceRootInToolAgentState,
+  type ToolAgentState,
+} from '../tool-agent.js';
+import type { AgentRuntimeOptions } from './types.js';
+
+function isToolAgentLikeState(state: unknown): state is ToolAgentState {
+  return (
+    typeof state === 'object'
+    && state !== null
+    && 'messages' in state
+    && Array.isArray((state as ToolAgentState).messages)
+    && typeof (state as ToolAgentState).steps === 'number'
+  );
+}
+
+function patchConfigWorkspaceRoot<Config>(config: Config, scopedRoot: string): Config {
+  if (typeof config !== 'object' || config === null || !('workspaceRoot' in config)) {
+    return config;
+  }
+  return { ...(config as Record<string, unknown>), workspaceRoot: scopedRoot } as Config;
+}
+
+function patchStateWorkspaceRoot<State>(state: State, scopedRoot: string): State {
+  if (!isToolAgentLikeState(state)) {
+    return state;
+  }
+  return patchBasicInfoWorkspaceRootInToolAgentState(state, scopedRoot) as State;
+}
+
+/** Child subagent runtimes must not inherit the parent workspace in system basic info or transport config. */
+export function scopeAgentRuntimeOptionsForSubagentWorkspace<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget,
+>(
+  options: AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget>,
+  scopedWorkspaceRoot: string,
+): AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget> {
+  const scopedRoot = scopedWorkspaceRoot.trim();
+  if (!scopedRoot) {
+    return options;
+  }
+
+  const scopeState = (state: State): State => patchStateWorkspaceRoot(state, scopedRoot);
+
+  return {
+    ...options,
+    config: patchConfigWorkspaceRoot(options.config, scopedRoot),
+    ...(options.hookSessionContext
+      ? { hookSessionContext: { ...options.hookSessionContext, workspaceRoot: scopedRoot } }
+      : {}),
+    createToolAgentState: (history, userInput) =>
+      scopeState(options.createToolAgentState(history, userInput)),
+    ...(options.createContinuationState
+      ? { createContinuationState: (history) => scopeState(options.createContinuationState!(history)) }
+      : {}),
+    ...(options.rebuildRetryStateAfterCompaction
+      ? {
+          rebuildRetryStateAfterCompaction: (history, userInput, retryState) =>
+            scopeState(options.rebuildRetryStateAfterCompaction!(history, userInput, retryState)),
+        }
+      : {}),
+  };
+}

--- a/packages/agent-core/src/runtime/subagent-workspace-scope.ts
+++ b/packages/agent-core/src/runtime/subagent-workspace-scope.ts
@@ -1,8 +1,10 @@
+import { appendLlmUserLlmMessage } from '../llm-tool-agent.js';
 import {
   patchBasicInfoWorkspaceRootInToolAgentState,
   type ToolAgentState,
 } from '../tool-agent.js';
 import type { AgentRuntimeOptions } from './types.js';
+import { pendingWorkspaceFilesFromInput } from './helpers.js';
 
 function isToolAgentLikeState(state: unknown): state is ToolAgentState {
   return (
@@ -62,5 +64,22 @@ export function scopeAgentRuntimeOptionsForSubagentWorkspace<
             scopeState(options.rebuildRetryStateAfterCompaction!(history, userInput, retryState)),
         }
       : {}),
+    ...(options.appendUserLlmMessage
+      ? {
+          appendUserLlmMessage: (state, message) =>
+            appendLlmUserLlmMessage(state as ToolAgentState, message, scopedRoot) as State,
+        }
+      : {}),
+    ...(options.resolveWorkspaceFilesForRoot
+      ? {
+          resolveWorkspaceFilesFromInput: (userInput) =>
+            options.resolveWorkspaceFilesForRoot!(scopedRoot, userInput),
+        }
+      : options.resolveWorkspaceFilesFromInput
+        ? {
+            resolveWorkspaceFilesFromInput: (userInput) =>
+              pendingWorkspaceFilesFromInput(scopedRoot, userInput),
+          }
+        : {}),
   };
 }

--- a/packages/agent-core/src/runtime/subagent-worktree-meta.test.ts
+++ b/packages/agent-core/src/runtime/subagent-worktree-meta.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  formatSubagentWorktreeMetaLine,
+  prependSubagentWorktreeMeta,
+} from './subagent-worktree-meta.js';
+
+test('formatSubagentWorktreeMetaLine uses subagent_worktree_at tags', () => {
+  const line = formatSubagentWorktreeMetaLine('/repo.worktrees/spirit-a', 'spirit/a');
+  assert.equal(line, '<subagent_worktree_at>path=/repo.worktrees/spirit-a,branch=spirit/a</subagent_worktree_at>');
+});
+
+test('prependSubagentWorktreeMeta prepends meta line when path and branch provided', () => {
+  const text = prependSubagentWorktreeMeta(
+    '[subagent completed]\ntitle=Task',
+    '/repo.worktrees/spirit-a',
+    'spirit/a',
+  );
+  assert.ok(text.startsWith('<subagent_worktree_at>'));
+  assert.ok(text.includes('[subagent completed]'));
+});
+
+test('prependSubagentWorktreeMeta leaves text unchanged without worktree fields', () => {
+  const body = '[subagent completed]\ntitle=Task';
+  assert.equal(prependSubagentWorktreeMeta(body), body);
+});

--- a/packages/agent-core/src/runtime/subagent-worktree-meta.ts
+++ b/packages/agent-core/src/runtime/subagent-worktree-meta.ts
@@ -1,0 +1,20 @@
+/** Worktree path/branch anchor for subagent tool results (mirrors user_message_at style). */
+const SUBAGENT_WORKTREE_OPEN = '<subagent_worktree_at>';
+const SUBAGENT_WORKTREE_CLOSE = '</subagent_worktree_at>';
+
+export function formatSubagentWorktreeMetaLine(worktreePath: string, branchName: string): string {
+  return `${SUBAGENT_WORKTREE_OPEN}path=${worktreePath},branch=${branchName}${SUBAGENT_WORKTREE_CLOSE}`;
+}
+
+export function prependSubagentWorktreeMeta(
+  text: string,
+  worktreePath?: string,
+  branchName?: string,
+): string {
+  const path = worktreePath?.trim();
+  const branch = branchName?.trim();
+  if (!path || !branch) {
+    return text;
+  }
+  return `${formatSubagentWorktreeMetaLine(path, branch)}\n${text}`;
+}

--- a/packages/agent-core/src/runtime/types.ts
+++ b/packages/agent-core/src/runtime/types.ts
@@ -418,6 +418,11 @@ export interface AgentRuntimeOptions<
   resolveWorkspaceFilesFromInput?: (
     userInput: string,
   ) => Promise<PendingWorkspaceFile[]> | PendingWorkspaceFile[];
+  /** Host-provided resolver used when scoping child subagent runtimes to a different workspace root. */
+  resolveWorkspaceFilesForRoot?: (
+    workspaceRoot: string,
+    userInput: string,
+  ) => Promise<PendingWorkspaceFile[]> | PendingWorkspaceFile[];
   bootstrapSubagentWorkspace?: SubagentWorkspaceBootstrap<ToolRequest, TrustTarget>;
 }
 

--- a/packages/agent-core/src/runtime/types.ts
+++ b/packages/agent-core/src/runtime/types.ts
@@ -210,6 +210,8 @@ export interface RuntimeSubagentSessionSummary {
   latestMessage?: string;
   finalOutput?: string;
   error?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
 }
 
 export interface RuntimeSubagentSessionArchiveEntry extends SubagentSessionArchiveEntry {
@@ -416,7 +418,34 @@ export interface AgentRuntimeOptions<
   resolveWorkspaceFilesFromInput?: (
     userInput: string,
   ) => Promise<PendingWorkspaceFile[]> | PendingWorkspaceFile[];
+  bootstrapSubagentWorkspace?: SubagentWorkspaceBootstrap<ToolRequest, TrustTarget>;
 }
+
+export interface SubagentWorkspaceBootstrapInput {
+  subagentSessionId: string;
+  task: string;
+  worktree: boolean;
+  parentWorkspaceRoot: string;
+}
+
+export type SubagentWorkspaceBootstrapResult<
+  ToolRequest = unknown,
+  TrustTarget = string,
+> =
+  | {
+      workspaceRoot: string;
+      worktreePath?: string;
+      branchName?: string;
+      toolExecutor?: ToolExecutor<ToolRequest, TrustTarget>;
+    }
+  | { error: string };
+
+export type SubagentWorkspaceBootstrap<
+  ToolRequest = unknown,
+  TrustTarget = string,
+> = (
+  input: SubagentWorkspaceBootstrapInput,
+) => Promise<SubagentWorkspaceBootstrapResult<ToolRequest, TrustTarget>>;
 
 export interface RuntimeTurnContext<ToolRequest> {
   requestTrace: JsonValue[];

--- a/packages/agent-core/src/tool-agent-basic-info-scope.test.ts
+++ b/packages/agent-core/src/tool-agent-basic-info-scope.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  patchBasicInfoWorkspaceRootInMessages,
+} from './tool-agent.js';
+
+test('patchBasicInfoWorkspaceRootInMessages rewrites Current workspace line', () => {
+  const messages = [
+    {
+      role: 'system',
+      content: [
+        '[SPIRIT_BASIC_INFO]',
+        'Basic information',
+        '',
+        'Current workspace:',
+        '- D:\\\\SpiritAgent',
+        '',
+        'Current terminal:',
+        '- powershell',
+      ].join('\n'),
+    },
+  ];
+
+  const patched = patchBasicInfoWorkspaceRootInMessages(
+    messages,
+    'D:\\SpiritAgent.worktrees\\spirit-read-readme',
+  );
+
+  assert.match(
+    String((patched[0] as { content: string }).content),
+    /Current workspace:\n- D:\\SpiritAgent\.worktrees\\spirit-read-readme/,
+  );
+});

--- a/packages/agent-core/src/tool-agent-basic-info-scope.test.ts
+++ b/packages/agent-core/src/tool-agent-basic-info-scope.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   patchBasicInfoWorkspaceRootInMessages,
+  patchBasicInfoWorkspaceRootInSystemText,
 } from './tool-agent.js';
 
 test('patchBasicInfoWorkspaceRootInMessages rewrites Current workspace line', () => {
@@ -31,4 +32,19 @@ test('patchBasicInfoWorkspaceRootInMessages rewrites Current workspace line', ()
     String((patched[0] as { content: string }).content),
     /Current workspace:\n- D:\\SpiritAgent\.worktrees\\spirit-read-readme/,
   );
+});
+
+test('patchBasicInfoWorkspaceRootInSystemText handles CRLF workspace lines', () => {
+  const content = [
+    '[SPIRIT_BASIC_INFO]',
+    'Basic information',
+    '',
+    'Current workspace:',
+    '- D:\\SpiritAgent',
+  ].join('\r\n');
+  const patched = patchBasicInfoWorkspaceRootInSystemText(
+    content,
+    'D:\\SpiritAgent.worktrees\\spirit-read-readme',
+  );
+  assert.match(patched, /Current workspace:\r?\n- D:\\SpiritAgent\.worktrees\\spirit-read-readme/);
 });

--- a/packages/agent-core/src/tool-agent.ts
+++ b/packages/agent-core/src/tool-agent.ts
@@ -812,6 +812,51 @@ export function buildBasicInfoSystemMessage(
   return lines.join('\n').trimEnd();
 }
 
+export function patchBasicInfoWorkspaceRootInMessages(
+  messages: JsonValue[],
+  workspaceRoot: string,
+): JsonValue[] {
+  const normalized = workspaceRoot.trim();
+  if (!normalized) {
+    return messages;
+  }
+
+  let changed = false;
+  const next = messages.map((message) => {
+    if (!isJsonObject(message) || message.role !== 'system' || typeof message.content !== 'string') {
+      return message;
+    }
+    if (!message.content.includes(BASIC_INFO_SECTION_PREFIX)) {
+      return message;
+    }
+    const nextContent = message.content.replace(
+      /Current workspace:\n- [^\n]+/,
+      `Current workspace:\n- ${normalized}`,
+    );
+    if (nextContent === message.content) {
+      return message;
+    }
+    changed = true;
+    return { ...message, content: nextContent };
+  });
+  return changed ? next : messages;
+}
+
+export function patchBasicInfoWorkspaceRootInToolAgentState(
+  state: ToolAgentState,
+  workspaceRoot: string,
+): ToolAgentState {
+  const normalized = workspaceRoot.trim();
+  if (!normalized) {
+    return state;
+  }
+  const messages = patchBasicInfoWorkspaceRootInMessages(state.messages, normalized);
+  if (messages === state.messages) {
+    return state;
+  }
+  return { ...state, messages };
+}
+
 export function hasDreamsSystemMessage(content: string): boolean {
   return content.includes(DREAMS_SECTION_PREFIX);
 }

--- a/packages/agent-core/src/tool-agent.ts
+++ b/packages/agent-core/src/tool-agent.ts
@@ -829,10 +829,7 @@ export function patchBasicInfoWorkspaceRootInMessages(
     if (!message.content.includes(BASIC_INFO_SECTION_PREFIX)) {
       return message;
     }
-    const nextContent = message.content.replace(
-      /Current workspace:\n- [^\n]+/,
-      `Current workspace:\n- ${normalized}`,
-    );
+    const nextContent = patchBasicInfoWorkspaceRootInSystemText(message.content, normalized);
     if (nextContent === message.content) {
       return message;
     }
@@ -840,6 +837,23 @@ export function patchBasicInfoWorkspaceRootInMessages(
     return { ...message, content: nextContent };
   });
   return changed ? next : messages;
+}
+
+/** Matches the Current workspace block emitted by buildBasicInfoSystemMessage. */
+export function patchBasicInfoWorkspaceRootInSystemText(
+  content: string,
+  workspaceRoot: string,
+): string {
+  const normalized = workspaceRoot.trim();
+  if (!normalized || !content.includes(BASIC_INFO_SECTION_PREFIX)) {
+    return content;
+  }
+
+  const workspaceBlock = /Current workspace:\r?\n- [^\r\n]*/;
+  if (!workspaceBlock.test(content)) {
+    return content;
+  }
+  return content.replace(workspaceBlock, `Current workspace:\n- ${normalized}`);
 }
 
 export function patchBasicInfoWorkspaceRootInToolAgentState(

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -230,6 +230,7 @@ export interface RunSubagentRequest {
   context_summary?: string;
   files_to_inspect: string[];
   expected_output?: string;
+  worktree?: boolean;
 }
 
 export type ApplyPatchOperationType = 'create_file' | 'update_file' | 'delete_file';
@@ -260,6 +261,7 @@ export type HostToolRequest<QuestionSpec = HostAskQuestionsQuestionSpec> =
       context_summary?: string;
       files_to_inspect: string[];
       expected_output?: string;
+      worktree?: boolean;
     }
   | {
       name: 'generate_image';
@@ -708,6 +710,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
           const successCriteria = optionalStringStrict(parsed, 'success_criteria');
           const contextSummary = optionalStringStrict(parsed, 'context_summary');
           const expectedOutput = optionalStringStrict(parsed, 'expected_output');
+          const worktree = optionalBoolean(parsed, 'worktree');
         return {
           name,
           task: requiredString(parsed, 'task'),
@@ -715,6 +718,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
           ...(contextSummary ? { context_summary: contextSummary } : {}),
           files_to_inspect: optionalStringArrayStrict(parsed, 'files_to_inspect'),
           ...(expectedOutput ? { expected_output: expectedOutput } : {}),
+          ...(worktree === true ? { worktree: true } : {}),
         };
         }
       case 'generate_image':


### PR DESCRIPTION
## Summary

- 为 `run_subagent` 增加 `worktree: true` 参数，支持在独立 git worktree 中运行子 Agent，同轮可并行多个工具块，父 turn 仍阻塞等待全部完成。
- agent-core 实现 bootstrap 回调、子 runtime 工作区 scope、worktree 结果 meta，以及 host-bridge CLI bootstrap。
- Desktop 实现 worktree 命名、bootstrap、scoped tool executor，并修复子会话 basic info、hook 上下文、审批继承与 bootstrap 失败回滚。

## Test plan

- [x] `packages/agent-core`: `npm run build`
- [x] `node --test` 覆盖 subagent-worktree-meta、tool-agent-basic-info-scope、subagent-workspace-scope 单测
- [x] `apps/desktop`: `npx tsc --noEmit`
- [x] 确认无 Concurrent / sleep / read_subagent 残留；`run_subagent` 保持阻塞批处理语义
