### PR TITLE
feat(desktop, agent-core): 非阻塞 Worktree 创建与 SubAgent 过程卡修复

### DIFF
--- a/apps/desktop/src/host/direct-media-turn.ts
+++ b/apps/desktop/src/host/direct-media-turn.ts
@@ -23,6 +23,7 @@ import {
   type DirectMediaTool as HostDirectMediaTool,
 } from './model-config.js';
 import type { SessionBundle } from './session-bundle.js';
+import { isWorktreeBootstrapInFlight } from './worktree-bootstrap-card.js';
 import { syncRuntimeHistoryFromBundleArchive } from './conversation-continuation.js';
 import type { SessionTurnOrchestratorContext } from './session-turn-orchestrator.js';
 import type { DesktopConfigFile } from './storage.js';
@@ -117,6 +118,9 @@ export function isSessionBundleBusy(bundle: SessionBundle | undefined): boolean 
     return false;
   }
   if (bundle.directMediaTurnInFlight === true) {
+    return true;
+  }
+  if (isWorktreeBootstrapInFlight(bundle.pendingWorktreeBootstrap)) {
     return true;
   }
   return bundle.runtime?.isBusy() === true;

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -227,6 +227,10 @@ import {
   type SessionTurnOrchestratorContext,
   type SubmitUserTurnAfterInitializedOptions,
 } from './session-turn-orchestrator.js';
+import {
+  startWorktreeBootstrapTurnCommand,
+  type WorktreeBootstrapHostContext,
+} from './worktree-bootstrap-orchestrator.js';
 import { isSessionBundleBusy } from './direct-media-turn.js';
 import {
   appendQueuedUserTurnSnapshots,
@@ -731,7 +735,36 @@ class DesktopHostService {
         this.insertUserApprovalReplyMessage(content, pendingToolCallId),
       normalizeApprovalDecision,
       runSessionEndForActive: (reason) => this.runSessionEndForBundle(this.activeBundle(), reason),
+      worktreeBootstrapHost: this.worktreeBootstrapHost(),
     };
+  }
+
+  private worktreeBootstrapHost(): WorktreeBootstrapHostContext {
+    return {
+      validateWorktreeBootstrapPreconditions: () => this.validateWorktreeBootstrapPreconditions(),
+      executeWorktreeBootstrap: (userPrompt) => this.executeWorktreeBootstrapForActiveBundle(userPrompt),
+      resolveWorktreeBootstrapSessionKey: () => this.activeBundle().id,
+      setLastRuntimeError: (error) => {
+        this.lastRuntimeError = error;
+      },
+    };
+  }
+
+  private validateWorktreeBootstrapPreconditions(): void {
+    const state = this.requireState();
+    const bundle = this.activeBundle();
+
+    if (!state.git.isRepository) {
+      throw new Error(i18n.t('error.notGitRepoForWorktree'));
+    }
+
+    const baseBranch = bundle.pendingGitBranch ?? state.git.branch;
+    if (!baseBranch) {
+      throw new Error(i18n.t('error.cannotDetermineBaseBranch'));
+    }
+    if (!state.git.branches.includes(baseBranch)) {
+      throw new Error(i18n.t('error.baseBranchNotFound', { branch: baseBranch }));
+    }
   }
 
   private getHookRunner(workspaceRoot: string): HookRunner {
@@ -1391,7 +1424,12 @@ class DesktopHostService {
 
       const isFirstTurn = bundle.messages.length === 0;
       if (isFirstTurn && bundle.workLocation === 'worktree') {
-        await this.bootstrapWorktreeForFirstTurn(trimmed);
+        return startWorktreeBootstrapTurnCommand(
+          this.sessionTurnContext(),
+          this.worktreeBootstrapHost(),
+          request.text,
+          { explicitWorkspaceFiles },
+        );
       }
 
       return this.submitUserTurnAfterInitialized(request.text, {
@@ -2808,13 +2846,9 @@ class DesktopHostService {
     state.ephemeralSessions = rememberEphemeralWorktreeSessionRecord(state.ephemeralSessions, record);
   }
 
-  private async bootstrapWorktreeForFirstTurn(userPrompt: string): Promise<void> {
+  private async executeWorktreeBootstrapForActiveBundle(userPrompt: string): Promise<void> {
     const state = this.requireState();
     const bundle = this.activeBundle();
-
-    if (!state.git.isRepository) {
-      throw new Error(i18n.t('error.notGitRepoForWorktree'));
-    }
 
     const repoRoot = await readPrimaryRepoRoot(state.workspaceRoot);
     const worktreeContext = await readWorkspaceGitSnapshot(state.workspaceRoot);
@@ -2825,9 +2859,6 @@ class DesktopHostService {
     const baseBranch = bundle.pendingGitBranch ?? state.git.branch;
     if (!baseBranch) {
       throw new Error(i18n.t('error.cannotDetermineBaseBranch'));
-    }
-    if (!state.git.branches.includes(baseBranch)) {
-      throw new Error(i18n.t('error.baseBranchNotFound', { branch: baseBranch }));
     }
 
     const names = await this.generateWorktreeNamesFromModel(userPrompt, baseBranch, repoRoot);

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2292,8 +2292,9 @@ class DesktopHostService {
         const bundle = this.activeBundle();
         return bundle.pendingGitBranch ?? state.git.branch;
       },
-      generateWorktreeNames: (task, baseBranch, repoRoot) =>
-        this.generateWorktreeNamesFromModel(task, baseBranch, repoRoot),
+      generateWorktreeNames: async () => {
+        throw new Error('subagent worktree naming is deterministic');
+      },
       buildScopedToolExecutor: (workspaceRoot) =>
         this.buildScopedSubagentToolExecutor(workspaceRoot, transportConfig, parentExecutor),
     });

--- a/apps/desktop/src/host/session-activation.ts
+++ b/apps/desktop/src/host/session-activation.ts
@@ -23,6 +23,7 @@ import type { DesktopTimelineTurnSnapshot, DesktopMessageTimeline } from './mess
 import { restoreMessagesFromArchive } from './message-ordering.js';
 import { currentApiBase, sameWorkspaceRoot } from './service-utils.js';
 import type { HostExtensionEvent } from '@spirit-agent/host-internal';
+import { cancelPendingWorktreeBootstrapOnBundle } from './worktree-bootstrap-orchestrator.js';
 
 interface ActivationState {
   workspaceRoot: string;
@@ -123,6 +124,7 @@ export async function openSessionCommand(
       && leaving.activeSession.kind !== 'ephemeral'
       && leavingMessageCount > 0
     ) {
+      cancelPendingWorktreeBootstrapOnBundle(leaving);
       await ctx.runSessionEndForBundle?.(leaving, 'switch');
       await ctx.persistSessionBundle(leaving, {
         fromRuntime:

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -196,6 +196,7 @@ export function resetSessionBundleInPlace(bundle: SessionBundle): void {
   bundle.sessionTitleSource = undefined;
   bundle.contextUsage = undefined;
   bundle.directMediaTurnInFlight = false;
+  bundle.pendingWorktreeBootstrap = undefined;
   bundle.queuedUserTurns = [];
   bundle.subagentDesktopMessagesBySessionId = new Map();
   bundle.subagentConversationProjections = new Map();

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -17,6 +17,7 @@ import type {
   FileRewindWarning,
 } from '../types.js';
 import type { QueuedUserTurn } from './message-queue.js';
+import type { PendingWorktreeBootstrap } from './worktree-bootstrap-card.js';
 import type { DesktopTimelineSegmentKind, DesktopMessageTimeline } from './message-timeline.js';
 import { createDesktopRewindMetadata, type StoredDesktopRewindMetadata } from './rewind.js';
 import { createTodoSessionScopeKey } from './todos.js';
@@ -70,6 +71,8 @@ export interface SessionBundle {
   contextUsage?: ConversationContextUsageSnapshot;
   /** Composer 直连生图/生视频后台执行中；与 runtime.isBusy 一并驱动 snapshot.isBusy。 */
   directMediaTurnInFlight?: boolean;
+  /** 首条 Worktree 消息：后台 bootstrap 完成前 gate LLM turn。不持久化。 */
+  pendingWorktreeBootstrap?: PendingWorktreeBootstrap;
   /** Per-session user message queue (projected in snapshot until sent). */
   queuedUserTurns: QueuedUserTurn[];
   /** SubAgent 子会话 desktop 投影（与主 timeline 同构，含 Thought/Compaction/工具卡）。 */

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -44,6 +44,7 @@ import { syncSubagentConversationProjections } from './subagent-conversation-pro
 import { toRuntimeAskQuestionsResult } from './service-utils.js';
 import {
   advancePendingWorktreeBootstrapCommand,
+  abortPendingWorktreeBootstrap,
   shouldAdvanceWorktreeBootstrap,
   type WorktreeBootstrapHostContext,
 } from './worktree-bootstrap-orchestrator.js';
@@ -376,6 +377,11 @@ export async function tickSessionCommand(
 export async function abortConversationInContext(
   ctx: SessionTurnOrchestratorContext,
 ): Promise<boolean> {
+  const bundle = ctx.activeBundle();
+  if (ctx.worktreeBootstrapHost && abortPendingWorktreeBootstrap(ctx, ctx.worktreeBootstrapHost, bundle)) {
+    return true;
+  }
+
   const runtime = ctx.requireRuntime();
   const interruptedAssistantText = runtime.pendingAssistantText().trim();
   const interruptedThinkingText = runtime.thinkingText().trim();

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -42,6 +42,11 @@ import {
 } from './direct-media-turn.js';
 import { syncSubagentConversationProjections } from './subagent-conversation-projection.js';
 import { toRuntimeAskQuestionsResult } from './service-utils.js';
+import {
+  advancePendingWorktreeBootstrapCommand,
+  shouldAdvanceWorktreeBootstrap,
+  type WorktreeBootstrapHostContext,
+} from './worktree-bootstrap-orchestrator.js';
 
 type RuntimeEventsFacade = {
   applyRuntimeHostEvents(events: RuntimeEvent<DesktopToolRequest>[]): void;
@@ -115,6 +120,7 @@ export interface SessionTurnOrchestratorContext {
   insertUserApprovalReplyMessage(content: string, pendingToolCallId?: string): void;
   normalizeApprovalDecision(decision: DesktopApprovalDecision | undefined): RuntimeApprovalDecision;
   runSessionEndForActive?(reason: import('@spirit-agent/core').SessionEndHookInput['reason']): Promise<void>;
+  worktreeBootstrapHost?: WorktreeBootstrapHostContext;
 }
 
 export async function submitUserTurnAfterInitializedCommand(
@@ -310,7 +316,7 @@ export async function pollCommand(ctx: SessionTurnOrchestratorContext): Promise<
   return ctx.runSerialized(async () => {
     await ctx.ensureInitialized(undefined, { fastPath: true });
     for (const bundle of ctx.allBundles()) {
-      if (bundle.runtime?.isBusy()) {
+      if (bundle.runtime?.isBusy() || shouldAdvanceWorktreeBootstrap(bundle)) {
         await tickSessionCommand(ctx, bundle);
       }
     }
@@ -329,6 +335,10 @@ export async function tickSessionCommand(
   bundle: SessionBundle,
   options: { light?: boolean } = {},
 ): Promise<void> {
+  if (ctx.worktreeBootstrapHost && shouldAdvanceWorktreeBootstrap(bundle)) {
+    await advancePendingWorktreeBootstrapCommand(ctx, ctx.worktreeBootstrapHost, bundle);
+  }
+
   const orchestration = ctx.orchestrationFor(bundle);
   if (bundle.runtime) {
     bundle.runtime.tickThinkingSpinner();

--- a/apps/desktop/src/host/subagent-conversation-projection.ts
+++ b/apps/desktop/src/host/subagent-conversation-projection.ts
@@ -1,4 +1,4 @@
-import type { RuntimeEvent, SubagentSessionArchiveEntry } from '@spirit-agent/core';
+import type { RuntimeEvent, SubagentSessionArchiveEntry, SubagentSessionStatus } from '@spirit-agent/core';
 import { llmMessageTextContent } from '@spirit-agent/core';
 
 import type { ConversationMessageSnapshot } from '../types.js';
@@ -9,6 +9,10 @@ import {
   DesktopMessageTimeline,
   type DesktopTimelineSegmentKind,
 } from './message-timeline.js';
+import {
+  resolveWorktreeBootstrapCardPhaseFromSubagentStatus,
+  upsertWorktreeBootstrapCardInTimeline,
+} from './worktree-bootstrap-card.js';
 import {
   DesktopRuntimeEventOrchestrator,
   runtimeEventsIncludeAppliedResponsesBuiltInToolPreview,
@@ -107,7 +111,9 @@ export class SubagentConversationProjection {
     const messages = existingMessages?.length
       ? existingMessages.map((message) => ({ ...message }))
       : seedMessagesFromSubagentSession(session);
-    return new SubagentConversationProjection(session.summary.sessionId, messages);
+    const projection = new SubagentConversationProjection(session.summary.sessionId, messages);
+    syncWorktreeBootstrapCardOnProjection(projection, session.summary.status, session.summary.sessionId);
+    return projection;
   }
 
   applyDrainedEvents(drained: RuntimeEvent<DesktopToolRequest>[]): void {
@@ -182,6 +188,8 @@ export function syncSubagentConversationProjections(
     return;
   }
 
+  syncSubagentWorktreeBootstrapCards(bundle, runtime);
+
   const childDrains = runtime.drainActiveChildSessionEvents();
   if (childDrains.length === 0) {
     return;
@@ -199,6 +207,43 @@ export function syncSubagentConversationProjections(
     bundle.subagentDesktopMessagesBySessionId.set(
       childDrain.sessionId,
       syncedMessages,
+    );
+  }
+}
+
+function syncWorktreeBootstrapCardOnProjection(
+  projection: SubagentConversationProjection,
+  status: SubagentSessionStatus,
+  sessionId: string,
+): void {
+  const phase = resolveWorktreeBootstrapCardPhaseFromSubagentStatus(status);
+  if (!phase) {
+    return;
+  }
+  upsertWorktreeBootstrapCardInTimeline(projection.messageTimeline, sessionId, phase);
+}
+
+function syncSubagentWorktreeBootstrapCards(
+  bundle: SessionBundle,
+  runtime: DesktopRuntime,
+): void {
+  for (const session of runtime.childSessionArchives()) {
+    const isWorktreeSubagent =
+      session.summary.status === 'bootstrapping'
+      || Boolean(session.summary.worktreePath);
+    if (!isWorktreeSubagent) {
+      continue;
+    }
+
+    const projection = ensureSubagentConversationProjection(bundle, session);
+    syncWorktreeBootstrapCardOnProjection(
+      projection,
+      session.summary.status,
+      session.summary.sessionId,
+    );
+    bundle.subagentDesktopMessagesBySessionId.set(
+      session.summary.sessionId,
+      projection.toMessages(),
     );
   }
 }

--- a/apps/desktop/src/host/subagent-stream-sync.ts
+++ b/apps/desktop/src/host/subagent-stream-sync.ts
@@ -5,7 +5,7 @@ import type { ConversationMessageSnapshot, ToolBlockSnapshot } from '../types.js
 export interface SubagentSessionArchiveSnapshot {
   summary: {
     parentToolCallId?: string;
-    status: 'running' | 'completed' | 'failed' | 'blocked';
+    status: 'bootstrapping' | 'running' | 'completed' | 'failed' | 'blocked';
     latestMessage?: string;
     finalOutput?: string;
   };

--- a/apps/desktop/src/host/subagent-viewer.ts
+++ b/apps/desktop/src/host/subagent-viewer.ts
@@ -268,7 +268,9 @@ export function buildSubagentViewerSnapshot(
 
   const projected = bundle.subagentDesktopMessagesBySessionId.get(session.summary.sessionId);
   const isLiveSession =
-    session.summary.status === 'running' || session.summary.status === 'blocked';
+    session.summary.status === 'bootstrapping'
+    || session.summary.status === 'running'
+    || session.summary.status === 'blocked';
 
   const resolved = resolveSubagentViewerMessages({
     projected,

--- a/apps/desktop/src/host/subagent-viewer.ts
+++ b/apps/desktop/src/host/subagent-viewer.ts
@@ -23,6 +23,83 @@ import {
 } from './subagent-conversation-projection.js';
 import { isRunSubagentToolCallPending } from './subagent-stream-sync.js';
 
+import { WORKTREE_BOOTSTRAP_TOOL_NAME } from './worktree-bootstrap-card.js';
+
+function summarizeViewerProcessMetadata(messages: readonly ConversationMessageSnapshot[]) {
+  let worktreeCards = 0;
+  let thinkingRows = 0;
+  let toolRows = 0;
+  for (const message of messages) {
+    if (message.tool?.toolName === WORKTREE_BOOTSTRAP_TOOL_NAME) {
+      worktreeCards += 1;
+    }
+    if (message.tool) {
+      toolRows += 1;
+    }
+    if (message.aux?.thinking?.trim()) {
+      thinkingRows += 1;
+    }
+  }
+  return { worktreeCards, thinkingRows, toolRows };
+}
+
+function projectedHasRicherProcessMetadata(
+  projected: readonly ConversationMessageSnapshot[],
+  history: readonly ConversationMessageSnapshot[],
+): boolean {
+  const projectedMeta = summarizeViewerProcessMetadata(projected);
+  const historyMeta = summarizeViewerProcessMetadata(history);
+  return (
+    projectedMeta.worktreeCards > historyMeta.worktreeCards
+    || projectedMeta.thinkingRows > historyMeta.thinkingRows
+    || projectedMeta.toolRows > historyMeta.toolRows
+  );
+}
+
+function lastAssistantBodyMessage(
+  messages: readonly ConversationMessageSnapshot[],
+): ConversationMessageSnapshot | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role === 'assistant' && !message.tool && message.content.trim()) {
+      return message;
+    }
+  }
+  return undefined;
+}
+
+function hasAssistantBodyText(messages: readonly ConversationMessageSnapshot[]): boolean {
+  return lastAssistantBodyMessage(messages) !== undefined;
+}
+
+function appendAssistantBodyFromHistory(
+  messages: ConversationMessageSnapshot[],
+  history: readonly ConversationMessageSnapshot[],
+  finalOutput: string | undefined,
+): ConversationMessageSnapshot[] {
+  if (hasAssistantBodyText(messages)) {
+    return patchCompletedAssistantOutput(messages, finalOutput);
+  }
+
+  const text = finalOutput?.trim() || lastAssistantBodyMessage(history)?.content.trim();
+  if (!text) {
+    return messages;
+  }
+
+  const bodyTemplate = lastAssistantBodyMessage(history);
+  const next = messages.map((entry) => ({ ...entry }));
+  next.push({
+    ...(bodyTemplate ?? {
+      id: next.length + 1,
+      role: 'assistant' as const,
+      pending: false,
+    }),
+    content: text,
+    pending: false,
+  });
+  return next;
+}
+
 function enrichSubagentToolBlock(input: {
   toolName: string;
   phase: ToolBlockSnapshot['phase'];
@@ -148,7 +225,7 @@ function patchCompletedAssistantOutput(
   return messages;
 }
 
-function resolveSubagentViewerMessages(input: {
+export function resolveSubagentViewerMessages(input: {
   projected?: ConversationMessageSnapshot[];
   historyMessages: ConversationMessageSnapshot[];
   isLiveSession: boolean;
@@ -180,6 +257,12 @@ function resolveSubagentViewerMessages(input: {
     const projectedLast = lastAssistantTextContent(projected);
     const historyLast = lastAssistantTextContent(history);
     if (historyLast.length > projectedLast.length) {
+      if (projectedHasRicherProcessMetadata(projected, history)) {
+        return {
+          messages: appendAssistantBodyFromHistory(projected, history, input.finalOutput),
+          source: 'projected-enriched-with-history-body',
+        };
+      }
       return {
         messages: patchCompletedAssistantOutput(history, input.finalOutput),
         source: 'history-longer-completed',

--- a/apps/desktop/src/host/subagent-worktree-bootstrap.ts
+++ b/apps/desktop/src/host/subagent-worktree-bootstrap.ts
@@ -49,7 +49,7 @@ export function createDesktopSubagentWorkspaceBootstrap(
         return { error: 'cannot determine base branch for subagent worktree' };
       }
 
-      const names = await deps.generateWorktreeNames(input.task, baseBranch, repoRoot);
+      const names = buildDeterministicSubagentWorktreeNames(input.subagentSessionId);
       const created = await createWorkspaceGitWorktree(repoRoot, names, baseBranch);
       createdWorktreePath = created.worktreePath;
       const scopedExecutor = await deps.buildScopedToolExecutor(created.worktreePath);

--- a/apps/desktop/src/host/worktree-bootstrap-card.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-card.ts
@@ -4,6 +4,7 @@ import i18n from '../lib/i18n-host.js';
 import { phaseToVerbContext } from '../lib/tool-verb-context.js';
 import type { ToolBlockSnapshot } from '../types.js';
 import type { DesktopRewindCheckpointSnapshot } from './rewind.js';
+import type { DesktopMessageTimeline } from './message-timeline.js';
 
 export const WORKTREE_BOOTSTRAP_TOOL_NAME = 'worktree_bootstrap';
 
@@ -44,4 +45,30 @@ export function isWorktreeBootstrapInFlight(
   pending: PendingWorktreeBootstrap | undefined,
 ): boolean {
   return pending?.phase === 'running';
+}
+
+export function upsertWorktreeBootstrapCardInTimeline(
+  timeline: DesktopMessageTimeline,
+  sessionKey: string,
+  phase: WorktreeBootstrapPhase,
+): void {
+  const toolCallId = worktreeBootstrapToolCallId(sessionKey);
+  const snapshot = buildWorktreeBootstrapToolSnapshot(phase);
+  snapshot.toolCallId = toolCallId;
+  timeline.upsertToolMessage(toolCallId, snapshot);
+}
+
+export function resolveWorktreeBootstrapCardPhaseFromSubagentStatus(
+  status: 'bootstrapping' | 'running' | 'completed' | 'failed' | 'blocked',
+): WorktreeBootstrapPhase | undefined {
+  if (status === 'bootstrapping') {
+    return 'running';
+  }
+  if (status === 'failed') {
+    return 'failed';
+  }
+  if (status === 'running' || status === 'blocked' || status === 'completed') {
+    return 'succeeded';
+  }
+  return undefined;
 }

--- a/apps/desktop/src/host/worktree-bootstrap-card.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-card.ts
@@ -1,0 +1,47 @@
+import type { PendingWorkspaceFile } from '@spirit-agent/core';
+
+import i18n from '../lib/i18n-host.js';
+import { phaseToVerbContext } from '../lib/tool-verb-context.js';
+import type { ToolBlockSnapshot } from '../types.js';
+import type { DesktopRewindCheckpointSnapshot } from './rewind.js';
+
+export const WORKTREE_BOOTSTRAP_TOOL_NAME = 'worktree_bootstrap';
+
+export type WorktreeBootstrapPhase = 'running' | 'succeeded' | 'failed';
+
+export interface PendingWorktreeBootstrap {
+  toolCallId: string;
+  userPrompt: string;
+  displayText: string;
+  explicitWorkspaceFiles?: PendingWorkspaceFile[];
+  userMessageId: number;
+  beforeUserCheckpoint: DesktopRewindCheckpointSnapshot;
+  phase: WorktreeBootstrapPhase;
+  error?: string;
+}
+
+export function worktreeBootstrapToolCallId(sessionKey: string): string {
+  return `worktree-bootstrap:${sessionKey}`;
+}
+
+export function buildWorktreeBootstrapToolSnapshot(
+  phase: WorktreeBootstrapPhase,
+): ToolBlockSnapshot {
+  const toolPhase: ToolBlockSnapshot['phase'] =
+    phase === 'running' ? 'running' : phase === 'succeeded' ? 'succeeded' : 'failed';
+  const verbContext = phaseToVerbContext(toolPhase);
+  return {
+    toolCallId: undefined,
+    toolName: WORKTREE_BOOTSTRAP_TOOL_NAME,
+    phase: toolPhase,
+    headline: i18n.t('tool.create', verbContext ? { context: verbContext } : {}),
+    headlineDetail: i18n.t('composer.workLocationWorktree'),
+    detailLines: [],
+  };
+}
+
+export function isWorktreeBootstrapInFlight(
+  pending: PendingWorktreeBootstrap | undefined,
+): boolean {
+  return pending?.phase === 'running';
+}

--- a/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
@@ -1,0 +1,225 @@
+import path from 'node:path';
+
+import type { PendingWorkspaceFile } from '@spirit-agent/core';
+import { cloneActiveSkills } from './runtime.js';
+
+import i18n from '../lib/i18n-host.js';
+import type { ConversationMessageSnapshot, DesktopSnapshot } from '../types.js';
+import type { DesktopRewindCheckpointSnapshot } from './rewind.js';
+import type { SessionBundle } from './session-bundle.js';
+import {
+  buildWorktreeBootstrapToolSnapshot,
+  isWorktreeBootstrapInFlight,
+  type PendingWorktreeBootstrap,
+  worktreeBootstrapToolCallId,
+} from './worktree-bootstrap-card.js';
+import type {
+  SessionTurnOrchestratorContext,
+  SubmitUserTurnAfterInitializedOptions,
+} from './session-turn-orchestrator.js';
+import {
+  applyDrainedRuntimeHostEvents,
+  drainQueuedUserTurnIfIdle,
+} from './session-turn-orchestrator.js';
+
+export interface WorktreeBootstrapHostContext {
+  validateWorktreeBootstrapPreconditions(): void;
+  executeWorktreeBootstrap(userPrompt: string): Promise<void>;
+  resolveWorktreeBootstrapSessionKey(): string;
+  setLastRuntimeError(error: string): void;
+}
+
+function defaultDisplayTextForUserTurn(
+  text: string,
+  explicitWorkspaceFiles: readonly PendingWorkspaceFile[],
+): string {
+  const trimmed = text.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  if (explicitWorkspaceFiles.length === 0) {
+    return '';
+  }
+  return i18n.t('error.attachedFiles', {
+    files: explicitWorkspaceFiles.map((file) => path.basename(file.path)).join(', '),
+  });
+}
+
+function pendingWorkspaceFilesToAttachmentSnapshots(
+  files: readonly PendingWorkspaceFile[],
+): ConversationMessageSnapshot['localFileAttachments'] {
+  return files.map((file) => ({
+    path: file.path,
+    name: path.basename(file.path),
+    isImage: file.kind === 'image',
+  }));
+}
+
+function syncMessagesFromTimeline(bundle: SessionBundle): void {
+  bundle.messages = bundle.messageTimeline.toMessages();
+}
+
+function upsertWorktreeBootstrapCard(
+  bundle: SessionBundle,
+  toolCallId: string,
+  phase: PendingWorktreeBootstrap['phase'],
+): void {
+  const snapshot = buildWorktreeBootstrapToolSnapshot(phase);
+  snapshot.toolCallId = toolCallId;
+  bundle.messageTimeline.upsertToolMessage(toolCallId, snapshot);
+  syncMessagesFromTimeline(bundle);
+}
+
+export async function startWorktreeBootstrapTurnCommand(
+  ctx: SessionTurnOrchestratorContext,
+  host: WorktreeBootstrapHostContext,
+  text: string,
+  options: SubmitUserTurnAfterInitializedOptions = {},
+): Promise<DesktopSnapshot> {
+  host.validateWorktreeBootstrapPreconditions();
+
+  const bundle = ctx.activeBundle();
+  const trimmed = text.trim();
+  const explicitWorkspaceFiles = options.explicitWorkspaceFiles ?? [];
+  const displayText = (options.displayText ?? defaultDisplayTextForUserTurn(text, explicitWorkspaceFiles)).trim();
+  if (!trimmed && explicitWorkspaceFiles.length === 0) {
+    throw new Error(i18n.t('error.messageRequired'));
+  }
+  if (!displayText) {
+    throw new Error(i18n.t('error.messageRequired'));
+  }
+
+  const turnSkills = cloneActiveSkills(options.turnSkills ?? []);
+  bundle.currentTurnSkills = turnSkills;
+  if (!bundle.runtime) {
+    await ctx.refreshRuntimeForBundle(bundle);
+    ctx.syncActiveRuntimePointer();
+  }
+
+  ctx.requireState();
+  if (bundle.activeSession?.readOnly) {
+    throw new Error(i18n.t('error.readonlySessionSend'));
+  }
+  bundle.rewindWarnings = [];
+  ctx.clearAssistantContinuationMarkers();
+  const todoSessionKeyBeforeEnsure = ctx.resolveTodoSessionKeyForBundle(bundle);
+  ctx.ensureActiveSession(displayText);
+  await ctx.reconcileTodoScopeAfterSessionPathChange(bundle, todoSessionKeyBeforeEnsure);
+  await ctx.maybeRefreshRuntimeAfterTodoScopeChange(bundle, todoSessionKeyBeforeEnsure);
+  const beforeUserCheckpoint = await ctx.buildRewindCheckpointSnapshot() as DesktopRewindCheckpointSnapshot;
+  const localFileAttachments =
+    explicitWorkspaceFiles.length > 0
+      ? pendingWorkspaceFilesToAttachmentSnapshots(explicitWorkspaceFiles)
+      : undefined;
+  const userMessage: ConversationMessageSnapshot = {
+    id: options.preallocatedMessageId ?? ctx.allocateMessageId(),
+    role: 'user',
+    content: displayText,
+    pending: false,
+    ...(localFileAttachments ? { localFileAttachments } : {}),
+  };
+  bundle.messages.push(userMessage);
+  bundle.messageTimeline.beginUserTurn(userMessage.content, {
+    messageId: userMessage.id,
+    ...(localFileAttachments ? { localFileAttachments } : {}),
+  });
+  ctx.resetStreamingPlacementState(false);
+
+  const toolCallId = worktreeBootstrapToolCallId(host.resolveWorktreeBootstrapSessionKey());
+  upsertWorktreeBootstrapCard(bundle, toolCallId, 'running');
+
+  bundle.pendingWorktreeBootstrap = {
+    toolCallId,
+    userPrompt: trimmed,
+    displayText,
+    explicitWorkspaceFiles: explicitWorkspaceFiles.length > 0 ? [...explicitWorkspaceFiles] : undefined,
+    userMessageId: userMessage.id,
+    beforeUserCheckpoint,
+    phase: 'running',
+  };
+
+  const todoSessionKeyBeforePersist = ctx.resolveTodoSessionKeyForBundle(bundle);
+  await ctx.persistCurrentSessionIfNeeded();
+  ctx.scheduleSessionTitleGenerationIfNeeded(displayText);
+  await ctx.reconcileTodoScopeAfterSessionPathChange(bundle, todoSessionKeyBeforePersist);
+  await ctx.maybeRefreshRuntimeAfterTodoScopeChange(bundle, todoSessionKeyBeforePersist);
+  if (turnSkills.length > 0) {
+    await ctx.refreshRuntimeForBundle(bundle);
+    ctx.syncActiveRuntimePointer();
+  }
+  await ctx.dispatchUserMessageExtensionEvent(trimmed, displayText, userMessage.id);
+  ctx.emitLiveSnapshotUpdate();
+  return ctx.buildSnapshot();
+}
+
+async function startStreamingAfterWorktreeBootstrap(
+  ctx: SessionTurnOrchestratorContext,
+  bundle: SessionBundle,
+  pending: PendingWorktreeBootstrap,
+): Promise<void> {
+  const runtime = ctx.requireRuntime();
+  await ctx.ensureToolExecutor(bundle);
+  try {
+    await runtime.startUserTurnStreaming(
+      pending.userPrompt,
+      [],
+      pending.explicitWorkspaceFiles ?? [],
+    );
+    ctx.refreshArchiveFromRuntime();
+    await ctx.recordRewindCheckpoint(pending.userMessageId, pending.beforeUserCheckpoint);
+    await runtime.poll();
+    applyDrainedRuntimeHostEvents(ctx, bundle, runtime.drainEvents());
+  } catch (error) {
+    bundle.currentTurnSkills = [];
+    ctx.orchestrationFor(bundle).assistantMessages.handleMessageRemoved(
+      bundle.messages.length - 1,
+      pending.userMessageId,
+      'send-user-rollback',
+    );
+    bundle.messages.pop();
+    ctx.rebuildMessageTimelineFromMessages();
+    throw error;
+  }
+
+  const orchestration = ctx.orchestrationFor(bundle);
+  orchestration.runtimeEvents.consumeCompletedTurnResult();
+  orchestration.runtimeEvents.syncPendingToolStates();
+  orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
+  await ctx.flushDeferredRuntimeRefreshIfIdle(bundle);
+  await ctx.refreshTodoSnapshotForBundle(bundle);
+}
+
+export async function advancePendingWorktreeBootstrapCommand(
+  ctx: SessionTurnOrchestratorContext,
+  host: WorktreeBootstrapHostContext,
+  bundle: SessionBundle,
+): Promise<void> {
+  const pending = bundle.pendingWorktreeBootstrap;
+  if (!isWorktreeBootstrapInFlight(pending)) {
+    return;
+  }
+
+  try {
+    await host.executeWorktreeBootstrap(pending!.userPrompt);
+    upsertWorktreeBootstrapCard(bundle, pending!.toolCallId, 'succeeded');
+    host.setLastRuntimeError('');
+    await startStreamingAfterWorktreeBootstrap(ctx, bundle, pending!);
+    bundle.pendingWorktreeBootstrap = undefined;
+    await ctx.persistCurrentSessionIfNeeded();
+    await drainQueuedUserTurnIfIdle(ctx, bundle);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    upsertWorktreeBootstrapCard(bundle, pending!.toolCallId, 'failed');
+    pending!.phase = 'failed';
+    pending!.error = message;
+    host.setLastRuntimeError(message);
+    bundle.pendingWorktreeBootstrap = undefined;
+    bundle.currentTurnSkills = [];
+    await ctx.persistCurrentSessionIfNeeded();
+    ctx.emitLiveSnapshotUpdate();
+  }
+}
+
+export function shouldAdvanceWorktreeBootstrap(bundle: SessionBundle): boolean {
+  return isWorktreeBootstrapInFlight(bundle.pendingWorktreeBootstrap);
+}

--- a/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
@@ -1,5 +1,8 @@
 import path from 'node:path';
 
+/**
+ * 主会话首条 Worktree 消息的非阻塞 bootstrap：先入 timeline，再在 poll tick 中完成 git/LLM 命名并 gate LLM turn。
+ */
 import type { PendingWorkspaceFile } from '@spirit-agent/core';
 import { cloneActiveSkills } from './runtime.js';
 
@@ -222,4 +225,30 @@ export async function advancePendingWorktreeBootstrapCommand(
 
 export function shouldAdvanceWorktreeBootstrap(bundle: SessionBundle): boolean {
   return isWorktreeBootstrapInFlight(bundle.pendingWorktreeBootstrap);
+}
+
+/** 切换/重置会话时终止 in-flight bootstrap；卡片标记 failed，不持久化 pending 状态。 */
+export function cancelPendingWorktreeBootstrapOnBundle(bundle: SessionBundle): void {
+  const pending = bundle.pendingWorktreeBootstrap;
+  if (!isWorktreeBootstrapInFlight(pending)) {
+    return;
+  }
+  upsertWorktreeBootstrapCard(bundle, pending!.toolCallId, 'failed');
+  bundle.pendingWorktreeBootstrap = undefined;
+  bundle.currentTurnSkills = [];
+}
+
+export function abortPendingWorktreeBootstrap(
+  ctx: SessionTurnOrchestratorContext,
+  host: WorktreeBootstrapHostContext,
+  bundle: SessionBundle,
+): boolean {
+  if (!isWorktreeBootstrapInFlight(bundle.pendingWorktreeBootstrap)) {
+    return false;
+  }
+  cancelPendingWorktreeBootstrapOnBundle(bundle);
+  host.setLastRuntimeError('');
+  void ctx.persistCurrentSessionIfNeeded();
+  ctx.emitLiveSnapshotUpdate();
+  return true;
 }

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -1058,6 +1058,8 @@
     "runCommand": "运行命令",
     "runShellVerb": "运行",
     "create": "创建",
+    "create_running": "创建中",
+    "create_succeeded": "已创建",
     "edit": "编辑",
     "delete": "删除",
     "diffArgsTruncated": "无法展示 Diff：工具参数在会话记录中已被截断。",

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -735,7 +735,7 @@ export interface DesktopSnapshot {
   automationsList: DesktopAutomationListItem[];
 }
 
-export type SubagentViewerSessionStatus = 'running' | 'completed' | 'failed' | 'blocked';
+export type SubagentViewerSessionStatus = 'bootstrapping' | 'running' | 'completed' | 'failed' | 'blocked';
 
 export interface SubagentViewerSnapshot {
   parentToolCallId: string;

--- a/apps/desktop/test/host/subagent-viewer-resolution.test.mjs
+++ b/apps/desktop/test/host/subagent-viewer-resolution.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { resolveSubagentViewerMessages } from '../../dist-electron/src/host/subagent-viewer.js';
+import { WORKTREE_BOOTSTRAP_TOOL_NAME } from '../../dist-electron/src/host/worktree-bootstrap-card.js';
+
+test('resolveSubagentViewerMessages keeps projected process rows when history has final body', () => {
+  const projected = [
+    { id: 1, role: 'user', content: 'Say stop', pending: false },
+    {
+      id: 2,
+      role: 'assistant',
+      content: '',
+      pending: false,
+      tool: {
+        toolName: WORKTREE_BOOTSTRAP_TOOL_NAME,
+        phase: 'succeeded',
+        headline: 'Created Worktree',
+        detailLines: [],
+      },
+    },
+    {
+      id: 3,
+      role: 'assistant',
+      content: '',
+      pending: false,
+      aux: { thinking: 'Need to return stop only.' },
+    },
+  ];
+  const history = [
+    { id: 1, role: 'user', content: 'Say stop', pending: false },
+    { id: 4, role: 'assistant', content: 'stop', pending: false },
+  ];
+
+  const resolved = resolveSubagentViewerMessages({
+    projected,
+    historyMessages: history,
+    isLiveSession: false,
+    finalOutput: 'stop',
+  });
+
+  assert.equal(resolved.source, 'projected-enriched-with-history-body');
+  assert.equal(resolved.messages.length, 4);
+  assert.equal(
+    resolved.messages[1]?.tool?.toolName,
+    WORKTREE_BOOTSTRAP_TOOL_NAME,
+  );
+  assert.equal(resolved.messages[2]?.aux?.thinking, 'Need to return stop only.');
+  assert.equal(resolved.messages[3]?.content, 'stop');
+});
+
+test('resolveSubagentViewerMessages still prefers history when projected has no extra process metadata', () => {
+  const projected = [
+    { id: 1, role: 'user', content: 'Say stop', pending: false },
+    { id: 2, role: 'assistant', content: 'st', pending: false },
+  ];
+  const history = [
+    { id: 1, role: 'user', content: 'Say stop', pending: false },
+    { id: 3, role: 'assistant', content: 'stop', pending: false },
+  ];
+
+  const resolved = resolveSubagentViewerMessages({
+    projected,
+    historyMessages: history,
+    isLiveSession: false,
+    finalOutput: 'stop',
+  });
+
+  assert.equal(resolved.source, 'history-longer-completed');
+  assert.equal(resolved.messages.length, 2);
+  assert.equal(resolved.messages[1]?.content, 'stop');
+});

--- a/apps/desktop/test/host/worktree-bootstrap-card.test.mjs
+++ b/apps/desktop/test/host/worktree-bootstrap-card.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isSessionBundleBusy } from '../../dist-electron/src/host/direct-media-turn.js';
+import {
+  buildWorktreeBootstrapToolSnapshot,
+  isWorktreeBootstrapInFlight,
+  worktreeBootstrapToolCallId,
+  WORKTREE_BOOTSTRAP_TOOL_NAME,
+} from '../../dist-electron/src/host/worktree-bootstrap-card.js';
+import { toolCallPhaseShowsShimmer } from '../../dist-electron/src/lib/tool-call-shimmer.js';
+import i18n from '../../dist-electron/src/lib/i18n-host.js';
+
+test('worktreeBootstrapToolCallId is stable per session key', () => {
+  assert.equal(worktreeBootstrapToolCallId('draft-1'), 'worktree-bootstrap:draft-1');
+});
+
+test('buildWorktreeBootstrapToolSnapshot uses create verb and Worktree detail', async () => {
+  await i18n.changeLanguage('en');
+  const running = buildWorktreeBootstrapToolSnapshot('running');
+  assert.equal(running.toolName, WORKTREE_BOOTSTRAP_TOOL_NAME);
+  assert.equal(running.phase, 'running');
+  assert.equal(running.headline, 'Creating');
+  assert.equal(running.headlineDetail, 'Worktree');
+  assert.equal(toolCallPhaseShowsShimmer(running.phase), true);
+
+  const succeeded = buildWorktreeBootstrapToolSnapshot('succeeded');
+  assert.equal(succeeded.headline, 'Created');
+  assert.equal(toolCallPhaseShowsShimmer(succeeded.phase), false);
+  assert.equal(succeeded.headlineDetail, 'Worktree');
+});
+
+test('buildWorktreeBootstrapToolSnapshot zh-CN progressive verbs', async () => {
+  await i18n.changeLanguage('zh-CN');
+  const running = buildWorktreeBootstrapToolSnapshot('running');
+  assert.equal(running.headline, '创建中');
+  const succeeded = buildWorktreeBootstrapToolSnapshot('succeeded');
+  assert.equal(succeeded.headline, '已创建');
+});
+
+test('isWorktreeBootstrapInFlight and isSessionBundleBusy', () => {
+  assert.equal(isWorktreeBootstrapInFlight(undefined), false);
+  assert.equal(
+    isWorktreeBootstrapInFlight({ phase: 'running' }),
+    true,
+  );
+  assert.equal(
+    isWorktreeBootstrapInFlight({ phase: 'succeeded' }),
+    false,
+  );
+
+  assert.equal(
+    isSessionBundleBusy({
+      pendingWorktreeBootstrap: { phase: 'running' },
+    }),
+    true,
+  );
+  assert.equal(
+    isSessionBundleBusy({
+      pendingWorktreeBootstrap: { phase: 'failed' },
+      runtime: { isBusy: () => false },
+    }),
+    false,
+  );
+});

--- a/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
+++ b/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
+import {
+  shouldAdvanceWorktreeBootstrap,
+  startWorktreeBootstrapTurnCommand,
+} from '../../dist-electron/src/host/worktree-bootstrap-orchestrator.js';
+import { WORKTREE_BOOTSTRAP_TOOL_NAME } from '../../dist-electron/src/host/worktree-bootstrap-card.js';
+
+function createTimelineHarness() {
+  let nextMessageId = 1;
+  const timeline = new DesktopMessageTimeline({
+    allocateMessageId: () => nextMessageId++,
+    reserveMessageId: (messageId) => {
+      if (messageId >= nextMessageId) {
+        nextMessageId = messageId + 1;
+      }
+    },
+  });
+  return { timeline, nextMessageId: () => nextMessageId };
+}
+
+test('startWorktreeBootstrapTurnCommand inserts user message and running worktree card', async () => {
+  const { timeline } = createTimelineHarness();
+  const bundle = {
+    id: 'draft-test',
+    messages: [],
+    messageTimeline: timeline,
+    currentTurnSkills: [],
+    rewindWarnings: [],
+    pendingWorktreeBootstrap: undefined,
+    activeSession: { readOnly: false },
+  };
+
+  let persisted = false;
+  const snapshot = await startWorktreeBootstrapTurnCommand(
+    {
+      activeBundle: () => bundle,
+      requireState: () => ({ workspaceRoot: '/repo' }),
+      refreshRuntimeForBundle: async () => {},
+      syncActiveRuntimePointer: () => {},
+      clearAssistantContinuationMarkers: () => {},
+      resolveTodoSessionKeyForBundle: () => 'todo-key',
+      ensureActiveSession: () => {},
+      reconcileTodoScopeAfterSessionPathChange: async () => {},
+      maybeRefreshRuntimeAfterTodoScopeChange: async () => {},
+      buildRewindCheckpointSnapshot: async () => ({
+        archive: { llmHistory: [] },
+        desktopMessages: [],
+      }),
+      allocateMessageId: () => 1,
+      resetStreamingPlacementState: () => {},
+      persistCurrentSessionIfNeeded: async () => {
+        persisted = true;
+      },
+      scheduleSessionTitleGenerationIfNeeded: () => {},
+      dispatchUserMessageExtensionEvent: async () => {},
+      emitLiveSnapshotUpdate: () => {},
+      buildSnapshot: () => ({ conversation: { messages: bundle.messages } }),
+    },
+    {
+      validateWorktreeBootstrapPreconditions: () => {},
+      executeWorktreeBootstrap: async () => {},
+      resolveWorktreeBootstrapSessionKey: () => 'draft-test',
+      setLastRuntimeError: () => {},
+    },
+    'build feature in worktree',
+    {},
+  );
+
+  assert.equal(persisted, true);
+  assert.equal(bundle.messages.length, 2);
+  assert.equal(bundle.messages[0]?.role, 'user');
+  assert.equal(bundle.messages[0]?.content, 'build feature in worktree');
+  assert.equal(bundle.messages[1]?.tool?.toolName, WORKTREE_BOOTSTRAP_TOOL_NAME);
+  assert.equal(bundle.messages[1]?.tool?.phase, 'running');
+  assert.equal(bundle.pendingWorktreeBootstrap?.phase, 'running');
+  assert.equal(shouldAdvanceWorktreeBootstrap(bundle), true);
+  assert.ok(snapshot);
+});

--- a/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
+++ b/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
 import {
+  cancelPendingWorktreeBootstrapOnBundle,
   shouldAdvanceWorktreeBootstrap,
   startWorktreeBootstrapTurnCommand,
 } from '../../dist-electron/src/host/worktree-bootstrap-orchestrator.js';
@@ -20,6 +21,24 @@ function createTimelineHarness() {
   });
   return { timeline, nextMessageId: () => nextMessageId };
 }
+
+test('cancelPendingWorktreeBootstrapOnBundle marks card failed and clears pending', async () => {
+  const { timeline } = createTimelineHarness();
+  const bundle = {
+    id: 'draft-cancel',
+    messages: [],
+    messageTimeline: timeline,
+    currentTurnSkills: [{ name: 'test' }],
+    pendingWorktreeBootstrap: {
+      toolCallId: 'worktree-bootstrap:draft-cancel',
+      phase: 'running',
+    },
+  };
+  timeline.beginUserTurn('hello', { messageId: 1 });
+  cancelPendingWorktreeBootstrapOnBundle(bundle);
+  assert.equal(bundle.pendingWorktreeBootstrap, undefined);
+  assert.equal(bundle.currentTurnSkills.length, 0);
+});
 
 test('startWorktreeBootstrapTurnCommand inserts user message and running worktree card', async () => {
   const { timeline } = createTimelineHarness();

--- a/packages/agent-core/src/ports.ts
+++ b/packages/agent-core/src/ports.ts
@@ -303,7 +303,7 @@ export interface AssistantAuxArchiveEntry {
   finishTaskNotice?: string;
 }
 
-export type SubagentSessionStatus = 'running' | 'completed' | 'failed' | 'blocked';
+export type SubagentSessionStatus = 'bootstrapping' | 'running' | 'completed' | 'failed' | 'blocked';
 
 export interface SubagentSessionSummary {
   sessionId: string;

--- a/packages/agent-core/src/runtime.ts
+++ b/packages/agent-core/src/runtime.ts
@@ -190,6 +190,20 @@ interface PendingSubagentExecution<Config, State, ToolRequest, TrustTarget> {
   streamingEmitBeginResponse: boolean;
 }
 
+interface PendingSubagentWorktreeBootstrap<State, ToolRequest, TrustTarget> {
+  parentRequest: ToolRequest;
+  parentToolCallId: string;
+  parentPendingUserInput: string;
+  parentState: State;
+  parentRemainingCalls: ToolCallRequest[];
+  parentTurn: RuntimeTurnContext<ToolRequest>;
+  childRecord: RuntimeSubagentSessionArchiveEntry;
+  request: RunSubagentRequest;
+  parentWorkspaceRoot: string;
+  resumeAsStreaming: boolean;
+  streamingEmitBeginResponse: boolean;
+}
+
 interface PendingSubagentBatchContinuation<State, ToolRequest> {
   parentState: State;
   parentPendingUserInput: string;
@@ -247,6 +261,10 @@ export class AgentRuntime<
   private pendingSubagentExecutions = new Map<
     string,
     PendingSubagentExecution<Config, State, ToolRequest, TrustTarget>
+  >();
+  private pendingSubagentWorktreeBootstraps = new Map<
+    string,
+    PendingSubagentWorktreeBootstrap<State, ToolRequest, TrustTarget>
   >();
   private pendingSubagentBatchContinuation:
     | PendingSubagentBatchContinuation<State, ToolRequest>
@@ -625,6 +643,7 @@ export class AgentRuntime<
       pending.childRuntime.abort();
     }
     this.pendingSubagentExecutions.clear();
+    this.pendingSubagentWorktreeBootstraps.clear();
     this.pendingSubagentBatchContinuation = undefined;
   }
 
@@ -662,6 +681,7 @@ export class AgentRuntime<
       this.pendingBackgroundToolExecution !== undefined ||
       this.pendingHistoryCompaction !== undefined ||
       this.pendingSubagentExecutions.size > 0 ||
+      this.pendingSubagentWorktreeBootstraps.size > 0 ||
       this.pendingQuestions !== undefined ||
       this.hasPendingApproval()
     );
@@ -990,6 +1010,7 @@ export class AgentRuntime<
     await this.pollPendingToolAgentRound();
     await this.pollPendingHistoryCompaction();
     await this.pollPendingBackgroundToolExecution();
+    await this.pollPendingSubagentWorktreeBootstrap();
     await this.pollPendingSubagentExecution();
   }
 
@@ -2808,6 +2829,32 @@ export class AgentRuntime<
           failed: true,
         };
       }
+
+      if (resumeAsStreaming) {
+        record.summary.status = 'bootstrapping';
+        const childUserTurn = buildRunSubagentUserTurn(request);
+        record.llmHistory = [{
+          role: 'user',
+          content: createLlmMessageContentFromText(childUserTurn),
+        }];
+        record.summary.latestMessage = truncateTextForSubagentSummary(request.task.trim(), 180);
+        this.childSessionsStore.push(record);
+        this.pendingSubagentWorktreeBootstraps.set(parentToolCallId, {
+          parentRequest,
+          parentToolCallId,
+          parentPendingUserInput,
+          parentState,
+          parentRemainingCalls,
+          parentTurn,
+          childRecord: record,
+          request,
+          parentWorkspaceRoot,
+          resumeAsStreaming,
+          streamingEmitBeginResponse,
+        });
+        return { kind: 'started' };
+      }
+
       const boot = await bootstrap({
         subagentSessionId: sessionId,
         task: request.task,
@@ -3007,6 +3054,181 @@ export class AgentRuntime<
     }
 
     await this.pollPendingSubagentExecution();
+  }
+
+  private async pollPendingSubagentWorktreeBootstrap(): Promise<void> {
+    if (this.pendingSubagentWorktreeBootstraps.size === 0) {
+      return;
+    }
+
+    for (const [parentToolCallId, pending] of [...this.pendingSubagentWorktreeBootstraps.entries()]) {
+      this.pendingSubagentWorktreeBootstraps.delete(parentToolCallId);
+      try {
+        await this.completePendingSubagentWorktreeBootstrap(pending);
+      } catch (error) {
+        await this.finishFailedSubagentWorktreeBootstrap(pending, renderError(error));
+      }
+    }
+  }
+
+  private async completePendingSubagentWorktreeBootstrap(
+    pending: PendingSubagentWorktreeBootstrap<State, ToolRequest, TrustTarget>,
+  ): Promise<void> {
+    const bootstrap = this.options.bootstrapSubagentWorkspace;
+    if (!bootstrap) {
+      await this.finishFailedSubagentWorktreeBootstrap(
+        pending,
+        'worktree subagents are not supported on this host.',
+      );
+      return;
+    }
+
+    const boot = await bootstrap({
+      subagentSessionId: pending.childRecord.summary.sessionId,
+      task: pending.request.task,
+      worktree: true,
+      parentWorkspaceRoot: pending.parentWorkspaceRoot,
+    });
+    if ('error' in boot) {
+      await this.finishFailedSubagentWorktreeBootstrap(pending, boot.error);
+      return;
+    }
+
+    if (boot.worktreePath) {
+      pending.childRecord.summary.worktreePath = boot.worktreePath;
+    }
+    if (boot.branchName) {
+      pending.childRecord.summary.worktreeBranch = boot.branchName;
+    }
+
+    const childRuntime = this.createChildRuntime(
+      pending.childRecord.summary.sessionId,
+      pending.childRecord.summary.title,
+      boot.toolExecutor ?? this.options.toolExecutor,
+      boot.workspaceRoot,
+    );
+
+    const subagentStartDenied = await this.runSubagentStartHook(
+      pending.childRecord.summary.sessionId,
+      pending.request,
+      boot.workspaceRoot,
+    );
+    if (subagentStartDenied) {
+      pending.childRecord.summary.status = 'failed';
+      pending.childRecord.summary.updatedAtUnixMs = Date.now();
+      pending.childRecord.summary.completedAtUnixMs = pending.childRecord.summary.updatedAtUnixMs;
+      pending.childRecord.summary.latestMessage = truncateTextForSubagentSummary(subagentStartDenied, 180);
+      pending.childRecord.summary.error = subagentStartDenied;
+      await this.finishFailedSubagentWorktreeBootstrap(pending, subagentStartDenied);
+      return;
+    }
+
+    const childUserTurn = buildRunSubagentUserTurn(pending.request);
+    try {
+      await childRuntime.startUserTurnStreaming(childUserTurn);
+      this.cachePendingSubagentExecution(this.buildPendingSubagentExecution(
+        pending.parentRequest,
+        pending.parentToolCallId,
+        pending.parentPendingUserInput,
+        pending.parentState,
+        pending.parentRemainingCalls,
+        pending.parentTurn,
+        childRuntime,
+        pending.childRecord,
+        pending.resumeAsStreaming,
+        pending.streamingEmitBeginResponse,
+      ));
+      this.refreshChildSessionRecord(pending.childRecord, childRuntime);
+      pending.childRecord.summary.status = childRuntime.currentPendingApproval() ? 'blocked' : 'running';
+    } catch (error) {
+      await this.finishFailedSubagentWorktreeBootstrap(pending, renderError(error));
+    }
+  }
+
+  private async finishFailedSubagentWorktreeBootstrap(
+    pending: PendingSubagentWorktreeBootstrap<State, ToolRequest, TrustTarget>,
+    errorText: string,
+  ): Promise<void> {
+    const failed = `[subagent failed] ${errorText}`;
+    pending.childRecord.summary.status = 'failed';
+    pending.childRecord.summary.updatedAtUnixMs = Date.now();
+    pending.childRecord.summary.completedAtUnixMs = pending.childRecord.summary.updatedAtUnixMs;
+    pending.childRecord.summary.latestMessage = truncateTextForSubagentSummary(failed, 180);
+    delete pending.childRecord.summary.finalOutput;
+    pending.childRecord.summary.error = failed;
+
+    const parentToolResultText = prependSubagentWorktreeMeta(
+      buildParentSubagentToolResultText(
+        pending.childRecord.summary.title,
+        failed,
+        true,
+        pending.childRecord.summary.sessionId,
+      ),
+      pending.childRecord.summary.worktreePath,
+      pending.childRecord.summary.worktreeBranch,
+    );
+
+    const finishedExecution = {
+      toolCallId: pending.parentToolCallId,
+      toolName: 'run_subagent',
+      request: pending.parentRequest,
+      output: failed,
+      failed: true,
+    };
+    pending.parentTurn.toolExecutions.push(finishedExecution);
+    this.emitEvent({ kind: 'tool-execution-finished', execution: finishedExecution });
+
+    const batch = this.pendingSubagentBatchContinuation;
+    const baseState = batch?.parentState ?? pending.parentState;
+    const resumedState = await this.appendToolResultMessageWithOutputTruncation(
+      baseState,
+      pending.parentToolCallId,
+      parentToolResultText,
+    );
+    if (batch) {
+      batch.parentState = resumedState;
+    }
+
+    if (this.pendingSubagentExecutions.size > 0) {
+      return;
+    }
+
+    const finalState = batch?.parentState ?? resumedState;
+    const continuation = batch ?? {
+      parentPendingUserInput: pending.parentPendingUserInput,
+      parentTurn: pending.parentTurn,
+      resumeAsStreaming: pending.resumeAsStreaming,
+      streamingEmitBeginResponse: pending.streamingEmitBeginResponse,
+    };
+    this.pendingSubagentBatchContinuation = undefined;
+
+    if (pending.parentRemainingCalls.length > 0) {
+      await this.processToolCallsAsync(
+        finalState,
+        continuation.parentPendingUserInput,
+        pending.parentRemainingCalls,
+        continuation.parentTurn,
+        continuation.resumeAsStreaming,
+        continuation.streamingEmitBeginResponse,
+      );
+      return;
+    }
+
+    if (continuation.resumeAsStreaming) {
+      await this.startStreamingRound(
+        finalState,
+        continuation.parentPendingUserInput,
+        continuation.parentTurn,
+        continuation.streamingEmitBeginResponse,
+      );
+      return;
+    }
+
+    this.startToolAgentRoundAsync(
+      finalState,
+      continuation.parentPendingUserInput,
+      continuation.parentTurn,
+    );
   }
 
   private async pollPendingSubagentExecution(): Promise<void> {

--- a/packages/host-internal/src/subagent-viewer.ts
+++ b/packages/host-internal/src/subagent-viewer.ts
@@ -1,7 +1,7 @@
 import type { LlmMessageContent, LlmToolCall, StoredLlmMessageArchiveEntry } from '@spirit-agent/core';
 import { llmMessageTextContent } from '@spirit-agent/core';
 
-export type SubagentViewerSessionStatus = 'running' | 'completed' | 'failed' | 'blocked';
+export type SubagentViewerSessionStatus = 'bootstrapping' | 'running' | 'completed' | 'failed' | 'blocked';
 
 export type SubagentViewerToolPhase =
   | 'preview'
@@ -79,7 +79,7 @@ function inferToolPhase(
   if (sessionStatus === 'blocked' && isLastUnresolvedTool) {
     return 'pending-approval';
   }
-  if (sessionStatus === 'running' || sessionStatus === 'blocked') {
+  if (sessionStatus === 'running' || sessionStatus === 'blocked' || sessionStatus === 'bootstrapping') {
     return 'running';
   }
   return 'succeeded';


### PR DESCRIPTION
## Summary

- 主会话与 SubAgent 的 Worktree 创建改为非阻塞：发送后立即进入会话并展示 Creating/Created Worktree 进度卡，bootstrap 在 poll tick 中完成后再启动 LLM turn。
- agent-core 新增 `bootstrapping` 状态；SubAgent 使用确定性 worktree 命名并在 Subagent Viewer 内同步进度卡。
- 修复 SubAgent 完成后 `resolveSubagentViewerMessages` 误选 history 导致 worktree/thinking 过程卡消失的问题。

## Test plan

- [x] Phase 1：`worktree-bootstrap-card` 与 `isSessionBundleBusy` 单测通过
- [x] Phase 2：主会话首条 Worktree 消息立即显示用户消息 + Creating Worktree 卡，完成后变 Created 并出现 Thinking/正文
- [x] Phase 3：父会话 `run_subagent(worktree=true)` 不长时间阻塞；Subagent Viewer 可见 worktree 卡 → Created → Thinking
- [x] Phase 4：bootstrap 期间 abort / 切换会话 / 失败边界；orchestrator 取消路径单测通过
- [x] SubAgent 完成后过程卡（worktree + thinking）合并为 process group 仍可见，正文输出后不消失
- [x] `npm run build:electron` 与相关 host 单测通过