### PR TITLE
fix(desktop): worktree 模式下同步 Host 工作区根目录

### DIFF
--- a/apps/desktop/src/host/resolve-session-workspace-root.ts
+++ b/apps/desktop/src/host/resolve-session-workspace-root.ts
@@ -1,0 +1,43 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import {
+  isSpiritBranchName,
+  listGitWorktrees,
+  readWorktreeContext,
+  resolvePrimaryRepoRoot,
+} from '@spirit-agent/host-internal';
+
+export async function resolveStoredSessionWorkspaceRoot(input: {
+  workspaceRoot: string;
+  gitBranch?: string;
+}): Promise<string> {
+  const trimmed = input.workspaceRoot.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  const resolved = path.resolve(trimmed);
+  const context = await readWorktreeContext(resolved);
+  if (context.isWorktree) {
+    return resolved;
+  }
+
+  const branch = input.gitBranch?.trim();
+  if (!branch || !isSpiritBranchName(branch)) {
+    return resolved;
+  }
+
+  try {
+    const primaryRepoRoot = await resolvePrimaryRepoRoot(resolved);
+    const worktrees = await listGitWorktrees(primaryRepoRoot);
+    const match = worktrees.find((entry) => entry.branch === branch && entry.path);
+    if (match?.path && existsSync(match.path)) {
+      return path.resolve(match.path);
+    }
+  } catch {
+    // 无法解析时保留 stored root
+  }
+
+  return resolved;
+}

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -812,6 +812,7 @@ class DesktopHostService {
       createMessageTimelineFromMessages: (messages, timelineSnapshot) =>
         this.createMessageTimelineFromMessages(messages, timelineSnapshot),
       syncPlanStateForBundle: (bundle) => this.syncPlanStateForBundle(bundle),
+      syncHostWorkspaceRootToActiveBundle: (bundle) => this.syncHostWorkspaceRootToActiveBundle(bundle),
       tickSession: (bundle) => this.tickSession(bundle),
       syncActiveRuntimePointer: () => this.syncActiveRuntimePointer(),
       refreshTodoSnapshotForBundle: (bundle) => this.refreshTodoSnapshotForBundle(bundle),

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2877,12 +2877,13 @@ class DesktopHostService {
 
   private async syncHostWorkspaceRootToActiveBundle(
     bundle: SessionBundle = this.activeBundle(),
-  ): Promise<void> {
+  ): Promise<boolean> {
     const state = this.requireState();
     if (!needsHostWorkspaceRootSync(bundle, state)) {
-      return;
+      return false;
     }
     await this.adoptWorkspaceRootForActiveBundle(resolveEffectiveWorkspaceRoot(bundle, state));
+    return true;
   }
 
   private async adoptWorkspaceRootForActiveBundle(workspaceRoot: string): Promise<void> {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -417,6 +417,10 @@ import {
   sameDreamCollectorSnapshot,
   sameWorkspaceRoot,
 } from './service-utils.js';
+import {
+  needsHostWorkspaceRootSync,
+  resolveEffectiveWorkspaceRoot,
+} from './workspace-root-sync.js';
 import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
 import { buildDesktopSnapshot, buildModelCatalogHints } from './snapshot.js';
 import {
@@ -2868,6 +2872,16 @@ class DesktopHostService {
 
     await this.adoptWorkspaceRootForActiveBundle(created.worktreePath);
     this.startDreamCollectorIfNeeded();
+  }
+
+  private async syncHostWorkspaceRootToActiveBundle(
+    bundle: SessionBundle = this.activeBundle(),
+  ): Promise<void> {
+    const state = this.requireState();
+    if (!needsHostWorkspaceRootSync(bundle, state)) {
+      return;
+    }
+    await this.adoptWorkspaceRootForActiveBundle(resolveEffectiveWorkspaceRoot(bundle, state));
   }
 
   private async adoptWorkspaceRootForActiveBundle(workspaceRoot: string): Promise<void> {

--- a/apps/desktop/src/host/session-activation.ts
+++ b/apps/desktop/src/host/session-activation.ts
@@ -59,6 +59,7 @@ export interface SessionActivationContext {
     timelineSnapshot?: DesktopTimelineTurnSnapshot[],
   ): DesktopMessageTimeline;
   syncPlanStateForBundle(bundle: SessionBundle): Promise<void>;
+  syncHostWorkspaceRootToActiveBundle(bundle: SessionBundle): Promise<void>;
   tickSession(bundle: SessionBundle): Promise<void>;
   syncActiveRuntimePointer(): void;
   refreshTodoSnapshotForBundle(bundle: SessionBundle): Promise<void>;
@@ -250,6 +251,7 @@ export async function finishSessionActivationCommand(
   bundle: SessionBundle,
   options?: { sessionStartSource?: SessionStartHookInput['source'] },
 ): Promise<void> {
+  await ctx.syncHostWorkspaceRootToActiveBundle(bundle);
   await ctx.syncPlanStateForBundle(bundle);
   if (bundle.runtime?.isBusy()) {
     await ctx.tickSession(bundle);

--- a/apps/desktop/src/host/session-activation.ts
+++ b/apps/desktop/src/host/session-activation.ts
@@ -60,7 +60,7 @@ export interface SessionActivationContext {
     timelineSnapshot?: DesktopTimelineTurnSnapshot[],
   ): DesktopMessageTimeline;
   syncPlanStateForBundle(bundle: SessionBundle): Promise<void>;
-  syncHostWorkspaceRootToActiveBundle(bundle: SessionBundle): Promise<void>;
+  syncHostWorkspaceRootToActiveBundle(bundle: SessionBundle): Promise<boolean>;
   tickSession(bundle: SessionBundle): Promise<void>;
   syncActiveRuntimePointer(): void;
   refreshTodoSnapshotForBundle(bundle: SessionBundle): Promise<void>;
@@ -257,8 +257,10 @@ export async function finishSessionActivationCommand(
   bundle: SessionBundle,
   options?: { sessionStartSource?: SessionStartHookInput['source'] },
 ): Promise<void> {
-  await ctx.syncHostWorkspaceRootToActiveBundle(bundle);
-  await ctx.syncPlanStateForBundle(bundle);
+  const adoptedWorkspaceRoot = await ctx.syncHostWorkspaceRootToActiveBundle(bundle);
+  if (!adoptedWorkspaceRoot) {
+    await ctx.syncPlanStateForBundle(bundle);
+  }
   if (bundle.runtime?.isBusy()) {
     await ctx.tickSession(bundle);
     ctx.syncActiveRuntimePointer();

--- a/apps/desktop/src/host/session-activation.ts
+++ b/apps/desktop/src/host/session-activation.ts
@@ -24,6 +24,7 @@ import { restoreMessagesFromArchive } from './message-ordering.js';
 import { currentApiBase, sameWorkspaceRoot } from './service-utils.js';
 import type { HostExtensionEvent } from '@spirit-agent/host-internal';
 import { cancelPendingWorktreeBootstrapOnBundle } from './worktree-bootstrap-orchestrator.js';
+import { resolveStoredSessionWorkspaceRoot } from './resolve-session-workspace-root.js';
 
 interface ActivationState {
   workspaceRoot: string;
@@ -180,7 +181,12 @@ export async function openSessionCommand(
     }
 
     const loaded = await loadStoredSession(filePath);
-    const workspaceRoot = loaded.workspaceRoot ?? ctx.requireState().workspaceRoot;
+    const workspaceRoot = loaded.workspaceRoot
+      ? await resolveStoredSessionWorkspaceRoot({
+          workspaceRoot: loaded.workspaceRoot,
+          gitBranch: loaded.gitBranch,
+        })
+      : ctx.requireState().workspaceRoot;
     const sameWorkspace =
       ctx.isInitialized()
       && Boolean(ctx.currentWorkspaceRoot())

--- a/apps/desktop/src/host/workspace-root-sync.ts
+++ b/apps/desktop/src/host/workspace-root-sync.ts
@@ -1,0 +1,25 @@
+import { sameWorkspaceRoot } from './service-utils.js';
+import type { SessionBundle } from './session-bundle.js';
+
+export interface HostWorkspaceRootState {
+  workspaceRoot: string;
+}
+
+export function resolveEffectiveWorkspaceRoot(
+  bundle: Pick<SessionBundle, 'workspaceRoot'>,
+  state: HostWorkspaceRootState,
+): string {
+  const fromBundle = bundle.workspaceRoot?.trim();
+  if (fromBundle) {
+    return fromBundle;
+  }
+  return state.workspaceRoot;
+}
+
+export function needsHostWorkspaceRootSync(
+  bundle: Pick<SessionBundle, 'workspaceRoot'>,
+  state: HostWorkspaceRootState,
+): boolean {
+  const effective = resolveEffectiveWorkspaceRoot(bundle, state);
+  return !sameWorkspaceRoot(state.workspaceRoot, effective);
+}

--- a/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
@@ -210,6 +210,7 @@ export async function advancePendingWorktreeBootstrapCommand(
     await startStreamingAfterWorktreeBootstrap(ctx, bundle, pending!);
     bundle.pendingWorktreeBootstrap = undefined;
     await ctx.persistCurrentSessionIfNeeded();
+    ctx.emitLiveSnapshotUpdate();
     await drainQueuedUserTurnIfIdle(ctx, bundle);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
@@ -206,6 +206,7 @@ export async function advancePendingWorktreeBootstrapCommand(
     await host.executeWorktreeBootstrap(pending!.userPrompt);
     upsertWorktreeBootstrapCard(bundle, pending!.toolCallId, 'succeeded');
     host.setLastRuntimeError('');
+    ctx.emitLiveSnapshotUpdate();
     await startStreamingAfterWorktreeBootstrap(ctx, bundle, pending!);
     bundle.pendingWorktreeBootstrap = undefined;
     await ctx.persistCurrentSessionIfNeeded();

--- a/apps/desktop/test/host/resolve-session-workspace-root.test.mjs
+++ b/apps/desktop/test/host/resolve-session-workspace-root.test.mjs
@@ -1,0 +1,111 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+
+import {
+  addGitWorktree,
+  buildWorktreeRootPath,
+} from '@spirit-agent/host-internal';
+
+import { resolveStoredSessionWorkspaceRoot } from '../../dist-electron/src/host/resolve-session-workspace-root.js';
+
+const execFileAsync = promisify(execFile);
+
+async function runGit(cwd, args) {
+  await execFileAsync('git', args, { cwd, windowsHide: true });
+}
+
+test('resolveStoredSessionWorkspaceRoot keeps linked worktree path as-is', async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), 'spirit-resolve-session-root-'));
+  const worktreeName = 'spirit-resolve-test';
+  const branchName = 'spirit/resolve-test';
+
+  try {
+    await runGit(repoRoot, ['init']);
+    await runGit(repoRoot, ['config', 'user.email', 'test@example.com']);
+    await runGit(repoRoot, ['config', 'user.name', 'Spirit Test']);
+    await writeFile(join(repoRoot, 'README.md'), '# hello\n');
+    await runGit(repoRoot, ['add', 'README.md']);
+    await runGit(repoRoot, ['commit', '-m', 'init']);
+
+    const { stdout: defaultBranchOutput } = await execFileAsync('git', ['branch', '--show-current'], {
+      cwd: repoRoot,
+      windowsHide: true,
+    });
+    const worktreePath = buildWorktreeRootPath(repoRoot, worktreeName);
+    await addGitWorktree(repoRoot, {
+      worktreePath,
+      branchName,
+      baseBranch: defaultBranchOutput.trim(),
+    });
+
+    const resolved = await resolveStoredSessionWorkspaceRoot({
+      workspaceRoot: worktreePath,
+      gitBranch: branchName,
+    });
+    assert.equal(resolved.replace(/\\/g, '/'), worktreePath.replace(/\\/g, '/'));
+  } finally {
+    await rm(`${repoRoot}.worktrees`, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    await rm(repoRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  }
+});
+
+test('resolveStoredSessionWorkspaceRoot maps stored primary repo root to existing spirit worktree', async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), 'spirit-resolve-session-root-'));
+  const worktreeName = 'spirit-resolve-fallback';
+  const branchName = 'spirit/resolve-fallback';
+
+  try {
+    await runGit(repoRoot, ['init']);
+    await runGit(repoRoot, ['config', 'user.email', 'test@example.com']);
+    await runGit(repoRoot, ['config', 'user.name', 'Spirit Test']);
+    await writeFile(join(repoRoot, 'README.md'), '# hello\n');
+    await runGit(repoRoot, ['add', 'README.md']);
+    await runGit(repoRoot, ['commit', '-m', 'init']);
+
+    const { stdout: defaultBranchOutput } = await execFileAsync('git', ['branch', '--show-current'], {
+      cwd: repoRoot,
+      windowsHide: true,
+    });
+    const worktreePath = buildWorktreeRootPath(repoRoot, worktreeName);
+    await addGitWorktree(repoRoot, {
+      worktreePath,
+      branchName,
+      baseBranch: defaultBranchOutput.trim(),
+    });
+
+    const resolved = await resolveStoredSessionWorkspaceRoot({
+      workspaceRoot: repoRoot,
+      gitBranch: branchName,
+    });
+    assert.equal(resolved.replace(/\\/g, '/'), worktreePath.replace(/\\/g, '/'));
+  } finally {
+    await rm(`${repoRoot}.worktrees`, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    await rm(repoRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  }
+});
+
+test('resolveStoredSessionWorkspaceRoot keeps primary repo when branch is not spirit/*', async () => {
+  const repoRoot = await mkdtemp(join(tmpdir(), 'spirit-resolve-session-root-'));
+
+  try {
+    await runGit(repoRoot, ['init']);
+    await runGit(repoRoot, ['config', 'user.email', 'test@example.com']);
+    await runGit(repoRoot, ['config', 'user.name', 'Spirit Test']);
+    await writeFile(join(repoRoot, 'README.md'), '# hello\n');
+    await runGit(repoRoot, ['add', 'README.md']);
+    await runGit(repoRoot, ['commit', '-m', 'init']);
+
+    const resolved = await resolveStoredSessionWorkspaceRoot({
+      workspaceRoot: repoRoot,
+      gitBranch: 'main',
+    });
+    assert.equal(resolved.replace(/\\/g, '/'), repoRoot.replace(/\\/g, '/'));
+  } finally {
+    await rm(repoRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+  }
+});

--- a/apps/desktop/test/host/resolve-session-workspace-root.test.mjs
+++ b/apps/desktop/test/host/resolve-session-workspace-root.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';

--- a/apps/desktop/test/host/session-activation-workspace-root.test.mjs
+++ b/apps/desktop/test/host/session-activation-workspace-root.test.mjs
@@ -21,6 +21,7 @@ test('finishSessionActivationCommand syncs host workspace root before plan state
   const ctx = {
     syncHostWorkspaceRootToActiveBundle: async (target) => {
       calls.push(['syncHostWorkspaceRootToActiveBundle', target.id]);
+      return false;
     },
     syncPlanStateForBundle: async (target) => {
       calls.push(['syncPlanStateForBundle', target.id]);
@@ -65,6 +66,7 @@ test('finishSessionActivationCommand still syncs host workspace root when runtim
   const ctx = {
     syncHostWorkspaceRootToActiveBundle: async (target) => {
       calls.push(['syncHostWorkspaceRootToActiveBundle', target.id]);
+      return false;
     },
     syncPlanStateForBundle: async (target) => {
       calls.push(['syncPlanStateForBundle', target.id]);
@@ -89,4 +91,48 @@ test('finishSessionActivationCommand still syncs host workspace root when runtim
     ['tickSession'],
     ['syncActiveRuntimePointer'],
   ]);
+});
+
+test('finishSessionActivationCommand skips plan sync when host workspace root was adopted', async () => {
+  const calls = [];
+  const bundle = createMinimalBundle();
+  const ctx = {
+    syncHostWorkspaceRootToActiveBundle: async (target) => {
+      calls.push(['syncHostWorkspaceRootToActiveBundle', target.id]);
+      return true;
+    },
+    syncPlanStateForBundle: async (target) => {
+      calls.push(['syncPlanStateForBundle', target.id]);
+    },
+    resetStreamingPlacementState: () => {
+      calls.push(['resetStreamingPlacementState']);
+    },
+    ensureToolExecutor: async () => {
+      calls.push(['ensureToolExecutor']);
+    },
+    refreshTodoSnapshotForBundle: async () => {
+      calls.push(['refreshTodoSnapshotForBundle']);
+    },
+    refreshRuntimeForBundle: async () => {
+      calls.push(['refreshRuntimeForBundle']);
+    },
+    flushDeferredRuntimeRefreshIfIdle: async () => {
+      calls.push(['flushDeferredRuntimeRefreshIfIdle']);
+    },
+    syncActiveRuntimePointer: () => {
+      calls.push(['syncActiveRuntimePointer']);
+    },
+    requireState: () => ({
+      config: { activeModel: 'test-model', models: [{ name: 'test-model' }] },
+      workspaceRoot: 'D:\\SpiritAgent.worktrees\\spirit-a',
+    }),
+  };
+
+  await finishSessionActivationCommand(ctx, bundle);
+
+  assert.equal(calls[0]?.[0], 'syncHostWorkspaceRootToActiveBundle');
+  assert.equal(
+    calls.filter((entry) => entry[0] === 'syncPlanStateForBundle').length,
+    0,
+  );
 });

--- a/apps/desktop/test/host/session-activation-workspace-root.test.mjs
+++ b/apps/desktop/test/host/session-activation-workspace-root.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { finishSessionActivationCommand } from '../../dist-electron/src/host/session-activation.js';
+
+function createMinimalBundle(overrides = {}) {
+  return {
+    id: 'session-a',
+    workspaceRoot: 'D:\\SpiritAgent.worktrees\\spirit-a',
+    messages: [],
+    messageTimeline: { toMessages: () => [] },
+    runtime: undefined,
+    runtimeActivationSignature: undefined,
+    ...overrides,
+  };
+}
+
+test('finishSessionActivationCommand syncs host workspace root before plan state', async () => {
+  const calls = [];
+  const bundle = createMinimalBundle();
+  const ctx = {
+    syncHostWorkspaceRootToActiveBundle: async (target) => {
+      calls.push(['syncHostWorkspaceRootToActiveBundle', target.id]);
+    },
+    syncPlanStateForBundle: async (target) => {
+      calls.push(['syncPlanStateForBundle', target.id]);
+    },
+    resetStreamingPlacementState: () => {
+      calls.push(['resetStreamingPlacementState']);
+    },
+    ensureToolExecutor: async () => {
+      calls.push(['ensureToolExecutor']);
+    },
+    refreshTodoSnapshotForBundle: async () => {
+      calls.push(['refreshTodoSnapshotForBundle']);
+    },
+    refreshRuntimeForBundle: async () => {
+      calls.push(['refreshRuntimeForBundle']);
+    },
+    flushDeferredRuntimeRefreshIfIdle: async () => {
+      calls.push(['flushDeferredRuntimeRefreshIfIdle']);
+    },
+    syncActiveRuntimePointer: () => {
+      calls.push(['syncActiveRuntimePointer']);
+    },
+    requireState: () => ({
+      config: { activeModel: 'test-model', models: [{ name: 'test-model' }] },
+      workspaceRoot: 'D:\\SpiritAgent',
+    }),
+  };
+
+  await finishSessionActivationCommand(ctx, bundle);
+
+  assert.deepEqual(calls.slice(0, 2), [
+    ['syncHostWorkspaceRootToActiveBundle', 'session-a'],
+    ['syncPlanStateForBundle', 'session-a'],
+  ]);
+});
+
+test('finishSessionActivationCommand still syncs host workspace root when runtime busy', async () => {
+  const calls = [];
+  const bundle = createMinimalBundle({
+    runtime: { isBusy: () => true },
+  });
+  const ctx = {
+    syncHostWorkspaceRootToActiveBundle: async (target) => {
+      calls.push(['syncHostWorkspaceRootToActiveBundle', target.id]);
+    },
+    syncPlanStateForBundle: async (target) => {
+      calls.push(['syncPlanStateForBundle', target.id]);
+    },
+    tickSession: async () => {
+      calls.push(['tickSession']);
+    },
+    syncActiveRuntimePointer: () => {
+      calls.push(['syncActiveRuntimePointer']);
+    },
+    requireState: () => ({
+      config: { activeModel: 'test-model', models: [{ name: 'test-model' }] },
+      workspaceRoot: 'D:\\SpiritAgent',
+    }),
+  };
+
+  await finishSessionActivationCommand(ctx, bundle);
+
+  assert.deepEqual(calls, [
+    ['syncHostWorkspaceRootToActiveBundle', 'session-a'],
+    ['syncPlanStateForBundle', 'session-a'],
+    ['tickSession'],
+    ['syncActiveRuntimePointer'],
+  ]);
+});

--- a/apps/desktop/test/host/workspace-root-sync.test.mjs
+++ b/apps/desktop/test/host/workspace-root-sync.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  needsHostWorkspaceRootSync,
+  resolveEffectiveWorkspaceRoot,
+} from '../../dist-electron/src/host/workspace-root-sync.js';
+
+test('resolveEffectiveWorkspaceRoot prefers bundle workspaceRoot', () => {
+  assert.equal(
+    resolveEffectiveWorkspaceRoot(
+      { workspaceRoot: 'D:\\SpiritAgent.worktrees\\spirit-a' },
+      { workspaceRoot: 'D:\\SpiritAgent' },
+    ),
+    'D:\\SpiritAgent.worktrees\\spirit-a',
+  );
+});
+
+test('resolveEffectiveWorkspaceRoot falls back to host state when bundle empty', () => {
+  assert.equal(
+    resolveEffectiveWorkspaceRoot({ workspaceRoot: '' }, { workspaceRoot: 'D:\\SpiritAgent' }),
+    'D:\\SpiritAgent',
+  );
+});
+
+test('needsHostWorkspaceRootSync is true when bundle worktree differs from host primary repo', () => {
+  assert.equal(
+    needsHostWorkspaceRootSync(
+      { workspaceRoot: 'D:\\SpiritAgent.worktrees\\spirit-a' },
+      { workspaceRoot: 'D:\\SpiritAgent' },
+    ),
+    true,
+  );
+});
+
+test('needsHostWorkspaceRootSync is false when paths match case-insensitively', () => {
+  assert.equal(
+    needsHostWorkspaceRootSync(
+      { workspaceRoot: 'd:/spiritagent.worktrees/spirit-a' },
+      { workspaceRoot: 'D:\\SpiritAgent.worktrees\\spirit-a' },
+    ),
+    false,
+  );
+});
+
+test('needsHostWorkspaceRootSync is false when both use primary repo', () => {
+  assert.equal(
+    needsHostWorkspaceRootSync(
+      { workspaceRoot: 'D:\\SpiritAgent' },
+      { workspaceRoot: 'D:\\SpiritAgent' },
+    ),
+    false,
+  );
+});

--- a/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
+++ b/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
@@ -168,11 +168,14 @@ test('advancePendingWorktreeBootstrapCommand emits snapshot after bootstrap befo
 
   assert.equal(bundle.pendingWorktreeBootstrap, undefined);
   assert.ok(callOrder.includes('executeWorktreeBootstrap'));
-  assert.ok(callOrder.includes('emitLiveSnapshotUpdate'));
+  assert.equal(callOrder.filter((entry) => entry === 'emitLiveSnapshotUpdate').length, 2);
   assert.ok(
     callOrder.indexOf('emitLiveSnapshotUpdate') > callOrder.indexOf('executeWorktreeBootstrap'),
   );
   assert.ok(
     callOrder.indexOf('startUserTurnStreaming') > callOrder.indexOf('emitLiveSnapshotUpdate'),
+  );
+  assert.ok(
+    callOrder.lastIndexOf('emitLiveSnapshotUpdate') > callOrder.indexOf('persistCurrentSessionIfNeeded'),
   );
 });

--- a/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
+++ b/apps/desktop/test/host/worktree-bootstrap-orchestrator.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
 import {
+  advancePendingWorktreeBootstrapCommand,
   cancelPendingWorktreeBootstrapOnBundle,
   shouldAdvanceWorktreeBootstrap,
   startWorktreeBootstrapTurnCommand,
@@ -97,4 +98,81 @@ test('startWorktreeBootstrapTurnCommand inserts user message and running worktre
   assert.equal(bundle.pendingWorktreeBootstrap?.phase, 'running');
   assert.equal(shouldAdvanceWorktreeBootstrap(bundle), true);
   assert.ok(snapshot);
+});
+
+test('advancePendingWorktreeBootstrapCommand emits snapshot after bootstrap before streaming', async () => {
+  const { timeline } = createTimelineHarness();
+  const bundle = {
+    id: 'draft-advance',
+    messages: [],
+    messageTimeline: timeline,
+    currentTurnSkills: [],
+    archiveHistory: [],
+    pendingWorktreeBootstrap: {
+      toolCallId: 'worktree-bootstrap:draft-advance',
+      phase: 'running',
+      userPrompt: 'hello',
+      displayText: 'hello',
+      userMessageId: 1,
+      beforeUserCheckpoint: {
+        archive: { llmHistory: [] },
+        desktopMessages: [],
+      },
+    },
+  };
+  timeline.beginUserTurn('hello', { messageId: 1 });
+
+  const callOrder = [];
+  await advancePendingWorktreeBootstrapCommand(
+    {
+      requireRuntime: () => ({
+        startUserTurnStreaming: async () => {
+          callOrder.push('startUserTurnStreaming');
+        },
+        poll: async () => {},
+        drainEvents: () => [],
+      }),
+      ensureToolExecutor: async () => {
+        callOrder.push('ensureToolExecutor');
+      },
+      refreshArchiveFromRuntime: () => {},
+      recordRewindCheckpoint: async () => {},
+      orchestrationFor: () => ({
+        assistantMessages: {
+          handleMessageRemoved: () => {},
+        },
+        runtimeEvents: {
+          consumeCompletedTurnResult: () => {},
+          syncPendingToolStates: () => {},
+          syncAssistantPrefixFromHistoryBeforeToolRow: () => {},
+        },
+      }),
+      flushDeferredRuntimeRefreshIfIdle: async () => {},
+      refreshTodoSnapshotForBundle: async () => {},
+      emitLiveSnapshotUpdate: () => {
+        callOrder.push('emitLiveSnapshotUpdate');
+      },
+      persistCurrentSessionIfNeeded: async () => {
+        callOrder.push('persistCurrentSessionIfNeeded');
+      },
+      drainQueuedUserTurnIfIdle: async () => {},
+    },
+    {
+      executeWorktreeBootstrap: async () => {
+        callOrder.push('executeWorktreeBootstrap');
+      },
+      setLastRuntimeError: () => {},
+    },
+    bundle,
+  );
+
+  assert.equal(bundle.pendingWorktreeBootstrap, undefined);
+  assert.ok(callOrder.includes('executeWorktreeBootstrap'));
+  assert.ok(callOrder.includes('emitLiveSnapshotUpdate'));
+  assert.ok(
+    callOrder.indexOf('emitLiveSnapshotUpdate') > callOrder.indexOf('executeWorktreeBootstrap'),
+  );
+  assert.ok(
+    callOrder.indexOf('startUserTurnStreaming') > callOrder.indexOf('emitLiveSnapshotUpdate'),
+  );
 });


### PR DESCRIPTION
## Summary

- 新增 effective workspaceRoot 判定与 adopt 薄封装，在会话激活时将 bundle.workspaceRoot 同步到 Host state
- worktree bootstrap 完成后立即 emit snapshot，右侧面板不再短暂停留主仓库
- openSession 对历史/中断 bootstrap 的会话从 spirit 分支与 worktree 列表反查有效 cwd
- 左侧工作区分组仍按主仓库聚合，不新增 `.worktrees/*` 工作区项

## Test plan

- [x] `node --test` 跑通 workspace-root-sync、session-activation-workspace-root、worktree-bootstrap-orchestrator、resolve-session-workspace-root 共 13 项
- [x] Desktop Electron：Worktree 首条消息 bootstrap 后右侧文件树/终端 cwd 指向 worktree
- [x] 主仓库与 worktree 会话切换后右侧面板目录随之切换
- [x] 重启后打开 worktree 会话仍指向 worktree
- [x] 左侧仍只显示主仓库分组