### PR TITLE
feat(acp-server): ACP Terminal Auth 与共享凭据集成

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ npm run dev:cli    # build TS packages, then cargo run -p spirit-agent
 
 [`packages/acp-server`](packages/acp-server) is a thin adapter that exposes Spirit Agent as an [Agent Client Protocol](https://agentclientprotocol.com) (ACP) server over stdio / ndJSON. Any ACP-compatible editor — such as **Zed** or **JetBrains Junie** — can connect to Spirit Agent as its AI coding engine without bespoke integration.
 
-- **Protocol surface** — `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/close`, `session/set_mode`.
+- **Terminal Auth** — `initialize` advertises a `type: "terminal"` auth method; clients run `spirit-agent-acp --setup` for interactive provider configuration, then call `authenticate` before `session/new`.
+- **Protocol surface** — `initialize`, `authenticate`, `logout`, `session/new`, `session/prompt`, `session/cancel`, `session/close`, `session/set_mode`.
 - **Streaming & thinking** — real-time `agent_message_chunk` streaming and `agent_thought_chunk` for model reasoning output.
 - **Permission bridge** — tool approval via ACP `request_permission` with allow-once / always-allow / reject options.
 - **Slash commands** — workspace and user Skills are advertised as `available_commands_update`; typing `/skill-name` activates the skill and injects its instructions into the system prompt.
@@ -124,9 +125,32 @@ npm run dev:cli    # build TS packages, then cargo run -p spirit-agent
 
 ### Quick start (Zed)
 
-1. Set `SPIRIT_ACP_API_KEY` as a **user or system environment variable** (Zed inherits it when spawning the agent process). Do **not** use `${SPIRIT_ACP_API_KEY}` in `settings.json` — Zed does not expand that syntax and will pass the literal string as the key.
-2. Build the server: `npm run build:acp-server`
-3. Add to your Zed `settings.json`:
+**Option A — Terminal Auth (ACP registry compatible)**
+
+1. Build the server: `npm run build:acp-server`
+2. Add to your Zed `settings.json` (no API key in `env`):
+
+```json
+"agent_servers": {
+  "Spirit Agent": {
+    "command": "node",
+    "args": ["path/to/packages/acp-server/dist/src/stdio-entry.js"]
+  }
+}
+```
+
+3. When the client prompts for authentication, choose **Run in terminal**. It spawns `--setup`, where you pick a provider, enter credentials, and select a model.
+4. Setup writes to the shared Spirit data directory (`config.json` + OS keyring — same store as Desktop/CLI). After setup completes, the client calls `authenticate`, then `session/new`.
+
+Manual setup (outside the editor):
+
+```bash
+node path/to/packages/acp-server/dist/src/stdio-entry.js --setup
+```
+
+**Option B — Environment variable override (legacy)**
+
+Set `SPIRIT_ACP_API_KEY` as a **user or system environment variable** (Zed inherits it when spawning the agent). Do **not** use `${SPIRIT_ACP_API_KEY}` in `settings.json` — Zed does not expand that syntax.
 
 ```json
 "agent_servers": {
@@ -141,14 +165,17 @@ npm run dev:cli    # build TS packages, then cargo run -p spirit-agent
 }
 ```
 
-Omit `SPIRIT_ACP_API_KEY` from `env` so the process inherits your user/system variable. Alternatively, put the key directly in `env` as a literal string (less ideal for shared configs).
+When `SPIRIT_ACP_API_KEY` is present at spawn time, the process is pre-authenticated and env settings override the shared config.
 
 | Environment variable | Required | Description |
 | --- | --- | --- |
-| `SPIRIT_ACP_API_KEY` | Yes | LLM provider API key — set as user/system env var, or literal in `env` |
-| `SPIRIT_ACP_MODEL` | No | Model name (default: `gpt-4.1-mini`) |
-| `SPIRIT_ACP_BASE_URL` | No | Custom LLM endpoint URL |
+| `SPIRIT_ACP_API_KEY` | No* | LLM API key — pre-authenticates when set; overrides shared config |
+| `SPIRIT_ACP_MODEL` | No | Model name when using env override (default: `gpt-4.1-mini`) |
+| `SPIRIT_ACP_BASE_URL` | No | Custom LLM endpoint URL when using env override |
 | `SPIRIT_ACP_WORKSPACE` | No | Workspace root (default: `cwd` from client) |
+| `SPIRIT_ACP_DATA_DIR` | No | Spirit data directory (default: `%APPDATA%/SpiritAgent` or `~/.spirit-agent`) |
+
+\*Required only for Option B, or omitted when using Terminal Auth + `--setup`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ npm run dev:cli    # build TS packages, then cargo run -p spirit-agent
 
 ### Quick start (Zed)
 
-**Option A — Terminal Auth (ACP registry compatible)**
-
 1. Build the server: `npm run build:acp-server`
 2. Add to your Zed `settings.json` (no API key in `env`):
 
@@ -148,34 +146,10 @@ Manual setup (outside the editor):
 node path/to/packages/acp-server/dist/src/stdio-entry.js --setup
 ```
 
-**Option B — Environment variable override (legacy)**
-
-Set `SPIRIT_ACP_API_KEY` as a **user or system environment variable** (Zed inherits it when spawning the agent). Do **not** use `${SPIRIT_ACP_API_KEY}` in `settings.json` — Zed does not expand that syntax.
-
-```json
-"agent_servers": {
-  "Spirit Agent": {
-    "command": "node",
-    "args": ["path/to/packages/acp-server/dist/src/stdio-entry.js"],
-    "env": {
-      "SPIRIT_ACP_MODEL": "gpt-4.1-mini",
-      "SPIRIT_ACP_BASE_URL": "https://api.openai.com/v1"
-    }
-  }
-}
-```
-
-When `SPIRIT_ACP_API_KEY` is present at spawn time, the process is pre-authenticated and env settings override the shared config.
-
 | Environment variable | Required | Description |
 | --- | --- | --- |
-| `SPIRIT_ACP_API_KEY` | No* | LLM API key — pre-authenticates when set; overrides shared config |
-| `SPIRIT_ACP_MODEL` | No | Model name when using env override (default: `gpt-4.1-mini`) |
-| `SPIRIT_ACP_BASE_URL` | No | Custom LLM endpoint URL when using env override |
 | `SPIRIT_ACP_WORKSPACE` | No | Workspace root (default: `cwd` from client) |
 | `SPIRIT_ACP_DATA_DIR` | No | Spirit data directory (default: `%APPDATA%/SpiritAgent` or `~/.spirit-agent`) |
-
-\*Required only for Option B, or omitted when using Terminal Auth + `--setup`.
 
 ## Development
 

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -121,8 +121,6 @@ npm run dev:cli    # 构建 TS 包，然后 cargo run -p spirit-agent
 
 ### 快速开始（Zed）
 
-**方式 A — Terminal Auth（符合 ACP 注册处要求）**
-
 1. 构建 server：`npm run build:acp-server`
 2. 在 Zed 的 `settings.json` 中添加（`env` 中无需 API Key）：
 
@@ -144,34 +142,10 @@ npm run dev:cli    # 构建 TS 包，然后 cargo run -p spirit-agent
 node path/to/packages/acp-server/dist/src/stdio-entry.js --setup
 ```
 
-**方式 B — 环境变量覆盖（旧版 Zed 配置）**
-
-将 `SPIRIT_ACP_API_KEY` 设为**用户或系统环境变量**。**不要**在 `settings.json` 里写 `${SPIRIT_ACP_API_KEY}`。
-
-```json
-"agent_servers": {
-  "Spirit Agent": {
-    "command": "node",
-    "args": ["path/to/packages/acp-server/dist/src/stdio-entry.js"],
-    "env": {
-      "SPIRIT_ACP_MODEL": "gpt-4.1-mini",
-      "SPIRIT_ACP_BASE_URL": "https://api.openai.com/v1"
-    }
-  }
-}
-```
-
-进程启动时若存在 `SPIRIT_ACP_API_KEY`，则视为已预认证，且 env 设置优先于共享 config。
-
 | 环境变量 | 必填 | 说明 |
 | --- | --- | --- |
-| `SPIRIT_ACP_API_KEY` | 否* | LLM API 密钥 — 设置则预认证并覆盖共享 config |
-| `SPIRIT_ACP_MODEL` | 否 | 使用 env 覆盖时的模型名（默认：`gpt-4.1-mini`） |
-| `SPIRIT_ACP_BASE_URL` | 否 | 使用 env 覆盖时的 LLM 端点 URL |
 | `SPIRIT_ACP_WORKSPACE` | 否 | 工作区根路径（默认：客户端 `cwd`） |
 | `SPIRIT_ACP_DATA_DIR` | 否 | Spirit 数据目录（默认：`%APPDATA%/SpiritAgent` 或 `~/.spirit-agent`） |
-
-\*方式 B 必填；使用 Terminal Auth + `--setup` 时可省略。
 
 ## 开发
 

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -112,7 +112,8 @@ npm run dev:cli    # 构建 TS 包，然后 cargo run -p spirit-agent
 
 [`packages/acp-server`](../packages/acp-server) 是一个薄适配层，通过 stdio / ndJSON 将 Spirit Agent 以 [Agent Client Protocol](https://agentclientprotocol.com)（ACP）服务器的形式对外暴露。任何兼容 ACP 的编辑器 — 如 **Zed** 或 **JetBrains Junie** — 都可以直接接入 Spirit Agent 作为其 AI 编码引擎，无需定制集成。
 
-- **协议表面** — `initialize`、`session/new`、`session/prompt`、`session/cancel`、`session/close`、`session/set_mode`。
+- **Terminal Auth** — `initialize` 声明 `type: "terminal"` 认证方式；客户端可 spawn `spirit-agent-acp --setup` 进行交互式 provider 配置，随后 `authenticate`，再 `session/new`。
+- **协议表面** — `initialize`、`authenticate`、`logout`、`session/new`、`session/prompt`、`session/cancel`、`session/close`、`session/set_mode`。
 - **流式与思考** — 实时 `agent_message_chunk` 流式输出，以及 `agent_thought_chunk` 用于模型推理过程展示。
 - **权限桥接** — 通过 ACP `request_permission` 进行工具审批，支持 allow-once / always-allow / reject 选项。
 - **Slash 命令** — 工作区与用户级 Skills 通过 `available_commands_update` 注册为命令；输入 `/skill-name` 即可激活 Skill 并将其指令注入系统提示词。
@@ -120,9 +121,32 @@ npm run dev:cli    # 构建 TS 包，然后 cargo run -p spirit-agent
 
 ### 快速开始（Zed）
 
-1. 将 `SPIRIT_ACP_API_KEY` 设为**用户或系统环境变量**（Zed 启动 agent 子进程时会继承）。**不要**在 `settings.json` 里写 `${SPIRIT_ACP_API_KEY}` — Zed 不会展开该语法，会把字面量当作 API Key。
-2. 构建 server：`npm run build:acp-server`
-3. 在 Zed 的 `settings.json` 中添加：
+**方式 A — Terminal Auth（符合 ACP 注册处要求）**
+
+1. 构建 server：`npm run build:acp-server`
+2. 在 Zed 的 `settings.json` 中添加（`env` 中无需 API Key）：
+
+```json
+"agent_servers": {
+  "Spirit Agent": {
+    "command": "node",
+    "args": ["path/to/packages/acp-server/dist/src/stdio-entry.js"]
+  }
+}
+```
+
+3. 客户端提示认证时选择 **Run in terminal**，会 spawn `--setup`：选择 provider、填写凭据、选定模型。
+4. Setup 写入 Spirit 共享数据目录（`config.json` + 系统 keyring，与 Desktop/CLI 共用）。完成后客户端调用 `authenticate`，再 `session/new`。
+
+也可在编辑器外手动 setup：
+
+```bash
+node path/to/packages/acp-server/dist/src/stdio-entry.js --setup
+```
+
+**方式 B — 环境变量覆盖（旧版 Zed 配置）**
+
+将 `SPIRIT_ACP_API_KEY` 设为**用户或系统环境变量**。**不要**在 `settings.json` 里写 `${SPIRIT_ACP_API_KEY}`。
 
 ```json
 "agent_servers": {
@@ -137,14 +161,17 @@ npm run dev:cli    # 构建 TS 包，然后 cargo run -p spirit-agent
 }
 ```
 
-`env` 中省略 `SPIRIT_ACP_API_KEY`，让进程继承用户/系统环境变量；或在 `env` 里直接写密钥字面量（不适合提交到共享配置）。
+进程启动时若存在 `SPIRIT_ACP_API_KEY`，则视为已预认证，且 env 设置优先于共享 config。
 
 | 环境变量 | 必填 | 说明 |
 | --- | --- | --- |
-| `SPIRIT_ACP_API_KEY` | 是 | LLM 提供商 API 密钥 — 建议设为用户/系统环境变量，或在 `env` 中写明文 |
-| `SPIRIT_ACP_MODEL` | 否 | 模型名称（默认：`gpt-4.1-mini`） |
-| `SPIRIT_ACP_BASE_URL` | 否 | 自定义 LLM 端点 URL |
-| `SPIRIT_ACP_WORKSPACE` | 否 | 工作区根路径（默认：客户端传入的 `cwd`） |
+| `SPIRIT_ACP_API_KEY` | 否* | LLM API 密钥 — 设置则预认证并覆盖共享 config |
+| `SPIRIT_ACP_MODEL` | 否 | 使用 env 覆盖时的模型名（默认：`gpt-4.1-mini`） |
+| `SPIRIT_ACP_BASE_URL` | 否 | 使用 env 覆盖时的 LLM 端点 URL |
+| `SPIRIT_ACP_WORKSPACE` | 否 | 工作区根路径（默认：客户端 `cwd`） |
+| `SPIRIT_ACP_DATA_DIR` | 否 | Spirit 数据目录（默认：`%APPDATA%/SpiritAgent` 或 `~/.spirit-agent`） |
+
+\*方式 B 必填；使用 Terminal Auth + `--setup` 时可省略。
 
 ## 开发
 

--- a/packages/acp-server/package-lock.json
+++ b/packages/acp-server/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@spirit-agent/acp-server",
       "version": "0.2.0",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.25.0",
+        "@agentclientprotocol/sdk": "^0.25.1",
         "@spirit-agent/core": "file:../agent-core",
         "@spirit-agent/host-internal": "file:../host-internal"
       },
@@ -30,14 +30,19 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/alibaba": "^1.0.22",
+        "@ai-sdk/amazon-bedrock": "^4.0.117",
         "@ai-sdk/anthropic": "^2.0.79",
+        "@ai-sdk/azure": "^3.0.74",
         "@ai-sdk/deepseek": "^2.0.32",
         "@ai-sdk/gateway": "^3.0.121",
+        "@ai-sdk/google": "^3.0.82",
+        "@ai-sdk/google-vertex": "^3.0.142",
         "@ai-sdk/moonshotai": "^2.0.23",
         "@ai-sdk/open-responses": "^1.0.16",
         "@ai-sdk/openai": "^3.0.67",
         "@ai-sdk/openai-compatible": "^2.0.46",
         "@ai-sdk/xai": "^3.0.93",
+        "@aws/bedrock-token-generator": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.175",
         "undici": "^7.27.2"
@@ -55,10 +60,12 @@
       "name": "@spirit-agent/host-internal",
       "version": "0.2.0",
       "dependencies": {
+        "@aws-sdk/client-bedrock": "^3.1068.0",
         "@spirit-agent/core": "file:../agent-core",
         "fast-glob": "^3.3.3",
         "fflate": "^0.8.2",
         "glob": "^13.0.6",
+        "google-auth-library": "^10.6.1",
         "ignore": "^5.3.2",
         "spirit-agent-repo": "file:../..",
         "tar": "^7.5.13",
@@ -75,9 +82,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.0.tgz",
-      "integrity": "sha512-wU1VgXNtMvdVotX49txc3WJUDV+/QbLpsgjMvFhlRmp37osdLbI7L7y+iwAlQATwfjLxcv1r1p3ZxZBcXlGhcQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.1.tgz",
+      "integrity": "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/packages/acp-server/package-lock.json
+++ b/packages/acp-server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.25.1",
+        "@napi-rs/keyring": "^1.2.0",
         "@spirit-agent/core": "file:../agent-core",
         "@spirit-agent/host-internal": "file:../host-internal"
       },
@@ -106,6 +107,225 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@npmcli/fs": {

--- a/packages/acp-server/package-lock.json
+++ b/packages/acp-server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.25.1",
+        "@inquirer/prompts": "^7.5.0",
         "@napi-rs/keyring": "^1.2.0",
         "@spirit-agent/core": "file:../agent-core",
         "@spirit-agent/host-internal": "file:../host-internal"
@@ -89,6 +90,395 @@
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.3.2.tgz",
+      "integrity": "sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.23.tgz",
+      "integrity": "sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/external-editor": "^1.0.3",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.23.tgz",
+      "integrity": "sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
+      "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.3.1.tgz",
+      "integrity": "sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.23.tgz",
+      "integrity": "sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.23.tgz",
+      "integrity": "sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
+      "integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.3.2",
+        "@inquirer/confirm": "^5.1.21",
+        "@inquirer/editor": "^4.2.23",
+        "@inquirer/expand": "^4.0.23",
+        "@inquirer/input": "^4.3.1",
+        "@inquirer/number": "^3.0.23",
+        "@inquirer/password": "^4.0.23",
+        "@inquirer/rawlist": "^4.1.11",
+        "@inquirer/search": "^3.2.2",
+        "@inquirer/select": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.11.tgz",
+      "integrity": "sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.2.2.tgz",
+      "integrity": "sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.4.2.tgz",
+      "integrity": "sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -364,7 +754,7 @@
       "version": "25.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -397,7 +787,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -453,11 +842,25 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -470,7 +873,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -613,6 +1015,22 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -633,7 +1051,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -762,6 +1179,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -882,6 +1308,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
@@ -922,7 +1354,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -1153,7 +1584,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
@@ -1276,6 +1707,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/packages/acp-server/package.json
+++ b/packages/acp-server/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@spirit-agent/core": "file:../agent-core",
     "@spirit-agent/host-internal": "file:../host-internal",
-    "@agentclientprotocol/sdk": "^0.25.1"
+    "@agentclientprotocol/sdk": "^0.25.1",
+    "@napi-rs/keyring": "^1.2.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",

--- a/packages/acp-server/package.json
+++ b/packages/acp-server/package.json
@@ -22,6 +22,7 @@
     "@spirit-agent/core": "file:../agent-core",
     "@spirit-agent/host-internal": "file:../host-internal",
     "@agentclientprotocol/sdk": "^0.25.1",
+    "@inquirer/prompts": "^7.5.0",
     "@napi-rs/keyring": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/acp-server/package.json
+++ b/packages/acp-server/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@spirit-agent/core": "file:../agent-core",
     "@spirit-agent/host-internal": "file:../host-internal",
-    "@agentclientprotocol/sdk": "^0.25.0"
+    "@agentclientprotocol/sdk": "^0.25.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",

--- a/packages/acp-server/src/acp-agent.ts
+++ b/packages/acp-server/src/acp-agent.ts
@@ -12,6 +12,7 @@ import { handleApprovalRequest, handleQuestionsRequest } from './permission-brid
 import { buildAvailableCommands, parseSlashCommand, buildActiveSkillPayload, upsertActiveSkill } from './skill-bridge.js';
 import { extractPromptImages } from './prompt-images.js';
 import { SessionManager } from './session-manager.js';
+import { mapSessionSetupError } from './transport/map-setup-error.js';
 import { AVAILABLE_MODES } from './types.js';
 import type { AcpServerConfig } from './types.js';
 
@@ -77,10 +78,15 @@ export class SpiritAcpAgent implements acp.Agent {
 
     const workspaceRoot = params.cwd;
 
-    const result = await this.sessionManager.createSession(
-      workspaceRoot,
-      (sessionId, event) => this.handleRuntimeEvent(sessionId, event),
-    );
+    let result;
+    try {
+      result = await this.sessionManager.createSession(
+        workspaceRoot,
+        (sessionId, event) => this.handleRuntimeEvent(sessionId, event),
+      );
+    } catch (err) {
+      throw mapSessionSetupError(err);
+    }
 
     // Create fresh mapper state for this session
     this.mapperStates.set(result.sessionId, createEventMapperState());

--- a/packages/acp-server/src/acp-agent.ts
+++ b/packages/acp-server/src/acp-agent.ts
@@ -3,7 +3,7 @@ import type * as schema from '@agentclientprotocol/sdk';
 import { RequestError } from '@agentclientprotocol/sdk';
 import type { JsonValue, RuntimeEvent } from '@spirit-agent/core';
 import type { AuthState } from './auth/auth-state.js';
-import { buildAuthMethodsForStartup } from './auth/build-auth-methods.js';
+import { buildAuthMethods } from './auth/build-auth-methods.js';
 import { TERMINAL_AUTH_METHOD_ID } from './auth/constants.js';
 import { canCreateSession } from './auth/session-auth.js';
 import { hasResolvableCredentials } from './credentials/index.js';
@@ -40,7 +40,7 @@ export class SpiritAcpAgent implements acp.Agent {
   async initialize(
     _params: schema.InitializeRequest,
   ): Promise<schema.InitializeResponse> {
-    const authMethods = buildAuthMethodsForStartup(this.config.spiritDataDir);
+    const authMethods = buildAuthMethods();
 
     return {
       protocolVersion: 1, // PROTOCOL_VERSION

--- a/packages/acp-server/src/acp-agent.ts
+++ b/packages/acp-server/src/acp-agent.ts
@@ -8,6 +8,7 @@ import { mapRuntimeEventToUpdate, createEventMapperState, type EventMapperState 
 import { handleApprovalRequest, handleQuestionsRequest } from './permission-bridge.js';
 import { buildAvailableCommands, parseSlashCommand, buildActiveSkillPayload, upsertActiveSkill } from './skill-bridge.js';
 import { extractPromptImages } from './prompt-images.js';
+import type { AuthState } from './auth/auth-state.js';
 
 /**
  * Spirit Agent implementation of the ACP Agent interface.
@@ -18,14 +19,16 @@ export class SpiritAcpAgent implements acp.Agent {
   private readonly connection: acp.AgentSideConnection;
   private readonly config: AcpServerConfig;
   private readonly sessionManager: SessionManager;
+  private readonly authState: AuthState;
   /** Per-session event mapper state for tracking streaming deltas */
   private readonly mapperStates = new Map<string, EventMapperState>();
   /** Per-session prompt generation counter to prevent stale turn results */
   private readonly promptGenerations = new Map<string, number>();
 
-  constructor(connection: acp.AgentSideConnection, config: AcpServerConfig) {
+  constructor(connection: acp.AgentSideConnection, config: AcpServerConfig, authState: AuthState) {
     this.connection = connection;
     this.config = config;
+    this.authState = authState;
     this.sessionManager = new SessionManager(config);
   }
 

--- a/packages/acp-server/src/acp-agent.ts
+++ b/packages/acp-server/src/acp-agent.ts
@@ -1,14 +1,19 @@
 import type * as acp from '@agentclientprotocol/sdk';
 import type * as schema from '@agentclientprotocol/sdk';
+import { RequestError } from '@agentclientprotocol/sdk';
 import type { JsonValue, RuntimeEvent } from '@spirit-agent/core';
-import { AVAILABLE_MODES } from './types.js';
-import type { AcpServerConfig } from './types.js';
-import { SessionManager } from './session-manager.js';
+import type { AuthState } from './auth/auth-state.js';
+import { buildAuthMethods } from './auth/build-auth-methods.js';
+import { TERMINAL_AUTH_METHOD_ID } from './auth/constants.js';
+import { canCreateSession } from './auth/session-auth.js';
+import { hasResolvableCredentials } from './credentials/index.js';
 import { mapRuntimeEventToUpdate, createEventMapperState, type EventMapperState } from './event-mapper.js';
 import { handleApprovalRequest, handleQuestionsRequest } from './permission-bridge.js';
 import { buildAvailableCommands, parseSlashCommand, buildActiveSkillPayload, upsertActiveSkill } from './skill-bridge.js';
 import { extractPromptImages } from './prompt-images.js';
-import type { AuthState } from './auth/auth-state.js';
+import { SessionManager } from './session-manager.js';
+import { AVAILABLE_MODES } from './types.js';
+import type { AcpServerConfig } from './types.js';
 
 /**
  * Spirit Agent implementation of the ACP Agent interface.
@@ -39,6 +44,9 @@ export class SpiritAcpAgent implements acp.Agent {
       protocolVersion: 1, // PROTOCOL_VERSION
       agentCapabilities: {
         loadSession: false,
+        auth: {
+          logout: {},
+        },
         promptCapabilities: {
           image: true,
         },
@@ -51,13 +59,20 @@ export class SpiritAcpAgent implements acp.Agent {
         title: 'Spirit Agent',
         version: '0.2.0',
       },
-      authMethods: [],
+      authMethods: buildAuthMethods(),
     };
   }
 
   async newSession(
     params: schema.NewSessionRequest,
   ): Promise<schema.NewSessionResponse> {
+    if (!canCreateSession(this.config, this.authState)) {
+      throw RequestError.authRequired(
+        undefined,
+        'Authentication required before creating a session',
+      );
+    }
+
     const workspaceRoot = params.cwd;
 
     const result = await this.sessionManager.createSession(
@@ -103,9 +118,30 @@ export class SpiritAcpAgent implements acp.Agent {
   }
 
   async authenticate(
-    _params: schema.AuthenticateRequest,
+    params: schema.AuthenticateRequest,
   ): Promise<schema.AuthenticateResponse | void> {
-    // Authentication is handled via environment variables (SPIRIT_ACP_API_KEY)
+    if (params.methodId !== TERMINAL_AUTH_METHOD_ID) {
+      throw RequestError.invalidParams(
+        { methodId: params.methodId, expected: TERMINAL_AUTH_METHOD_ID },
+        `Unsupported authentication method: ${params.methodId}`,
+      );
+    }
+
+    if (!hasResolvableCredentials(this.config.spiritDataDir)) {
+      throw RequestError.authRequired(
+        { reason: 'missing_credentials' },
+        'Provider credentials are not configured. Run setup in the terminal first.',
+      );
+    }
+
+    this.authState.markAuthenticated();
+    return {};
+  }
+
+  async unstable_logout(
+    _params: schema.LogoutRequest,
+  ): Promise<schema.LogoutResponse | void> {
+    this.authState.logout();
     return {};
   }
 

--- a/packages/acp-server/src/acp-agent.ts
+++ b/packages/acp-server/src/acp-agent.ts
@@ -3,7 +3,7 @@ import type * as schema from '@agentclientprotocol/sdk';
 import { RequestError } from '@agentclientprotocol/sdk';
 import type { JsonValue, RuntimeEvent } from '@spirit-agent/core';
 import type { AuthState } from './auth/auth-state.js';
-import { buildAuthMethods } from './auth/build-auth-methods.js';
+import { buildAuthMethodsForStartup } from './auth/build-auth-methods.js';
 import { TERMINAL_AUTH_METHOD_ID } from './auth/constants.js';
 import { canCreateSession } from './auth/session-auth.js';
 import { hasResolvableCredentials } from './credentials/index.js';
@@ -40,6 +40,8 @@ export class SpiritAcpAgent implements acp.Agent {
   async initialize(
     _params: schema.InitializeRequest,
   ): Promise<schema.InitializeResponse> {
+    const authMethods = buildAuthMethodsForStartup(this.config.spiritDataDir);
+
     return {
       protocolVersion: 1, // PROTOCOL_VERSION
       agentCapabilities: {
@@ -59,7 +61,7 @@ export class SpiritAcpAgent implements acp.Agent {
         title: 'Spirit Agent',
         version: '0.2.0',
       },
-      authMethods: buildAuthMethods(),
+      authMethods,
     };
   }
 

--- a/packages/acp-server/src/auth/auth-state.ts
+++ b/packages/acp-server/src/auth/auth-state.ts
@@ -1,8 +1,8 @@
 /**
  * In-process ACP authentication state for a single agent connection.
  *
- * Env-provided API keys or existing shared keyring/config credentials pre-authenticate
- * the process; first-time setup still uses Terminal Auth when no credentials exist.
+ * Existing shared keyring/config credentials pre-authenticate the process;
+ * first-time setup uses Terminal Auth when no credentials exist.
  */
 export class AuthState {
   private authenticated: boolean;
@@ -24,7 +24,7 @@ export class AuthState {
   }
 }
 
-/** Env API key or existing shared keyring/config credentials pre-authenticate the process. */
+/** Shared keyring/config credentials pre-authenticate the process when present. */
 export function createAuthState(preAuthenticated = false): AuthState {
   return new AuthState(preAuthenticated);
 }

--- a/packages/acp-server/src/auth/auth-state.ts
+++ b/packages/acp-server/src/auth/auth-state.ts
@@ -1,0 +1,30 @@
+/**
+ * In-process ACP authentication state for a single agent connection.
+ *
+ * Env-provided API keys pre-authenticate the process; shared keyring/config
+ * credentials require an explicit authenticate call (wired in Phase 4).
+ */
+export class AuthState {
+  private authenticated: boolean;
+
+  constructor(preAuthenticated = false) {
+    this.authenticated = preAuthenticated;
+  }
+
+  isAuthenticated(): boolean {
+    return this.authenticated;
+  }
+
+  markAuthenticated(): void {
+    this.authenticated = true;
+  }
+
+  logout(): void {
+    this.authenticated = false;
+  }
+}
+
+/** Env API key bypasses the authenticate handshake. */
+export function createAuthState(hasEnvApiKey: boolean): AuthState {
+  return new AuthState(hasEnvApiKey);
+}

--- a/packages/acp-server/src/auth/auth-state.ts
+++ b/packages/acp-server/src/auth/auth-state.ts
@@ -1,8 +1,8 @@
 /**
  * In-process ACP authentication state for a single agent connection.
  *
- * Env-provided API keys pre-authenticate the process; shared keyring/config
- * credentials require an explicit authenticate call (wired in Phase 4).
+ * Env-provided API keys or existing shared keyring/config credentials pre-authenticate
+ * the process; first-time setup still uses Terminal Auth when no credentials exist.
  */
 export class AuthState {
   private authenticated: boolean;
@@ -24,7 +24,7 @@ export class AuthState {
   }
 }
 
-/** Env API key bypasses the authenticate handshake. */
-export function createAuthState(hasEnvApiKey: boolean): AuthState {
-  return new AuthState(hasEnvApiKey);
+/** Env API key or existing shared keyring/config credentials pre-authenticate the process. */
+export function createAuthState(preAuthenticated = false): AuthState {
+  return new AuthState(preAuthenticated);
 }

--- a/packages/acp-server/src/auth/build-auth-methods.ts
+++ b/packages/acp-server/src/auth/build-auth-methods.ts
@@ -6,7 +6,6 @@ import {
   TERMINAL_AUTH_METHOD_ID,
   TERMINAL_AUTH_NAME,
 } from './constants.js';
-import { shouldAdvertiseAuthMethods } from './session-auth.js';
 
 /** Terminal Auth method advertised during initialize. */
 export function buildTerminalAuthMethod(): schema.AuthMethod {
@@ -21,9 +20,4 @@ export function buildTerminalAuthMethod(): schema.AuthMethod {
 
 export function buildAuthMethods(): schema.AuthMethod[] {
   return [buildTerminalAuthMethod()];
-}
-
-/** Empty when shared credentials already exist — avoids clients showing repeat auth UI. */
-export function buildAuthMethodsForStartup(spiritDataDir: string): schema.AuthMethod[] {
-  return shouldAdvertiseAuthMethods(spiritDataDir) ? buildAuthMethods() : [];
 }

--- a/packages/acp-server/src/auth/build-auth-methods.ts
+++ b/packages/acp-server/src/auth/build-auth-methods.ts
@@ -6,6 +6,7 @@ import {
   TERMINAL_AUTH_METHOD_ID,
   TERMINAL_AUTH_NAME,
 } from './constants.js';
+import { shouldAdvertiseAuthMethods } from './session-auth.js';
 
 /** Terminal Auth method advertised during initialize. */
 export function buildTerminalAuthMethod(): schema.AuthMethod {
@@ -20,4 +21,9 @@ export function buildTerminalAuthMethod(): schema.AuthMethod {
 
 export function buildAuthMethods(): schema.AuthMethod[] {
   return [buildTerminalAuthMethod()];
+}
+
+/** Empty when shared credentials already exist — avoids clients showing repeat auth UI. */
+export function buildAuthMethodsForStartup(spiritDataDir: string): schema.AuthMethod[] {
+  return shouldAdvertiseAuthMethods(spiritDataDir) ? buildAuthMethods() : [];
 }

--- a/packages/acp-server/src/auth/build-auth-methods.ts
+++ b/packages/acp-server/src/auth/build-auth-methods.ts
@@ -1,0 +1,23 @@
+import type * as schema from '@agentclientprotocol/sdk';
+
+import {
+  TERMINAL_AUTH_ARGS,
+  TERMINAL_AUTH_DESCRIPTION,
+  TERMINAL_AUTH_METHOD_ID,
+  TERMINAL_AUTH_NAME,
+} from './constants.js';
+
+/** Terminal Auth method advertised during initialize. */
+export function buildTerminalAuthMethod(): schema.AuthMethod {
+  return {
+    id: TERMINAL_AUTH_METHOD_ID,
+    name: TERMINAL_AUTH_NAME,
+    description: TERMINAL_AUTH_DESCRIPTION,
+    type: 'terminal',
+    args: [...TERMINAL_AUTH_ARGS],
+  };
+}
+
+export function buildAuthMethods(): schema.AuthMethod[] {
+  return [buildTerminalAuthMethod()];
+}

--- a/packages/acp-server/src/auth/constants.ts
+++ b/packages/acp-server/src/auth/constants.ts
@@ -1,0 +1,8 @@
+export const TERMINAL_AUTH_METHOD_ID = 'spirit-terminal-setup';
+
+export const TERMINAL_AUTH_ARGS = ['--setup'] as const;
+
+export const TERMINAL_AUTH_NAME = 'Run in terminal';
+
+export const TERMINAL_AUTH_DESCRIPTION =
+  'Interactive provider and API key setup in the terminal';

--- a/packages/acp-server/src/auth/session-auth.ts
+++ b/packages/acp-server/src/auth/session-auth.ts
@@ -10,10 +10,6 @@ export function createInitialAuthState(config: AcpServerConfig): AuthState {
   return new AuthState(shouldPreAuthenticateFromSharedConfig(config.spiritDataDir));
 }
 
-export function shouldAdvertiseAuthMethods(spiritDataDir: string): boolean {
-  return !shouldPreAuthenticateFromSharedConfig(spiritDataDir);
-}
-
 export function canCreateSession(config: AcpServerConfig, authState: AuthState): boolean {
   if (!authState.isAuthenticated()) {
     return false;

--- a/packages/acp-server/src/auth/session-auth.ts
+++ b/packages/acp-server/src/auth/session-auth.ts
@@ -1,33 +1,20 @@
-import { resolveEnvApiKey } from '../config.js';
 import { hasResolvableCredentials } from '../credentials/index.js';
 import type { AcpServerConfig } from '../types.js';
 import { AuthState } from './auth-state.js';
-
-export function isEnvPreAuthenticated(): boolean {
-  return resolveEnvApiKey() !== undefined;
-}
 
 export function shouldPreAuthenticateFromSharedConfig(spiritDataDir: string): boolean {
   return hasResolvableCredentials(spiritDataDir);
 }
 
 export function createInitialAuthState(config: AcpServerConfig): AuthState {
-  const preAuthenticated =
-    isEnvPreAuthenticated() || shouldPreAuthenticateFromSharedConfig(config.spiritDataDir);
-  return new AuthState(preAuthenticated);
+  return new AuthState(shouldPreAuthenticateFromSharedConfig(config.spiritDataDir));
 }
 
 export function shouldAdvertiseAuthMethods(spiritDataDir: string): boolean {
-  if (isEnvPreAuthenticated()) {
-    return false;
-  }
   return !shouldPreAuthenticateFromSharedConfig(spiritDataDir);
 }
 
 export function canCreateSession(config: AcpServerConfig, authState: AuthState): boolean {
-  if (isEnvPreAuthenticated()) {
-    return true;
-  }
   if (!authState.isAuthenticated()) {
     return false;
   }

--- a/packages/acp-server/src/auth/session-auth.ts
+++ b/packages/acp-server/src/auth/session-auth.ts
@@ -1,0 +1,18 @@
+import { resolveEnvApiKey } from '../config.js';
+import { hasResolvableCredentials } from '../credentials/index.js';
+import type { AcpServerConfig } from '../types.js';
+import type { AuthState } from './auth-state.js';
+
+export function isEnvPreAuthenticated(): boolean {
+  return resolveEnvApiKey() !== undefined;
+}
+
+export function canCreateSession(config: AcpServerConfig, authState: AuthState): boolean {
+  if (isEnvPreAuthenticated()) {
+    return true;
+  }
+  if (!authState.isAuthenticated()) {
+    return false;
+  }
+  return hasResolvableCredentials(config.spiritDataDir);
+}

--- a/packages/acp-server/src/auth/session-auth.ts
+++ b/packages/acp-server/src/auth/session-auth.ts
@@ -1,10 +1,27 @@
 import { resolveEnvApiKey } from '../config.js';
 import { hasResolvableCredentials } from '../credentials/index.js';
 import type { AcpServerConfig } from '../types.js';
-import type { AuthState } from './auth-state.js';
+import { AuthState } from './auth-state.js';
 
 export function isEnvPreAuthenticated(): boolean {
   return resolveEnvApiKey() !== undefined;
+}
+
+export function shouldPreAuthenticateFromSharedConfig(spiritDataDir: string): boolean {
+  return hasResolvableCredentials(spiritDataDir);
+}
+
+export function createInitialAuthState(config: AcpServerConfig): AuthState {
+  const preAuthenticated =
+    isEnvPreAuthenticated() || shouldPreAuthenticateFromSharedConfig(config.spiritDataDir);
+  return new AuthState(preAuthenticated);
+}
+
+export function shouldAdvertiseAuthMethods(spiritDataDir: string): boolean {
+  if (isEnvPreAuthenticated()) {
+    return false;
+  }
+  return !shouldPreAuthenticateFromSharedConfig(spiritDataDir);
 }
 
 export function canCreateSession(config: AcpServerConfig, authState: AuthState): boolean {

--- a/packages/acp-server/src/config.ts
+++ b/packages/acp-server/src/config.ts
@@ -2,24 +2,29 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { AcpServerConfig } from './types.js';
 
+const DEFAULT_MODEL = 'gpt-4.1-mini';
+
 /**
- * Reads ACP server configuration from environment variables.
- *
- * Required:
- *   SPIRIT_ACP_API_KEY — API key for the LLM provider
- *
- * Optional:
- *   SPIRIT_ACP_MODEL — model name (default: 'gpt-4.1-mini')
- *   SPIRIT_ACP_BASE_URL — custom LLM endpoint URL
- *   SPIRIT_ACP_WORKSPACE — workspace root path (default: process.cwd())
+ * Resolves the Spirit Agent data directory (shared with Desktop / CLI).
  */
-export function configFromEnv(): AcpServerConfig {
+export function resolveSpiritDataDir(): string {
+  const override = process.env['SPIRIT_ACP_DATA_DIR']?.trim();
+  if (override) {
+    return override;
+  }
+  if (process.env['APPDATA']) {
+    return join(process.env['APPDATA'], 'SpiritAgent');
+  }
+  return join(homedir(), '.spirit-agent');
+}
+
+/**
+ * Reads SPIRIT_ACP_API_KEY when set. Validates placeholder syntax.
+ */
+export function resolveEnvApiKey(): string | undefined {
   const apiKey = process.env['SPIRIT_ACP_API_KEY']?.trim();
   if (!apiKey) {
-    throw new Error(
-      'SPIRIT_ACP_API_KEY environment variable is required. '
-      + 'Set it to your LLM provider API key.',
-    );
+    return undefined;
   }
   if (apiKey.includes('${')) {
     throw new Error(
@@ -29,25 +34,44 @@ export function configFromEnv(): AcpServerConfig {
       + 'or remove SPIRIT_ACP_API_KEY from agent_servers.env and set it as a system/user environment variable.',
     );
   }
+  return apiKey;
+}
 
-  const model = process.env['SPIRIT_ACP_MODEL']?.trim() || 'gpt-4.1-mini';
+/**
+ * Loads ACP server settings from environment variables.
+ * API key is optional — Terminal Auth may supply credentials later.
+ */
+export function loadBaseConfig(): AcpServerConfig {
+  const model = process.env['SPIRIT_ACP_MODEL']?.trim() || DEFAULT_MODEL;
   const workspaceRoot = process.env['SPIRIT_ACP_WORKSPACE']?.trim() || process.cwd();
-
-  // Use APPDATA/SpiritAgent on Windows, ~/.spirit-agent elsewhere
-  const spiritDataDir = process.env['SPIRIT_ACP_DATA_DIR']?.trim()
-    || (process.env['APPDATA']
-      ? join(process.env['APPDATA'], 'SpiritAgent')
-      : join(homedir(), '.spirit-agent'));
+  const spiritDataDir = resolveSpiritDataDir();
+  const apiKey = resolveEnvApiKey();
 
   const config: AcpServerConfig = {
     model,
-    apiKey,
     workspaceRoot,
     spiritDataDir,
   };
+  if (apiKey !== undefined) {
+    config.apiKey = apiKey;
+  }
   const baseUrl = process.env['SPIRIT_ACP_BASE_URL']?.trim();
   if (baseUrl) {
     config.baseUrl = baseUrl;
+  }
+  return config;
+}
+
+/**
+ * @deprecated Prefer {@link loadBaseConfig}. Kept for callers that require an API key.
+ */
+export function configFromEnv(): AcpServerConfig {
+  const config = loadBaseConfig();
+  if (!config.apiKey) {
+    throw new Error(
+      'SPIRIT_ACP_API_KEY environment variable is required. '
+      + 'Set it to your LLM provider API key.',
+    );
   }
   return config;
 }

--- a/packages/acp-server/src/config.ts
+++ b/packages/acp-server/src/config.ts
@@ -1,22 +1,12 @@
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-import type { AcpServerConfig } from './types.js';
+import { resolveSpiritDataDir } from './credentials/spirit-config.js';import type { AcpServerConfig } from './types.js';
 
 const DEFAULT_MODEL = 'gpt-4.1-mini';
 
 /**
  * Resolves the Spirit Agent data directory (shared with Desktop / CLI).
+ * @deprecated Prefer {@link resolveSpiritDataDir} from credentials/spirit-config.
  */
-export function resolveSpiritDataDir(): string {
-  const override = process.env['SPIRIT_ACP_DATA_DIR']?.trim();
-  if (override) {
-    return override;
-  }
-  if (process.env['APPDATA']) {
-    return join(process.env['APPDATA'], 'SpiritAgent');
-  }
-  return join(homedir(), '.spirit-agent');
-}
+export { resolveSpiritDataDir };
 
 /**
  * Reads SPIRIT_ACP_API_KEY when set. Validates placeholder syntax.

--- a/packages/acp-server/src/config.ts
+++ b/packages/acp-server/src/config.ts
@@ -1,6 +1,5 @@
-import { resolveSpiritDataDir } from './credentials/spirit-config.js';import type { AcpServerConfig } from './types.js';
-
-const DEFAULT_MODEL = 'gpt-4.1-mini';
+import { resolveSpiritDataDir } from './credentials/spirit-config.js';
+import type { AcpServerConfig } from './types.js';
 
 /**
  * Resolves the Spirit Agent data directory (shared with Desktop / CLI).
@@ -9,59 +8,15 @@ const DEFAULT_MODEL = 'gpt-4.1-mini';
 export { resolveSpiritDataDir };
 
 /**
- * Reads SPIRIT_ACP_API_KEY when set. Validates placeholder syntax.
- */
-export function resolveEnvApiKey(): string | undefined {
-  const apiKey = process.env['SPIRIT_ACP_API_KEY']?.trim();
-  if (!apiKey) {
-    return undefined;
-  }
-  if (apiKey.includes('${')) {
-    throw new Error(
-      'SPIRIT_ACP_API_KEY looks like an unexpanded placeholder (e.g. "${SPIRIT_ACP_API_KEY}"). '
-      + 'Zed settings.json does not expand ${VAR} syntax. '
-      + 'Either put the key directly in agent_servers.env, '
-      + 'or remove SPIRIT_ACP_API_KEY from agent_servers.env and set it as a system/user environment variable.',
-    );
-  }
-  return apiKey;
-}
-
-/**
- * Loads ACP server settings from environment variables.
- * API key is optional — Terminal Auth may supply credentials later.
+ * Loads ACP server runtime paths. LLM credentials and models come from shared
+ * Spirit config + keyring (Terminal Auth / `--setup`), not environment variables.
  */
 export function loadBaseConfig(): AcpServerConfig {
-  const model = process.env['SPIRIT_ACP_MODEL']?.trim() || DEFAULT_MODEL;
   const workspaceRoot = process.env['SPIRIT_ACP_WORKSPACE']?.trim() || process.cwd();
   const spiritDataDir = resolveSpiritDataDir();
-  const apiKey = resolveEnvApiKey();
 
-  const config: AcpServerConfig = {
-    model,
+  return {
     workspaceRoot,
     spiritDataDir,
   };
-  if (apiKey !== undefined) {
-    config.apiKey = apiKey;
-  }
-  const baseUrl = process.env['SPIRIT_ACP_BASE_URL']?.trim();
-  if (baseUrl) {
-    config.baseUrl = baseUrl;
-  }
-  return config;
-}
-
-/**
- * @deprecated Prefer {@link loadBaseConfig}. Kept for callers that require an API key.
- */
-export function configFromEnv(): AcpServerConfig {
-  const config = loadBaseConfig();
-  if (!config.apiKey) {
-    throw new Error(
-      'SPIRIT_ACP_API_KEY environment variable is required. '
-      + 'Set it to your LLM provider API key.',
-    );
-  }
-  return config;
 }

--- a/packages/acp-server/src/credentials/credentials.ts
+++ b/packages/acp-server/src/credentials/credentials.ts
@@ -1,0 +1,254 @@
+import type { ModelProviderId } from '@spirit-agent/host-internal';
+
+import { keyringStore } from './keyring-store.js';
+import {
+  KEYRING_GLOBAL_ACCOUNT,
+  KEYRING_SERVICE,
+  modelKeyAccount,
+  modelProviderKeyScope,
+  providerAccessKeyIdAccount,
+  providerKeyAccount,
+  providerSecretAccessKeyAccount,
+  providerVertexClientEmailAccount,
+  providerVertexPrivateKeyAccount,
+} from './provider-accounts.js';
+import {
+  loadActiveModelProfile,
+  loadSpiritConfig,
+  saveSpiritConfig,
+} from './spirit-config.js';
+import type {
+  BedrockSetupCredentials,
+  GoogleVertexSetupCredentials,
+  ProviderSetupResult,
+  SpiritConfigFile,
+  SpiritModelProfile,
+} from './types.js';
+
+export { loadActiveModelProfile, loadSpiritConfig, saveSpiritConfig };
+export type { ProviderSetupResult, SpiritConfigFile, SpiritModelProfile };
+
+function readProviderKey(providerId: string): string | undefined {
+  const value = keyringStore().getPassword(KEYRING_SERVICE, providerKeyAccount(providerId));
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function readModelKey(modelName: string): string | undefined {
+  const value = keyringStore().getPassword(KEYRING_SERVICE, modelKeyAccount(modelName));
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function readGlobalKey(): string | undefined {
+  const value = keyringStore().getPassword(KEYRING_SERVICE, KEYRING_GLOBAL_ACCOUNT);
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+export function readBedrockCredentials(providerId: ModelProviderId): BedrockSetupCredentials {
+  const credentials: BedrockSetupCredentials = {};
+  const apiKey = readProviderKey(providerId);
+  if (apiKey) {
+    credentials.apiKey = apiKey;
+  }
+  const accessKeyId = keyringStore()
+    .getPassword(KEYRING_SERVICE, providerAccessKeyIdAccount(providerId))
+    ?.trim();
+  if (accessKeyId) {
+    credentials.accessKeyId = accessKeyId;
+  }
+  const secretAccessKey = keyringStore()
+    .getPassword(KEYRING_SERVICE, providerSecretAccessKeyAccount(providerId))
+    ?.trim();
+  if (secretAccessKey) {
+    credentials.secretAccessKey = secretAccessKey;
+  }
+  return credentials;
+}
+
+export function readGoogleVertexCredentials(
+  providerId: ModelProviderId,
+): GoogleVertexSetupCredentials {
+  const credentials: GoogleVertexSetupCredentials = {};
+  const apiKey = readProviderKey(providerId);
+  if (apiKey) {
+    credentials.apiKey = apiKey;
+  }
+  const clientEmail = keyringStore()
+    .getPassword(KEYRING_SERVICE, providerVertexClientEmailAccount(providerId))
+    ?.trim();
+  if (clientEmail) {
+    credentials.clientEmail = clientEmail;
+  }
+  const privateKey = keyringStore()
+    .getPassword(KEYRING_SERVICE, providerVertexPrivateKeyAccount(providerId))
+    ?.trim();
+  if (privateKey) {
+    credentials.privateKey = privateKey;
+  }
+  return credentials;
+}
+
+function hasBedrockRuntimeCredentials(credentials: BedrockSetupCredentials): boolean {
+  if (credentials.apiKey?.trim()) {
+    return true;
+  }
+  return Boolean(credentials.accessKeyId?.trim() && credentials.secretAccessKey?.trim());
+}
+
+function hasGoogleVertexRuntimeCredentials(input: {
+  apiKey?: string;
+  clientEmail?: string;
+  privateKey?: string;
+  vertexProject?: string;
+  vertexLocation?: string;
+}): boolean {
+  if (input.apiKey?.trim()) {
+    return true;
+  }
+  if (input.clientEmail?.trim() && input.privateKey?.trim()) {
+    return Boolean(input.vertexProject?.trim() && input.vertexLocation?.trim());
+  }
+  return Boolean(input.vertexProject?.trim() && input.vertexLocation?.trim());
+}
+
+function hasProviderSecret(providerId: ModelProviderId, profile: SpiritModelProfile): boolean {
+  if (readProviderKey(providerId)) {
+    return true;
+  }
+  if (providerId === 'amazon-bedrock') {
+    return hasBedrockRuntimeCredentials(readBedrockCredentials('amazon-bedrock'));
+  }
+  if (providerId === 'google-vertex-ai') {
+    const credentials = readGoogleVertexCredentials('google-vertex-ai');
+    const vertexInput: {
+      apiKey?: string;
+      clientEmail?: string;
+      privateKey?: string;
+      vertexProject?: string;
+      vertexLocation?: string;
+    } = {};
+    if (credentials.apiKey) {
+      vertexInput.apiKey = credentials.apiKey;
+    }
+    if (credentials.clientEmail) {
+      vertexInput.clientEmail = credentials.clientEmail;
+    }
+    if (credentials.privateKey) {
+      vertexInput.privateKey = credentials.privateKey;
+    }
+    if (profile.vertexProject) {
+      vertexInput.vertexProject = profile.vertexProject;
+    }
+    if (profile.vertexLocation) {
+      vertexInput.vertexLocation = profile.vertexLocation;
+    }
+    return hasGoogleVertexRuntimeCredentials(vertexInput);
+  }
+  return false;
+}
+
+export function resolveStoredApiKeyForProfile(profile: SpiritModelProfile): string | undefined {
+  const scope = modelProviderKeyScope(profile.provider);
+  const providerKey = readProviderKey(scope);
+  if (providerKey) {
+    return providerKey;
+  }
+  const modelKey = readModelKey(profile.name);
+  if (modelKey) {
+    return modelKey;
+  }
+  return readGlobalKey();
+}
+
+export function hasResolvableCredentials(spiritDataDir: string): boolean {
+  const profile = loadActiveModelProfile(spiritDataDir);
+  if (!profile) {
+    return false;
+  }
+  const scope = modelProviderKeyScope(profile.provider);
+  if (hasProviderSecret(scope, profile)) {
+    return true;
+  }
+  return Boolean(resolveStoredApiKeyForProfile(profile));
+}
+
+function saveProviderApiKey(providerId: ModelProviderId, apiKey: string | undefined): void {
+  const store = keyringStore();
+  const account = providerKeyAccount(providerId);
+  if (apiKey?.trim()) {
+    store.setPassword(KEYRING_SERVICE, account, apiKey.trim());
+    return;
+  }
+  store.deletePassword(KEYRING_SERVICE, account);
+}
+
+function saveBedrockCredentials(
+  providerId: ModelProviderId,
+  credentials: BedrockSetupCredentials,
+): void {
+  saveProviderApiKey(providerId, credentials.apiKey);
+  const store = keyringStore();
+  const accessKeyId = credentials.accessKeyId?.trim();
+  if (accessKeyId) {
+    store.setPassword(KEYRING_SERVICE, providerAccessKeyIdAccount(providerId), accessKeyId);
+  } else {
+    store.deletePassword(KEYRING_SERVICE, providerAccessKeyIdAccount(providerId));
+  }
+  const secretAccessKey = credentials.secretAccessKey?.trim();
+  if (secretAccessKey) {
+    store.setPassword(KEYRING_SERVICE, providerSecretAccessKeyAccount(providerId), secretAccessKey);
+  } else {
+    store.deletePassword(KEYRING_SERVICE, providerSecretAccessKeyAccount(providerId));
+  }
+}
+
+function saveGoogleVertexCredentials(
+  providerId: ModelProviderId,
+  credentials: GoogleVertexSetupCredentials,
+): void {
+  saveProviderApiKey(providerId, credentials.apiKey);
+  const store = keyringStore();
+  const clientEmail = credentials.clientEmail?.trim();
+  if (clientEmail) {
+    store.setPassword(KEYRING_SERVICE, providerVertexClientEmailAccount(providerId), clientEmail);
+  } else {
+    store.deletePassword(KEYRING_SERVICE, providerVertexClientEmailAccount(providerId));
+  }
+  const privateKey = credentials.privateKey?.trim();
+  if (privateKey) {
+    store.setPassword(KEYRING_SERVICE, providerVertexPrivateKeyAccount(providerId), privateKey);
+  } else {
+    store.deletePassword(KEYRING_SERVICE, providerVertexPrivateKeyAccount(providerId));
+  }
+}
+
+export async function saveProviderSetup(
+  spiritDataDir: string,
+  setup: ProviderSetupResult,
+): Promise<void> {
+  const existing = loadSpiritConfig(spiritDataDir);
+  const models = existing?.models.filter((model) => model.name !== setup.profile.name) ?? [];
+  models.push(setup.profile);
+
+  const config: SpiritConfigFile = {
+    ...(existing ?? { models: [], activeModel: '' }),
+    models,
+    activeModel: setup.profile.name,
+  };
+  await saveSpiritConfig(spiritDataDir, config);
+
+  const scope = setup.providerScope;
+  if (scope === 'amazon-bedrock' && setup.bedrock) {
+    saveBedrockCredentials(scope, setup.bedrock);
+    return;
+  }
+  if (scope === 'google-vertex-ai' && setup.vertex) {
+    saveGoogleVertexCredentials(scope, setup.vertex);
+    return;
+  }
+  if (setup.apiKey?.trim()) {
+    saveProviderApiKey(scope, setup.apiKey);
+  }
+}

--- a/packages/acp-server/src/credentials/credentials.ts
+++ b/packages/acp-server/src/credentials/credentials.ts
@@ -228,6 +228,15 @@ export async function saveProviderSetup(
   spiritDataDir: string,
   setup: ProviderSetupResult,
 ): Promise<void> {
+  const scope = setup.providerScope;
+  if (scope === 'amazon-bedrock' && setup.bedrock) {
+    saveBedrockCredentials(scope, setup.bedrock);
+  } else if (scope === 'google-vertex-ai' && setup.vertex) {
+    saveGoogleVertexCredentials(scope, setup.vertex);
+  } else if (setup.apiKey?.trim()) {
+    saveProviderApiKey(scope, setup.apiKey);
+  }
+
   const existing = loadSpiritConfig(spiritDataDir);
   const models = existing?.models.filter((model) => model.name !== setup.profile.name) ?? [];
   models.push(setup.profile);
@@ -238,17 +247,4 @@ export async function saveProviderSetup(
     activeModel: setup.profile.name,
   };
   await saveSpiritConfig(spiritDataDir, config);
-
-  const scope = setup.providerScope;
-  if (scope === 'amazon-bedrock' && setup.bedrock) {
-    saveBedrockCredentials(scope, setup.bedrock);
-    return;
-  }
-  if (scope === 'google-vertex-ai' && setup.vertex) {
-    saveGoogleVertexCredentials(scope, setup.vertex);
-    return;
-  }
-  if (setup.apiKey?.trim()) {
-    saveProviderApiKey(scope, setup.apiKey);
-  }
 }

--- a/packages/acp-server/src/credentials/index.ts
+++ b/packages/acp-server/src/credentials/index.ts
@@ -1,0 +1,12 @@
+export {
+  hasResolvableCredentials,
+  loadActiveModelProfile,
+  loadSpiritConfig,
+  readBedrockCredentials,
+  readGoogleVertexCredentials,
+  resolveStoredApiKeyForProfile,
+  saveProviderSetup,
+  saveSpiritConfig,
+} from './credentials.js';
+export { setKeyringStoreForTests, type KeyringStore } from './keyring-store.js';
+export type { ProviderSetupResult, SpiritConfigFile, SpiritModelProfile } from './types.js';

--- a/packages/acp-server/src/credentials/keyring-store.ts
+++ b/packages/acp-server/src/credentials/keyring-store.ts
@@ -1,0 +1,147 @@
+import { Entry } from '@napi-rs/keyring';
+
+/** Windows Credential Manager UTF-16 blob limit (bytes). */
+const KEYRING_MAX_UTF16_BYTES = 2560;
+
+/** Chunk size with margin below {@link KEYRING_MAX_UTF16_BYTES}. */
+const KEYRING_MAX_CHUNK_UTF16_BYTES = 2500;
+
+const KEYRING_SHARD_MARKER = '__spirit_keyring_sharded_v1__:';
+
+function utf16LeByteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf16le');
+}
+
+function shardKeyringAccount(baseAccount: string, index: number): string {
+  return `${baseAccount}::shard::${index}`;
+}
+
+function splitKeyringPassword(
+  password: string,
+  maxUtf16Bytes = KEYRING_MAX_CHUNK_UTF16_BYTES,
+): string[] {
+  if (utf16LeByteLength(password) <= maxUtf16Bytes) {
+    return [password];
+  }
+
+  const chunks: string[] = [];
+  let offset = 0;
+  while (offset < password.length) {
+    let end = offset + 1;
+    while (
+      end < password.length
+      && utf16LeByteLength(password.slice(offset, end + 1)) <= maxUtf16Bytes
+    ) {
+      end += 1;
+    }
+    chunks.push(password.slice(offset, end));
+    offset = end;
+  }
+  return chunks;
+}
+
+function parseShardedKeyringPrimary(value: string): number | undefined {
+  if (!value.startsWith(KEYRING_SHARD_MARKER)) {
+    return undefined;
+  }
+  const count = Number.parseInt(value.slice(KEYRING_SHARD_MARKER.length), 10);
+  if (!Number.isFinite(count) || count < 2) {
+    return undefined;
+  }
+  return count;
+}
+
+function buildShardedKeyringPrimary(shardCount: number): string {
+  return `${KEYRING_SHARD_MARKER}${shardCount}`;
+}
+
+function readKeyringEntry(service: string, account: string): string | undefined {
+  try {
+    const value = new Entry(service, account).getPassword();
+    return value ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getKeyringPassword(service: string, account: string): string | undefined {
+  const primary = readKeyringEntry(service, account);
+  if (primary === undefined) {
+    return undefined;
+  }
+
+  const shardCount = parseShardedKeyringPrimary(primary);
+  if (shardCount === undefined) {
+    return primary;
+  }
+
+  let joined = '';
+  for (let index = 0; index < shardCount; index += 1) {
+    const shard = readKeyringEntry(service, shardKeyringAccount(account, index));
+    if (shard === undefined) {
+      return undefined;
+    }
+    joined += shard;
+  }
+  return joined;
+}
+
+export function setKeyringPassword(service: string, account: string, password: string): void {
+  deleteKeyringPassword(service, account);
+
+  const chunks = splitKeyringPassword(password);
+  if (chunks.length === 1) {
+    new Entry(service, account).setPassword(chunks[0]!);
+    return;
+  }
+
+  // 先写分片再写 primary 标记，避免崩溃后 primary 指向缺失 shard。
+  for (let index = 0; index < chunks.length; index += 1) {
+    new Entry(service, shardKeyringAccount(account, index)).setPassword(chunks[index]!);
+  }
+  new Entry(service, account).setPassword(buildShardedKeyringPrimary(chunks.length));
+}
+
+export function deleteKeyringPassword(service: string, account: string): void {
+  const primary = readKeyringEntry(service, account);
+  const shardCount = primary ? parseShardedKeyringPrimary(primary) : undefined;
+
+  if (shardCount !== undefined) {
+    for (let index = 0; index < shardCount; index += 1) {
+      try {
+        new Entry(service, shardKeyringAccount(account, index)).deletePassword();
+      } catch {
+        /* 无条目时忽略 */
+      }
+    }
+  }
+
+  try {
+    new Entry(service, account).deletePassword();
+  } catch {
+    /* 无条目时忽略 */
+  }
+}
+
+/** Test-only override for keyring operations. */
+export interface KeyringStore {
+  getPassword(service: string, account: string): string | undefined;
+  setPassword(service: string, account: string, password: string): void;
+  deletePassword(service: string, account: string): void;
+}
+
+export const defaultKeyringStore: KeyringStore = {
+  getPassword: getKeyringPassword,
+  setPassword: setKeyringPassword,
+  deletePassword: deleteKeyringPassword,
+};
+
+let keyringStoreOverride: KeyringStore | undefined;
+
+export function setKeyringStoreForTests(store: KeyringStore | undefined): void {
+  keyringStoreOverride = store;
+}
+
+export function keyringStore(): KeyringStore {
+  return keyringStoreOverride ?? defaultKeyringStore;
+}

--- a/packages/acp-server/src/credentials/provider-accounts.ts
+++ b/packages/acp-server/src/credentials/provider-accounts.ts
@@ -1,0 +1,33 @@
+import type { ModelProviderId } from '@spirit-agent/host-internal';
+
+export const KEYRING_SERVICE = 'SpiritAgent';
+export const KEYRING_GLOBAL_ACCOUNT = 'openai_api_key';
+
+export function providerKeyAccount(providerId: string): string {
+  return `provider::${providerId}`;
+}
+
+export function providerAccessKeyIdAccount(providerId: string): string {
+  return `provider::${providerId}::access-key-id`;
+}
+
+export function providerSecretAccessKeyAccount(providerId: string): string {
+  return `provider::${providerId}::secret-access-key`;
+}
+
+export function providerVertexClientEmailAccount(providerId: string): string {
+  return `provider::${providerId}::client-email`;
+}
+
+export function providerVertexPrivateKeyAccount(providerId: string): string {
+  return `provider::${providerId}::private-key`;
+}
+
+export function modelKeyAccount(modelName: string): string {
+  return `model::${modelName}`;
+}
+
+/** Config profiles without `provider` use custom-scoped keys. */
+export function modelProviderKeyScope(provider?: ModelProviderId): ModelProviderId {
+  return provider ?? 'custom';
+}

--- a/packages/acp-server/src/credentials/spirit-config.ts
+++ b/packages/acp-server/src/credentials/spirit-config.ts
@@ -111,8 +111,15 @@ export function loadSpiritConfig(spiritDataDir: string): SpiritConfigFile | unde
   if (!existsSync(filePath)) {
     return undefined;
   }
-  const raw = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
-  return normalizeConfig(raw);
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null) {
+      return undefined;
+    }
+    return normalizeConfig(parsed as Record<string, unknown>);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function saveSpiritConfig(

--- a/packages/acp-server/src/credentials/spirit-config.ts
+++ b/packages/acp-server/src/credentials/spirit-config.ts
@@ -1,0 +1,133 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { SpiritConfigFile, SpiritModelProfile } from './types.js';
+
+const CONFIG_FILE_NAME = 'config.json';
+const APP_DATA_DIR_NAME = 'SpiritAgent';
+
+export function resolveSpiritDataDir(): string {
+  const envOverride = process.env['SPIRIT_ACP_DATA_DIR']?.trim()
+    || process.env['SPIRIT_AGENT_DATA_DIR']?.trim();
+  if (envOverride) {
+    return envOverride;
+  }
+
+  const appData = process.env['APPDATA']?.trim();
+  if (appData) {
+    return join(appData, APP_DATA_DIR_NAME);
+  }
+
+  const home = process.env['HOME']?.trim() || homedir()?.trim();
+  if (home) {
+    if (process.platform === 'darwin') {
+      return join(home, 'Library', 'Application Support', APP_DATA_DIR_NAME);
+    }
+    if (process.platform === 'linux') {
+      const xdgDataHome = process.env['XDG_DATA_HOME']?.trim();
+      if (xdgDataHome) {
+        return join(xdgDataHome, APP_DATA_DIR_NAME);
+      }
+      return join(home, '.local', 'share', APP_DATA_DIR_NAME);
+    }
+    return join(home, '.spirit-agent');
+  }
+
+  const userProfile = process.env['USERPROFILE']?.trim();
+  if (userProfile) {
+    return join(userProfile, '.spirit-agent');
+  }
+
+  return join(homedir(), '.spirit-agent');
+}
+
+export function configFilePath(spiritDataDir: string): string {
+  return join(spiritDataDir, CONFIG_FILE_NAME);
+}
+
+function normalizeModelProfile(raw: unknown): SpiritModelProfile | undefined {
+  if (typeof raw !== 'object' || raw === null) {
+    return undefined;
+  }
+  const record = raw as Record<string, unknown>;
+  const name = typeof record['name'] === 'string' ? record['name'].trim() : '';
+  const apiBase = typeof record['apiBase'] === 'string' ? record['apiBase'].trim() : '';
+  if (!name || !apiBase) {
+    return undefined;
+  }
+
+  const profile: SpiritModelProfile = { name, apiBase };
+  if (typeof record['provider'] === 'string') {
+    profile.provider = record['provider'] as NonNullable<SpiritModelProfile['provider']>;
+  }
+  if (typeof record['transportKind'] === 'string') {
+    profile.transportKind = record['transportKind'] as NonNullable<SpiritModelProfile['transportKind']>;
+  }
+  if (typeof record['reasoningEffort'] === 'string') {
+    profile.reasoningEffort = record['reasoningEffort'] as NonNullable<SpiritModelProfile['reasoningEffort']>;
+  }
+  if (typeof record['providerSite'] === 'string') {
+    profile.providerSite = record['providerSite'];
+  }
+  if (typeof record['alibabaWorkspaceId'] === 'string') {
+    profile.alibabaWorkspaceId = record['alibabaWorkspaceId'];
+  }
+  if (typeof record['awsRegion'] === 'string') {
+    profile.awsRegion = record['awsRegion'];
+  }
+  if (typeof record['azureResourceName'] === 'string') {
+    profile.azureResourceName = record['azureResourceName'];
+  }
+  if (typeof record['vertexProject'] === 'string') {
+    profile.vertexProject = record['vertexProject'];
+  }
+  if (typeof record['vertexLocation'] === 'string') {
+    profile.vertexLocation = record['vertexLocation'];
+  }
+  if (Array.isArray(record['capabilities'])) {
+    profile.capabilities = record['capabilities'] as NonNullable<SpiritModelProfile['capabilities']>;
+  }
+  return profile;
+}
+
+function normalizeConfig(raw: Record<string, unknown>): SpiritConfigFile {
+  const modelsRaw = Array.isArray(raw['models']) ? raw['models'] : [];
+  const models = modelsRaw
+    .map(normalizeModelProfile)
+    .filter((model): model is SpiritModelProfile => model !== undefined);
+
+  const activeModel = typeof raw['activeModel'] === 'string' ? raw['activeModel'].trim() : '';
+  return {
+    ...raw,
+    models,
+    activeModel: activeModel || models[0]?.name || '',
+  };
+}
+
+export function loadSpiritConfig(spiritDataDir: string): SpiritConfigFile | undefined {
+  const filePath = configFilePath(spiritDataDir);
+  if (!existsSync(filePath)) {
+    return undefined;
+  }
+  const raw = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  return normalizeConfig(raw);
+}
+
+export async function saveSpiritConfig(
+  spiritDataDir: string,
+  config: SpiritConfigFile,
+): Promise<void> {
+  const filePath = configFilePath(spiritDataDir);
+  await mkdir(spiritDataDir, { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+}
+
+export function loadActiveModelProfile(spiritDataDir: string): SpiritModelProfile | undefined {
+  const config = loadSpiritConfig(spiritDataDir);
+  if (!config?.activeModel.trim()) {
+    return undefined;
+  }
+  return config.models.find((model) => model.name === config.activeModel);
+}

--- a/packages/acp-server/src/credentials/types.ts
+++ b/packages/acp-server/src/credentials/types.ts
@@ -1,0 +1,51 @@
+import type { ModelProviderId, ProviderModelTransportKind } from '@spirit-agent/host-internal';
+
+export type SpiritModelCapability = 'chat' | 'image' | 'video' | 'imageGeneration' | 'videoGeneration';
+
+export type SpiritModelReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+/** Subset of Desktop `ModelProfileSnapshot` used by ACP setup and transport resolution. */
+export interface SpiritModelProfile {
+  name: string;
+  apiBase: string;
+  reasoningEffort?: SpiritModelReasoningEffort;
+  supportedReasoningEfforts?: SpiritModelReasoningEffort[];
+  capabilities?: SpiritModelCapability[];
+  provider?: ModelProviderId;
+  transportKind?: ProviderModelTransportKind;
+  providerSite?: string;
+  alibabaWorkspaceId?: string;
+  awsRegion?: string;
+  azureResourceName?: string;
+  vertexProject?: string;
+  vertexLocation?: string;
+  contextLength?: number;
+}
+
+/** Minimal `config.json` fields read/written by ACP; other Desktop fields are preserved on merge. */
+export interface SpiritConfigFile {
+  models: SpiritModelProfile[];
+  activeModel: string;
+  [key: string]: unknown;
+}
+
+export interface BedrockSetupCredentials {
+  apiKey?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}
+
+export interface GoogleVertexSetupCredentials {
+  apiKey?: string;
+  clientEmail?: string;
+  privateKey?: string;
+}
+
+/** Result collected by the setup wizard before persistence. */
+export interface ProviderSetupResult {
+  profile: SpiritModelProfile;
+  providerScope: ModelProviderId;
+  apiKey?: string;
+  bedrock?: BedrockSetupCredentials;
+  vertex?: GoogleVertexSetupCredentials;
+}

--- a/packages/acp-server/src/runtime-factory.ts
+++ b/packages/acp-server/src/runtime-factory.ts
@@ -44,7 +44,8 @@ import {
 } from '@spirit-agent/host-internal';
 
 import { createNoopPeer } from './noop-peer.js';
-import { toLlmTransportConfig, type AcpServerConfig } from './types.js';
+import { resolveTransportConfig } from './transport/resolve-transport.js';
+import type { AcpServerConfig } from './types.js';
 
 export type AcpHostRuntime = AgentRuntime<LlmTransportConfig, LlmToolAgentState, JsonValue, JsonValue>;
 
@@ -73,7 +74,7 @@ export async function createAcpRuntime(
   onEvent: (event: RuntimeEvent<JsonValue>) => void,
   initialMode: SpiritAgentMode = 'agent',
 ): Promise<AcpRuntimeResult> {
-  const transportConfig = toLlmTransportConfig(config);
+  const transportConfig = resolveTransportConfig(config);
   const workspaceRoot = config.workspaceRoot;
   const spiritDataDir = config.spiritDataDir;
 

--- a/packages/acp-server/src/setup/provider-wizard.ts
+++ b/packages/acp-server/src/setup/provider-wizard.ts
@@ -1,0 +1,242 @@
+import type { ModelProviderId, ProviderModelTransportKind } from '@spirit-agent/host-internal';
+import {
+  listProviderConnectSiteOptions,
+  providerConnectSiteRequiresWorkspaceId,
+  providerSupportsSiteSelection,
+  resolveProviderConnectApiBase,
+} from '@spirit-agent/host-internal';
+
+import type { SpiritModelProfile } from '../credentials/types.js';
+
+const DEFAULT_API_BASE = 'https://api.openai.com/v1';
+
+export function resolveSetupTransportKind(
+  provider: ModelProviderId,
+  requested?: ProviderModelTransportKind,
+): ProviderModelTransportKind {
+  if (requested) {
+    if (
+      (provider === 'google' || provider === 'google-vertex-ai')
+      && (requested === 'open-responses' || requested === 'anthropic')
+    ) {
+      return 'openai-compatible';
+    }
+    if (provider === 'azure') {
+      return 'open-responses';
+    }
+    return requested;
+  }
+
+  if (provider === 'anthropic') {
+    return 'anthropic';
+  }
+  if (provider === 'amazon-bedrock') {
+    return 'bedrock';
+  }
+  if (provider === 'azure') {
+    return 'open-responses';
+  }
+  return 'openai-compatible';
+}
+
+export function resolveProfileApiBase(profile: {
+  provider?: ModelProviderId;
+  transportKind?: ProviderModelTransportKind;
+  apiBase?: string;
+  providerSite?: string;
+  alibabaWorkspaceId?: string;
+  awsRegion?: string;
+  azureResourceName?: string;
+  vertexProject?: string;
+  vertexLocation?: string;
+}): string {
+  if (profile.provider === 'amazon-bedrock') {
+    const region = profile.awsRegion?.trim();
+    if (region) {
+      return resolveProviderConnectApiBase('amazon-bedrock', 'bedrock');
+    }
+  }
+
+  if (profile.provider === 'google-vertex-ai') {
+    const project = profile.vertexProject?.trim();
+    const location = profile.vertexLocation?.trim();
+    if (project && location) {
+      return `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}`;
+    }
+    const trimmed = profile.apiBase?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+    return '';
+  }
+
+  if (profile.provider === 'azure') {
+    const resourceName = profile.azureResourceName?.trim();
+    if (resourceName) {
+      return `https://${resourceName}.openai.azure.com/openai/v1`;
+    }
+    const trimmed = profile.apiBase?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+    throw new Error('Azure model is missing azureResourceName.');
+  }
+
+  if (profile.provider && profile.provider !== 'custom') {
+    const transportKind = resolveSetupTransportKind(profile.provider, profile.transportKind);
+    return resolveProviderConnectApiBase(profile.provider, transportKind, {
+      ...(profile.providerSite ? { site: profile.providerSite } : {}),
+      ...(profile.alibabaWorkspaceId?.trim()
+        ? { workspaceId: profile.alibabaWorkspaceId.trim() }
+        : {}),
+    });
+  }
+
+  const trimmed = profile.apiBase?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : DEFAULT_API_BASE;
+}
+
+export function validateModelName(modelName: string): string | undefined {
+  const trimmed = modelName.trim();
+  if (!trimmed) {
+    return 'Model name is required.';
+  }
+  return undefined;
+}
+
+export function validateApiKeyRequired(provider: ModelProviderId, apiKey: string): string | undefined {
+  if (provider === 'amazon-bedrock' || provider === 'google-vertex-ai' || provider === 'custom') {
+    return undefined;
+  }
+  if (!apiKey.trim()) {
+    return 'API key is required for this provider.';
+  }
+  return undefined;
+}
+
+export function validateBedrockCredentials(input: {
+  apiKey?: string;
+  accessKeyId?: string;
+  secretAccessKey?: string;
+  awsRegion?: string;
+}): string | undefined {
+  if (!input.awsRegion?.trim()) {
+    return 'AWS region is required for Amazon Bedrock.';
+  }
+  const hasApiKey = Boolean(input.apiKey?.trim());
+  const hasIam = Boolean(input.accessKeyId?.trim() && input.secretAccessKey?.trim());
+  if (!hasApiKey && !hasIam) {
+    return 'Provide either a Bedrock API key or IAM access key credentials.';
+  }
+  return undefined;
+}
+
+export function validateVertexCredentials(input: {
+  apiKey?: string;
+  clientEmail?: string;
+  privateKey?: string;
+  vertexProject?: string;
+  vertexLocation?: string;
+}): string | undefined {
+  if (!input.vertexProject?.trim() || !input.vertexLocation?.trim()) {
+    return 'GCP project ID and location are required for Google Vertex AI.';
+  }
+  const hasApiKey = Boolean(input.apiKey?.trim());
+  const hasSa = Boolean(input.clientEmail?.trim() && input.privateKey?.trim());
+  if (!hasApiKey && !hasSa) {
+    return 'Provide either a Vertex API key or a service account email and private key.';
+  }
+  return undefined;
+}
+
+export function validateAzureSetup(input: {
+  azureResourceName?: string;
+  apiKey?: string;
+  modelName?: string;
+}): string | undefined {
+  if (!input.azureResourceName?.trim()) {
+    return 'Azure resource name is required.';
+  }
+  if (!input.apiKey?.trim()) {
+    return 'Azure API key is required.';
+  }
+  if (!input.modelName?.trim()) {
+    return 'Azure deployment name is required.';
+  }
+  return undefined;
+}
+
+export function validateCustomSetup(input: { apiBase?: string; apiKey?: string; modelName?: string }): string | undefined {
+  if (!input.apiBase?.trim()) {
+    return 'API base URL is required for custom providers.';
+  }
+  if (!input.apiKey?.trim()) {
+    return 'API key is required for custom providers.';
+  }
+  if (!input.modelName?.trim()) {
+    return 'Model name is required.';
+  }
+  return undefined;
+}
+
+export function buildSetupProfile(input: {
+  provider: ModelProviderId;
+  modelName: string;
+  transportKind?: ProviderModelTransportKind;
+  providerSite?: string;
+  alibabaWorkspaceId?: string;
+  awsRegion?: string;
+  azureResourceName?: string;
+  vertexProject?: string;
+  vertexLocation?: string;
+  apiBaseOverride?: string;
+}): SpiritModelProfile {
+  const transportKind = resolveSetupTransportKind(input.provider, input.transportKind);
+  const profile: SpiritModelProfile = {
+    name: input.modelName.trim(),
+    apiBase: input.apiBaseOverride?.trim() || '',
+    reasoningEffort: 'medium',
+    capabilities: ['chat', 'image'],
+    provider: input.provider === 'custom' ? 'custom' : input.provider,
+    transportKind,
+  };
+  if (input.providerSite) {
+    profile.providerSite = input.providerSite;
+  }
+  if (input.alibabaWorkspaceId?.trim()) {
+    profile.alibabaWorkspaceId = input.alibabaWorkspaceId.trim();
+  }
+  if (input.awsRegion?.trim()) {
+    profile.awsRegion = input.awsRegion.trim();
+  }
+  if (input.azureResourceName?.trim()) {
+    profile.azureResourceName = input.azureResourceName.trim();
+  }
+  if (input.vertexProject?.trim()) {
+    profile.vertexProject = input.vertexProject.trim();
+  }
+  if (input.vertexLocation?.trim()) {
+    profile.vertexLocation = input.vertexLocation.trim();
+  }
+  if (input.apiBaseOverride?.trim()) {
+    profile.apiBase = input.apiBaseOverride.trim();
+  } else {
+    profile.apiBase = resolveProfileApiBase(profile);
+  }
+  return profile;
+}
+
+export function providerNeedsSiteSelection(provider: ModelProviderId): boolean {
+  return providerSupportsSiteSelection(provider);
+}
+
+export function listSiteOptions(provider: ModelProviderId): Array<{ value: string; name: string }> {
+  return listProviderConnectSiteOptions(provider).map((site) => ({
+    value: site.id,
+    name: site.fallbackLabel,
+  }));
+}
+
+export function siteNeedsWorkspaceId(provider: ModelProviderId, siteId: string): boolean {
+  return providerConnectSiteRequiresWorkspaceId(provider, siteId);
+}

--- a/packages/acp-server/src/setup/run-interactive-setup.ts
+++ b/packages/acp-server/src/setup/run-interactive-setup.ts
@@ -1,0 +1,383 @@
+import { readFileSync } from 'node:fs';
+
+import { confirm, input, password, select } from '@inquirer/prompts';
+import {
+  PROVIDER_PICKER_ROWS,
+  listProviderModels,
+  type ModelProviderId,
+} from '@spirit-agent/host-internal';
+
+import type { ProviderSetupResult } from '../credentials/types.js';
+import {
+  buildSetupProfile,
+  listSiteOptions,
+  providerNeedsSiteSelection,
+  resolveProfileApiBase,
+  resolveSetupTransportKind,
+  siteNeedsWorkspaceId,
+  validateApiKeyRequired,
+  validateAzureSetup,
+  validateBedrockCredentials,
+  validateCustomSetup,
+  validateModelName,
+  validateVertexCredentials,
+} from './provider-wizard.js';
+
+async function promptModelId(
+  provider: ModelProviderId,
+  apiKey: string,
+  profileDraft: ReturnType<typeof buildSetupProfile>,
+  extras?: {
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    vertexClientEmail?: string;
+    vertexPrivateKey?: string;
+  },
+): Promise<string> {
+  const transportKind = resolveSetupTransportKind(provider, profileDraft.transportKind);
+  const baseUrl = resolveProfileApiBase(profileDraft);
+
+  let catalog: Array<{ id: string; displayName?: string }> = [];
+  if (provider !== 'custom') {
+    try {
+      const listed = await listProviderModels({
+        provider,
+        transportKind,
+        apiKey: apiKey.trim(),
+        baseUrl,
+        ...(profileDraft.awsRegion ? { awsRegion: profileDraft.awsRegion } : {}),
+        ...(profileDraft.vertexProject ? { vertexProject: profileDraft.vertexProject } : {}),
+        ...(profileDraft.vertexLocation ? { vertexLocation: profileDraft.vertexLocation } : {}),
+        ...(extras?.accessKeyId ? { accessKeyId: extras.accessKeyId } : {}),
+        ...(extras?.secretAccessKey ? { secretAccessKey: extras.secretAccessKey } : {}),
+        ...(extras?.vertexClientEmail ? { vertexClientEmail: extras.vertexClientEmail } : {}),
+        ...(extras?.vertexPrivateKey ? { vertexPrivateKey: extras.vertexPrivateKey } : {}),
+      });
+      catalog = listed.map((entry) => ({
+        id: entry.id,
+        ...(entry.displayName ? { displayName: entry.displayName } : {}),
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[acp-server] Could not fetch model catalog: ${message}`);
+    }
+  }
+
+  if (catalog.length > 0) {
+    const choice = await select({
+      message: 'Select a model',
+      choices: [
+        ...catalog.slice(0, 40).map((entry) => ({
+          name: entry.displayName ? `${entry.id} — ${entry.displayName}` : entry.id,
+          value: entry.id,
+        })),
+        { name: 'Enter model ID manually', value: '__manual__' },
+      ],
+    });
+    if (choice !== '__manual__') {
+      return choice;
+    }
+  }
+
+  const modelName = await input({
+    message: provider === 'azure' ? 'Azure deployment name' : 'Model ID',
+    validate: (value) => validateModelName(value) ?? true,
+  });
+  return modelName.trim();
+}
+
+async function collectBedrockCredentials(): Promise<{
+  apiKey?: string;
+  bedrock: NonNullable<ProviderSetupResult['bedrock']>;
+  awsRegion: string;
+}> {
+  const awsRegion = await input({
+    message: 'AWS region (e.g. us-east-1)',
+    validate: (value) => (value.trim() ? true : 'Region is required.'),
+  });
+  const authMode = await select({
+    message: 'Bedrock authentication',
+    choices: [
+      { name: 'API key (Bearer)', value: 'api_key' as const },
+      { name: 'IAM access key', value: 'iam' as const },
+    ],
+  });
+
+  if (authMode === 'api_key') {
+    const apiKey = await password({
+      message: 'Bedrock API key',
+      mask: '*',
+      validate: (value) => (value.trim() ? true : 'API key is required.'),
+    });
+    const bedrock = { apiKey: apiKey.trim(), awsRegion: awsRegion.trim() };
+    const error = validateBedrockCredentials(bedrock);
+    if (error) {
+      throw new Error(error);
+    }
+    return { apiKey: apiKey.trim(), bedrock, awsRegion: awsRegion.trim() };
+  }
+
+  const accessKeyId = await input({
+    message: 'AWS access key ID',
+    validate: (value) => (value.trim() ? true : 'Access key ID is required.'),
+  });
+  const secretAccessKey = await password({
+    message: 'AWS secret access key',
+    mask: '*',
+    validate: (value) => (value.trim() ? true : 'Secret access key is required.'),
+  });
+  const bedrock = {
+    accessKeyId: accessKeyId.trim(),
+    secretAccessKey: secretAccessKey.trim(),
+    awsRegion: awsRegion.trim(),
+  };
+  const error = validateBedrockCredentials(bedrock);
+  if (error) {
+    throw new Error(error);
+  }
+  return { bedrock, awsRegion: awsRegion.trim() };
+}
+
+async function collectVertexCredentials(): Promise<{
+  apiKey?: string;
+  vertex: NonNullable<ProviderSetupResult['vertex']>;
+  vertexProject: string;
+  vertexLocation: string;
+}> {
+  const vertexProject = await input({
+    message: 'GCP project ID',
+    validate: (value) => (value.trim() ? true : 'Project ID is required.'),
+  });
+  const vertexLocation = await input({
+    message: 'GCP location (e.g. us-central1)',
+    validate: (value) => (value.trim() ? true : 'Location is required.'),
+  });
+  const authMode = await select({
+    message: 'Vertex authentication',
+    choices: [
+      { name: 'API key', value: 'api_key' as const },
+      { name: 'Service account', value: 'service_account' as const },
+    ],
+  });
+
+  if (authMode === 'api_key') {
+    const apiKey = await password({
+      message: 'Vertex API key',
+      mask: '*',
+      validate: (value) => (value.trim() ? true : 'API key is required.'),
+    });
+    const vertex = {
+      apiKey: apiKey.trim(),
+      vertexProject: vertexProject.trim(),
+      vertexLocation: vertexLocation.trim(),
+    };
+    const error = validateVertexCredentials(vertex);
+    if (error) {
+      throw new Error(error);
+    }
+    return {
+      apiKey: apiKey.trim(),
+      vertex: { apiKey: apiKey.trim() },
+      vertexProject: vertexProject.trim(),
+      vertexLocation: vertexLocation.trim(),
+    };
+  }
+
+  const clientEmail = await input({
+    message: 'Service account client email',
+    validate: (value) => (value.trim() ? true : 'Client email is required.'),
+  });
+  const keySource = await select({
+    message: 'Private key input',
+    choices: [
+      { name: 'Paste PEM private key', value: 'paste' as const },
+      { name: 'Path to service account JSON', value: 'file' as const },
+    ],
+  });
+  let privateKey = '';
+  if (keySource === 'file') {
+    const jsonPath = await input({
+      message: 'Path to service account JSON file',
+      validate: (value) => (value.trim() ? true : 'Path is required.'),
+    });
+    const raw = readFileSync(jsonPath.trim(), 'utf8');
+    const parsed = JSON.parse(raw) as { private_key?: string; client_email?: string };
+    privateKey = parsed.private_key?.trim() ?? '';
+    if (!privateKey) {
+      throw new Error('Service account JSON is missing private_key.');
+    }
+  } else {
+    privateKey = await input({
+      message: 'Paste private key (PEM)',
+      validate: (value) => (value.trim() ? true : 'Private key is required.'),
+    });
+  }
+
+  const vertex = {
+    clientEmail: clientEmail.trim(),
+    privateKey: privateKey.trim(),
+  };
+  const error = validateVertexCredentials({
+    clientEmail: vertex.clientEmail,
+    privateKey: vertex.privateKey,
+    vertexProject: vertexProject.trim(),
+    vertexLocation: vertexLocation.trim(),
+  });
+  if (error) {
+    throw new Error(error);
+  }
+  return {
+    vertex,
+    vertexProject: vertexProject.trim(),
+    vertexLocation: vertexLocation.trim(),
+  };
+}
+
+export async function runProviderWizard(): Promise<ProviderSetupResult> {
+  const provider = await select({
+    message: 'LLM provider',
+    choices: PROVIDER_PICKER_ROWS.map((row) => ({
+      name: row.fallbackLabel,
+      value: row.id,
+    })),
+  });
+
+  let providerSite: string | undefined;
+  if (providerNeedsSiteSelection(provider)) {
+    providerSite = await select({
+      message: 'Provider region / site',
+      choices: listSiteOptions(provider),
+    });
+  }
+
+  let alibabaWorkspaceId: string | undefined;
+  if (provider === 'alibaba' && providerSite && siteNeedsWorkspaceId(provider, providerSite)) {
+    alibabaWorkspaceId = await input({
+      message: 'Alibaba workspace ID',
+      validate: (value) => (value.trim() ? true : 'Workspace ID is required for this region.'),
+    });
+  }
+
+  let apiKey = '';
+  let bedrock: ProviderSetupResult['bedrock'];
+  let vertex: ProviderSetupResult['vertex'];
+  let awsRegion: string | undefined;
+  let azureResourceName: string | undefined;
+  let vertexProject: string | undefined;
+  let vertexLocation: string | undefined;
+  let apiBaseOverride: string | undefined;
+
+  if (provider === 'amazon-bedrock') {
+    const collected = await collectBedrockCredentials();
+    bedrock = collected.bedrock;
+    apiKey = collected.apiKey ?? '';
+    awsRegion = collected.awsRegion;
+  } else if (provider === 'google-vertex-ai') {
+    const collected = await collectVertexCredentials();
+    vertex = collected.vertex;
+    apiKey = collected.apiKey ?? '';
+    vertexProject = collected.vertexProject;
+    vertexLocation = collected.vertexLocation;
+  } else if (provider === 'azure') {
+    azureResourceName = await input({
+      message: 'Azure OpenAI resource name',
+      validate: (value) => (value.trim() ? true : 'Resource name is required.'),
+    });
+    apiKey = await password({
+      message: 'Azure API key',
+      mask: '*',
+      validate: (value) => (value.trim() ? true : 'API key is required.'),
+    });
+  } else if (provider === 'custom') {
+    apiBaseOverride = await input({
+      message: 'API base URL',
+      validate: (value) => (value.trim() ? true : 'API base URL is required.'),
+    });
+    apiKey = await password({
+      message: 'API key',
+      mask: '*',
+      validate: (value) => (value.trim() ? true : 'API key is required.'),
+    });
+  } else {
+    apiKey = await password({
+      message: 'API key',
+      mask: '*',
+      validate: (value) => validateApiKeyRequired(provider, value) ?? true,
+    });
+  }
+
+  const draftProfile = buildSetupProfile({
+    provider,
+    modelName: 'placeholder',
+    ...(providerSite ? { providerSite } : {}),
+    ...(alibabaWorkspaceId ? { alibabaWorkspaceId } : {}),
+    ...(awsRegion ? { awsRegion } : {}),
+    ...(azureResourceName ? { azureResourceName } : {}),
+    ...(vertexProject ? { vertexProject } : {}),
+    ...(vertexLocation ? { vertexLocation } : {}),
+    ...(apiBaseOverride ? { apiBaseOverride } : {}),
+  });
+
+  const modelName = await promptModelId(provider, apiKey, draftProfile, {
+    ...(bedrock?.accessKeyId ? { accessKeyId: bedrock.accessKeyId } : {}),
+    ...(bedrock?.secretAccessKey ? { secretAccessKey: bedrock.secretAccessKey } : {}),
+    ...(vertex?.clientEmail ? { vertexClientEmail: vertex.clientEmail } : {}),
+    ...(vertex?.privateKey ? { vertexPrivateKey: vertex.privateKey } : {}),
+  });
+
+  if (provider === 'azure') {
+    const azureError = validateAzureSetup({
+      ...(azureResourceName ? { azureResourceName } : {}),
+      apiKey,
+      modelName,
+    });
+    if (azureError) {
+      throw new Error(azureError);
+    }
+  }
+  if (provider === 'custom') {
+    const customError = validateCustomSetup({
+      ...(apiBaseOverride ? { apiBase: apiBaseOverride } : {}),
+      apiKey,
+      modelName,
+    });
+    if (customError) {
+      throw new Error(customError);
+    }
+  }
+
+  const profile = buildSetupProfile({
+    provider,
+    modelName,
+    ...(providerSite ? { providerSite } : {}),
+    ...(alibabaWorkspaceId ? { alibabaWorkspaceId } : {}),
+    ...(awsRegion ? { awsRegion } : {}),
+    ...(azureResourceName ? { azureResourceName } : {}),
+    ...(vertexProject ? { vertexProject } : {}),
+    ...(vertexLocation ? { vertexLocation } : {}),
+    ...(apiBaseOverride ? { apiBaseOverride } : {}),
+  });
+
+  const confirmed = await confirm({
+    message: `Save ${profile.name} (${provider}) as the active model?`,
+    default: true,
+  });
+  if (!confirmed) {
+    throw new Error('Setup cancelled.');
+  }
+
+  const result: ProviderSetupResult = {
+    profile,
+    providerScope: provider,
+  };
+  if (apiKey.trim()) {
+    result.apiKey = apiKey.trim();
+  }
+  if (bedrock) {
+    result.bedrock = bedrock;
+  }
+  if (vertex) {
+    result.vertex = vertex;
+  }
+  return result;
+}

--- a/packages/acp-server/src/setup/run-setup.ts
+++ b/packages/acp-server/src/setup/run-setup.ts
@@ -1,7 +1,25 @@
+import { resolveSpiritDataDir } from '../credentials/spirit-config.js';
+import { saveProviderSetup } from '../credentials/index.js';
+import { runProviderWizard } from './run-interactive-setup.js';
+
 /**
- * Interactive provider setup entry (--setup). Full wizard implemented in Phase 3.
+ * Terminal Auth setup entry (`--setup`).
+ * Writes provider credentials to the shared Spirit keyring and config.json.
  */
 export async function runSetup(): Promise<void> {
-  console.error('[acp-server] Provider setup is not available yet.');
-  process.exitCode = 1;
+  console.error('Spirit Agent — provider setup\n');
+  try {
+    const setup = await runProviderWizard();
+    await saveProviderSetup(resolveSpiritDataDir(), setup);
+    console.error(`\nSetup complete. Active model: ${setup.profile.name}`);
+    console.error('Return to your ACP client to authenticate and create a session.');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message !== 'Setup cancelled.') {
+      console.error(`Setup failed: ${message}`);
+    } else {
+      console.error(message);
+    }
+    process.exitCode = 1;
+  }
 }

--- a/packages/acp-server/src/setup/run-setup.ts
+++ b/packages/acp-server/src/setup/run-setup.ts
@@ -1,0 +1,7 @@
+/**
+ * Interactive provider setup entry (--setup). Full wizard implemented in Phase 3.
+ */
+export async function runSetup(): Promise<void> {
+  console.error('[acp-server] Provider setup is not available yet.');
+  process.exitCode = 1;
+}

--- a/packages/acp-server/src/stdio-entry.ts
+++ b/packages/acp-server/src/stdio-entry.ts
@@ -7,30 +7,21 @@
  * All logging is redirected to stderr to avoid polluting the ndJSON stream.
  *
  * Usage:
- *   node dist/stdio-entry.js
+ *   node dist/stdio-entry.js              — ACP ndJSON server
+ *   node dist/stdio-entry.js --setup      — interactive provider setup (Terminal Auth)
  *
  * Environment variables:
- *   SPIRIT_ACP_API_KEY   — Required. LLM provider API key.
+ *   SPIRIT_ACP_API_KEY   — Optional. LLM provider API key (pre-authenticates when set).
  *   SPIRIT_ACP_MODEL     — Optional. Model name (default: gpt-4.1-mini).
  *   SPIRIT_ACP_BASE_URL  — Optional. Custom LLM endpoint URL.
  *   SPIRIT_ACP_WORKSPACE — Optional. Workspace root (default: cwd).
- *
- * Editor configuration example (Zed settings.json):
- *   Set SPIRIT_ACP_API_KEY as a user/system environment variable first.
- *   Do not use "${SPIRIT_ACP_API_KEY}" — Zed does not expand that syntax.
- *   "agent_servers": {
- *     "Spirit Agent": {
- *       "command": "node",
- *       "args": ["path/to/packages/acp-server/dist/stdio-entry.js"],
- *       "env": { "SPIRIT_ACP_MODEL": "gpt-4.1-mini" }
- *     }
- *   }
  */
 
 import { Readable, Writable } from 'node:stream';
 import * as acp from '@agentclientprotocol/sdk';
+import { createAuthState } from './auth/auth-state.js';
 import { SpiritAcpAgent } from './acp-agent.js';
-import { configFromEnv } from './config.js';
+import { loadBaseConfig, resolveEnvApiKey } from './config.js';
 
 // Redirect console.log → stderr to prevent polluting the ndJSON stdout stream.
 console.log = (...args: unknown[]) => {
@@ -45,16 +36,27 @@ process.on('unhandledRejection', (reason) => {
   console.error('[acp-server] Unhandled rejection:', reason);
 });
 
-// Parse configuration from environment variables
-const config = configFromEnv();
+async function main(): Promise<void> {
+  if (process.argv.includes('--setup')) {
+    const { runSetup } = await import('./setup/run-setup.js');
+    await runSetup();
+    return;
+  }
 
-// Set up ndJSON stream over stdin/stdout
-const output = Writable.toWeb(process.stdout);
-const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
-const stream = acp.ndJsonStream(output, input);
+  const config = loadBaseConfig();
+  const authState = createAuthState(resolveEnvApiKey() !== undefined);
 
-// Create the ACP agent connection
-new acp.AgentSideConnection(
-  (conn) => new SpiritAcpAgent(conn, config),
-  stream,
-);
+  const output = Writable.toWeb(process.stdout);
+  const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
+  const stream = acp.ndJsonStream(output, input);
+
+  new acp.AgentSideConnection(
+    (conn) => new SpiritAcpAgent(conn, config, authState),
+    stream,
+  );
+}
+
+main().catch((err) => {
+  console.error('[acp-server] Fatal error:', err);
+  process.exitCode = 1;
+});

--- a/packages/acp-server/src/stdio-entry.ts
+++ b/packages/acp-server/src/stdio-entry.ts
@@ -19,9 +19,9 @@
 
 import { Readable, Writable } from 'node:stream';
 import * as acp from '@agentclientprotocol/sdk';
-import { createAuthState } from './auth/auth-state.js';
+import { createInitialAuthState } from './auth/session-auth.js';
 import { SpiritAcpAgent } from './acp-agent.js';
-import { loadBaseConfig, resolveEnvApiKey } from './config.js';
+import { loadBaseConfig } from './config.js';
 
 // Redirect console.log → stderr to prevent polluting the ndJSON stdout stream.
 console.log = (...args: unknown[]) => {
@@ -44,7 +44,7 @@ async function main(): Promise<void> {
   }
 
   const config = loadBaseConfig();
-  const authState = createAuthState(resolveEnvApiKey() !== undefined);
+  const authState = createInitialAuthState(config);
 
   const output = Writable.toWeb(process.stdout);
   const input = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;

--- a/packages/acp-server/src/stdio-entry.ts
+++ b/packages/acp-server/src/stdio-entry.ts
@@ -11,10 +11,8 @@
  *   node dist/stdio-entry.js --setup      — interactive provider setup (Terminal Auth)
  *
  * Environment variables:
- *   SPIRIT_ACP_API_KEY   — Optional. LLM provider API key (pre-authenticates when set).
- *   SPIRIT_ACP_MODEL     — Optional. Model name (default: gpt-4.1-mini).
- *   SPIRIT_ACP_BASE_URL  — Optional. Custom LLM endpoint URL.
  *   SPIRIT_ACP_WORKSPACE — Optional. Workspace root (default: cwd).
+ *   SPIRIT_ACP_DATA_DIR  — Optional. Spirit data directory (same as SPIRIT_AGENT_DATA_DIR).
  */
 
 import { Readable, Writable } from 'node:stream';

--- a/packages/acp-server/src/transport/map-setup-error.ts
+++ b/packages/acp-server/src/transport/map-setup-error.ts
@@ -1,0 +1,18 @@
+import { RequestError } from '@agentclientprotocol/sdk';
+
+/** Maps transport/session setup failures to ACP JSON-RPC errors. */
+export function mapSessionSetupError(err: unknown): RequestError {
+  const message = err instanceof Error ? err.message : String(err);
+  if (
+    message.includes('Run spirit-agent-acp --setup')
+    || message.includes('Run --setup')
+    || message.includes('No active model configured')
+    || message.includes('No API key found')
+    || message.includes('No Vertex credentials')
+    || message.includes('requires a Bearer API key or IAM credentials')
+    || message.includes('missing AWS region')
+  ) {
+    return RequestError.authRequired(undefined, message);
+  }
+  return RequestError.internalError(undefined, message);
+}

--- a/packages/acp-server/src/transport/resolve-transport.ts
+++ b/packages/acp-server/src/transport/resolve-transport.ts
@@ -15,7 +15,6 @@ import {
   type ModelProviderId,
 } from '@spirit-agent/host-internal';
 
-import { resolveEnvApiKey } from '../config.js';
 import {
   loadActiveModelProfile,
   readBedrockCredentials,
@@ -24,7 +23,7 @@ import {
 } from '../credentials/index.js';
 import type { SpiritModelCapability, SpiritModelProfile } from '../credentials/types.js';
 import { resolveProfileApiBase, resolveSetupTransportKind } from '../setup/provider-wizard.js';
-import { toLlmTransportConfig, type AcpServerConfig } from '../types.js';
+import type { AcpServerConfig } from '../types.js';
 
 function modelCapabilitiesFromConfig(
   capabilities: readonly SpiritModelCapability[],
@@ -263,14 +262,9 @@ function buildTransportFromProfile(
 }
 
 /**
- * Resolves LLM transport: env override first, then shared Spirit config + keyring.
+ * Resolves LLM transport from shared Spirit config + keyring.
  */
 export function resolveTransportConfig(config: AcpServerConfig): LlmTransportConfig {
-  const envKey = resolveEnvApiKey();
-  if (envKey) {
-    return toLlmTransportConfig({ ...config, apiKey: envKey });
-  }
-
   const profile = loadActiveModelProfile(config.spiritDataDir);
   if (!profile) {
     throw new Error('No active model configured. Run spirit-agent-acp --setup first.');

--- a/packages/acp-server/src/transport/resolve-transport.ts
+++ b/packages/acp-server/src/transport/resolve-transport.ts
@@ -1,0 +1,297 @@
+import {
+  resolveOpenResponsesReasoningSummary,
+  type AnthropicTransportConfig,
+  type LlmModelCapabilities,
+  type LlmTransportConfig,
+  type OpenResponsesSdkProvider,
+} from '@spirit-agent/core';
+import {
+  resolveAnthropicTransportReasoningEffortForContext,
+  resolveOpenAiTransportReasoningEffortForContext,
+} from '@spirit-agent/core/reasoning-effort';
+import {
+  bedrockMantleApiBaseFromRegion,
+  isBedrockMantleOpenAiModel,
+  type ModelProviderId,
+} from '@spirit-agent/host-internal';
+
+import { resolveEnvApiKey } from '../config.js';
+import {
+  loadActiveModelProfile,
+  readBedrockCredentials,
+  readGoogleVertexCredentials,
+  resolveStoredApiKeyForProfile,
+} from '../credentials/index.js';
+import type { SpiritModelCapability, SpiritModelProfile } from '../credentials/types.js';
+import { resolveProfileApiBase, resolveSetupTransportKind } from '../setup/provider-wizard.js';
+import { toLlmTransportConfig, type AcpServerConfig } from '../types.js';
+
+function modelCapabilitiesFromConfig(
+  capabilities: readonly SpiritModelCapability[],
+): LlmModelCapabilities {
+  return {
+    ...(capabilities.includes('chat') ? { chat: true } : {}),
+    ...(capabilities.includes('image') ? { imageInput: true } : {}),
+    ...(capabilities.includes('video') ? { videoInput: true } : {}),
+    ...(capabilities.includes('imageGeneration') ? { imageGeneration: true } : {}),
+  };
+}
+
+function openAiCompatibleVendorFromProvider(
+  provider?: ModelProviderId,
+): Exclude<ModelProviderId, 'anthropic' | 'amazon-bedrock'> | undefined {
+  return provider && provider !== 'anthropic' && provider !== 'amazon-bedrock'
+    ? provider
+    : undefined;
+}
+
+function normalizeAnthropicSupportedEfforts(
+  efforts?: readonly string[],
+): AnthropicTransportConfig['supportedEfforts'] {
+  if (efforts === undefined) {
+    return undefined;
+  }
+  return efforts.filter((effort): effort is NonNullable<AnthropicTransportConfig['supportedEfforts']>[number] => (
+    effort === 'low'
+    || effort === 'medium'
+    || effort === 'high'
+    || effort === 'xhigh'
+    || effort === 'max'
+  ));
+}
+
+function buildTransportFromProfile(
+  profile: SpiritModelProfile,
+  apiKey: string,
+  workspaceRoot: string,
+): LlmTransportConfig {
+  const baseUrl = resolveProfileApiBase(profile);
+  const transportKind = resolveSetupTransportKind(profile.provider ?? 'custom', profile.transportKind);
+  const model = profile.name;
+
+  if (
+    profile.provider === 'amazon-bedrock'
+    && isBedrockMantleOpenAiModel(model)
+  ) {
+    const region = profile.awsRegion?.trim();
+    if (!region) {
+      throw new Error('Amazon Bedrock model is missing AWS region configuration.');
+    }
+    const bedrockCredentials = readBedrockCredentials('amazon-bedrock');
+    const resolvedApiKey = apiKey.trim() || bedrockCredentials.apiKey?.trim() || '';
+    const accessKeyId = bedrockCredentials.accessKeyId?.trim();
+    const secretAccessKey = bedrockCredentials.secretAccessKey?.trim();
+    if (!resolvedApiKey && !(accessKeyId && secretAccessKey)) {
+      throw new Error('Amazon Bedrock Mantle requires a Bearer API key or IAM credentials.');
+    }
+    const normalizedReasoningEffort = resolveOpenAiTransportReasoningEffortForContext(
+      profile.reasoningEffort,
+      {
+        provider: 'openai',
+        transportKind: 'open-responses',
+        model,
+      },
+    );
+    const mantleBaseUrl = bedrockMantleApiBaseFromRegion(region);
+    const reasoningSummary = resolveOpenResponsesReasoningSummary({
+      llmVendor: 'openai',
+      model,
+      baseUrl: mantleBaseUrl,
+      ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
+    });
+
+    return {
+      transportKind: 'open-responses',
+      apiKey: resolvedApiKey,
+      model,
+      baseUrl: mantleBaseUrl,
+      workspaceRoot,
+      spiritAgentMode: 'agent',
+      responsesProvider: 'openai',
+      llmVendor: 'openai',
+      store: false,
+      ...(profile.capabilities
+        ? { modelCapabilities: modelCapabilitiesFromConfig(profile.capabilities) }
+        : {}),
+      ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
+      ...(reasoningSummary ? { reasoningSummary } : {}),
+      ...(!resolvedApiKey && accessKeyId && secretAccessKey
+        ? {
+            bedrockMantleIam: {
+              region,
+              accessKeyId,
+              secretAccessKey,
+            },
+          }
+        : {}),
+    };
+  }
+
+  if (transportKind === 'open-responses') {
+    const llmVendor = openAiCompatibleVendorFromProvider(profile.provider);
+    const normalizedReasoningEffort = resolveOpenAiTransportReasoningEffortForContext(
+      profile.reasoningEffort,
+      {
+        ...(profile.provider ? { provider: profile.provider } : {}),
+        transportKind: 'open-responses',
+        model,
+      },
+    );
+    const responsesProvider: OpenResponsesSdkProvider | undefined =
+      profile.provider === 'openai'
+        ? 'openai'
+        : profile.provider === 'xai'
+          ? 'xai'
+          : profile.provider === 'vercel-ai-gateway' || profile.provider === 'openrouter'
+            ? undefined
+            : 'open-responses-compatible';
+    const reasoningSummary = resolveOpenResponsesReasoningSummary({
+      ...(llmVendor ? { llmVendor } : {}),
+      model,
+      ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
+    });
+
+    return {
+      transportKind: 'open-responses',
+      apiKey,
+      model,
+      baseUrl,
+      workspaceRoot,
+      spiritAgentMode: 'agent',
+      ...(responsesProvider ? { responsesProvider } : {}),
+      store: false,
+      ...(llmVendor ? { llmVendor } : {}),
+      ...(profile.capabilities
+        ? { modelCapabilities: modelCapabilitiesFromConfig(profile.capabilities) }
+        : {}),
+      ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
+      ...(reasoningSummary ? { reasoningSummary } : {}),
+    };
+  }
+
+  if (transportKind === 'anthropic') {
+    const supportedAnthropicEfforts = normalizeAnthropicSupportedEfforts(profile.supportedReasoningEfforts);
+    const anthropicEffort = resolveAnthropicTransportReasoningEffortForContext(
+      profile.reasoningEffort,
+      {
+        ...(profile.provider ? { provider: profile.provider } : {}),
+        ...(profile.transportKind ? { transportKind: profile.transportKind } : {}),
+        model,
+      },
+    );
+    return {
+      transportKind: 'anthropic',
+      apiKey,
+      model,
+      baseUrl,
+      workspaceRoot,
+      ...(profile.capabilities
+        ? { modelCapabilities: modelCapabilitiesFromConfig(profile.capabilities) }
+        : {}),
+      ...(supportedAnthropicEfforts !== undefined
+        ? { supportedEfforts: supportedAnthropicEfforts }
+        : {}),
+      ...(anthropicEffort ? { effort: anthropicEffort } : {}),
+    };
+  }
+
+  if (transportKind === 'bedrock') {
+    const region = profile.awsRegion?.trim();
+    if (!region) {
+      throw new Error('Amazon Bedrock model is missing AWS region configuration.');
+    }
+    const bedrockCredentials = readBedrockCredentials('amazon-bedrock');
+    const resolvedApiKey = apiKey.trim() || bedrockCredentials.apiKey?.trim() || '';
+    const accessKeyId = bedrockCredentials.accessKeyId?.trim();
+    const secretAccessKey = bedrockCredentials.secretAccessKey?.trim();
+    const normalizedReasoningEffort = resolveOpenAiTransportReasoningEffortForContext(
+      profile.reasoningEffort,
+      {
+        ...(profile.provider ? { provider: profile.provider } : {}),
+        transportKind: 'bedrock',
+        model,
+      },
+    );
+    return {
+      transportKind: 'bedrock',
+      model,
+      region,
+      ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
+      ...(accessKeyId && secretAccessKey ? { accessKeyId, secretAccessKey } : {}),
+      baseUrl,
+      workspaceRoot,
+      ...(profile.capabilities
+        ? { modelCapabilities: modelCapabilitiesFromConfig(profile.capabilities) }
+        : {}),
+      ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
+    };
+  }
+
+  const llmVendor = openAiCompatibleVendorFromProvider(profile.provider);
+  const normalizedReasoningEffort = resolveOpenAiTransportReasoningEffortForContext(
+    profile.reasoningEffort,
+    {
+      ...(profile.provider ? { provider: profile.provider } : {}),
+      ...(profile.transportKind ? { transportKind: profile.transportKind } : {}),
+      model,
+    },
+  );
+  const vertexCredentials = profile.provider === 'google-vertex-ai'
+    ? readGoogleVertexCredentials('google-vertex-ai')
+    : undefined;
+  const vertexProject = profile.vertexProject?.trim();
+  const vertexLocation = profile.vertexLocation?.trim();
+  const vertexClientEmail = vertexCredentials?.clientEmail?.trim();
+  const vertexPrivateKey = vertexCredentials?.privateKey?.trim();
+
+  return {
+    transportKind: 'openai-compatible',
+    apiKey,
+    model,
+    baseUrl,
+    workspaceRoot,
+    ...(llmVendor ? { llmVendor } : {}),
+    ...(vertexProject ? { vertexProject } : {}),
+    ...(vertexLocation ? { vertexLocation } : {}),
+    ...(vertexClientEmail ? { vertexClientEmail } : {}),
+    ...(vertexPrivateKey ? { vertexPrivateKey } : {}),
+    ...(profile.capabilities
+      ? { modelCapabilities: modelCapabilitiesFromConfig(profile.capabilities) }
+      : {}),
+    ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
+  };
+}
+
+/**
+ * Resolves LLM transport: env override first, then shared Spirit config + keyring.
+ */
+export function resolveTransportConfig(config: AcpServerConfig): LlmTransportConfig {
+  const envKey = resolveEnvApiKey();
+  if (envKey) {
+    return toLlmTransportConfig({ ...config, apiKey: envKey });
+  }
+
+  const profile = loadActiveModelProfile(config.spiritDataDir);
+  if (!profile) {
+    throw new Error('No active model configured. Run spirit-agent-acp --setup first.');
+  }
+
+  const apiKey = resolveStoredApiKeyForProfile(profile) ?? '';
+  if (!apiKey.trim() && profile.provider === 'google-vertex-ai') {
+    const vertex = readGoogleVertexCredentials('google-vertex-ai');
+    const hasVertex = Boolean(
+      vertex.apiKey?.trim()
+      || (vertex.clientEmail?.trim() && vertex.privateKey?.trim()),
+    );
+    if (!hasVertex) {
+      throw new Error(`No Vertex credentials found for model "${profile.name}". Run --setup again.`);
+    }
+  } else if (
+    !apiKey.trim()
+    && profile.provider !== 'amazon-bedrock'
+  ) {
+    throw new Error(`No API key found for model "${profile.name}". Run --setup again.`);
+  }
+
+  return buildTransportFromProfile(profile, apiKey, config.workspaceRoot);
+}

--- a/packages/acp-server/src/types.ts
+++ b/packages/acp-server/src/types.ts
@@ -8,8 +8,8 @@ import type { JsonValue } from '@spirit-agent/core';
 export interface AcpServerConfig {
   /** LLM model name (default: 'gpt-4.1-mini') */
   model: string;
-  /** API key for the LLM provider (required) */
-  apiKey: string;
+  /** API key from SPIRIT_ACP_API_KEY when set at spawn time */
+  apiKey?: string;
   /** Custom base URL for the LLM endpoint (optional) */
   baseUrl?: string;
   /** Workspace root path (default: process.cwd()) */
@@ -22,9 +22,13 @@ export interface AcpServerConfig {
  * Converts AcpServerConfig to an LlmTransportConfig usable by agent-core.
  */
 export function toLlmTransportConfig(config: AcpServerConfig): LlmTransportConfig {
+  const apiKey = config.apiKey?.trim();
+  if (!apiKey) {
+    throw new Error('API key is required to build LLM transport configuration.');
+  }
   const result: import('@spirit-agent/core').OpenAiTransportConfig = {
     transportKind: 'openai-compatible',
-    apiKey: config.apiKey,
+    apiKey,
     model: config.model,
     workspaceRoot: config.workspaceRoot,
   };

--- a/packages/acp-server/src/types.ts
+++ b/packages/acp-server/src/types.ts
@@ -3,39 +3,13 @@ import type { HostToolExecutorProxy } from '@spirit-agent/core/host-bridge';
 import type { JsonValue } from '@spirit-agent/core';
 
 /**
- * ACP Server configuration derived from environment variables or ACP parameters.
+ * ACP Server runtime paths. LLM transport is resolved from shared Spirit config + keyring.
  */
 export interface AcpServerConfig {
-  /** LLM model name (default: 'gpt-4.1-mini') */
-  model: string;
-  /** API key from SPIRIT_ACP_API_KEY when set at spawn time */
-  apiKey?: string;
-  /** Custom base URL for the LLM endpoint (optional) */
-  baseUrl?: string;
   /** Workspace root path (default: process.cwd()) */
   workspaceRoot: string;
   /** Spirit data directory (default: APPDATA/SpiritAgent or ~/.spirit-agent) */
   spiritDataDir: string;
-}
-
-/**
- * Converts AcpServerConfig to an LlmTransportConfig usable by agent-core.
- */
-export function toLlmTransportConfig(config: AcpServerConfig): LlmTransportConfig {
-  const apiKey = config.apiKey?.trim();
-  if (!apiKey) {
-    throw new Error('API key is required to build LLM transport configuration.');
-  }
-  const result: import('@spirit-agent/core').OpenAiTransportConfig = {
-    transportKind: 'openai-compatible',
-    apiKey,
-    model: config.model,
-    workspaceRoot: config.workspaceRoot,
-  };
-  if (config.baseUrl !== undefined) {
-    result.baseUrl = config.baseUrl;
-  }
-  return result;
 }
 
 /**

--- a/packages/acp-server/test/credentials.test.ts
+++ b/packages/acp-server/test/credentials.test.ts
@@ -9,7 +9,11 @@ import {
   saveProviderSetup,
   setKeyringStoreForTests,
 } from '../src/credentials/index.js';
-import { providerKeyAccount } from '../src/credentials/provider-accounts.js';
+import {
+  providerAccessKeyIdAccount,
+  providerKeyAccount,
+  providerSecretAccessKeyAccount,
+} from '../src/credentials/provider-accounts.js';
 
 test('loadSpiritConfig returns undefined for invalid JSON', () => {
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-config-'));
@@ -77,6 +81,45 @@ test('saveProviderSetup persists keyring and config together', async () => {
     const config = loadSpiritConfig(dir);
     assert.equal(config?.activeModel, 'gpt-4o-mini');
     assert.equal(config?.models.length, 1);
+  } finally {
+    setKeyringStoreForTests(undefined);
+  }
+});
+
+test('saveProviderSetup persists bedrock IAM credentials', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-save-bedrock-'));
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+
+  const setup = {
+    profile: {
+      name: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+      apiBase: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      provider: 'amazon-bedrock' as const,
+      transportKind: 'bedrock' as const,
+      awsRegion: 'us-east-1',
+    },
+    providerScope: 'amazon-bedrock' as const,
+    bedrock: {
+      accessKeyId: 'AKIAEXAMPLE',
+      secretAccessKey: 'secret-key',
+    },
+  };
+
+  try {
+    await saveProviderSetup(dir, setup);
+    assert.equal(passwords.get(providerAccessKeyIdAccount('amazon-bedrock')), 'AKIAEXAMPLE');
+    assert.equal(passwords.get(providerSecretAccessKeyAccount('amazon-bedrock')), 'secret-key');
+    const config = loadSpiritConfig(dir);
+    assert.equal(config?.activeModel, setup.profile.name);
   } finally {
     setKeyringStoreForTests(undefined);
   }

--- a/packages/acp-server/test/credentials.test.ts
+++ b/packages/acp-server/test/credentials.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  loadSpiritConfig,
+  saveProviderSetup,
+  setKeyringStoreForTests,
+} from '../src/credentials/index.js';
+import { providerKeyAccount } from '../src/credentials/provider-accounts.js';
+
+test('saveProviderSetup writes keyring before config', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-save-'));
+  const setup = {
+    profile: {
+      name: 'gpt-4o-mini',
+      apiBase: 'https://api.openai.com/v1',
+      provider: 'openai' as const,
+    },
+    providerScope: 'openai' as const,
+    apiKey: 'secret-key',
+  };
+
+  setKeyringStoreForTests({
+    getPassword: () => undefined,
+    setPassword: () => {
+      throw new Error('keyring unavailable');
+    },
+    deletePassword: () => {},
+  });
+
+  try {
+    await assert.rejects(
+      () => saveProviderSetup(dir, setup),
+      /keyring unavailable/,
+    );
+    assert.equal(existsSync(join(dir, 'config.json')), false);
+  } finally {
+    setKeyringStoreForTests(undefined);
+  }
+});
+
+test('saveProviderSetup persists keyring and config together', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-save-'));
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+
+  const setup = {
+    profile: {
+      name: 'gpt-4o-mini',
+      apiBase: 'https://api.openai.com/v1',
+      provider: 'openai' as const,
+    },
+    providerScope: 'openai' as const,
+    apiKey: 'secret-key',
+  };
+
+  try {
+    await saveProviderSetup(dir, setup);
+    assert.equal(passwords.get(providerKeyAccount('openai')), 'secret-key');
+    const config = loadSpiritConfig(dir);
+    assert.equal(config?.activeModel, 'gpt-4o-mini');
+    assert.equal(config?.models.length, 1);
+  } finally {
+    setKeyringStoreForTests(undefined);
+  }
+});

--- a/packages/acp-server/test/credentials.test.ts
+++ b/packages/acp-server/test/credentials.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -10,6 +10,12 @@ import {
   setKeyringStoreForTests,
 } from '../src/credentials/index.js';
 import { providerKeyAccount } from '../src/credentials/provider-accounts.js';
+
+test('loadSpiritConfig returns undefined for invalid JSON', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-config-'));
+  writeFileSync(join(dir, 'config.json'), '{not json', 'utf8');
+  assert.equal(loadSpiritConfig(dir), undefined);
+});
 
 test('saveProviderSetup writes keyring before config', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-save-'));

--- a/packages/acp-server/test/resolve-transport.test.ts
+++ b/packages/acp-server/test/resolve-transport.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { loadBaseConfig } from '../src/config.js';
+import {
+  providerAccessKeyIdAccount,
+  providerSecretAccessKeyAccount,
+} from '../src/credentials/provider-accounts.js';
+import { setKeyringStoreForTests } from '../src/credentials/index.js';
+import { resolveTransportConfig } from '../src/transport/resolve-transport.js';
+
+test('resolveTransportConfig builds bedrock transport from IAM credentials', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-bedrock-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      models: [{
+        name: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+        apiBase: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+        provider: 'amazon-bedrock',
+        transportKind: 'bedrock',
+        awsRegion: 'us-east-1',
+      }],
+      activeModel: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    }),
+    'utf8',
+  );
+
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+  passwords.set(providerAccessKeyIdAccount('amazon-bedrock'), 'AKIAEXAMPLE');
+  passwords.set(providerSecretAccessKeyAccount('amazon-bedrock'), 'secret-key');
+
+  try {
+    const config = loadBaseConfig();
+    config.spiritDataDir = dir;
+    const transport = resolveTransportConfig(config);
+    assert.equal(transport.transportKind, 'bedrock');
+    if (transport.transportKind === 'bedrock') {
+      assert.equal(transport.region, 'us-east-1');
+      assert.equal(transport.accessKeyId, 'AKIAEXAMPLE');
+      assert.equal(transport.secretAccessKey, 'secret-key');
+    }
+  } finally {
+    setKeyringStoreForTests(undefined);
+  }
+});

--- a/packages/acp-server/test/resolve-transport.test.ts
+++ b/packages/acp-server/test/resolve-transport.test.ts
@@ -8,6 +8,8 @@ import { loadBaseConfig } from '../src/config.js';
 import {
   providerAccessKeyIdAccount,
   providerSecretAccessKeyAccount,
+  providerVertexClientEmailAccount,
+  providerVertexPrivateKeyAccount,
 } from '../src/credentials/provider-accounts.js';
 import { setKeyringStoreForTests } from '../src/credentials/index.js';
 import { resolveTransportConfig } from '../src/transport/resolve-transport.js';
@@ -51,6 +53,52 @@ test('resolveTransportConfig builds bedrock transport from IAM credentials', () 
       assert.equal(transport.region, 'us-east-1');
       assert.equal(transport.accessKeyId, 'AKIAEXAMPLE');
       assert.equal(transport.secretAccessKey, 'secret-key');
+    }
+  } finally {
+    setKeyringStoreForTests(undefined);
+  }
+});
+
+test('resolveTransportConfig builds vertex transport from service account credentials', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-vertex-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      models: [{
+        name: 'gemini-2.0-flash',
+        apiBase: 'https://us-central1-aiplatform.googleapis.com/v1',
+        provider: 'google-vertex-ai',
+        vertexProject: 'my-project',
+        vertexLocation: 'us-central1',
+      }],
+      activeModel: 'gemini-2.0-flash',
+    }),
+    'utf8',
+  );
+
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+  passwords.set(providerVertexClientEmailAccount('google-vertex-ai'), 'sa@my-project.iam.gserviceaccount.com');
+  passwords.set(providerVertexPrivateKeyAccount('google-vertex-ai'), '-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----');
+
+  try {
+    const config = loadBaseConfig();
+    config.spiritDataDir = dir;
+    const transport = resolveTransportConfig(config);
+    assert.equal(transport.transportKind, 'openai-compatible');
+    if (transport.transportKind === 'openai-compatible') {
+      assert.equal(transport.vertexProject, 'my-project');
+      assert.equal(transport.vertexLocation, 'us-central1');
+      assert.equal(transport.vertexClientEmail, 'sa@my-project.iam.gserviceaccount.com');
+      assert.ok(transport.vertexPrivateKey?.includes('BEGIN PRIVATE KEY'));
     }
   } finally {
     setKeyringStoreForTests(undefined);

--- a/packages/acp-server/test/terminal-auth.test.ts
+++ b/packages/acp-server/test/terminal-auth.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { AuthState, createAuthState } from '../src/auth/auth-state.js';
+import { buildAuthMethods, buildTerminalAuthMethod } from '../src/auth/build-auth-methods.js';
+import {
+  TERMINAL_AUTH_ARGS,
+  TERMINAL_AUTH_METHOD_ID,
+} from '../src/auth/constants.js';
+import { canCreateSession, isEnvPreAuthenticated } from '../src/auth/session-auth.js';
+import { loadBaseConfig, resolveEnvApiKey } from '../src/config.js';
+import { hasResolvableCredentials, setKeyringStoreForTests } from '../src/credentials/index.js';
+import { providerKeyAccount } from '../src/credentials/provider-accounts.js';
+import {
+  validateAzureSetup,
+  validateBedrockCredentials,
+  validateCustomSetup,
+  validateModelName,
+  buildSetupProfile,
+} from '../src/setup/provider-wizard.js';
+import { resolveTransportConfig } from '../src/transport/resolve-transport.js';
+
+test('buildTerminalAuthMethod declares terminal setup args', () => {
+  const method = buildTerminalAuthMethod();
+  assert.equal(method.id, TERMINAL_AUTH_METHOD_ID);
+  assert.equal((method as { type?: string }).type, 'terminal');
+  assert.deepEqual((method as { args?: string[] }).args, [...TERMINAL_AUTH_ARGS]);
+});
+
+test('buildAuthMethods returns a non-empty terminal method list', () => {
+  const methods = buildAuthMethods();
+  assert.equal(methods.length, 1);
+  assert.equal((methods[0] as { type?: string }).type, 'terminal');
+});
+
+test('AuthState pre-authenticates when constructed with true', () => {
+  const state = createAuthState(true);
+  assert.equal(state.isAuthenticated(), true);
+  state.logout();
+  assert.equal(state.isAuthenticated(), false);
+});
+
+test('canCreateSession allows env API key without authenticate', () => {
+  const previous = process.env['SPIRIT_ACP_API_KEY'];
+  process.env['SPIRIT_ACP_API_KEY'] = 'test-key';
+  try {
+    const config = loadBaseConfig();
+    const authState = new AuthState(false);
+    assert.equal(canCreateSession(config, authState), true);
+    assert.equal(isEnvPreAuthenticated(), true);
+  } finally {
+    if (previous === undefined) {
+      delete process.env['SPIRIT_ACP_API_KEY'];
+    } else {
+      process.env['SPIRIT_ACP_API_KEY'] = previous;
+    }
+  }
+});
+
+test('canCreateSession requires authenticate when using shared credentials', () => {
+  const previous = process.env['SPIRIT_ACP_API_KEY'];
+  delete process.env['SPIRIT_ACP_API_KEY'];
+
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      models: [{
+        name: 'gpt-4o-mini',
+        apiBase: 'https://api.openai.com/v1',
+        provider: 'openai',
+      }],
+      activeModel: 'gpt-4o-mini',
+    }),
+    'utf8',
+  );
+
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+  passwords.set(providerKeyAccount('openai'), 'stored-key');
+
+  try {
+    const config = loadBaseConfig();
+    config.spiritDataDir = dir;
+    const unauthenticated = new AuthState(false);
+    assert.equal(hasResolvableCredentials(dir), true);
+    assert.equal(canCreateSession(config, unauthenticated), false);
+
+    unauthenticated.markAuthenticated();
+    assert.equal(canCreateSession(config, unauthenticated), true);
+  } finally {
+    setKeyringStoreForTests(undefined);
+    if (previous === undefined) {
+      delete process.env['SPIRIT_ACP_API_KEY'];
+    } else {
+      process.env['SPIRIT_ACP_API_KEY'] = previous;
+    }
+  }
+});
+
+test('loadBaseConfig does not require SPIRIT_ACP_API_KEY', () => {
+  const previous = process.env['SPIRIT_ACP_API_KEY'];
+  delete process.env['SPIRIT_ACP_API_KEY'];
+  try {
+    const config = loadBaseConfig();
+    assert.equal(config.apiKey, undefined);
+  } finally {
+    if (previous === undefined) {
+      delete process.env['SPIRIT_ACP_API_KEY'];
+    } else {
+      process.env['SPIRIT_ACP_API_KEY'] = previous;
+    }
+  }
+});
+
+test('resolveEnvApiKey rejects unexpanded placeholders', () => {
+  const previous = process.env['SPIRIT_ACP_API_KEY'];
+  process.env['SPIRIT_ACP_API_KEY'] = '${SPIRIT_ACP_API_KEY}';
+  try {
+    assert.throws(() => resolveEnvApiKey(), /unexpanded placeholder/);
+  } finally {
+    if (previous === undefined) {
+      delete process.env['SPIRIT_ACP_API_KEY'];
+    } else {
+      process.env['SPIRIT_ACP_API_KEY'] = previous;
+    }
+  }
+});
+
+test('resolveTransportConfig prefers env override', () => {
+  const previousKey = process.env['SPIRIT_ACP_API_KEY'];
+  const previousModel = process.env['SPIRIT_ACP_MODEL'];
+  process.env['SPIRIT_ACP_API_KEY'] = 'env-key';
+  process.env['SPIRIT_ACP_MODEL'] = 'gpt-test';
+  try {
+    const config = loadBaseConfig();
+    const transport = resolveTransportConfig(config);
+    assert.equal(transport.transportKind, 'openai-compatible');
+    if (transport.transportKind === 'openai-compatible') {
+      assert.equal(transport.apiKey, 'env-key');
+      assert.equal(transport.model, 'gpt-test');
+    }
+  } finally {
+    if (previousKey === undefined) {
+      delete process.env['SPIRIT_ACP_API_KEY'];
+    } else {
+      process.env['SPIRIT_ACP_API_KEY'] = previousKey;
+    }
+    if (previousModel === undefined) {
+      delete process.env['SPIRIT_ACP_MODEL'];
+    } else {
+      process.env['SPIRIT_ACP_MODEL'] = previousModel;
+    }
+  }
+});
+
+test('setup validation helpers catch missing fields', () => {
+  assert.ok(validateModelName(''));
+  assert.ok(validateBedrockCredentials({ awsRegion: 'us-east-1' }));
+  assert.ok(validateAzureSetup({ azureResourceName: 'my-resource', apiKey: 'k', modelName: '' }));
+  assert.equal(
+    validateCustomSetup({ apiBase: 'https://example.com/v1', apiKey: 'k', modelName: 'm' }),
+    undefined,
+  );
+});
+
+test('buildSetupProfile resolves preset provider api base', () => {
+  const profile = buildSetupProfile({
+    provider: 'openai',
+    modelName: 'gpt-4o-mini',
+  });
+  assert.equal(profile.provider, 'openai');
+  assert.ok(profile.apiBase.includes('openai.com'));
+});

--- a/packages/acp-server/test/terminal-auth.test.ts
+++ b/packages/acp-server/test/terminal-auth.test.ts
@@ -10,8 +10,8 @@ import {
   TERMINAL_AUTH_ARGS,
   TERMINAL_AUTH_METHOD_ID,
 } from '../src/auth/constants.js';
-import { canCreateSession, createInitialAuthState, isEnvPreAuthenticated } from '../src/auth/session-auth.js';
-import { loadBaseConfig, resolveEnvApiKey } from '../src/config.js';
+import { canCreateSession, createInitialAuthState } from '../src/auth/session-auth.js';
+import { loadBaseConfig } from '../src/config.js';
 import { hasResolvableCredentials, setKeyringStoreForTests } from '../src/credentials/index.js';
 import { providerKeyAccount } from '../src/credentials/provider-accounts.js';
 import {
@@ -43,27 +43,7 @@ test('AuthState pre-authenticates when constructed with true', () => {
   assert.equal(state.isAuthenticated(), false);
 });
 
-test('canCreateSession allows env API key without authenticate', () => {
-  const previous = process.env['SPIRIT_ACP_API_KEY'];
-  process.env['SPIRIT_ACP_API_KEY'] = 'test-key';
-  try {
-    const config = loadBaseConfig();
-    const authState = new AuthState(false);
-    assert.equal(canCreateSession(config, authState), true);
-    assert.equal(isEnvPreAuthenticated(), true);
-  } finally {
-    if (previous === undefined) {
-      delete process.env['SPIRIT_ACP_API_KEY'];
-    } else {
-      process.env['SPIRIT_ACP_API_KEY'] = previous;
-    }
-  }
-});
-
 test('buildAuthMethodsForStartup omits methods when shared credentials exist', () => {
-  const previous = process.env['SPIRIT_ACP_API_KEY'];
-  delete process.env['SPIRIT_ACP_API_KEY'];
-
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
@@ -95,18 +75,10 @@ test('buildAuthMethodsForStartup omits methods when shared credentials exist', (
     assert.equal(buildAuthMethodsForStartup(mkdtempSync(join(tmpdir(), 'spirit-acp-empty-'))).length, 1);
   } finally {
     setKeyringStoreForTests(undefined);
-    if (previous === undefined) {
-      delete process.env['SPIRIT_ACP_API_KEY'];
-    } else {
-      process.env['SPIRIT_ACP_API_KEY'] = previous;
-    }
   }
 });
 
 test('createInitialAuthState pre-authenticates when shared credentials exist', () => {
-  const previous = process.env['SPIRIT_ACP_API_KEY'];
-  delete process.env['SPIRIT_ACP_API_KEY'];
-
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
@@ -141,18 +113,10 @@ test('createInitialAuthState pre-authenticates when shared credentials exist', (
     assert.equal(canCreateSession(config, authState), true);
   } finally {
     setKeyringStoreForTests(undefined);
-    if (previous === undefined) {
-      delete process.env['SPIRIT_ACP_API_KEY'];
-    } else {
-      process.env['SPIRIT_ACP_API_KEY'] = previous;
-    }
   }
 });
 
 test('canCreateSession requires authenticate when using shared credentials without pre-auth', () => {
-  const previous = process.env['SPIRIT_ACP_API_KEY'];
-  delete process.env['SPIRIT_ACP_API_KEY'];
-
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
@@ -190,67 +154,54 @@ test('canCreateSession requires authenticate when using shared credentials witho
     assert.equal(canCreateSession(config, unauthenticated), true);
   } finally {
     setKeyringStoreForTests(undefined);
-    if (previous === undefined) {
-      delete process.env['SPIRIT_ACP_API_KEY'];
-    } else {
-      process.env['SPIRIT_ACP_API_KEY'] = previous;
-    }
   }
 });
 
-test('loadBaseConfig does not require SPIRIT_ACP_API_KEY', () => {
-  const previous = process.env['SPIRIT_ACP_API_KEY'];
-  delete process.env['SPIRIT_ACP_API_KEY'];
+test('loadBaseConfig only resolves runtime paths', () => {
+  const config = loadBaseConfig();
+  assert.ok(config.workspaceRoot);
+  assert.ok(config.spiritDataDir);
+  assert.equal(Object.keys(config).sort().join(','), 'spiritDataDir,workspaceRoot');
+});
+
+test('resolveTransportConfig reads shared config and keyring', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-transport-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      models: [{
+        name: 'gpt-4o-mini',
+        apiBase: 'https://api.openai.com/v1',
+        provider: 'openai',
+      }],
+      activeModel: 'gpt-4o-mini',
+    }),
+    'utf8',
+  );
+
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+  passwords.set(providerKeyAccount('openai'), 'stored-key');
+
   try {
     const config = loadBaseConfig();
-    assert.equal(config.apiKey, undefined);
-  } finally {
-    if (previous === undefined) {
-      delete process.env['SPIRIT_ACP_API_KEY'];
-    } else {
-      process.env['SPIRIT_ACP_API_KEY'] = previous;
-    }
-  }
-});
-
-test('resolveEnvApiKey rejects unexpanded placeholders', () => {
-  const previous = process.env['SPIRIT_ACP_API_KEY'];
-  process.env['SPIRIT_ACP_API_KEY'] = '${SPIRIT_ACP_API_KEY}';
-  try {
-    assert.throws(() => resolveEnvApiKey(), /unexpanded placeholder/);
-  } finally {
-    if (previous === undefined) {
-      delete process.env['SPIRIT_ACP_API_KEY'];
-    } else {
-      process.env['SPIRIT_ACP_API_KEY'] = previous;
-    }
-  }
-});
-
-test('resolveTransportConfig prefers env override', () => {
-  const previousKey = process.env['SPIRIT_ACP_API_KEY'];
-  const previousModel = process.env['SPIRIT_ACP_MODEL'];
-  process.env['SPIRIT_ACP_API_KEY'] = 'env-key';
-  process.env['SPIRIT_ACP_MODEL'] = 'gpt-test';
-  try {
-    const config = loadBaseConfig();
+    config.spiritDataDir = dir;
     const transport = resolveTransportConfig(config);
     assert.equal(transport.transportKind, 'openai-compatible');
     if (transport.transportKind === 'openai-compatible') {
-      assert.equal(transport.apiKey, 'env-key');
-      assert.equal(transport.model, 'gpt-test');
+      assert.equal(transport.apiKey, 'stored-key');
+      assert.equal(transport.model, 'gpt-4o-mini');
     }
   } finally {
-    if (previousKey === undefined) {
-      delete process.env['SPIRIT_ACP_API_KEY'];
-    } else {
-      process.env['SPIRIT_ACP_API_KEY'] = previousKey;
-    }
-    if (previousModel === undefined) {
-      delete process.env['SPIRIT_ACP_MODEL'];
-    } else {
-      process.env['SPIRIT_ACP_MODEL'] = previousModel;
-    }
+    setKeyringStoreForTests(undefined);
   }
 });
 

--- a/packages/acp-server/test/terminal-auth.test.ts
+++ b/packages/acp-server/test/terminal-auth.test.ts
@@ -5,12 +5,12 @@ import { join } from 'node:path';
 import test from 'node:test';
 
 import { AuthState, createAuthState } from '../src/auth/auth-state.js';
-import { buildAuthMethods, buildTerminalAuthMethod } from '../src/auth/build-auth-methods.js';
+import { buildAuthMethods, buildAuthMethodsForStartup, buildTerminalAuthMethod } from '../src/auth/build-auth-methods.js';
 import {
   TERMINAL_AUTH_ARGS,
   TERMINAL_AUTH_METHOD_ID,
 } from '../src/auth/constants.js';
-import { canCreateSession, isEnvPreAuthenticated } from '../src/auth/session-auth.js';
+import { canCreateSession, createInitialAuthState, isEnvPreAuthenticated } from '../src/auth/session-auth.js';
 import { loadBaseConfig, resolveEnvApiKey } from '../src/config.js';
 import { hasResolvableCredentials, setKeyringStoreForTests } from '../src/credentials/index.js';
 import { providerKeyAccount } from '../src/credentials/provider-accounts.js';
@@ -60,7 +60,96 @@ test('canCreateSession allows env API key without authenticate', () => {
   }
 });
 
-test('canCreateSession requires authenticate when using shared credentials', () => {
+test('buildAuthMethodsForStartup omits methods when shared credentials exist', () => {
+  const previous = process.env['SPIRIT_ACP_API_KEY'];
+  delete process.env['SPIRIT_ACP_API_KEY'];
+
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      models: [{
+        name: 'gpt-4o-mini',
+        apiBase: 'https://api.openai.com/v1',
+        provider: 'openai',
+      }],
+      activeModel: 'gpt-4o-mini',
+    }),
+    'utf8',
+  );
+
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+  passwords.set(providerKeyAccount('openai'), 'stored-key');
+
+  try {
+    assert.equal(buildAuthMethodsForStartup(dir).length, 0);
+    assert.equal(buildAuthMethodsForStartup(mkdtempSync(join(tmpdir(), 'spirit-acp-empty-'))).length, 1);
+  } finally {
+    setKeyringStoreForTests(undefined);
+    if (previous === undefined) {
+      delete process.env['SPIRIT_ACP_API_KEY'];
+    } else {
+      process.env['SPIRIT_ACP_API_KEY'] = previous;
+    }
+  }
+});
+
+test('createInitialAuthState pre-authenticates when shared credentials exist', () => {
+  const previous = process.env['SPIRIT_ACP_API_KEY'];
+  delete process.env['SPIRIT_ACP_API_KEY'];
+
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      models: [{
+        name: 'gpt-4o-mini',
+        apiBase: 'https://api.openai.com/v1',
+        provider: 'openai',
+      }],
+      activeModel: 'gpt-4o-mini',
+    }),
+    'utf8',
+  );
+
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+  passwords.set(providerKeyAccount('openai'), 'stored-key');
+
+  try {
+    const config = loadBaseConfig();
+    config.spiritDataDir = dir;
+    const authState = createInitialAuthState(config);
+    assert.equal(authState.isAuthenticated(), true);
+    assert.equal(canCreateSession(config, authState), true);
+  } finally {
+    setKeyringStoreForTests(undefined);
+    if (previous === undefined) {
+      delete process.env['SPIRIT_ACP_API_KEY'];
+    } else {
+      process.env['SPIRIT_ACP_API_KEY'] = previous;
+    }
+  }
+});
+
+test('canCreateSession requires authenticate when using shared credentials without pre-auth', () => {
   const previous = process.env['SPIRIT_ACP_API_KEY'];
   delete process.env['SPIRIT_ACP_API_KEY'];
 

--- a/packages/acp-server/test/terminal-auth.test.ts
+++ b/packages/acp-server/test/terminal-auth.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import test from 'node:test';
 
 import { AuthState, createAuthState } from '../src/auth/auth-state.js';
-import { buildAuthMethods, buildAuthMethodsForStartup, buildTerminalAuthMethod } from '../src/auth/build-auth-methods.js';
+import { buildAuthMethods, buildTerminalAuthMethod } from '../src/auth/build-auth-methods.js';
 import {
   TERMINAL_AUTH_ARGS,
   TERMINAL_AUTH_METHOD_ID,
@@ -43,7 +43,7 @@ test('AuthState pre-authenticates when constructed with true', () => {
   assert.equal(state.isAuthenticated(), false);
 });
 
-test('buildAuthMethodsForStartup omits methods when shared credentials exist', () => {
+test('buildAuthMethods returns terminal auth even when shared credentials exist', () => {
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
@@ -71,8 +71,50 @@ test('buildAuthMethodsForStartup omits methods when shared credentials exist', (
   passwords.set(providerKeyAccount('openai'), 'stored-key');
 
   try {
-    assert.equal(buildAuthMethodsForStartup(dir).length, 0);
-    assert.equal(buildAuthMethodsForStartup(mkdtempSync(join(tmpdir(), 'spirit-acp-empty-'))).length, 1);
+    assert.equal(buildAuthMethods().length, 1);
+  } finally {
+    setKeyringStoreForTests(undefined);
+  }
+});
+
+test('logout allows authenticate to restore session creation', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      models: [{
+        name: 'gpt-4o-mini',
+        apiBase: 'https://api.openai.com/v1',
+        provider: 'openai',
+      }],
+      activeModel: 'gpt-4o-mini',
+    }),
+    'utf8',
+  );
+
+  const passwords = new Map<string, string>();
+  setKeyringStoreForTests({
+    getPassword: (_service, account) => passwords.get(account),
+    setPassword: (_service, account, password) => {
+      passwords.set(account, password);
+    },
+    deletePassword: (_service, account) => {
+      passwords.delete(account);
+    },
+  });
+  passwords.set(providerKeyAccount('openai'), 'stored-key');
+
+  try {
+    const config = loadBaseConfig();
+    config.spiritDataDir = dir;
+    const authState = createInitialAuthState(config);
+    assert.equal(canCreateSession(config, authState), true);
+
+    authState.logout();
+    assert.equal(canCreateSession(config, authState), false);
+
+    authState.markAuthenticated();
+    assert.equal(canCreateSession(config, authState), true);
   } finally {
     setKeyringStoreForTests(undefined);
   }

--- a/packages/acp-server/test/transport-error.test.ts
+++ b/packages/acp-server/test/transport-error.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { mapSessionSetupError } from '../src/transport/map-setup-error.js';
+
+test('mapSessionSetupError maps missing credentials to authRequired', () => {
+  const err = mapSessionSetupError(new Error('No API key found for model "gpt-4o-mini". Run --setup again.'));
+  assert.equal(err.code, -32000);
+});
+
+test('mapSessionSetupError maps unexpected failures to internalError', () => {
+  const err = mapSessionSetupError(new Error('Unexpected runtime failure'));
+  assert.equal(err.code, -32603);
+});


### PR DESCRIPTION
## Summary

- 实现 ACP Terminal Auth：initialize / uthenticate / logout 握手，以及 session/new 门禁；--setup 交互式 provider 配置写入与 Desktop/CLI 共用的 config.json + keyring。
- 运行时从共享配置解析 LLM transport（OpenAI 兼容 /Users Anthropic、Bedrock、Vertex 等），移除 SPIRIT_ACP_API_KEY 等环境变量覆盖路径。
- 审查修复：initialize 始终返回 Terminal authMethods（删除凭据存在时隐藏逻辑）；logout 后可通过 uthenticate 恢复建会话；saveProviderSetup 先写 keyring 再写 config；transport 失败映射为 ACP RequestError；loadSpiritConfig 对损坏 JSON 容错。
- 补充单测（59 项）：Terminal Auth、凭据持久化顺序、Bedrock/Vertex transport、transport 错误映射等。

## Test plan

- [x] 
pm test in packages/acp-server（59/59 pass）
- [x] 
pm run build:acp-server 编译通过
- [x] 手动：spirit-agent-acp --setup 写入共享 config + keyring
- [x] 手动：Zed 配置 gent_servers 后 Terminal Auth 流程（setup → authenticate → session/new）
- [x] 手动：共享 Desktop 凭据存在时预认证且 logout → uthenticate 可恢复
- [x] 手动：无凭据时 session/new 返回 authRequired 而非普通 Error