### PR TITLE
feat(agent-core, desktop, host-internal): 工具输出超长截断归档与 read_file 展示

### DIFF
--- a/apps/cli/src/host_runtime.rs
+++ b/apps/cli/src/host_runtime.rs
@@ -809,7 +809,7 @@ mod tests {
 
     #[test]
     fn glob_tool_block_shows_pattern_detail_and_output_excerpt() {
-        let output = "[glob]\npattern: src/**/*.ts\nmatches: 2\ntruncated: false\n\nsrc/app.ts\nsrc/lib/util.ts\n";
+        let output = "[glob]\npattern: src/**/*.ts\nmatches: 2\n\nsrc/app.ts\nsrc/lib/util.ts\n";
         let block = build_tool_result_block(
             &ToolUiRequest::new("glob", json!({ "pattern": "src/**/*.ts" })),
             "glob",

--- a/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
+++ b/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
@@ -19,6 +19,7 @@ const RENDERER_SAFE_HOST_INTERNAL_SUBPATHS = new Set([
   'bedrock-mantle',
   'google-vertex-endpoints',
   'skill-paths',
+  'tool-output-archive-path',
   'github-pull-request-url',
   'github-pull-request-checks-pages',
   'github-pull-request-conversation-pages',

--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -16,11 +16,13 @@ import { isStandaloneThinkingMessage } from '../lib/conversation-thinking-ui.js'
 import { listDirectoryToolDisplayPath } from '@spirit-agent/host-internal/skill-paths';
 
 import {
-  isSkillMarkdownPath,
   parseReadFilePathFromRequest,
-  readFileVerbKey,
-  skillFolderBasename,
+  lineRangeForReadFile,
 } from '../lib/read-file-skill-display.js';
+import {
+  readFileToolHeadlineDetail,
+  readFileVerbKey,
+} from '../lib/read-file-tool-display.js';
 import { phaseToVerbContext } from '../lib/tool-verb-context.js';
 import {
   hasActiveRunSubagentToolInMessages,
@@ -1073,11 +1075,12 @@ function readFileSummaryCopy(request: unknown, phase?: ToolBlockSnapshot['phase'
 
   const record = request as Record<string, unknown>;
   const rawPath = parseReadFilePathFromRequest(request);
-  const displayPath = isSkillMarkdownPath(rawPath)
-    ? skillFolderBasename(rawPath)
-    : displayPathForReadFile(rawPath);
   const lineRange = lineRangeForReadFile(record.start_line, record.end_line);
-  const detail = `${displayPath}${lineRange}`.trim();
+  const detail = readFileToolHeadlineDetail(rawPath, {
+    emptyFileLabel: i18n.t('tool.file'),
+    toolOutputLabel: i18n.t('tool.toolOutput'),
+    lineRange,
+  });
 
   return {
     headline: i18n.t(readFileVerbKey(rawPath), tOpts),
@@ -1140,27 +1143,6 @@ function displayPathForReadFile(path: string): string {
 
   const segments = normalized.split('/').filter(Boolean);
   return segments[segments.length - 1] || normalized;
-}
-
-function lineRangeForReadFile(startLine: unknown, endLine: unknown): string {
-  const start = positiveLineNumber(startLine);
-  const end = positiveLineNumber(endLine);
-  if (start !== undefined && end !== undefined) {
-    return ` ${start} - ${end}`;
-  }
-  if (start !== undefined) {
-    return ` ${start} -`;
-  }
-  if (end !== undefined) {
-    return ` 1 - ${end}`;
-  }
-  return '';
-}
-
-function positiveLineNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isInteger(value) && value > 0
-    ? value
-    : undefined;
 }
 
 export function restoreMessagesFromArchive(

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -30,6 +30,7 @@ import {
 } from '@spirit-agent/core';
 import {
   persistPreCompactionHistoryArchive,
+  persistToolOutputArchive,
   removePreCompactionHistoryArchive,
   resolveWorkspaceFileReferenceAttachmentsFromInput,
 } from '@spirit-agent/host-internal';
@@ -170,6 +171,8 @@ export function createDesktopRuntime(input: {
       }),
     removePreCompactionHistoryArchive: async (archivePath) =>
       removePreCompactionHistoryArchive(archivePath),
+    persistToolOutputArchive: async (input) =>
+      persistToolOutputArchive(spiritAgentDataDir(), input),
   }, input.history.map((message) => normalizeStoredLlmMessage(message)));
 }
 

--- a/apps/desktop/src/lib/read-file-skill-display.ts
+++ b/apps/desktop/src/lib/read-file-skill-display.ts
@@ -59,6 +59,20 @@ export function readFileDisplayBase(path: string, emptyLabel: string): string {
   return readFileToolDisplayBase(path, emptyLabel);
 }
 
+export function readFileHeadlineDetailForPath(
+  rawPath: string,
+  options: {
+    emptyFileLabel: string;
+    lineRange?: string;
+  },
+): string {
+  const lineRange = options.lineRange ?? '';
+  const base = isSkillMarkdownPath(rawPath)
+    ? skillFolderBasename(rawPath)
+    : readFileToolDisplayBase(rawPath, options.emptyFileLabel);
+  return `${base}${lineRange}`.trim();
+}
+
 function positiveLineNumber(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isInteger(value) && value > 0
     ? value

--- a/apps/desktop/src/lib/read-file-tool-display.ts
+++ b/apps/desktop/src/lib/read-file-tool-display.ts
@@ -1,0 +1,28 @@
+import {
+  readFileHeadlineDetailForPath,
+  readFileVerbKey,
+} from './read-file-skill-display.js';
+import {
+  isToolOutputArchivePath,
+  toolOutputArchiveHeadlineDetail,
+} from './tool-output-archive-display.js';
+
+export function readFileToolHeadlineDetail(
+  rawPath: string,
+  options: {
+    emptyFileLabel: string;
+    toolOutputLabel: string;
+    lineRange?: string;
+  },
+): string {
+  const lineRange = options.lineRange ?? '';
+  if (isToolOutputArchivePath(rawPath)) {
+    return toolOutputArchiveHeadlineDetail(options.toolOutputLabel, lineRange);
+  }
+  return readFileHeadlineDetailForPath(rawPath, {
+    emptyFileLabel: options.emptyFileLabel,
+    lineRange,
+  });
+}
+
+export { readFileVerbKey };

--- a/apps/desktop/src/lib/tool-call-display.ts
+++ b/apps/desktop/src/lib/tool-call-display.ts
@@ -10,10 +10,12 @@ import {
   lineRangeForReadFile,
   parseReadFilePathFromToolSnapshot,
   parseReadFileRequestRecordFromArgsExcerpt,
-  readFileDisplayBase,
-  readFileVerbKey,
   storedReadFileHeadlineUsesSkillVerb,
 } from '@/lib/read-file-skill-display';
+import {
+  readFileToolHeadlineDetail,
+  readFileVerbKey,
+} from '@/lib/read-file-tool-display';
 import { phaseToVerbContext } from '@/lib/tool-verb-context';
 import type { ToolBlockSnapshot } from '@/types';
 
@@ -139,11 +141,14 @@ function readFileToolSummaryParts(tool: ToolBlockSnapshot): ToolCallSummaryParts
 
   if (rawPath) {
     const argsRecord = parseReadFileRequestRecordFromArgsExcerpt(tool.argsExcerpt);
-    const base = readFileDisplayBase(rawPath, i18n.t('tool.file'));
     const lineRange = argsRecord
       ? lineRangeForReadFile(argsRecord.start_line, argsRecord.end_line)
       : '';
-    const computedDetail = `${base}${lineRange}`.trim();
+    const computedDetail = readFileToolHeadlineDetail(rawPath, {
+      emptyFileLabel: i18n.t('tool.file'),
+      toolOutputLabel: i18n.t('tool.toolOutput'),
+      lineRange,
+    });
     return {
       headline: i18n.t(readFileVerbKey(rawPath), tOpts),
       ...((computedDetail || snapshotDetail) ? { detail: computedDetail || snapshotDetail } : {}),
@@ -154,9 +159,13 @@ function readFileToolSummaryParts(tool: ToolBlockSnapshot): ToolCallSummaryParts
     const legacy = LEGACY_READ_FILE_HEADLINE.exec(tool.headline.trim());
     if (legacy) {
       const legacyPath = legacy[1].trim();
+      const legacyDetail = readFileToolHeadlineDetail(legacyPath, {
+        emptyFileLabel: i18n.t('tool.file'),
+        toolOutputLabel: i18n.t('tool.toolOutput'),
+      });
       return {
         headline: i18n.t(readFileVerbKey(legacyPath), tOpts),
-        detail: legacyPath,
+        detail: legacyDetail,
       };
     }
   }

--- a/apps/desktop/src/lib/tool-output-archive-display.ts
+++ b/apps/desktop/src/lib/tool-output-archive-display.ts
@@ -1,0 +1,10 @@
+import { isToolOutputArchivePath } from '@spirit-agent/host-internal/tool-output-archive-path';
+
+export { isToolOutputArchivePath };
+
+export function toolOutputArchiveHeadlineDetail(
+  toolOutputLabel: string,
+  lineRange = '',
+): string {
+  return `${toolOutputLabel}${lineRange}`.trim();
+}

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1094,6 +1094,7 @@
     "read": "Read",
     "use": "Use",
     "file": "File",
+    "toolOutput": "tool output",
     "directory": "Directory",
     "generateImage": "Generate image",
     "generateVideo": "Generate video",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -1092,6 +1092,7 @@
     "read": "查看",
     "use": "使用",
     "file": "文件",
+    "toolOutput": "工具输出",
     "directory": "目录",
     "generateImage": "生成图片",
     "generateVideo": "生成视频",

--- a/apps/desktop/test/host/message-ordering.test.mjs
+++ b/apps/desktop/test/host/message-ordering.test.mjs
@@ -198,6 +198,17 @@ test('toolCallSummaryForPhase: read_file splits headline and path detail', () =>
   );
 });
 
+test('toolCallSummaryForPhase: read_file tool-output-archives uses tool output detail', () => {
+  assert.deepEqual(
+    toolCallSummaryForPhase('succeeded', 'read_file', {
+      path: 'C:/Users/pc/AppData/Roaming/SpiritAgent/tool-output-archives/sess/call_1.txt',
+      start_line: 1,
+      end_line: 5,
+    }),
+    { headline: '查看', headlineDetail: '工具输出 1 - 5' },
+  );
+});
+
 test('toolCallSummaryCopyForRequest: shell reason and command', () => {
   assert.deepEqual(
     toolCallSummaryCopyForRequest('run_shell_command', {

--- a/apps/desktop/test/lib/tool-call-display.test.mjs
+++ b/apps/desktop/test/lib/tool-call-display.test.mjs
@@ -201,6 +201,29 @@ test('getToolCallSummaryParts: read_file SKILL.md re-translates from stored Chin
   }
 });
 
+test('getToolCallSummaryParts: read_file tool-output-archives uses tool output detail', async () => {
+  await i18n.changeLanguage('en');
+  try {
+    assert.deepEqual(
+      getToolCallSummaryParts({
+        toolName: 'read_file',
+        phase: 'succeeded',
+        headline: 'Read',
+        headlineDetail: 'call_1.txt',
+        argsExcerpt: JSON.stringify({
+          path: 'C:/Users/pc/AppData/Roaming/SpiritAgent/tool-output-archives/sess/call_1.txt',
+          start_line: 1,
+          end_line: 5,
+        }),
+        detailLines: [],
+      }),
+      { headline: 'Read', detail: 'tool output 1 - 5' },
+    );
+  } finally {
+    await i18n.changeLanguage('zh-CN');
+  }
+});
+
 test('getToolCallSummaryParts: legacy Chinese "查看" headline still parsed', () => {
   assert.deepEqual(
     getToolCallSummaryParts({

--- a/packages/acp-server/src/runtime-factory.ts
+++ b/packages/acp-server/src/runtime-factory.ts
@@ -40,6 +40,7 @@ import {
   ensureBuiltinAuthoringSkills,
   loadHostInstructionMetadata,
   persistPreCompactionHistoryArchive,
+  persistToolOutputArchive,
   removePreCompactionHistoryArchive,
 } from '@spirit-agent/host-internal';
 
@@ -224,6 +225,8 @@ export async function createAcpRuntime(
       }),
     removePreCompactionHistoryArchive: async (archivePath) =>
       removePreCompactionHistoryArchive(archivePath),
+    persistToolOutputArchive: async (input) =>
+      persistToolOutputArchive(spiritDataDir, input),
     onEvent,
   });
 

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -166,6 +166,15 @@ interface CliHostInternalModule {
     options?: { sessionId?: string },
   ) => Promise<string>;
   removePreCompactionHistoryArchive?: (archivePath: string) => Promise<void>;
+  persistToolOutputArchive?: (
+    spiritDataDir: string,
+    input: {
+      content: string;
+      sessionId?: string;
+      toolCallId?: string;
+      messageIndex?: number;
+    },
+  ) => Promise<string>;
   loadHostInstructionMetadata: (
     context: { workspaceRoot: string; spiritDataDir: string },
     options?: { planMode?: boolean; agentMode?: SpiritAgentMode; activePlanPath?: string },
@@ -1815,6 +1824,19 @@ async function createRuntime(
         await remove(archivePath);
       } catch {
         // Best-effort orphan cleanup.
+      }
+    },
+    persistToolOutputArchive: async (input) => {
+      const hostInternal = await ensureCliHostInternal(workspaceRoot);
+      const persist = hostInternal?.module.persistToolOutputArchive;
+      if (!hostInternal || typeof persist !== 'function') {
+        return undefined;
+      }
+
+      try {
+        return await persist(hostInternal.spiritDataDir, input);
+      } catch {
+        return undefined;
       }
     },
   }, history) as HostRuntime;

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -3467,7 +3467,7 @@ function buildParentSubagentToolResultText(
   }
 
   const label = failed ? 'error:' : 'final_output:';
-  return `${header}\ntitle=${normalizedTitle}\n${sessionLine}${label}\n${truncateTextForParentSubagentResult(normalizedOutput, 6000)}`;
+  return `${header}\ntitle=${normalizedTitle}\n${sessionLine}${label}\n${normalizedOutput}`;
 }
 
 function buildParentSubagentToolResultTextFromRequest<ToolRequest>(
@@ -3498,15 +3498,6 @@ function resolveSubagentResultText(
     || latestAssistantMessage(record.llmHistory)?.trim()
     || record.summary.latestMessage?.trim()
     || normalizedOutput;
-}
-
-function truncateTextForParentSubagentResult(text: string, maxChars: number): string {
-  const chars = Array.from(text);
-  if (chars.length <= maxChars) {
-    return text;
-  }
-
-  return `${chars.slice(0, maxChars).join('')}\n\n...<subagent result truncated>`;
 }
 
 function singleLineStatusText(text: string): string {

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -107,6 +107,7 @@ import {
   persistToolExecutionResult as persistToolExecutionResultInternal,
 } from './runtime/tool-execution.js';
 import { buildRuntimeToolExecution } from './runtime/turn-machine.js';
+import { prepareRuntimeToolResultContentForAppend } from './runtime/tool-output-append.js';
 import type {
   AgentRuntimeOptions,
   AssistantAuxKind,
@@ -288,6 +289,19 @@ export class AgentRuntime<
     this.loopEnabledStore = false;
     this.runtimeDepthStore = runtimeDepth;
     this.childSessionCounterStore = 0;
+  }
+
+  private async appendToolResultMessageWithOutputTruncation(
+    state: State,
+    toolCallId: string,
+    content: string,
+  ): Promise<State> {
+    const preparedContent = await prepareRuntimeToolResultContentForAppend(
+      this.options,
+      toolCallId,
+      content,
+    );
+    return this.options.appendToolResultMessage(state, toolCallId, preparedContent);
   }
 
   history(): readonly LlmMessage[] {
@@ -1068,7 +1082,7 @@ export class AgentRuntime<
       this.emitEvent({ kind: 'tool-execution-finished', execution: finished });
       enqueueDeferredToolOutputGuidance(pending.turn, pending.toolName, execution.output);
 
-      const resumedState = this.options.appendToolResultMessage(
+      const resumedState = await this.appendToolResultMessageWithOutputTruncation(
         pending.state,
         pending.toolCallId,
         execution.output.summaryText,
@@ -1247,7 +1261,7 @@ export class AgentRuntime<
     this.completedTurnResultStore = undefined;
 
     const resumeAfterToolOutput = async (output: string): Promise<void> => {
-      const resumedState = this.options.appendToolResultMessage(
+      const resumedState = await this.appendToolResultMessageWithOutputTruncation(
         pending.state,
         pending.toolCallId,
         output,
@@ -1377,7 +1391,7 @@ export class AgentRuntime<
       this.emitEvent({ kind: 'tool-execution-finished', execution: finished });
       enqueueDeferredToolOutputGuidance(pending.turn, pending.toolName, execution.output);
 
-      const resumedStateWithToolOutput = this.options.appendToolResultMessage(
+      const resumedStateWithToolOutput = await this.appendToolResultMessageWithOutputTruncation(
         resumedState,
         pending.toolCallId,
         execution.output.summaryText,
@@ -1658,7 +1672,7 @@ export class AgentRuntime<
       failed: outcome.failed,
     });
 
-    const resumedState = this.options.appendToolResultMessage(
+    const resumedState = await this.appendToolResultMessageWithOutputTruncation(
       state,
       toolCallId,
       parentToolResultText,
@@ -1842,7 +1856,7 @@ export class AgentRuntime<
       failed: outcome.failed,
     });
 
-    const resumedState = this.options.appendToolResultMessage(
+    const resumedState = await this.appendToolResultMessageWithOutputTruncation(
       state,
       toolCallId,
       parentToolResultText,
@@ -2577,7 +2591,7 @@ export class AgentRuntime<
       }
 
       const output = await this.options.generateImage(imageRequest);
-      const resumedState = this.options.appendToolResultMessage(
+      const resumedState = await this.appendToolResultMessageWithOutputTruncation(
         state,
         toolCallId,
         output.summaryText,
@@ -2653,7 +2667,7 @@ export class AgentRuntime<
       }
 
       const output = await this.options.generateVideo(videoRequest);
-      const resumedState = this.options.appendToolResultMessage(
+      const resumedState = await this.appendToolResultMessageWithOutputTruncation(
         state,
         toolCallId,
         output.summaryText,
@@ -3100,7 +3114,7 @@ export class AgentRuntime<
 
     const batch = this.pendingSubagentBatchContinuation;
     const baseState = batch?.parentState ?? pending.parentState;
-    const resumedState = this.options.appendToolResultMessage(
+    const resumedState = await this.appendToolResultMessageWithOutputTruncation(
       baseState,
       pending.parentToolCallId,
       parentToolResultText,

--- a/packages/agent-core/src/runtime/background-tools.ts
+++ b/packages/agent-core/src/runtime/background-tools.ts
@@ -3,6 +3,7 @@ import type { JsonObject } from '../ports.js';
 import { createToolExecutionTextOutput } from '../ports.js';
 
 import { renderError } from './helpers.js';
+import { prepareRuntimeToolResultContentForAppend } from './tool-output-append.js';
 import { toolInputFromArgumentsJson } from '../hooks/integration.js';
 import { runPostToolUseSideEffects } from '../hooks/tool-hooks.js';
 import { commitToolExecutionOutput, type TurnMachineRuntime } from './turn-machine.js';
@@ -266,10 +267,15 @@ export async function pollPendingBackgroundToolExecution<
     pending.failed,
   );
 
+  const preparedOutput = await prepareRuntimeToolResultContentForAppend(
+    runtime.options,
+    pending.toolCallId,
+    pending.output.summaryText,
+  );
   const resumedState = runtime.options.appendToolResultMessage(
     pending.state,
     pending.toolCallId,
-    pending.output.summaryText,
+    preparedOutput,
   );
   if (pending.remainingCalls.length > 0) {
     runtime.queuePendingToolCallContinuation(

--- a/packages/agent-core/src/runtime/compaction.runtime.test.ts
+++ b/packages/agent-core/src/runtime/compaction.runtime.test.ts
@@ -250,6 +250,80 @@ test('compactHistoryImmediate archives pre-truncation history and compacts post-
   assert.ok(compactionToolText.length < longToolOutput.length);
 });
 
+test('compactHistoryImmediate persists tool output archive path in truncated excerpt', async () => {
+  const longToolOutput = 'y'.repeat(20_000);
+  const archivePath = '/SpiritAgent/tool-output-archives/smoke-sess/call-1.txt';
+  const history: LlmMessage[] = [
+    { role: 'user', content: createLlmMessageContentFromText('investigate') },
+    {
+      role: 'tool',
+      toolCallId: 'call-1',
+      content: createLlmMessageContentFromText(longToolOutput),
+    },
+  ];
+
+  let persistedContent = '';
+  let compactionToolText = '';
+
+  const llmTransport: LlmTransport<undefined, TestState> = {
+    startToolAgentRound: async () => {
+      throw new Error('not used');
+    },
+    async compactHistoryManual(_config, targetHistory) {
+      const toolMessage = targetHistory.find((entry) => entry.role === 'tool');
+      compactionToolText = llmMessageTextContent(toolMessage?.content ?? []);
+      targetHistory.splice(0, targetHistory.length, {
+        role: 'system',
+        content: createLlmMessageContentFromText(`${COMPACT_SUMMARY_PREFIX}\nsummary`),
+      });
+      return { droppedMessages: 1, beforeLength: 2, afterLength: 1 };
+    },
+    compactSummaryText: () => 'summary',
+    isContextOverflowError: () => false,
+    llmHistoryAsApiMessages: () => [],
+    llmSystemPromptsForExport: () => ({}),
+  };
+
+  const options: AgentRuntimeOptions<undefined, TestState, never> = {
+    config: undefined,
+    llmTransport,
+    truncateHistoryForCompaction: truncateLlmHistoryForCompaction,
+    toolExecutor: {
+      execute: async () => {
+        throw new Error('not used');
+      },
+    } as unknown as AgentRuntimeOptions<undefined, TestState, never>['toolExecutor'],
+    createToolAgentState: () => ({ messages: [] }),
+    appendToolResultMessage: (state) => state,
+    extractAssistantText: () => undefined,
+    persistToolOutputArchive: async ({ content }) => {
+      persistedContent = content;
+      return archivePath;
+    },
+  };
+
+  const runtime: CompactionRuntime<undefined, TestState, never> = {
+    options,
+    historyStore: history,
+    compactionTextStore: '',
+    pendingHistoryCompaction: undefined,
+    completedManualHistoryCompactionResultStore: undefined,
+    emitEvent: () => {},
+    completeTurn: () => {},
+    startToolAgentRoundAsync: () => {},
+    startStreamingRound: async () => {},
+    takeCompletedManualHistoryCompactionResult: () => undefined,
+    isBusy: () => false,
+    poll: async () => {},
+  };
+
+  await compactHistoryImmediate(runtime);
+
+  assert.equal(persistedContent, longToolOutput);
+  assert.match(compactionToolText, /Full output archived at: \/SpiritAgent\/tool-output-archives\/smoke-sess\/call-1\.txt/u);
+  assert.match(compactionToolText, /Use read_file on that path only when you need omitted details\./u);
+});
+
 test('compactHistoryImmediate removes orphan archive when compaction fails after persist', async () => {
   const archivePath = '/tmp/spirit/compaction-archives/pre-compact-orphan.json';
   const history: LlmMessage[] = [

--- a/packages/agent-core/src/runtime/compaction.ts
+++ b/packages/agent-core/src/runtime/compaction.ts
@@ -3,6 +3,10 @@ import { setImmediate as waitForImmediate } from 'node:timers/promises';
 import { buildPreCompactionHistoryArchive } from '../compaction-archive.js';
 import type { CompactHistoryManualContext, LlmMessage } from '../ports.js';
 import { resolveHookSessionContext } from '../hooks/integration.js';
+import {
+  prepareToolOutputTruncationForHistory,
+  prepareToolOutputTruncationForToolAgentState,
+} from '../tool-output-truncation.js';
 
 import { cloneHistory, renderError } from './helpers.js';
 import type {
@@ -118,7 +122,48 @@ function buildCompactionRecord(
   };
 }
 
-function prepareHistoryForCompaction<
+function shouldPrepareToolOutputTruncation<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget = string,
+>(runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>): boolean {
+  return (
+    runtime.options.truncateHistoryForCompaction !== undefined ||
+    runtime.options.persistToolOutputArchive !== undefined
+  );
+}
+
+export async function prepareStateForContextRetryAsync<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget = string,
+>(
+  options: AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget>,
+  state: State,
+): Promise<{ state: State; changed: boolean }> {
+  if (
+    !options.truncateStateForContextRetry &&
+    !options.persistToolOutputArchive
+  ) {
+    return { state, changed: false };
+  }
+
+  const sessionId = resolveHookSessionContext(options).sessionId;
+  const prepareOptions = {
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(options.persistToolOutputArchive !== undefined
+      ? { persistArchive: options.persistToolOutputArchive }
+      : {}),
+  };
+  return prepareToolOutputTruncationForToolAgentState(state as never, prepareOptions) as Promise<{
+    state: State;
+    changed: boolean;
+  }>;
+}
+
+async function prepareHistoryForCompaction<
   Config,
   State,
   ToolRequest,
@@ -126,12 +171,19 @@ function prepareHistoryForCompaction<
 >(
   runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
   archiveSourceHistory: LlmMessage[],
-): LlmMessage[] {
-  if (!runtime.options.truncateHistoryForCompaction) {
+): Promise<LlmMessage[]> {
+  if (!shouldPrepareToolOutputTruncation(runtime)) {
     return cloneHistory(archiveSourceHistory);
   }
 
-  const prepared = runtime.options.truncateHistoryForCompaction(archiveSourceHistory);
+  const sessionId = resolveHookSessionContext(runtime.options).sessionId;
+  const prepareOptions = {
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(runtime.options.persistToolOutputArchive !== undefined
+      ? { persistArchive: runtime.options.persistToolOutputArchive }
+      : {}),
+  };
+  const prepared = await prepareToolOutputTruncationForHistory(archiveSourceHistory, prepareOptions);
   return cloneHistory(prepared.history);
 }
 
@@ -148,7 +200,7 @@ export async function compactHistoryImmediate<
     runtime,
     archiveSourceHistory,
   );
-  const historyForCompaction = prepareHistoryForCompaction(runtime, archiveSourceHistory);
+  const historyForCompaction = await prepareHistoryForCompaction(runtime, archiveSourceHistory);
   runtime.historyStore = cloneHistory(historyForCompaction);
 
   const compactionContext: CompactHistoryManualContext | undefined =
@@ -186,25 +238,27 @@ export function startHistoryCompactionAsync<
   resumeAsStreaming = false,
   streamingEmitBeginResponse = true,
 ): void {
-  const archiveSourceHistory = cloneHistory(runtime.historyStore);
-  const historyForCompaction = prepareHistoryForCompaction(runtime, archiveSourceHistory);
-  runtime.historyStore = cloneHistory(historyForCompaction);
+  void (async () => {
+    const archiveSourceHistory = cloneHistory(runtime.historyStore);
+    const historyForCompaction = await prepareHistoryForCompaction(runtime, archiveSourceHistory);
+    runtime.historyStore = cloneHistory(historyForCompaction);
 
-  runtime.compactionTextStore = '';
-  const pending: PendingAutoHistoryCompaction<State, ToolRequest> = {
-    kind: 'auto-retry',
-    pendingUserInput,
-    retryState,
-    turn,
-    originalError,
-    toolTruncationApplied,
-    resumeAsStreaming,
-    streamingEmitBeginResponse,
-    compactedHistory: undefined,
-    result: undefined,
-    failure: undefined,
-  };
-  launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+    runtime.compactionTextStore = '';
+    const pending: PendingAutoHistoryCompaction<State, ToolRequest> = {
+      kind: 'auto-retry',
+      pendingUserInput,
+      retryState,
+      turn,
+      originalError,
+      toolTruncationApplied,
+      resumeAsStreaming,
+      streamingEmitBeginResponse,
+      compactedHistory: undefined,
+      result: undefined,
+      failure: undefined,
+    };
+    launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+  })();
 }
 
 export function startManualHistoryCompactionAsync<
@@ -215,18 +269,20 @@ export function startManualHistoryCompactionAsync<
 >(
   runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
 ): void {
-  const archiveSourceHistory = cloneHistory(runtime.historyStore);
-  const historyForCompaction = prepareHistoryForCompaction(runtime, archiveSourceHistory);
-  runtime.historyStore = cloneHistory(historyForCompaction);
+  void (async () => {
+    const archiveSourceHistory = cloneHistory(runtime.historyStore);
+    const historyForCompaction = await prepareHistoryForCompaction(runtime, archiveSourceHistory);
+    runtime.historyStore = cloneHistory(historyForCompaction);
 
-  runtime.compactionTextStore = '';
-  const pending: PendingManualHistoryCompaction = {
-    kind: 'manual',
-    compactedHistory: undefined,
-    result: undefined,
-    failure: undefined,
-  };
-  launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+    runtime.compactionTextStore = '';
+    const pending: PendingManualHistoryCompaction = {
+      kind: 'manual',
+      compactedHistory: undefined,
+      result: undefined,
+      failure: undefined,
+    };
+    launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+  })();
 }
 
 export function launchHistoryCompaction<

--- a/packages/agent-core/src/runtime/compaction.ts
+++ b/packages/agent-core/src/runtime/compaction.ts
@@ -238,26 +238,34 @@ export function startHistoryCompactionAsync<
   resumeAsStreaming = false,
   streamingEmitBeginResponse = true,
 ): void {
-  void (async () => {
-    const archiveSourceHistory = cloneHistory(runtime.historyStore);
-    const historyForCompaction = await prepareHistoryForCompaction(runtime, archiveSourceHistory);
-    runtime.historyStore = cloneHistory(historyForCompaction);
+  runtime.compactionTextStore = '';
+  const pending: PendingAutoHistoryCompaction<State, ToolRequest> = {
+    kind: 'auto-retry',
+    pendingUserInput,
+    retryState,
+    turn,
+    originalError,
+    toolTruncationApplied,
+    resumeAsStreaming,
+    streamingEmitBeginResponse,
+    compactedHistory: undefined,
+    result: undefined,
+    failure: undefined,
+  };
+  runtime.pendingHistoryCompaction = pending;
 
-    runtime.compactionTextStore = '';
-    const pending: PendingAutoHistoryCompaction<State, ToolRequest> = {
-      kind: 'auto-retry',
-      pendingUserInput,
-      retryState,
-      turn,
-      originalError,
-      toolTruncationApplied,
-      resumeAsStreaming,
-      streamingEmitBeginResponse,
-      compactedHistory: undefined,
-      result: undefined,
-      failure: undefined,
-    };
-    launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+  void (async () => {
+    try {
+      const archiveSourceHistory = cloneHistory(runtime.historyStore);
+      const historyForCompaction = await prepareHistoryForCompaction(runtime, archiveSourceHistory);
+      runtime.historyStore = cloneHistory(historyForCompaction);
+      launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+    } catch (error: unknown) {
+      if (runtime.pendingHistoryCompaction !== pending) {
+        return;
+      }
+      pending.failure = renderError(error);
+    }
   })();
 }
 
@@ -269,19 +277,27 @@ export function startManualHistoryCompactionAsync<
 >(
   runtime: CompactionRuntime<Config, State, ToolRequest, TrustTarget>,
 ): void {
-  void (async () => {
-    const archiveSourceHistory = cloneHistory(runtime.historyStore);
-    const historyForCompaction = await prepareHistoryForCompaction(runtime, archiveSourceHistory);
-    runtime.historyStore = cloneHistory(historyForCompaction);
+  runtime.compactionTextStore = '';
+  const pending: PendingManualHistoryCompaction = {
+    kind: 'manual',
+    compactedHistory: undefined,
+    result: undefined,
+    failure: undefined,
+  };
+  runtime.pendingHistoryCompaction = pending;
 
-    runtime.compactionTextStore = '';
-    const pending: PendingManualHistoryCompaction = {
-      kind: 'manual',
-      compactedHistory: undefined,
-      result: undefined,
-      failure: undefined,
-    };
-    launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+  void (async () => {
+    try {
+      const archiveSourceHistory = cloneHistory(runtime.historyStore);
+      const historyForCompaction = await prepareHistoryForCompaction(runtime, archiveSourceHistory);
+      runtime.historyStore = cloneHistory(historyForCompaction);
+      launchHistoryCompaction(runtime, pending, historyForCompaction, archiveSourceHistory);
+    } catch (error: unknown) {
+      if (runtime.pendingHistoryCompaction !== pending) {
+        return;
+      }
+      pending.failure = renderError(error);
+    }
   })();
 }
 

--- a/packages/agent-core/src/runtime/streaming.ts
+++ b/packages/agent-core/src/runtime/streaming.ts
@@ -28,6 +28,7 @@ import type {
 } from './types.js';
 import type { ToolExecutionResult } from './tool-execution.js';
 import type { EarlyInternalToolCallResult, TurnMachineRuntime } from './turn-machine.js';
+import { prepareStateForContextRetryAsync } from './compaction.js';
 import { isResponsesBuiltInToolName } from '../open-responses/responses-built-in-tools.js';
 import { startEarlyToolExecution } from './turn-machine.js';
 
@@ -581,14 +582,11 @@ export async function handlePendingStreamEvent<
     pending.turn.autoCompactAttempts < (runtime.options.maxAutoCompactRetries ?? 1)
   ) {
     pending.turn.autoCompactAttempts += 1;
-    const preparedRetry = runtime.options.truncateStateForContextRetry
-      ? runtime.options.truncateStateForContextRetry(
-          runtime.options.createToolAgentState(runtime.historyStore, pending.pendingUserInput),
-        )
-      : {
-          state: runtime.options.createToolAgentState(runtime.historyStore, pending.pendingUserInput),
-          changed: false,
-        };
+    const retryState = runtime.options.createToolAgentState(
+      runtime.historyStore,
+      pending.pendingUserInput,
+    );
+    const preparedRetry = await prepareStateForContextRetryAsync(runtime.options, retryState);
 
     if (runtime.pendingAssistantTextStore.trim()) {
       runtime.emitEvent({ kind: 'replace-pending-assistant', text: '' });
@@ -651,14 +649,11 @@ export async function handlePendingStreamingCompletion<
       pending.turn.autoCompactAttempts < (runtime.options.maxAutoCompactRetries ?? 1)
     ) {
       pending.turn.autoCompactAttempts += 1;
-      const preparedRetry = runtime.options.truncateStateForContextRetry
-        ? runtime.options.truncateStateForContextRetry(
-            runtime.options.createToolAgentState(runtime.historyStore, pending.pendingUserInput),
-          )
-        : {
-            state: runtime.options.createToolAgentState(runtime.historyStore, pending.pendingUserInput),
-            changed: false,
-          };
+      const retryState = runtime.options.createToolAgentState(
+        runtime.historyStore,
+        pending.pendingUserInput,
+      );
+      const preparedRetry = await prepareStateForContextRetryAsync(runtime.options, retryState);
 
       if (runtime.pendingAssistantTextStore.trim()) {
         runtime.emitEvent({ kind: 'replace-pending-assistant', text: '' });

--- a/packages/agent-core/src/runtime/tool-output-append.ts
+++ b/packages/agent-core/src/runtime/tool-output-append.ts
@@ -1,0 +1,25 @@
+import { resolveHookSessionContext } from '../hooks/integration.js';
+import { prepareToolOutputForAppend } from '../tool-output-truncation.js';
+
+import type { AgentRuntimeOptions } from './types.js';
+
+export async function prepareRuntimeToolResultContentForAppend<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget = string,
+>(
+  options: AgentRuntimeOptions<Config, State, ToolRequest, TrustTarget>,
+  toolCallId: string,
+  content: string,
+): Promise<string> {
+  const sessionId = resolveHookSessionContext(options).sessionId;
+  return prepareToolOutputForAppend({
+    content,
+    toolCallId,
+    ...(sessionId !== undefined ? { sessionId } : {}),
+    ...(options.persistToolOutputArchive !== undefined
+      ? { persistArchive: options.persistToolOutputArchive }
+      : {}),
+  });
+}

--- a/packages/agent-core/src/runtime/turn-machine.ts
+++ b/packages/agent-core/src/runtime/turn-machine.ts
@@ -43,6 +43,7 @@ import {
   renderError,
   toolArtifactsFromOutput,
 } from './helpers.js';
+import { prepareRuntimeToolResultContentForAppend } from './tool-output-append.js';
 import type { ToolExecutionResult } from './tool-execution.js';
 import type {
   AgentRuntimeOptions,
@@ -799,12 +800,17 @@ export async function executeAuthorizedToolCall<
     Date.now() - startedAt,
     execution.failed,
   );
-  const resumedState = appendToolResultForRound(
+  const preparedContent = await prepareRuntimeToolResultContentForAppend(
+    runtime.options,
+    toolCallId,
+    execution.output.summaryText,
+  );
+  const resumedState = await appendToolResultForRoundAsync(
     runtime,
     state,
     toolCallId,
     toolName,
-    execution.output.summaryText,
+    preparedContent,
     execution.failed,
   );
   if (remainingCalls.length > 0) {
@@ -814,7 +820,7 @@ export async function executeAuthorizedToolCall<
   return runTurnLoop(runtime, resumedState, pendingUserInput, turn);
 }
 
-function appendToolResultForRound<
+async function appendToolResultForRoundAsync<
   Config,
   State,
   ToolRequest,
@@ -826,7 +832,7 @@ function appendToolResultForRound<
   toolName: string,
   content: string,
   failed = false,
-): State {
+): Promise<State> {
   if (
     toolName === APPLY_PATCH_HOST_TOOL_NAME
     && isOpenResponsesTransportConfig(runtime.options.config as any)
@@ -1120,10 +1126,18 @@ export async function processToolCallsAsync<
         });
         return;
       }
-      currentState = runtime.options.appendToolResultMessage(
-        currentState,
+      const preparedOutput = await prepareRuntimeToolResultContentForAppend(
+        runtime.options,
         call.id,
         earlyOutcome.output.summaryText,
+      );
+      currentState = await appendToolResultForRoundAsync(
+        runtime,
+        currentState,
+        call.id,
+        call.name,
+        preparedOutput,
+        earlyOutcome.execution.failed,
       );
       if (queueRemainingToolCallsAsync(
         runtime,
@@ -1418,10 +1432,18 @@ export async function processToolCallsAsync<
       Date.now() - startedAt,
       execution.failed,
     );
-    currentState = runtime.options.appendToolResultMessage(
-      currentState,
+    const preparedOutput = await prepareRuntimeToolResultContentForAppend(
+      runtime.options,
       call.id,
       execution.output.summaryText,
+    );
+    currentState = await appendToolResultForRoundAsync(
+      runtime,
+      currentState,
+      call.id,
+      call.name,
+      preparedOutput,
+      execution.failed,
     );
     if (queueRemainingToolCallsAsync(
       runtime,

--- a/packages/agent-core/src/runtime/turn-machine.ts
+++ b/packages/agent-core/src/runtime/turn-machine.ts
@@ -32,6 +32,7 @@ import {
 } from '../hooks/tool-hooks.js';
 import { toolInputFromArgumentsJson } from '../hooks/integration.js';
 import { appendToolResultMessages, isJsonObject } from '../tool-agent.js';
+import { prepareStateForContextRetryAsync } from './compaction.js';
 import { buildEarlyExecutableArgumentsJson } from '../tool-streaming-preview-gate.js';
 import {
   applyDeferredUserGuidance,
@@ -447,9 +448,7 @@ export async function runTurnLoop<
         turn.autoCompactAttempts < (runtime.options.maxAutoCompactRetries ?? 1)
       ) {
         turn.autoCompactAttempts += 1;
-        const preparedRetry = runtime.options.truncateStateForContextRetry
-          ? runtime.options.truncateStateForContextRetry(currentState)
-          : { state: currentState, changed: false };
+        const preparedRetry = await prepareStateForContextRetryAsync(runtime.options, currentState);
 
         try {
           const compaction = await runtime.compactHistoryImmediate();
@@ -975,9 +974,7 @@ export async function handlePendingToolAgentRoundCompletion<
       pending.turn.autoCompactAttempts < (runtime.options.maxAutoCompactRetries ?? 1)
     ) {
       pending.turn.autoCompactAttempts += 1;
-      const preparedRetry = runtime.options.truncateStateForContextRetry
-        ? runtime.options.truncateStateForContextRetry(pending.state)
-        : { state: pending.state, changed: false };
+      const preparedRetry = await prepareStateForContextRetryAsync(runtime.options, pending.state);
       runtime.startHistoryCompactionAsync(
         preparedRetry.state,
         pending.pendingUserInput,

--- a/packages/agent-core/src/runtime/types.ts
+++ b/packages/agent-core/src/runtime/types.ts
@@ -415,6 +415,12 @@ export interface AgentRuntimeOptions<
     sessionId?: string;
   }) => Promise<string | undefined>;
   removePreCompactionHistoryArchive?: (archivePath: string) => Promise<void>;
+  persistToolOutputArchive?: (input: {
+    sessionId?: string;
+    toolCallId?: string;
+    content: string;
+    messageIndex?: number;
+  }) => Promise<string | undefined>;
   resolveWorkspaceFilesFromInput?: (
     userInput: string,
   ) => Promise<PendingWorkspaceFile[]> | PendingWorkspaceFile[];

--- a/packages/agent-core/src/shell-tool-result.test.ts
+++ b/packages/agent-core/src/shell-tool-result.test.ts
@@ -37,25 +37,25 @@ test('serializeRunShellCommandToolResult returns compact JSON for LLM context', 
   });
 });
 
-test('serializeRunShellCommandToolResult marks truncated output and stays valid JSON', () => {
+test('serializeRunShellCommandToolResult preserves full output without truncation', () => {
+  const longOutput = 'x'.repeat(20);
   const json = serializeRunShellCommandToolResult(
     buildRunShellCommandToolResult({
       terminal: 'bash',
       workspace: '/tmp',
       command: 'cat',
       exitCode: 0,
-      stdout: 'x'.repeat(20),
+      stdout: longOutput,
       stderr: '',
     }),
-    10,
   );
 
   const parsed = JSON.parse(json) as {
     output: string;
     truncated?: boolean;
   };
-  assert.equal(parsed.output, 'x'.repeat(10));
-  assert.equal(parsed.truncated, true);
+  assert.equal(parsed.output, longOutput);
+  assert.equal(parsed.truncated, undefined);
 });
 
 test('parseRunShellCommandToolResult rejects legacy human transcript', () => {

--- a/packages/agent-core/src/shell-tool-result.ts
+++ b/packages/agent-core/src/shell-tool-result.ts
@@ -7,8 +7,6 @@ export type RunShellCommandToolResult = {
   truncated?: boolean;
 };
 
-export const DEFAULT_SHELL_TOOL_OUTPUT_MAX_CHARS = 16_000;
-
 export function combineShellToolOutput(stdout: string, stderr: string): string {
   const hasStdout = stdout.length > 0;
   const hasStderr = stderr.length > 0;
@@ -42,24 +40,13 @@ export function buildRunShellCommandToolResult(input: {
   };
 }
 
-export function serializeRunShellCommandToolResult(
-  result: RunShellCommandToolResult,
-  maxOutputChars: number = DEFAULT_SHELL_TOOL_OUTPUT_MAX_CHARS,
-): string {
-  let output = result.output;
-  let truncated = result.truncated === true;
-  if ([...output].length > maxOutputChars) {
-    output = truncateChars(output, maxOutputChars);
-    truncated = true;
-  }
-
+export function serializeRunShellCommandToolResult(result: RunShellCommandToolResult): string {
   const payload: RunShellCommandToolResult = {
     terminal: result.terminal,
     workspace: result.workspace,
     command: result.command,
     exitCode: result.exitCode,
-    output,
-    ...(truncated ? { truncated: true } : {}),
+    output: result.output,
   };
   return JSON.stringify(payload);
 }
@@ -94,12 +81,4 @@ function isRunShellCommandToolResult(value: unknown): value is RunShellCommandTo
     typeof record.output === 'string' &&
     (record.truncated === undefined || typeof record.truncated === 'boolean')
   );
-}
-
-function truncateChars(value: string, maxChars: number): string {
-  const chars = [...value];
-  if (chars.length <= maxChars) {
-    return value;
-  }
-  return chars.slice(0, maxChars).join('');
 }

--- a/packages/agent-core/src/smoke/cases/runtime/parity/compaction.case.ts
+++ b/packages/agent-core/src/smoke/cases/runtime/parity/compaction.case.ts
@@ -18,6 +18,7 @@ import {
   type ScriptedState,
   type ScriptedToolRequest,
 } from './harness.js';
+import { truncateLlmHistoryForCompaction } from '../../../../llm-tool-agent.js';
 
 export async function runCompactionCase(): Promise<RuntimeParityCaseResult> {
   const pollingCompactEvents: RuntimeEvent<ScriptedToolRequest>[] = [];
@@ -189,9 +190,52 @@ export async function runCompactionCase(): Promise<RuntimeParityCaseResult> {
     throw new Error(`pre-compaction archive smoke 归档消息数异常: ${persistedMessageCount}`);
   }
 
+  const toolOutputArchivePath = '/tmp/spirit-smoke/tool-output-archives/smoke-tool-archive/call-archive-tool.txt';
+  let persistedToolOutput = '';
+  const toolOutputArchiveRuntime = new AgentRuntime({
+    config: undefined,
+    llmTransport: new CompactTransport(),
+    toolExecutor: new CompactExecutor(),
+    createToolAgentState: createScriptedState,
+    appendToolResultMessage: appendScriptedToolResult,
+    appendUserMessage: appendScriptedUserMessage,
+    extractAssistantText: extractScriptedAssistantText,
+    truncateHistoryForCompaction: truncateLlmHistoryForCompaction,
+    rebuildRetryStateAfterCompaction: rebuildScriptedStateAfterCompaction,
+    hookSessionContext: {
+      sessionId: 'smoke-tool-archive',
+      conversationPath: null,
+      workspaceRoot: '/tmp',
+      model: 'test-model',
+    },
+    persistToolOutputArchive: async ({ content }) => {
+      persistedToolOutput = content;
+      return toolOutputArchivePath;
+    },
+  }, [
+    {
+      role: 'user',
+      content: createLlmMessageContentFromText('inspect large tool output'),
+    },
+    {
+      role: 'tool',
+      toolCallId: 'call-archive-tool',
+      content: createLlmMessageContentFromText('z'.repeat(20_000)),
+    },
+  ]);
+
+  const toolOutputArchiveRecord = await toolOutputArchiveRuntime.compactHistory();
+  if (!persistedToolOutput || persistedToolOutput.length !== 20_000) {
+    throw new Error('tool output archive smoke 未持久化完整 tool 输出。');
+  }
+  if (toolOutputArchiveRecord.beforeLength < 2) {
+    throw new Error('tool output archive smoke 压缩前后长度异常。');
+  }
+
   return {
     compactResult,
     pollingCompactResult,
     archiveCompactionResult: archiveRecord,
+    toolOutputArchiveCompactionResult: toolOutputArchiveRecord,
   };
 }

--- a/packages/agent-core/src/tool-agent.ts
+++ b/packages/agent-core/src/tool-agent.ts
@@ -32,6 +32,11 @@ export const COMPACT_SUMMARY_PREFIX = '[SPIRIT_COMPACT_SUMMARY]';
 export const PRE_COMPACTION_ARCHIVE_READ_FILE_GUIDANCE =
   'Important details may be recovered by reading this file with read_file.';
 
+export const TOOL_OUTPUT_ARCHIVE_READ_FILE_GUIDANCE =
+  'Use read_file on that path only when you need omitted details.';
+
+export const TOOL_OUTPUT_TRUNCATION_LABEL = '[tool output truncated for context retry]';
+
 const PRE_COMPACTION_ARCHIVE_EXAMPLE_PATH =
   '/path/to/compaction-archives/pre-compact-session-1234567890.json';
 
@@ -482,11 +487,7 @@ export function truncateHistoryForCompaction(
       };
     }
 
-    const replacement = buildContextRetryExcerpt(
-      contentText,
-      TOOL_OUTPUT_RETRY_MAX_CHARS,
-      '[tool output truncated for context retry]',
-    );
+    const replacement = buildContextRetryExcerpt(contentText);
     if (replacement === undefined) {
       return {
         role: message.role,
@@ -1020,29 +1021,28 @@ function truncateMessageContentForRetry(
   content: string,
 ): string | undefined {
   if (role === 'tool') {
-    return buildContextRetryExcerpt(
-      content,
-      TOOL_OUTPUT_RETRY_MAX_CHARS,
-      '[tool output truncated for context retry]',
-    );
+    return buildContextRetryExcerpt(content);
   }
 
   return undefined;
 }
 
-function buildContextRetryExcerpt(
+export function buildContextRetryExcerpt(
   text: string,
-  maxChars: number,
-  label: string,
+  archivePath?: string,
 ): string | undefined {
   const chars = Array.from(text);
-  if (chars.length <= maxChars) {
+  if (chars.length <= TOOL_OUTPUT_RETRY_MAX_CHARS) {
     return undefined;
   }
 
   const totalLines = text.split(/\r?\n/).length;
-  const overhead = Array.from(label).length + 160;
-  const usable = Math.max(maxChars - overhead, 256);
+  const label = TOOL_OUTPUT_TRUNCATION_LABEL;
+  const archiveHint = archivePath?.trim()
+    ? `\nFull output archived at: ${archivePath.trim()}\n${TOOL_OUTPUT_ARCHIVE_READ_FILE_GUIDANCE}`
+    : '';
+  const overhead = Array.from(label).length + Array.from(archiveHint).length + 160;
+  const usable = Math.max(TOOL_OUTPUT_RETRY_MAX_CHARS - overhead, 256);
   const headChars = Math.floor((usable * TOOL_TRUNCATION_HEAD_RATIO_NUM) / TOOL_TRUNCATION_HEAD_RATIO_DEN);
   const tailChars = Math.max(usable - headChars, 0);
   const head = takeFirstChars(text, headChars);
@@ -1050,9 +1050,11 @@ function buildContextRetryExcerpt(
   const omittedChars = Math.max(chars.length - Array.from(head).length - Array.from(tail).length, 0);
   const omittedLines = Math.max(totalLines - head.split(/\r?\n/).length - tail.split(/\r?\n/).length, 0);
 
+  const middle = `${label} omitted_chars=${omittedChars} omitted_lines≈${omittedLines}${archiveHint}`;
+
   return [
     head,
-    `${label} omitted_chars=${omittedChars} omitted_lines≈${omittedLines}`,
+    middle,
     tail,
   ]
     .filter((part) => part.trim().length > 0)

--- a/packages/agent-core/src/tool-output-truncation.test.ts
+++ b/packages/agent-core/src/tool-output-truncation.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLlmMessageContentFromText, llmMessageTextContent } from './ports.js';
+import {
+  TOOL_OUTPUT_ARCHIVE_READ_FILE_GUIDANCE,
+  TOOL_OUTPUT_TRUNCATION_LABEL,
+  buildContextRetryExcerpt,
+} from './tool-agent.js';
+import { prepareToolOutputTruncationForHistory } from './tool-output-truncation.js';
+
+test('buildContextRetryExcerpt includes archive path guidance when provided', () => {
+  const longText = 'line\n'.repeat(8_000);
+  const excerpt = buildContextRetryExcerpt(longText, '/tmp/archive/call_1.txt');
+
+  assert.ok(excerpt);
+  assert.match(excerpt!, new RegExp(TOOL_OUTPUT_TRUNCATION_LABEL.replace(/[[\]]/g, '\\$&')));
+  assert.match(excerpt!, /Full output archived at: \/tmp\/archive\/call_1\.txt/u);
+  assert.match(excerpt!, new RegExp(TOOL_OUTPUT_ARCHIVE_READ_FILE_GUIDANCE.replace(/[[\]]/g, '\\$&')));
+  assert.ok(excerpt!.length < longText.length);
+});
+
+test('prepareToolOutputTruncationForHistory persists full output and injects archive path', async () => {
+  const longToolOutput = 'x'.repeat(20_000);
+  let persistedContent = '';
+  const history = [
+    { role: 'user' as const, content: createLlmMessageContentFromText('hello') },
+    {
+      role: 'tool' as const,
+      toolCallId: 'call_abc',
+      content: createLlmMessageContentFromText(longToolOutput),
+    },
+  ];
+
+  const prepared = await prepareToolOutputTruncationForHistory(history, {
+    sessionId: 'sess-1',
+    persistArchive: async ({ content }) => {
+      persistedContent = content;
+      return '/SpiritAgent/tool-output-archives/sess-1/call_abc.txt';
+    },
+  });
+
+  assert.equal(prepared.changed, true);
+  assert.equal(persistedContent, longToolOutput);
+  const toolMessage = prepared.history[1];
+  assert.ok(toolMessage);
+  const toolText = llmMessageTextContent(toolMessage.content);
+  assert.match(toolText, /Full output archived at: \/SpiritAgent\/tool-output-archives\/sess-1\/call_abc\.txt/u);
+  assert.ok(toolText.length < longToolOutput.length);
+});
+
+test('prepareToolOutputTruncationForHistory still truncates when archive persist fails', async () => {
+  const longToolOutput = 'y'.repeat(20_000);
+  const prepared = await prepareToolOutputTruncationForHistory(
+    [{
+      role: 'tool',
+      toolCallId: 'call_fail',
+      content: createLlmMessageContentFromText(longToolOutput),
+    }],
+    {
+      persistArchive: async () => {
+        throw new Error('disk full');
+      },
+    },
+  );
+
+  assert.equal(prepared.changed, true);
+  const toolMessage = prepared.history[0];
+  assert.ok(toolMessage);
+  const toolText = llmMessageTextContent(toolMessage.content);
+  assert.match(toolText, new RegExp(TOOL_OUTPUT_TRUNCATION_LABEL.replace(/[[\]]/g, '\\$&')));
+  assert.doesNotMatch(toolText, /Full output archived at:/u);
+});

--- a/packages/agent-core/src/tool-output-truncation.test.ts
+++ b/packages/agent-core/src/tool-output-truncation.test.ts
@@ -7,7 +7,7 @@ import {
   TOOL_OUTPUT_TRUNCATION_LABEL,
   buildContextRetryExcerpt,
 } from './tool-agent.js';
-import { prepareToolOutputTruncationForHistory } from './tool-output-truncation.js';
+import { prepareToolOutputForAppend, prepareToolOutputTruncationForHistory } from './tool-output-truncation.js';
 
 test('buildContextRetryExcerpt includes archive path guidance when provided', () => {
   const longText = 'line\n'.repeat(8_000);
@@ -47,6 +47,31 @@ test('prepareToolOutputTruncationForHistory persists full output and injects arc
   const toolText = llmMessageTextContent(toolMessage.content);
   assert.match(toolText, /Full output archived at: \/SpiritAgent\/tool-output-archives\/sess-1\/call_abc\.txt/u);
   assert.ok(toolText.length < longToolOutput.length);
+});
+
+test('prepareToolOutputForAppend persists and truncates large tool output on append', async () => {
+  const longToolOutput = 'y'.repeat(20_000);
+  let persistedContent = '';
+  const prepared = await prepareToolOutputForAppend({
+    content: longToolOutput,
+    toolCallId: 'call_append_1',
+    sessionId: 'session_1',
+    persistArchive: async ({ content }) => {
+      persistedContent = content;
+      return '/tmp/archive/call_append_1.txt';
+    },
+  });
+
+  assert.equal(persistedContent, longToolOutput);
+  assert.match(prepared, /Full output archived at: \/tmp\/archive\/call_append_1\.txt/u);
+  assert.match(prepared, new RegExp(TOOL_OUTPUT_TRUNCATION_LABEL.replace(/[[\]]/g, '\\$&')));
+  assert.ok(prepared.length < longToolOutput.length);
+});
+
+test('prepareToolOutputForAppend leaves short tool output unchanged', async () => {
+  const shortOutput = 'ok';
+  const prepared = await prepareToolOutputForAppend({ content: shortOutput });
+  assert.equal(prepared, shortOutput);
 });
 
 test('prepareToolOutputTruncationForHistory still truncates when archive persist fails', async () => {

--- a/packages/agent-core/src/tool-output-truncation.ts
+++ b/packages/agent-core/src/tool-output-truncation.ts
@@ -1,0 +1,178 @@
+import {
+  cloneLlmMessageContent,
+  cloneLlmProviderState,
+  createLlmMessageContentFromText,
+  llmMessageTextContent,
+  type LlmMessage,
+} from './ports.js';
+import {
+  buildContextRetryExcerpt,
+  cloneJsonValue,
+  isJsonObject,
+  type ToolAgentState,
+} from './tool-agent.js';
+
+export type PersistToolOutputArchiveInput = {
+  sessionId?: string;
+  toolCallId?: string;
+  content: string;
+  messageIndex?: number;
+};
+
+export type PersistToolOutputArchiveFn = (
+  input: PersistToolOutputArchiveInput,
+) => Promise<string | undefined>;
+
+export type PrepareToolOutputTruncationOptions = {
+  sessionId?: string;
+  persistArchive?: PersistToolOutputArchiveFn;
+};
+
+async function truncateToolMessageContent(
+  content: string,
+  options: PrepareToolOutputTruncationOptions & {
+    toolCallId?: string;
+    messageIndex?: number;
+  },
+): Promise<string | undefined> {
+  let archivePath: string | undefined;
+  if (options.persistArchive) {
+    try {
+      archivePath = await options.persistArchive({
+        content,
+        ...(options.sessionId !== undefined ? { sessionId: options.sessionId } : {}),
+        ...(options.toolCallId !== undefined ? { toolCallId: options.toolCallId } : {}),
+        ...(options.messageIndex !== undefined ? { messageIndex: options.messageIndex } : {}),
+      });
+    } catch {
+      // Best-effort archive persist; truncation still proceeds without a path hint.
+    }
+  }
+
+  return buildContextRetryExcerpt(content, archivePath);
+}
+
+function readToolCallIdFromToolAgentMessage(message: Record<string, unknown>): string | undefined {
+  if (typeof message.tool_call_id === 'string' && message.tool_call_id.length > 0) {
+    return message.tool_call_id;
+  }
+  if (typeof message.toolCallId === 'string' && message.toolCallId.length > 0) {
+    return message.toolCallId;
+  }
+  return undefined;
+}
+
+export async function prepareToolOutputTruncationForHistory(
+  history: LlmMessage[],
+  options: PrepareToolOutputTruncationOptions = {},
+): Promise<{ history: LlmMessage[]; changed: boolean }> {
+  let changed = false;
+  const nextHistory = await Promise.all(
+    history.map(async (message, messageIndex) => {
+      const contentText = llmMessageTextContent(message.content);
+      if (message.role !== 'tool') {
+        return {
+          role: message.role,
+          content: cloneLlmMessageContent(message.content),
+          ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
+          ...(message.toolCalls !== undefined
+            ? {
+                toolCalls: message.toolCalls.map((toolCall) => ({
+                  id: toolCall.id,
+                  name: toolCall.name,
+                  argumentsJson: toolCall.argumentsJson,
+                })),
+              }
+            : {}),
+          ...(message.providerState !== undefined
+            ? { providerState: cloneLlmProviderState(message.providerState) }
+            : {}),
+        };
+      }
+
+      const replacement = await truncateToolMessageContent(contentText, {
+        ...options,
+        ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
+        messageIndex,
+      });
+      if (replacement === undefined) {
+        return {
+          role: message.role,
+          content: cloneLlmMessageContent(message.content),
+          ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
+          ...(message.toolCalls !== undefined
+            ? {
+                toolCalls: message.toolCalls.map((toolCall) => ({
+                  id: toolCall.id,
+                  name: toolCall.name,
+                  argumentsJson: toolCall.argumentsJson,
+                })),
+              }
+            : {}),
+        };
+      }
+
+      changed = true;
+      return {
+        role: message.role,
+        content: createLlmMessageContentFromText(replacement),
+        ...(message.toolCallId !== undefined ? { toolCallId: message.toolCallId } : {}),
+        ...(message.toolCalls !== undefined
+          ? {
+              toolCalls: message.toolCalls.map((toolCall) => ({
+                id: toolCall.id,
+                name: toolCall.name,
+                argumentsJson: toolCall.argumentsJson,
+              })),
+            }
+          : {}),
+        ...(message.providerState !== undefined
+          ? { providerState: cloneLlmProviderState(message.providerState) }
+          : {}),
+      };
+    }),
+  );
+
+  return {
+    history: nextHistory,
+    changed,
+  };
+}
+
+export async function prepareToolOutputTruncationForToolAgentState(
+  state: ToolAgentState,
+  options: PrepareToolOutputTruncationOptions = {},
+): Promise<{ state: ToolAgentState; changed: boolean }> {
+  let changed = false;
+  const messages = await Promise.all(
+    state.messages.map(async (message, messageIndex) => {
+      if (!isJsonObject(message) || typeof message.content !== 'string' || message.role !== 'tool') {
+        return cloneJsonValue(message);
+      }
+
+      const toolCallId = readToolCallIdFromToolAgentMessage(message);
+      const replacement = await truncateToolMessageContent(message.content, {
+        ...options,
+        ...(toolCallId !== undefined ? { toolCallId } : {}),
+        messageIndex,
+      });
+      if (replacement === undefined) {
+        return { ...message };
+      }
+
+      changed = true;
+      return {
+        ...message,
+        content: replacement,
+      };
+    }),
+  );
+
+  return {
+    state: {
+      messages,
+      steps: state.steps,
+    },
+    changed,
+  };
+}

--- a/packages/agent-core/src/tool-output-truncation.ts
+++ b/packages/agent-core/src/tool-output-truncation.ts
@@ -52,6 +52,20 @@ async function truncateToolMessageContent(
   return buildContextRetryExcerpt(content, archivePath);
 }
 
+export async function prepareToolOutputForAppend(input: {
+  content: string;
+  sessionId?: string;
+  toolCallId?: string;
+  persistArchive?: PersistToolOutputArchiveFn;
+}): Promise<string> {
+  const replacement = await truncateToolMessageContent(input.content, {
+    ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+    ...(input.toolCallId !== undefined ? { toolCallId: input.toolCallId } : {}),
+    ...(input.persistArchive !== undefined ? { persistArchive: input.persistArchive } : {}),
+  });
+  return replacement ?? input.content;
+}
+
 function readToolCallIdFromToolAgentMessage(message: Record<string, unknown>): string | undefined {
   if (typeof message.tool_call_id === 'string' && message.tool_call_id.length > 0) {
     return message.tool_call_id;

--- a/packages/host-internal/package.json
+++ b/packages/host-internal/package.json
@@ -79,6 +79,10 @@
       "types": "./dist/skill-paths.d.ts",
       "default": "./dist/skill-paths.js"
     },
+    "./tool-output-archive-path": {
+      "types": "./dist/tool-output-archive-path.d.ts",
+      "default": "./dist/tool-output-archive-path.js"
+    },
     "./tools": {
       "types": "./dist/tools.d.ts",
       "default": "./dist/tools.js"

--- a/packages/host-internal/src/compaction-archive.ts
+++ b/packages/host-internal/src/compaction-archive.ts
@@ -3,20 +3,12 @@ import path from 'node:path';
 
 import type { PreCompactionHistoryArchive } from '@spirit-agent/core';
 
+import { sanitizeSessionIdForFilename } from './spirit-filename-sanitize.js';
+
 export const COMPACTION_ARCHIVES_DIR_NAME = 'compaction-archives';
 
 export function resolveCompactionArchivesDir(spiritDataDir: string): string {
   return path.join(spiritDataDir, COMPACTION_ARCHIVES_DIR_NAME);
-}
-
-function sanitizeSessionIdForFilename(sessionId: string | undefined): string {
-  const normalized = sessionId?.trim();
-  if (!normalized) {
-    return 'unknown';
-  }
-
-  const sanitized = normalized.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-  return sanitized.length > 0 ? sanitized : 'unknown';
 }
 
 export function buildPreCompactionArchiveFileName(

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -10,6 +10,8 @@ export * from './automation-trigger-message.js';
 export * from './automation-host-tool.js';
 export * from './built-in-skills.js';
 export * from './compaction-archive.js';
+export * from './tool-output-archive.js';
+export * from './spirit-filename-sanitize.js';
 export * from './todos.js';
 export * from './extensions.js';
 export * from './file-rewind.js';

--- a/packages/host-internal/src/spirit-filename-sanitize.ts
+++ b/packages/host-internal/src/spirit-filename-sanitize.ts
@@ -1,0 +1,25 @@
+export function sanitizeSessionIdForFilename(sessionId: string | undefined): string {
+  const normalized = sessionId?.trim();
+  if (!normalized) {
+    return 'unknown';
+  }
+
+  const sanitized = normalized.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return sanitized.length > 0 ? sanitized : 'unknown';
+}
+
+export function sanitizeToolCallIdForFilename(toolCallId: string | undefined, messageIndex?: number): string {
+  const normalized = toolCallId?.trim();
+  if (normalized) {
+    const sanitized = normalized.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+    if (sanitized.length > 0) {
+      return sanitized;
+    }
+  }
+
+  if (messageIndex !== undefined) {
+    return `msg-${messageIndex}`;
+  }
+
+  return 'unknown';
+}

--- a/packages/host-internal/src/tool-output-archive-path.test.ts
+++ b/packages/host-internal/src/tool-output-archive-path.test.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isToolOutputArchivePath } from './tool-output-archive-path.js';
+
+test('isToolOutputArchivePath matches SpiritAgent tool-output-archives paths', () => {
+  assert.equal(
+    isToolOutputArchivePath(
+      'C:\\Users\\pc\\AppData\\Roaming\\SpiritAgent\\tool-output-archives\\sess\\call_1.txt',
+    ),
+    true,
+  );
+  assert.equal(isToolOutputArchivePath('/tmp/tool-output-archives/sess/call_1.txt'), true);
+  assert.equal(isToolOutputArchivePath('src/App.tsx'), false);
+});

--- a/packages/host-internal/src/tool-output-archive-path.ts
+++ b/packages/host-internal/src/tool-output-archive-path.ts
@@ -1,0 +1,18 @@
+/**
+ * 工具输出归档路径常量与纯路径判断（无 Node 内置依赖，可供 Desktop renderer 安全 import）。
+ */
+
+export const TOOL_OUTPUT_ARCHIVES_DIR_NAME = 'tool-output-archives';
+
+function normalizePath(filePath: string): string {
+  return filePath.trim().replace(/\\/g, '/');
+}
+
+export function isToolOutputArchivePath(filePath: string): boolean {
+  const normalized = normalizePath(filePath);
+  if (!normalized) {
+    return false;
+  }
+  const segment = TOOL_OUTPUT_ARCHIVES_DIR_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(?:^|/)${segment}(?:/|$)`, 'u').test(normalized);
+}

--- a/packages/host-internal/src/tool-output-archive.test.ts
+++ b/packages/host-internal/src/tool-output-archive.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { readFile, rm } from 'node:fs/promises';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  buildToolOutputArchiveFileName,
+  persistToolOutputArchive,
+  resolveToolOutputArchivesDir,
+  TOOL_OUTPUT_ARCHIVES_DIR_NAME,
+} from './tool-output-archive.js';
+import {
+  sanitizeSessionIdForFilename,
+  sanitizeToolCallIdForFilename,
+} from './spirit-filename-sanitize.js';
+
+test('sanitizeSessionIdForFilename normalizes unsafe characters', () => {
+  assert.equal(sanitizeSessionIdForFilename('session/abc:123'), 'session-abc-123');
+  assert.equal(sanitizeSessionIdForFilename(undefined), 'unknown');
+});
+
+test('sanitizeToolCallIdForFilename falls back to message index', () => {
+  assert.equal(sanitizeToolCallIdForFilename('call_abc/123'), 'call_abc-123');
+  assert.equal(sanitizeToolCallIdForFilename(undefined, 4), 'msg-4');
+});
+
+test('buildToolOutputArchiveFileName uses sanitized tool call id', () => {
+  assert.equal(buildToolOutputArchiveFileName('call:1'), 'call-1.txt');
+});
+
+test('persistToolOutputArchive writes session-scoped archive with header', async () => {
+  const spiritDataDir = await mkdtemp(join(tmpdir(), 'spirit-tool-output-archive-'));
+
+  try {
+    const filePath = await persistToolOutputArchive(spiritDataDir, {
+      sessionId: 'sess/one',
+      toolCallId: 'call_123',
+      content: 'full tool output body',
+    });
+
+    assert.match(filePath, /tool-output-archives[\\/]sess-one[\\/]call_123\.txt$/u);
+    const body = await readFile(filePath, 'utf8');
+    assert.match(body, /^# spirit-tool-output-archive/u);
+    assert.match(body, /# tool_call_id: call_123/u);
+    assert.match(body, /# archived_at_unix_ms: \d+/u);
+    assert.match(body, /---\nfull tool output body/u);
+    assert.equal(resolveToolOutputArchivesDir(spiritDataDir).endsWith(TOOL_OUTPUT_ARCHIVES_DIR_NAME), true);
+  } finally {
+    await rm(spiritDataDir, { recursive: true, force: true });
+  }
+});
+
+test('persistToolOutputArchive overwrites the same tool call archive path', async () => {
+  const spiritDataDir = await mkdtemp(join(tmpdir(), 'spirit-tool-output-archive-overwrite-'));
+
+  try {
+    const firstPath = await persistToolOutputArchive(spiritDataDir, {
+      sessionId: 'sess',
+      toolCallId: 'call_a',
+      content: 'first',
+    });
+    const secondPath = await persistToolOutputArchive(spiritDataDir, {
+      sessionId: 'sess',
+      toolCallId: 'call_a',
+      content: 'second',
+    });
+
+    assert.equal(firstPath, secondPath);
+    const body = await readFile(secondPath, 'utf8');
+    assert.match(body, /second/u);
+    assert.doesNotMatch(body, /\nfirst$/u);
+  } finally {
+    await rm(spiritDataDir, { recursive: true, force: true });
+  }
+});

--- a/packages/host-internal/src/tool-output-archive.ts
+++ b/packages/host-internal/src/tool-output-archive.ts
@@ -5,8 +5,9 @@ import {
   sanitizeSessionIdForFilename,
   sanitizeToolCallIdForFilename,
 } from './spirit-filename-sanitize.js';
+import { TOOL_OUTPUT_ARCHIVES_DIR_NAME } from './tool-output-archive-path.js';
 
-export const TOOL_OUTPUT_ARCHIVES_DIR_NAME = 'tool-output-archives';
+export { isToolOutputArchivePath, TOOL_OUTPUT_ARCHIVES_DIR_NAME } from './tool-output-archive-path.js';
 
 export interface PersistToolOutputArchiveInput {
   content: string;

--- a/packages/host-internal/src/tool-output-archive.ts
+++ b/packages/host-internal/src/tool-output-archive.ts
@@ -1,0 +1,56 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  sanitizeSessionIdForFilename,
+  sanitizeToolCallIdForFilename,
+} from './spirit-filename-sanitize.js';
+
+export const TOOL_OUTPUT_ARCHIVES_DIR_NAME = 'tool-output-archives';
+
+export interface PersistToolOutputArchiveInput {
+  content: string;
+  sessionId?: string;
+  toolCallId?: string;
+  messageIndex?: number;
+}
+
+export function resolveToolOutputArchivesDir(spiritDataDir: string): string {
+  return path.join(spiritDataDir, TOOL_OUTPUT_ARCHIVES_DIR_NAME);
+}
+
+export function buildToolOutputArchiveFileName(
+  toolCallId: string | undefined,
+  messageIndex?: number,
+): string {
+  return `${sanitizeToolCallIdForFilename(toolCallId, messageIndex)}.txt`;
+}
+
+function buildToolOutputArchiveBody(
+  input: PersistToolOutputArchiveInput,
+  archivedAtUnixMs: number,
+): string {
+  const toolCallId = input.toolCallId?.trim() || sanitizeToolCallIdForFilename(undefined, input.messageIndex);
+  return [
+    '# spirit-tool-output-archive',
+    `# tool_call_id: ${toolCallId}`,
+    `# archived_at_unix_ms: ${archivedAtUnixMs}`,
+    '---',
+    input.content,
+  ].join('\n');
+}
+
+export async function persistToolOutputArchive(
+  spiritDataDir: string,
+  input: PersistToolOutputArchiveInput,
+): Promise<string> {
+  const sessionKey = sanitizeSessionIdForFilename(input.sessionId);
+  const archivesDir = path.join(resolveToolOutputArchivesDir(spiritDataDir), sessionKey);
+  await mkdir(archivesDir, { recursive: true });
+
+  const fileName = buildToolOutputArchiveFileName(input.toolCallId, input.messageIndex);
+  const filePath = path.join(archivesDir, fileName);
+  const archivedAtUnixMs = Date.now();
+  await writeFile(filePath, buildToolOutputArchiveBody(input, archivedAtUnixMs), 'utf8');
+  return filePath;
+}

--- a/packages/host-internal/src/tools.test.ts
+++ b/packages/host-internal/src/tools.test.ts
@@ -492,7 +492,7 @@ test('glob returns matching workspace files for a glob pattern', async () => {
     });
 
     assertTextToolOutput(output);
-    assert.match(output, /^\[glob\]\npattern: src\/\*\*\/\*\.ts\nmatches: 2\ntruncated: false/um);
+    assert.match(output, /^\[glob\]\npattern: src\/\*\*\/\*\.ts\nmatches: 2\n/um);
     assert.match(output, /\nsrc\/app\.ts\n/u);
     assert.match(output, /\nsrc\/nested\/util\.ts\n/u);
     assert.doesNotMatch(output, /note\.md/u);

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -22,12 +22,14 @@ import {
 } from '@spirit-agent/core';
 
 import { applyDiff } from './apply-diff.js';
+import { resolveCompactionArchivesDir } from './compaction-archive.js';
 import {
   defaultShellForPty,
   shellCommandParameterDescriptionForResolvedShell,
   shellDisplayNameForResolvedShell,
 } from './default-terminal-shell.js';
 import { runShellCommand } from './shell-execution.js';
+import { resolveToolOutputArchivesDir } from './tool-output-archive.js';
 import {
   readHostFileSnapshot,
   type HostFileChangeKind,
@@ -1335,7 +1337,8 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
   private isAllowedReadLocation(canonical: string): boolean {
     return (
       isWithinRoot(canonical, this.workspaceRoot) ||
-      isInsideSpiritManagedUserArea(canonical, this.context)
+      isInsideSpiritManagedUserArea(canonical, this.context) ||
+      isSpiritDataInternalReadPath(canonical, this.context.spiritDataDir)
     );
   }
 
@@ -2836,6 +2839,15 @@ function isJsonObject(value: HostJsonValue): value is HostJsonObject {
 function isWithinRoot(candidate: string, root: string): boolean {
   const relative = path.relative(root, candidate);
   return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+}
+
+function isSpiritDataInternalReadPath(resolvedPath: string, spiritDataDir: string): boolean {
+  const resolvedSpiritDataDir = path.resolve(spiritDataDir);
+  const allowedRoots = [
+    resolveCompactionArchivesDir(resolvedSpiritDataDir),
+    resolveToolOutputArchivesDir(resolvedSpiritDataDir),
+  ];
+  return allowedRoots.some((allowed) => pathHasPrefix(resolvedPath, allowed));
 }
 
 function isInsideSpiritManagedUserArea(

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -86,15 +86,10 @@ import {
 
 const PERMISSIONS_FILE = 'tool-permissions.json';
 const MAX_READ_LINES_DEFAULT = 200;
-const MAX_DIRECTORY_LIST_RESULTS = 4000;
-const MAX_WEB_FETCH_OUTPUT_CHARS = 24_000;
 const WEB_FETCH_TIMEOUT_MS = 20_000;
 const WEB_FETCH_IMAGE_CACHE_DIR = 'tool-web-fetch-images';
 const WEB_FETCH_IMAGE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const WEB_FETCH_IMAGE_CACHE_MAX_FILES = 128;
-const MAX_GLOB_RESULTS = 1000;
-const MAX_SEARCH_RESULTS = 80;
-const MAX_SEARCH_MATCHES_PER_FILE = 3;
 const MAX_SEARCH_FILE_BYTES = 1_000_000;
 const BROWSER_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36';
@@ -1465,14 +1460,13 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
     const directories: string[] = [];
     let skippedDirs = 0;
     let skippedSymlinks = 0;
-    let truncated = false;
 
     let entries;
     try {
       entries = await readdir(root, { withFileTypes: true });
     } catch {
       skippedDirs += 1;
-      return `[list]\npath: ${root}\nfiles: 0\ntruncated: false\nskipped_dirs: ${skippedDirs}\nskipped_symlinks: ${skippedSymlinks}\n\n（无法读取目录）`;
+      return `[list]\npath: ${root}\nfiles: 0\nskipped_dirs: ${skippedDirs}\nskipped_symlinks: ${skippedSymlinks}\n\n（无法读取目录）`;
     }
 
     for (const entry of entries) {
@@ -1489,17 +1483,13 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
         directories.push(entryPath);
       } else if (fileType.isFile()) {
         files.push(entryPath);
-        if (files.length >= MAX_DIRECTORY_LIST_RESULTS) {
-          truncated = true;
-          break;
-        }
       }
     }
 
     directories.sort((left, right) => left.localeCompare(right));
     files.sort((left, right) => left.localeCompare(right));
 
-    let out = `[list]\npath: ${root}\ndirectories: ${directories.length}\nfiles: ${files.length}\ntruncated: ${truncated ? 'true' : 'false'}\nskipped_dirs: ${skippedDirs}\nskipped_symlinks: ${skippedSymlinks}\n\n`;
+    let out = `[list]\npath: ${root}\ndirectories: ${directories.length}\nfiles: ${files.length}\nskipped_dirs: ${skippedDirs}\nskipped_symlinks: ${skippedSymlinks}\n\n`;
 
     if (directories.length === 0 && files.length === 0) {
       out += '（目录为空）';
@@ -1517,10 +1507,6 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
           out += `${file}\n`;
         }
       }
-    }
-
-    if (truncated) {
-      out += `\n...<结果已截断，最多列出 ${MAX_DIRECTORY_LIST_RESULTS} 个文件>`;
     }
 
     return out;
@@ -1620,21 +1606,14 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
       .map((value) => value.replace(/\\/gu, '/'))
       .sort((left, right) => left.localeCompare(right));
 
-    const truncated = matches.length > MAX_GLOB_RESULTS;
-    const shown = truncated ? matches.slice(0, MAX_GLOB_RESULTS) : matches;
-
-    let out = `[glob]\npattern: ${pattern}\nmatches: ${matches.length}\ntruncated: ${truncated ? 'true' : 'false'}\n\n`;
-    if (shown.length === 0) {
+    let out = `[glob]\npattern: ${pattern}\nmatches: ${matches.length}\n\n`;
+    if (matches.length === 0) {
       out += '未搜索到文件';
       return out;
     }
 
-    for (const file of shown) {
+    for (const file of matches) {
       out += `${file}\n`;
-    }
-
-    if (truncated) {
-      out += `\n...<结果已截断，最多列出 ${MAX_GLOB_RESULTS} 个文件>`;
     }
     return out;
   }
@@ -1650,37 +1629,32 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
     const files = new Set<string>();
     const hits: string[] = [];
 
-    const visitFile = async (filePath: string): Promise<boolean> => {
-      if (hits.length >= MAX_SEARCH_RESULTS) {
-        return false;
-      }
-
+    const visitFile = async (filePath: string): Promise<void> => {
       const ext = path.extname(filePath).toLowerCase();
       if (BINARY_EXTENSIONS.has(ext)) {
-        return true;
+        return;
       }
 
       let st;
       try {
         st = await lstat(filePath);
       } catch {
-        return true;
+        return;
       }
       if (!st.isFile() || st.size > MAX_SEARCH_FILE_BYTES) {
-        return true;
+        return;
       }
 
       let content: string;
       try {
         content = await readFile(filePath, 'utf8');
       } catch {
-        return true;
+        return;
       }
 
       const rel = path.relative(this.workspaceRoot, filePath).replace(/\\/gu, '/');
       const relDisplay = rel || '.';
       const lines = content.split(/\r?\n/u);
-      let fileMatchCount = 0;
 
       for (let index = 0; index < lines.length; index += 1) {
         const line = lines[index] ?? '';
@@ -1689,22 +1663,10 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
         }
 
         files.add(relDisplay);
-        if (hits.length < MAX_SEARCH_RESULTS && fileMatchCount < MAX_SEARCH_MATCHES_PER_FILE) {
-          hits.push(`${relDisplay}:${index + 1} | ${truncateChars(normalizeSearchLine(line), 180)}`);
-        }
-        fileMatchCount += 1;
-        if (hits.length >= MAX_SEARCH_RESULTS) {
-          return false;
-        }
+        hits.push(`${relDisplay}:${index + 1} | ${normalizeSearchLine(line)}`);
       }
-
-      return true;
     };
     const walk = async (dir: string): Promise<void> => {
-      if (hits.length >= MAX_SEARCH_RESULTS) {
-        return;
-      }
-
       let entries;
       try {
         entries = await readdir(dir, { withFileTypes: true });
@@ -1713,10 +1675,6 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
       }
 
       for (const entry of entries) {
-        if (hits.length >= MAX_SEARCH_RESULTS) {
-          return;
-        }
-
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) {
           if (SEARCH_IGNORE_DIR_NAMES.has(entry.name)) {
@@ -1724,10 +1682,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
           }
           await walk(full);
         } else if (entry.isFile()) {
-          const ok = await visitFile(full);
-          if (!ok) {
-            return;
-          }
+          await visitFile(full);
         }
       }
     };
@@ -1930,11 +1885,9 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
       const raw = await response.text();
       const extracted = extractWebText(raw, contentType);
       const normalized = normalizeWebText(extracted);
-      const preview = truncateChars(normalized, MAX_WEB_FETCH_OUTPUT_CHARS);
       const totalChars = [...normalized].length;
-      const truncated = totalChars > MAX_WEB_FETCH_OUTPUT_CHARS;
       return createHostToolTextOutput(
-        `[web]\nurl: ${parsedUrl}\nfinal_url: ${finalUrl}\nstatus: ${status}\ncontent_type: ${contentType}\nuser_agent: ${BROWSER_USER_AGENT}\ncontent_chars: ${totalChars}\ntruncated: ${truncated ? 'true' : 'false'}\n\ncontent\n${preview}${truncated ? '\n\n...<网页内容已截断>' : ''}`,
+        `[web]\nurl: ${parsedUrl}\nfinal_url: ${finalUrl}\nstatus: ${status}\ncontent_type: ${contentType}\nuser_agent: ${BROWSER_USER_AGENT}\ncontent_chars: ${totalChars}\n\ncontent\n${normalized}`,
       );
     } finally {
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary

- 超长 tool 输出在 append 进 history 前统一按 12k 截断，落盘至 `{spiritDataDir}/tool-output-archives/` 并在 excerpt 注入 `Full output archived at` 与 read_file 引导
- 移除各工具宿主层自有截断，compaction / context retry 与 append 共用 `tool-output-truncation` 与 `persistToolOutputArchive`
- Desktop / ACP / CLI 注入归档 persist 回调；read_file 白名单允许读取归档目录
- read_file 读取 `tool-output-archives` 路径时，工具卡 headlineDetail 显示「工具输出」/ tool output（非归档文件名）；路径判断与展示模块分离（`tool-output-archive-path`、`read-file-tool-display`）

## Test plan

- [x] `packages/host-internal`: `tool-output-archive.test.js`、`tool-output-archive-path.test.js`、`skill-paths.test.js`
- [x] `packages/agent-core`: `tool-output-truncation.test.js`、`compaction.runtime.test.js`
- [x] `apps/desktop`: `message-ordering.test.mjs`（含 tool-output-archives 用例）、`tool-call-display.test.mjs`
- [x] Desktop 手动：shell 输出约 10000 行，LLM export 含截断标签与 `Full output archived at`，归档文件落盘
- [x] Desktop 手动：read_file 读取归档路径，工具卡显示「查看 工具输出」/ Read tool output
- [x] `npm run build:electron`（desktop）、`npm run build`（host-internal / agent-core）