### PR TITLE
feat(desktop): 加速工作区文件树目录展开

### DIFF
--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -369,7 +369,12 @@ export function WorkspaceFilesPanel({
 
   const loadDir = useCallback(
     async (rel: string) => {
-      setCache((c) => ({ ...c, [rel]: { status: "loading" } }));
+      setCache((c) => {
+        if (c[rel]?.status === "ready") {
+          return c;
+        }
+        return { ...c, [rel]: { status: "loading" } };
+      });
       try {
         const { entries } = await listExplorerChildren(rel);
         setCache((c) => ({ ...c, [rel]: { status: "ready", entries } }));

--- a/apps/desktop/src/host/workspace-files.ts
+++ b/apps/desktop/src/host/workspace-files.ts
@@ -104,7 +104,9 @@ export async function listWorkspaceExplorerChildren(
   const normalizedParent = relativePath.replace(/\\/g, '/').trim();
   let ignoreFlags: boolean[];
   try {
-    ignoreFlags = await resolveWorkspaceExplorerIgnoreFlags(workspaceRoot, normalizedParent, entries);
+    ignoreFlags = await resolveWorkspaceExplorerIgnoreFlags(workspaceRoot, normalizedParent, entries, {
+      preferInProcess: true,
+    });
   } catch {
     ignoreFlags = entries.map(() => false);
   }

--- a/packages/host-internal/src/workspace-ignore.test.ts
+++ b/packages/host-internal/src/workspace-ignore.test.ts
@@ -93,3 +93,26 @@ test('resolveWorkspaceExplorerIgnoreFlags returns empty array for empty entries'
     assert.deepEqual(flags, []);
   });
 });
+
+test('resolveWorkspaceExplorerIgnoreFlags preferInProcess matches gitignore rules in repositories', async () => {
+  await withTempWorkspace(async (root) => {
+    await initGitRepo(root);
+    await writeFile(join(root, '.gitignore'), 'node_modules/\n.env\n', 'utf8');
+    await mkdir(join(root, 'node_modules'), { recursive: true });
+    await writeFile(join(root, '.env'), 'SECRET=1\n', 'utf8');
+    await writeFile(join(root, 'src.ts'), 'export {}\n', 'utf8');
+
+    const flags = await resolveWorkspaceExplorerIgnoreFlags(
+      root,
+      '',
+      [
+        { name: 'node_modules', kind: 'dir' },
+        { name: '.env', kind: 'file' },
+        { name: 'src.ts', kind: 'file' },
+      ],
+      { preferInProcess: true },
+    );
+
+    assert.deepEqual(flags, [true, true, false]);
+  });
+});

--- a/packages/host-internal/src/workspace-ignore.ts
+++ b/packages/host-internal/src/workspace-ignore.ts
@@ -42,13 +42,36 @@ function explorerEntryGitCheckIgnorePath(
   return entry.kind === 'dir' ? `${relativePath}/` : relativePath;
 }
 
+export interface ResolveWorkspaceExplorerIgnoreFlagsOptions {
+  /** Explorer 热路径：优先走内存 ignore 匹配，避免每次 spawn git check-ignore。 */
+  preferInProcess?: boolean;
+}
+
 export async function resolveWorkspaceExplorerIgnoreFlags(
   workspaceRoot: string,
   parentRelPath: string,
   entries: readonly WorkspaceExplorerIgnoreEntry[],
+  options?: ResolveWorkspaceExplorerIgnoreFlagsOptions,
 ): Promise<boolean[]> {
   if (entries.length === 0) {
     return [];
+  }
+
+  if (options?.preferInProcess === true) {
+    try {
+      return await resolveViaIgnoreLibrary(workspaceRoot, parentRelPath, entries);
+    } catch {
+      // 非阻塞：内存匹配失败时回退 git。
+    }
+    try {
+      const viaGit = await resolveViaGitCheckIgnore(workspaceRoot, parentRelPath, entries);
+      if (viaGit !== null) {
+        return viaGit;
+      }
+    } catch {
+      // 非阻塞
+    }
+    return entries.map(() => false);
   }
 
   try {


### PR DESCRIPTION
## Summary

- Explorer 列目录启用 `preferInProcess` ignore 匹配，避免每次展开 spawn `git check-ignore`（约 65–80ms/次）
- 背景刷新已缓存目录时，`loadDir` 不再将 ready 态误切为 loading，减少展开闪烁

## Test plan

- [x] 手动展开多个目录（含 `packages`、`apps` 等），首次展开明显更快
- [x] 重复展开已缓存目录，子项即时显示（约 30ms 级）
- [x] `packages/host-internal` workspace-ignore 单测通过（含 `preferInProcess` 用例）
- [x] git 仓库内 ignore 着色与修复前一致（如 `node_modules` 仍显示为 ignored）
