### PR TITLE
feat(desktop, agent-core, host-internal): SubAgent Worktree 改用 LLM 命名

### DIFF
--- a/apps/desktop/src/host/ephemeral-llm-tasks.ts
+++ b/apps/desktop/src/host/ephemeral-llm-tasks.ts
@@ -1,13 +1,10 @@
 import {
-  appendLlmToolResultMessages,
   buildDreamReadHostToolDefinitions,
-  createLlmTransport,
-  extractLastLlmAssistantText,
-  startLlmToolAgentState,
   type LlmExtensionSystemPrompt,
   type LlmToolAgentBasicInfo,
   type LlmTransportConfig,
 } from '@spirit-agent/core';
+import { generateWorktreeNamesFromTask } from '@spirit-agent/host-internal';
 
 import i18n from '../lib/i18n-host.js';
 import { resolveDesktopAgentMode } from '../lib/agent-mode.js';
@@ -22,7 +19,6 @@ import {
 } from './sessions.js';
 import {
   currentApiBase,
-  parseGeneratedWorktreeNamingResponse,
 } from './service-utils.js';
 import type {
   DesktopConfigFile,
@@ -64,16 +60,31 @@ export async function generateWorktreeNamesFromModelTask(
   const baseMessages = buildBaseMessages(prompt);
 
   try {
-    const assistantText = await runEphemeralToolAgentRounds({
-      context,
-      transportConfig,
-      prompt,
-      failurePrefixKey: 'error.autoWorktreeNameFailed',
-      noBodyKey: 'error.autoWorktreeNameFailedNoBody',
-      interactiveToolKey: 'error.autoWorktreeNameFailedInteractiveTool',
-      incompleteKey: 'error.autoWorktreeNameFailedIncomplete',
+    const dreamContextText = await buildDreamContextText({
+      workspaceRoot: context.workspaceRoot,
+      gitBranch: context.gitBranch,
     });
-    const names = parseGeneratedWorktreeNamingResponse(assistantText);
+    const names = await generateWorktreeNamesFromTask({
+      transport: transportConfig,
+      task: context.userPrompt,
+      baseBranch: context.baseBranch,
+      repoRoot: context.repoRoot,
+      workspaceRoot: context.workspaceRoot,
+      toolExecutor: context.toolExecutor,
+      enabledRules: context.metadata.rules.enabledRules,
+      enabledSkillCatalog: context.metadata.skills.enabledSkillCatalog,
+      extensionSystemPrompts: context.extensionSystemPrompts,
+      planMetadata: context.metadata.planMetadata,
+      runtimeBasicInfo: context.runtimeBasicInfo,
+      ...(dreamContextText ? { dreamContextText } : {}),
+      extraToolDefinitions: context.gitBranch ? buildDreamReadHostToolDefinitions() : [],
+      errorMessages: {
+        failurePrefix: (error) => i18n.t('error.autoWorktreeNameFailed', { error }),
+        noBody: i18n.t('error.autoWorktreeNameFailedNoBody'),
+        interactiveTool: (name) => i18n.t('error.autoWorktreeNameFailedInteractiveTool', { name }),
+        incomplete: i18n.t('error.autoWorktreeNameFailedIncomplete'),
+      },
+    });
     context.rememberEphemeralSession(buildWorktreeEphemeralSessionRecord({
       path: sessionPath,
       displayName: `[Worktree] ${names.worktreeName}`,
@@ -107,85 +118,6 @@ function buildTaskTransportConfig(context: EphemeralLlmTaskContext): LlmTranspor
     profile: context.taskProfile,
     agentMode: resolveDesktopAgentMode(context.config),
   });
-}
-
-async function runEphemeralToolAgentRounds(input: {
-  context: EphemeralLlmTaskContext;
-  transportConfig: LlmTransportConfig;
-  prompt: string;
-  failurePrefixKey: string;
-  noBodyKey: string;
-  interactiveToolKey: string;
-  incompleteKey: string;
-}): Promise<string> {
-  const { context, transportConfig } = input;
-  const llmTransport = createLlmTransport(transportConfig);
-  context.toolExecutor.setActiveTransportConfig(transportConfig);
-  const dreamContextText = await buildDreamContextText({
-    workspaceRoot: context.workspaceRoot,
-    gitBranch: context.gitBranch,
-  });
-  const dreamToolDefinitions = context.gitBranch ? buildDreamReadHostToolDefinitions() : [];
-  let toolState = startLlmToolAgentState(
-    [],
-    input.prompt,
-    context.workspaceRoot,
-    context.metadata.rules.enabledRules,
-    context.metadata.skills.enabledSkillCatalog,
-    [],
-    transportConfig.model,
-    context.metadata.planMetadata,
-    context.extensionSystemPrompts,
-    dreamContextText || undefined,
-    undefined,
-    context.runtimeBasicInfo,
-  );
-
-  for (let round = 0; round < 6; round += 1) {
-    const completion = await llmTransport.startToolAgentRound(
-      transportConfig,
-      toolState,
-      dreamToolDefinitions,
-    );
-
-    if (completion.kind !== 'success') {
-      throw new Error(i18n.t(input.failurePrefixKey, { error: completion.error }));
-    }
-
-    toolState = completion.result.state;
-
-    if (completion.result.step.kind === 'final-response-ready') {
-      const assistantText = extractLastLlmAssistantText(toolState)?.trim();
-      if (!assistantText) {
-        throw new Error(i18n.t(input.noBodyKey));
-      }
-      return assistantText;
-    }
-
-    const toolResults = [];
-    for (const call of completion.result.step.calls) {
-      const request = await context.toolExecutor.requestFromFunctionCall(call.name, call.argumentsJson);
-      const requestWithMetadata = context.toolExecutor.attachRequestMetadata
-        ? context.toolExecutor.attachRequestMetadata(request, {
-            toolCallId: call.id,
-            toolName: call.name,
-          })
-        : request;
-      const authorization = await context.toolExecutor.authorize(requestWithMetadata);
-      if (authorization.kind !== 'allowed') {
-        throw new Error(i18n.t(input.interactiveToolKey, { name: call.name }));
-      }
-      const output = await context.toolExecutor.execute(requestWithMetadata);
-      toolResults.push({
-        toolCallId: call.id,
-        content: output.summaryText,
-      });
-    }
-
-    toolState = appendLlmToolResultMessages(toolState, toolResults);
-  }
-
-  throw new Error(i18n.t(input.incompleteKey));
 }
 
 function buildBaseMessages(prompt: string): ConversationMessageSnapshot[] {

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -17,8 +17,8 @@ import type {
 } from '../types.js';
 import type { DesktopToolRequest } from './contracts.js';
 import {
-  isSpiritBranchName,
-  isSpiritWorktreeName,
+  normalizeGeneratedWorktreeNames as normalizeGeneratedWorktreeNamesInternal,
+  parseGeneratedWorktreeNamingResponse as parseGeneratedWorktreeNamingResponseInternal,
   resolveWorkspaceGroupingRoot,
 } from '@spirit-agent/host-internal';
 import type { GeneratedWorktreeNames } from './worktree-naming.js';
@@ -116,62 +116,51 @@ export function normalizeGeneratedWorktreeNames(value: {
   worktreeName?: unknown;
   branchName?: unknown;
 }): GeneratedWorktreeNames {
-  if (typeof value.worktreeName !== 'string' || typeof value.branchName !== 'string') {
-    throw new Error(i18n.t('error.autoWorktreeNameFailedMissingFields'));
+  try {
+    return normalizeGeneratedWorktreeNamesInternal(value);
+  } catch (error) {
+    throw mapWorktreeNamingValidationError(error);
   }
-
-  const worktreeName = value.worktreeName.trim();
-  const branchName = value.branchName.trim();
-  if (!worktreeName || !branchName) {
-    throw new Error(i18n.t('error.autoWorktreeNameFailedEmpty'));
-  }
-  if (!isSpiritWorktreeName(worktreeName)) {
-    throw new Error(i18n.t('error.autoWorktreeNameFailedInvalidWorktreeName', { worktreeName }));
-  }
-  if (!isSpiritBranchName(branchName)) {
-    throw new Error(i18n.t('error.autoWorktreeNameFailedInvalidBranchName', { branchName }));
-  }
-
-  return { worktreeName, branchName };
 }
 
 export function parseGeneratedWorktreeNamingResponse(rawText: string): GeneratedWorktreeNames {
-  const trimmed = rawText.trim();
-  if (!trimmed) {
-    throw new Error(i18n.t('error.autoWorktreeNameFailedNoBody'));
-  }
-
-  const candidate = extractJsonObjectText(trimmed);
-
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(candidate);
-  } catch {
-    throw new Error(i18n.t('error.autoWorktreeNameFailedInvalidJson'));
+    return parseGeneratedWorktreeNamingResponseInternal(rawText);
+  } catch (error) {
+    throw mapWorktreeNamingValidationError(error);
   }
-
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new Error(i18n.t('error.autoWorktreeNameFailedNotObject'));
-  }
-
-  return normalizeGeneratedWorktreeNames(parsed as { worktreeName?: unknown; branchName?: unknown });
 }
 
-function extractJsonObjectText(text: string): string {
-  if (text.startsWith('```')) {
-    const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-    if (fenceMatch?.[1]) {
-      return fenceMatch[1].trim();
-    }
+function mapWorktreeNamingValidationError(error: unknown): Error {
+  if (!(error instanceof Error)) {
+    return new Error(i18n.t('error.autoWorktreeNameFailedInvalidJson'));
   }
 
-  const firstBrace = text.indexOf('{');
-  const lastBrace = text.lastIndexOf('}');
-  if (firstBrace >= 0 && lastBrace > firstBrace) {
-    return text.slice(firstBrace, lastBrace + 1).trim();
+  const message = error.message;
+  if (message.includes('missing worktreeName or branchName')) {
+    return new Error(i18n.t('error.autoWorktreeNameFailedMissingFields'));
   }
-
-  return text;
+  if (message.includes('empty worktreeName or branchName')) {
+    return new Error(i18n.t('error.autoWorktreeNameFailedEmpty'));
+  }
+  if (message.includes('Invalid worktreeName format:')) {
+    const worktreeName = message.replace(/^Invalid worktreeName format:\s*/u, '').trim();
+    return new Error(i18n.t('error.autoWorktreeNameFailedInvalidWorktreeName', { worktreeName }));
+  }
+  if (message.includes('Invalid branchName format:')) {
+    const branchName = message.replace(/^Invalid branchName format:\s*/u, '').trim();
+    return new Error(i18n.t('error.autoWorktreeNameFailedInvalidBranchName', { branchName }));
+  }
+  if (message.includes('no assistant text')) {
+    return new Error(i18n.t('error.autoWorktreeNameFailedNoBody'));
+  }
+  if (message.includes('not valid JSON')) {
+    return new Error(i18n.t('error.autoWorktreeNameFailedInvalidJson'));
+  }
+  if (message.includes('must be a JSON object')) {
+    return new Error(i18n.t('error.autoWorktreeNameFailedNotObject'));
+  }
+  return error;
 }
 
 export function sameDreamCollectorSnapshot(

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2292,9 +2292,8 @@ class DesktopHostService {
         const bundle = this.activeBundle();
         return bundle.pendingGitBranch ?? state.git.branch;
       },
-      generateWorktreeNames: async () => {
-        throw new Error('subagent worktree naming is deterministic');
-      },
+      generateWorktreeNames: (task, baseBranch, repoRoot) =>
+        this.generateWorktreeNamesFromModel(task, baseBranch, repoRoot),
       buildScopedToolExecutor: (workspaceRoot) =>
         this.buildScopedSubagentToolExecutor(workspaceRoot, transportConfig, parentExecutor),
     });

--- a/apps/desktop/src/host/subagent-worktree-bootstrap.ts
+++ b/apps/desktop/src/host/subagent-worktree-bootstrap.ts
@@ -49,7 +49,7 @@ export function createDesktopSubagentWorkspaceBootstrap(
         return { error: 'cannot determine base branch for subagent worktree' };
       }
 
-      const names = buildDeterministicSubagentWorktreeNames(input.subagentSessionId);
+      const names = await deps.generateWorktreeNames(input.task, baseBranch, repoRoot);
       const created = await createWorkspaceGitWorktree(repoRoot, names, baseBranch);
       createdWorktreePath = created.worktreePath;
       const scopedExecutor = await deps.buildScopedToolExecutor(created.worktreePath);
@@ -71,25 +71,6 @@ export function createDesktopSubagentWorkspaceBootstrap(
       const message = error instanceof Error ? error.message : String(error);
       return { error: message };
     }
-  };
-}
-
-export function normalizeSubagentWorktreeSlug(sessionId: string): string {
-  const slug = sessionId
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, '-')
-    .replace(/^-+|-+$/gu, '');
-  return slug.length > 0 ? slug : 'subagent';
-}
-
-export function buildDeterministicSubagentWorktreeNames(sessionId: string): {
-  worktreeName: string;
-  branchName: string;
-} {
-  const slug = normalizeSubagentWorktreeSlug(sessionId).slice(0, 48);
-  return {
-    worktreeName: `spirit-subagent-${slug}`,
-    branchName: `spirit/subagent-${slug}`,
   };
 }
 

--- a/apps/desktop/src/host/worktree-naming.ts
+++ b/apps/desktop/src/host/worktree-naming.ts
@@ -1,25 +1,4 @@
-export function buildWorktreeNamingPrompt(input: {
-  userPrompt: string;
-  baseBranch: string;
-  repoRoot: string;
-}): string {
-  return [
-    'Generate Git worktree and branch names for the user task below.',
-    'Return JSON only: {"worktreeName":"...","branchName":"..."}. No Markdown, no explanations, no extra keys.',
-    'Naming rules:',
-    '- worktreeName must use kebab-case segments and start with "spirit-", e.g. spirit-add-worktree-ui',
-    '- branchName must start with "spirit/" and use kebab-case segments after the slash, e.g. spirit/add-worktree-ui',
-    '- Both names should summarize the user task in short English tokens.',
-    '',
-    `repository: ${input.repoRoot}`,
-    `baseBranch: ${input.baseBranch}`,
-    '',
-    '[user task]',
-    input.userPrompt.trim() || '(empty)',
-  ].join('\n');
-}
-
-export interface GeneratedWorktreeNames {
-  worktreeName: string;
-  branchName: string;
-}
+export {
+  buildWorktreeNamingPrompt,
+  type GeneratedWorktreeNames,
+} from '@spirit-agent/host-internal';

--- a/apps/desktop/test/host/subagent-worktree-bootstrap.test.mjs
+++ b/apps/desktop/test/host/subagent-worktree-bootstrap.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+
+import { createDesktopSubagentWorkspaceBootstrap } from '../../dist-electron/src/host/subagent-worktree-bootstrap.js';
+
+const execFileAsync = promisify(execFile);
+
+async function runGit(cwd, args) {
+  await execFileAsync('git', args, { cwd, windowsHide: true });
+}
+
+async function createTempGitRepo() {
+  const repoRoot = await realpath(await mkdtemp(join(tmpdir(), 'spirit-subagent-bootstrap-')));
+  await runGit(repoRoot, ['init']);
+  await runGit(repoRoot, ['config', 'user.email', 'test@example.com']);
+  await runGit(repoRoot, ['config', 'user.name', 'Spirit Test']);
+  await writeFile(join(repoRoot, 'README.md'), '# hello\n');
+  await runGit(repoRoot, ['add', 'README.md']);
+  await runGit(repoRoot, ['commit', '-m', 'init']);
+  const { stdout } = await execFileAsync('git', ['branch', '--show-current'], {
+    cwd: repoRoot,
+    windowsHide: true,
+  });
+  return { repoRoot, defaultBranch: stdout.trim() };
+}
+
+test('createDesktopSubagentWorkspaceBootstrap passes subagent task to generateWorktreeNames', async () => {
+  const { repoRoot, defaultBranch } = await createTempGitRepo();
+  const namingCalls = [];
+
+  try {
+    const bootstrap = createDesktopSubagentWorkspaceBootstrap({
+      parentWorkspaceRoot: repoRoot,
+      isGitRepository: true,
+      resolveBaseBranch: () => defaultBranch,
+      generateWorktreeNames: async (task, baseBranch, resolvedRepoRoot) => {
+        namingCalls.push({ task, baseBranch, resolvedRepoRoot });
+        return {
+          worktreeName: 'spirit-subagent-task-naming',
+          branchName: 'spirit/subagent-task-naming',
+        };
+      },
+      buildScopedToolExecutor: async (workspaceRoot) => ({
+        workspaceRoot,
+      }),
+    });
+
+    const result = await bootstrap({
+      subagentSessionId: 'subagent-test-1',
+      task: 'Inspect repository layout only',
+      worktree: true,
+      parentWorkspaceRoot: repoRoot,
+    });
+
+    assert.equal(namingCalls.length, 1);
+    assert.equal(namingCalls[0]?.task, 'Inspect repository layout only');
+    assert.equal(namingCalls[0]?.baseBranch, defaultBranch);
+    assert.equal(namingCalls[0]?.resolvedRepoRoot, repoRoot);
+    assert.equal(result.worktreePath?.includes('spirit-subagent-task-naming'), true);
+    assert.equal(result.branchName, 'spirit/subagent-task-naming');
+  } finally {
+    await rm(`${repoRoot}.worktrees`, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }).catch(() => {});
+    await rm(repoRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  }
+});

--- a/packages/agent-core/src/host-bridge.ts
+++ b/packages/agent-core/src/host-bridge.ts
@@ -950,13 +950,44 @@ async function bootstrapCliSubagentWorkspace(
       return { error: 'cannot determine base branch for subagent worktree' };
     }
 
-    const slug = input.subagentSessionId
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/gu, '-')
-      .replace(/^-+|-+$/gu, '')
-      .slice(0, 48) || 'subagent';
-    const worktreeName = `spirit-subagent-${slug}`;
-    const branchName = `spirit/subagent-${slug}`;
+    const config = transportConfig;
+    if (!config) {
+      return { error: 'transportConfig is not initialized for worktree subagent naming' };
+    }
+
+    const namingModulePath = path.join(path.dirname(modulePath), 'generate-worktree-names.js');
+    const naming = await import(pathToFileURL(namingModulePath).href) as {
+      generateWorktreeNamesFromTask: (input: {
+        transport: NonNullable<typeof transportConfig>;
+        task: string;
+        baseBranch: string;
+        repoRoot: string;
+        workspaceRoot: string;
+        toolExecutor: typeof toolExecutor;
+        enabledRules: typeof enabledRules;
+        enabledSkillCatalog: typeof enabledSkillCatalog;
+        extensionSystemPrompts: typeof extensionSystemPrompts;
+        planMetadata: typeof planMetadata;
+        runtimeBasicInfo: ReturnType<typeof buildRuntimeBasicInfo>;
+      }) => Promise<{ worktreeName: string; branchName: string }>;
+    };
+
+    const names = await naming.generateWorktreeNamesFromTask({
+      transport: config,
+      task: input.task,
+      baseBranch,
+      repoRoot,
+      workspaceRoot: parentRoot,
+      toolExecutor,
+      enabledRules,
+      enabledSkillCatalog,
+      extensionSystemPrompts,
+      planMetadata,
+      runtimeBasicInfo: buildRuntimeBasicInfo(parentRoot, host.service),
+    });
+
+    const worktreeName = names.worktreeName;
+    const branchName = names.branchName;
     const worktreePath = git.buildWorktreeRootPath(repoRoot, worktreeName);
     await git.addGitWorktree(repoRoot, {
       worktreePath,

--- a/packages/host-internal/src/generate-worktree-names.ts
+++ b/packages/host-internal/src/generate-worktree-names.ts
@@ -1,0 +1,158 @@
+import {
+  appendLlmToolResultMessages,
+  createLlmTransport,
+  extractLastLlmAssistantText,
+  startLlmToolAgentState,
+  type JsonValue,
+  type LlmEnabledRule,
+  type LlmEnabledSkillCatalogEntry,
+  type LlmExtensionSystemPrompt,
+  type LlmPlanMetadata,
+  type LlmToolAgentBasicInfo,
+  type LlmTransportConfig,
+  type ToolExecutor,
+} from '@spirit-agent/core';
+
+import {
+  buildWorktreeNamingPrompt,
+  parseGeneratedWorktreeNamingResponse,
+  type GeneratedWorktreeNames,
+} from './worktree-naming.js';
+
+export interface WorktreeNamingErrorMessages {
+  failurePrefix: (error: string) => string;
+  noBody: string;
+  interactiveTool: (toolName: string) => string;
+  incomplete: string;
+}
+
+export interface GenerateWorktreeNamesFromTaskInput {
+  transport: LlmTransportConfig;
+  task: string;
+  baseBranch: string;
+  repoRoot: string;
+  workspaceRoot: string;
+  toolExecutor: ToolExecutor;
+  enabledRules?: readonly LlmEnabledRule[];
+  enabledSkillCatalog?: readonly LlmEnabledSkillCatalogEntry[];
+  extensionSystemPrompts?: readonly LlmExtensionSystemPrompt[];
+  planMetadata?: LlmPlanMetadata;
+  runtimeBasicInfo?: LlmToolAgentBasicInfo;
+  dreamContextText?: string;
+  extraToolDefinitions?: JsonValue;
+  errorMessages?: WorktreeNamingErrorMessages;
+}
+
+const defaultErrorMessages: WorktreeNamingErrorMessages = {
+  failurePrefix: (error) => `Worktree naming failed: ${error}`,
+  noBody: 'Worktree naming returned no assistant text.',
+  interactiveTool: (toolName) => `Worktree naming cannot run interactive tool: ${toolName}`,
+  incomplete: 'Worktree naming did not finish within the allowed rounds.',
+};
+
+export async function generateWorktreeNamesFromTask(
+  input: GenerateWorktreeNamesFromTaskInput,
+): Promise<GeneratedWorktreeNames> {
+  const prompt = buildWorktreeNamingPrompt({
+    userPrompt: input.task,
+    baseBranch: input.baseBranch,
+    repoRoot: input.repoRoot,
+  });
+  const assistantText = await runWorktreeNamingToolAgentRounds({
+    transport: input.transport,
+    prompt,
+    workspaceRoot: input.workspaceRoot,
+    toolExecutor: input.toolExecutor,
+    enabledRules: input.enabledRules ?? [],
+    enabledSkillCatalog: input.enabledSkillCatalog ?? [],
+    extensionSystemPrompts: input.extensionSystemPrompts ?? [],
+    ...(input.planMetadata !== undefined ? { planMetadata: input.planMetadata } : {}),
+    ...(input.runtimeBasicInfo !== undefined ? { runtimeBasicInfo: input.runtimeBasicInfo } : {}),
+    ...(input.dreamContextText !== undefined ? { dreamContextText: input.dreamContextText } : {}),
+    extraToolDefinitions: input.extraToolDefinitions ?? [],
+    errorMessages: input.errorMessages ?? defaultErrorMessages,
+  });
+  return parseGeneratedWorktreeNamingResponse(assistantText);
+}
+
+async function runWorktreeNamingToolAgentRounds(input: {
+  transport: LlmTransportConfig;
+  prompt: string;
+  workspaceRoot: string;
+  toolExecutor: ToolExecutor;
+  enabledRules: readonly LlmEnabledRule[];
+  enabledSkillCatalog: readonly LlmEnabledSkillCatalogEntry[];
+  extensionSystemPrompts: readonly LlmExtensionSystemPrompt[];
+  planMetadata?: LlmPlanMetadata;
+  runtimeBasicInfo?: LlmToolAgentBasicInfo;
+  dreamContextText?: string;
+  extraToolDefinitions: JsonValue;
+  errorMessages: WorktreeNamingErrorMessages;
+}): Promise<string> {
+  const llmTransport = createLlmTransport(input.transport);
+  const toolExecutor = input.toolExecutor as ToolExecutor & {
+    setActiveTransportConfig?: (config: LlmTransportConfig) => void;
+  };
+  toolExecutor.setActiveTransportConfig?.(input.transport);
+
+  let toolState = startLlmToolAgentState(
+    [],
+    input.prompt,
+    input.workspaceRoot,
+    [...input.enabledRules],
+    [...input.enabledSkillCatalog],
+    [],
+    input.transport.model,
+    input.planMetadata,
+    [...input.extensionSystemPrompts],
+    input.dreamContextText || undefined,
+    undefined,
+    input.runtimeBasicInfo,
+  );
+
+  for (let round = 0; round < 6; round += 1) {
+    const completion = await llmTransport.startToolAgentRound(
+      input.transport,
+      toolState,
+      input.extraToolDefinitions,
+    );
+
+    if (completion.kind !== 'success') {
+      throw new Error(input.errorMessages.failurePrefix(completion.error));
+    }
+
+    toolState = completion.result.state;
+
+    if (completion.result.step.kind === 'final-response-ready') {
+      const assistantText = extractLastLlmAssistantText(toolState)?.trim();
+      if (!assistantText) {
+        throw new Error(input.errorMessages.noBody);
+      }
+      return assistantText;
+    }
+
+    const toolResults = [];
+    for (const call of completion.result.step.calls) {
+      const request = await input.toolExecutor.requestFromFunctionCall(call.name, call.argumentsJson);
+      const requestWithMetadata = input.toolExecutor.attachRequestMetadata
+        ? input.toolExecutor.attachRequestMetadata(request, {
+            toolCallId: call.id,
+            toolName: call.name,
+          })
+        : request;
+      const authorization = await input.toolExecutor.authorize(requestWithMetadata);
+      if (authorization.kind !== 'allowed') {
+        throw new Error(input.errorMessages.interactiveTool(call.name));
+      }
+      const output = await input.toolExecutor.execute(requestWithMetadata);
+      toolResults.push({
+        toolCallId: call.id,
+        content: output.summaryText,
+      });
+    }
+
+    toolState = appendLlmToolResultMessages(toolState, toolResults);
+  }
+
+  throw new Error(input.errorMessages.incomplete);
+}

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -37,5 +37,7 @@ export * from './tools.js';
 export * from './workspace-file-reference-query.js';
 export * from './workspace-file-references.js';
 export * from './workspace-ignore.js';
+export * from './worktree-naming.js';
+export * from './generate-worktree-names.js';
 export * from './hooks/index.js';
 export * from './lsp/index.js';

--- a/packages/host-internal/src/worktree-naming.test.ts
+++ b/packages/host-internal/src/worktree-naming.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildWorktreeNamingPrompt,
+  normalizeGeneratedWorktreeNames,
+  parseGeneratedWorktreeNamingResponse,
+} from './worktree-naming.js';
+
+test('buildWorktreeNamingPrompt includes task and repository metadata', () => {
+  const prompt = buildWorktreeNamingPrompt({
+    userPrompt: 'Add worktree UI polish',
+    baseBranch: 'main',
+    repoRoot: '/tmp/repo',
+  });
+
+  assert.match(prompt, /Add worktree UI polish/);
+  assert.match(prompt, /baseBranch: main/);
+  assert.match(prompt, /repository: \/tmp\/repo/);
+});
+
+test('parseGeneratedWorktreeNamingResponse accepts valid JSON', () => {
+  const parsed = parseGeneratedWorktreeNamingResponse(
+    '{"worktreeName":"spirit-add-worktree-ui","branchName":"spirit/add-worktree-ui"}',
+  );
+  assert.deepEqual(parsed, {
+    worktreeName: 'spirit-add-worktree-ui',
+    branchName: 'spirit/add-worktree-ui',
+  });
+});
+
+test('normalizeGeneratedWorktreeNames rejects invalid formats', () => {
+  assert.throws(
+    () => normalizeGeneratedWorktreeNames({
+      worktreeName: 'feature/foo',
+      branchName: 'spirit/add-worktree-ui',
+    }),
+    /worktreeName/,
+  );
+  assert.throws(
+    () => normalizeGeneratedWorktreeNames({
+      worktreeName: 'spirit-add-worktree-ui',
+      branchName: 'feature/foo',
+    }),
+    /branchName/,
+  );
+});

--- a/packages/host-internal/src/worktree-naming.ts
+++ b/packages/host-internal/src/worktree-naming.ts
@@ -1,0 +1,89 @@
+import { isSpiritBranchName, isSpiritWorktreeName } from './git-workspace.js';
+
+export interface GeneratedWorktreeNames {
+  worktreeName: string;
+  branchName: string;
+}
+
+export function buildWorktreeNamingPrompt(input: {
+  userPrompt: string;
+  baseBranch: string;
+  repoRoot: string;
+}): string {
+  return [
+    'Generate Git worktree and branch names for the user task below.',
+    'Return JSON only: {"worktreeName":"...","branchName":"..."}. No Markdown, no explanations, no extra keys.',
+    'Naming rules:',
+    '- worktreeName must use kebab-case segments and start with "spirit-", e.g. spirit-add-worktree-ui',
+    '- branchName must start with "spirit/" and use kebab-case segments after the slash, e.g. spirit/add-worktree-ui',
+    '- Both names should summarize the user task in short English tokens.',
+    '',
+    `repository: ${input.repoRoot}`,
+    `baseBranch: ${input.baseBranch}`,
+    '',
+    '[user task]',
+    input.userPrompt.trim() || '(empty)',
+  ].join('\n');
+}
+
+export function normalizeGeneratedWorktreeNames(value: {
+  worktreeName?: unknown;
+  branchName?: unknown;
+}): GeneratedWorktreeNames {
+  if (typeof value.worktreeName !== 'string' || typeof value.branchName !== 'string') {
+    throw new Error('Worktree naming response is missing worktreeName or branchName.');
+  }
+
+  const worktreeName = value.worktreeName.trim();
+  const branchName = value.branchName.trim();
+  if (!worktreeName || !branchName) {
+    throw new Error('Worktree naming response contains empty worktreeName or branchName.');
+  }
+  if (!isSpiritWorktreeName(worktreeName)) {
+    throw new Error(`Invalid worktreeName format: ${worktreeName}`);
+  }
+  if (!isSpiritBranchName(branchName)) {
+    throw new Error(`Invalid branchName format: ${branchName}`);
+  }
+
+  return { worktreeName, branchName };
+}
+
+export function parseGeneratedWorktreeNamingResponse(rawText: string): GeneratedWorktreeNames {
+  const trimmed = rawText.trim();
+  if (!trimmed) {
+    throw new Error('Worktree naming returned no assistant text.');
+  }
+
+  const candidate = extractJsonObjectText(trimmed);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+  } catch {
+    throw new Error('Worktree naming response is not valid JSON.');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Worktree naming response must be a JSON object.');
+  }
+
+  return normalizeGeneratedWorktreeNames(parsed as { worktreeName?: unknown; branchName?: unknown });
+}
+
+function extractJsonObjectText(text: string): string {
+  if (text.startsWith('```')) {
+    const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+    if (fenceMatch?.[1]) {
+      return fenceMatch[1].trim();
+    }
+  }
+
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    return text.slice(firstBrace, lastBrace + 1).trim();
+  }
+
+  return text;
+}


### PR DESCRIPTION
## Summary

- 在 `host-internal` 抽取 Worktree LLM 命名共享模块（prompt、parse/normalize、`generateWorktreeNamesFromTask`），供 Desktop 与 CLI 复用
- Desktop SubAgent Worktree bootstrap 改为基于 `run_subagent` 的 task 调用 LLM 生成 `spirit-*` 目录与 `spirit/*` 分支名，移除 `spirit-subagent-<sessionId>` 确定性 slug
- CLI `bootstrapCliSubagentWorkspace` 同步接入 LLM 命名（使用当前 `transportConfig.model`），失败时不做 deterministic fallback

## Test plan

- [x] `packages/host-internal` build 通过
- [x] `packages/host-internal` `worktree-naming.test.js` 单测通过
- [x] `apps/desktop` build 通过
- [x] `apps/desktop/test/host/subagent-worktree-bootstrap.test.mjs` 验证 task 传入命名回调
- [x] `apps/desktop/test/host/worktree-naming.test.mjs` 通过
- [x] `apps/desktop/test/host/worktree-bootstrap-card.test.mjs` 通过
- [x] `packages/agent-core` build 通过
- [x] 清理确定性 SubAgent Worktree 命名残留
- [x] macOS 临时 git 仓库路径 `/var` vs `/private/var` 单测兼容（`realpath(mkdtemp(...))`）