### PR TITLE
feat(desktop): 深化 macOS 通知交互

### DIFF
--- a/apps/desktop/electron/desktop-attention.ts
+++ b/apps/desktop/electron/desktop-attention.ts
@@ -1,10 +1,11 @@
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, app } from 'electron';
 
 let mainWindowRef: BrowserWindow | undefined;
 let pendingApproval = false;
 let pendingQuestions = false;
 let pendingTaskComplete = false;
 let flashFrameActive = false;
+let dockBounceId: number | undefined;
 
 function shouldRequestAttention(away: boolean): boolean {
   return away && (pendingApproval || pendingQuestions || pendingTaskComplete);
@@ -49,5 +50,16 @@ export function refreshDesktopAttention(away: boolean): void {
 
   if (process.platform === 'win32' || process.platform === 'linux') {
     window.flashFrame(active);
+    return;
+  }
+
+  if (process.platform === 'darwin' && app.dock) {
+    if (dockBounceId !== undefined) {
+      app.dock.cancelBounce(dockBounceId);
+      dockBounceId = undefined;
+    }
+    if (active) {
+      dockBounceId = app.dock.bounce('informational');
+    }
   }
 }

--- a/apps/desktop/electron/desktop-notifications.ts
+++ b/apps/desktop/electron/desktop-notifications.ts
@@ -187,7 +187,7 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
   const windowsToastPayload = {
     title: payload.title,
     body: payload.body,
-    tag: payload.tag,
+    tag,
     actions: buttonActions.map((action) => ({ type: 'button' as const, text: action.text })),
   };
   const useWindowsToastXml =

--- a/apps/desktop/electron/desktop-notifications.ts
+++ b/apps/desktop/electron/desktop-notifications.ts
@@ -184,6 +184,7 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
 
   const textAction = payload.actions?.find((action) => action.type === 'text');
   const buttonActions = payload.actions?.filter((action) => action.type === 'button') ?? [];
+  const canHandleReply = payload.kind === 'approval' || payload.kind === 'ask-questions';
   const windowsToastPayload = {
     title: payload.title,
     body: payload.body,
@@ -207,7 +208,7 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
         ...(buttonActions.length > 0
           ? { actions: buttonActions.map((action) => ({ type: 'button' as const, text: action.text })) }
           : {}),
-        ...(textAction && process.platform === 'darwin'
+        ...(textAction && canHandleReply && process.platform === 'darwin'
           ? { hasReply: true, replyPlaceholder: textAction.placeholder ?? textAction.text }
           : {}),
       });
@@ -222,7 +223,7 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
     });
   }
 
-  if ((payload.kind === 'approval' || payload.kind === 'ask-questions') && textAction) {
+  if (canHandleReply && textAction) {
     notification.on('reply', (_event, reply) => {
       void replyHandler?.({
         kind: payload.kind as 'approval' | 'ask-questions',

--- a/apps/desktop/electron/desktop-notifications.ts
+++ b/apps/desktop/electron/desktop-notifications.ts
@@ -1,5 +1,11 @@
 import { app, BrowserWindow, Notification } from 'electron';
 
+import type {
+  DesktopNotificationAction,
+  DesktopNotificationContext,
+  DesktopNotificationKind,
+} from '../src/lib/desktop-notification-types.js';
+
 import {
   buildWindowsToastXml,
   parseWindowsToastActivation,
@@ -9,27 +15,33 @@ import {
 
 const DESKTOP_APP_USER_MODEL_ID = 'ai.spiritagent.desktop';
 
-export type DesktopNotificationAction = {
-  type: 'button';
-  text: string;
-};
-
 export type DesktopNotificationPayload = {
   title: string;
   body?: string;
   tag?: string;
   silent?: boolean;
   actions?: DesktopNotificationAction[];
-  /** When set, action index 0/1 map to allow/deny approval. */
-  kind?: 'task-complete' | 'approval' | 'ask-questions' | 'generic';
+  kind?: DesktopNotificationKind;
+  context?: DesktopNotificationContext;
+};
+
+export type DesktopNotificationReplyPayload = {
+  kind: Extract<DesktopNotificationKind, 'approval' | 'ask-questions'>;
+  text: string;
+  context?: DesktopNotificationContext;
 };
 
 export type ApprovalNotificationHandler = (
   decision: 'allow' | 'deny',
 ) => Promise<void>;
 
+export type NotificationReplyHandler = (
+  payload: DesktopNotificationReplyPayload,
+) => void | Promise<void>;
+
 let mainWindowRef: BrowserWindow | undefined;
 let approvalHandler: ApprovalNotificationHandler | undefined;
+let replyHandler: NotificationReplyHandler | undefined;
 let permissionRequested = false;
 let windowsActivationHandlerRegistered = false;
 let approvalActionInFlight = false;
@@ -137,15 +149,23 @@ async function ensureNotificationPermission(): Promise<boolean> {
 
 export function registerDesktopNotifications(
   mainWindow: BrowserWindow,
-  options?: { onApprovalAction?: ApprovalNotificationHandler },
+  options?: {
+    onApprovalAction?: ApprovalNotificationHandler;
+    onNotificationReply?: NotificationReplyHandler;
+  },
 ): void {
   mainWindowRef = mainWindow;
   approvalHandler = options?.onApprovalAction;
+  replyHandler = options?.onNotificationReply;
   registerWindowsToastActivationHandler();
 }
 
 export function setApprovalNotificationHandler(handler: ApprovalNotificationHandler | undefined): void {
   approvalHandler = handler;
+}
+
+export function setNotificationReplyHandler(handler: NotificationReplyHandler | undefined): void {
+  replyHandler = handler;
 }
 
 export async function showDesktopNotification(payload: DesktopNotificationPayload): Promise<boolean> {
@@ -162,12 +182,20 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
     }
   }
 
+  const textAction = payload.actions?.find((action) => action.type === 'text');
+  const buttonActions = payload.actions?.filter((action) => action.type === 'button') ?? [];
+  const windowsToastPayload = {
+    title: payload.title,
+    body: payload.body,
+    tag: payload.tag,
+    actions: buttonActions.map((action) => ({ type: 'button' as const, text: action.text })),
+  };
   const useWindowsToastXml =
-    process.platform === 'win32' && shouldUseWindowsToastXml(payload);
+    process.platform === 'win32' && shouldUseWindowsToastXml(windowsToastPayload);
 
   const notification = useWindowsToastXml
     ? new Notification({
-        toastXml: buildWindowsToastXml(payload),
+        toastXml: buildWindowsToastXml(windowsToastPayload),
         silent: payload.silent === true,
         ...(tag ? { tag } : {}),
       })
@@ -176,8 +204,11 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
         body: payload.body,
         silent: payload.silent === true,
         ...(tag ? { tag } : {}),
-        ...(payload.actions && payload.actions.length > 0
-          ? { actions: payload.actions }
+        ...(buttonActions.length > 0
+          ? { actions: buttonActions.map((action) => ({ type: 'button' as const, text: action.text })) }
+          : {}),
+        ...(textAction && process.platform === 'darwin'
+          ? { hasReply: true, replyPlaceholder: textAction.placeholder ?? textAction.text }
           : {}),
       });
 
@@ -185,9 +216,19 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
     focusMainWindow();
   });
 
-  if (payload.kind === 'approval' && payload.actions && payload.actions.length > 0) {
+  if (payload.kind === 'approval' && buttonActions.length > 0) {
     notification.on('action', (event, legacyIndex) => {
       handleApprovalActionIndex(resolveNotificationActionIndex(event, legacyIndex));
+    });
+  }
+
+  if ((payload.kind === 'approval' || payload.kind === 'ask-questions') && textAction) {
+    notification.on('reply', (_event, reply) => {
+      void replyHandler?.({
+        kind: payload.kind as 'approval' | 'ask-questions',
+        text: reply,
+        context: payload.context,
+      });
     });
   }
 

--- a/apps/desktop/electron/desktop-notifications.ts
+++ b/apps/desktop/electron/desktop-notifications.ts
@@ -184,7 +184,7 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
 
   const textAction = payload.actions?.find((action) => action.type === 'text');
   const buttonActions = payload.actions?.filter((action) => action.type === 'button') ?? [];
-  const canHandleReply = payload.kind === 'approval' || payload.kind === 'ask-questions';
+  const replyKind = payload.kind === 'approval' || payload.kind === 'ask-questions' ? payload.kind : undefined;
   const windowsToastPayload = {
     title: payload.title,
     body: payload.body,
@@ -208,7 +208,7 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
         ...(buttonActions.length > 0
           ? { actions: buttonActions.map((action) => ({ type: 'button' as const, text: action.text })) }
           : {}),
-        ...(textAction && canHandleReply && process.platform === 'darwin'
+        ...(textAction && replyKind && process.platform === 'darwin'
           ? { hasReply: true, replyPlaceholder: textAction.placeholder ?? textAction.text }
           : {}),
       });
@@ -223,13 +223,15 @@ export async function showDesktopNotification(payload: DesktopNotificationPayloa
     });
   }
 
-  if (canHandleReply && textAction) {
+  if (replyKind && textAction) {
     notification.on('reply', (_event, reply) => {
-      void replyHandler?.({
-        kind: payload.kind as 'approval' | 'ask-questions',
-        text: reply,
-        context: payload.context,
-      });
+      void Promise.resolve(
+        replyHandler?.({
+          kind: replyKind,
+          text: reply,
+          context: payload.context,
+        }),
+      ).catch(() => undefined);
     });
   }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -643,6 +643,11 @@ async function createMainWindow(): Promise<BrowserWindow> {
 
   registerDesktopNotifications(window, {
     onApprovalAction: handleApprovalNotificationAction,
+    onNotificationReply: (payload) => {
+      if (!window.webContents.isDestroyed()) {
+        window.webContents.send('desktop:notification-reply', payload);
+      }
+    },
   });
   registerDesktopAttention(window);
   registerWindowPresence(window);

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -576,8 +576,16 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
     body?: string;
     tag?: string;
     silent?: boolean;
-    actions?: Array<{ type: 'button'; text: string }>;
+    actions?: Array<
+      | { type: 'button'; text: string; action?: 'allow' | 'deny' | 'focus' }
+      | { type: 'text'; text: string; placeholder?: string; action: 'reply' }
+    >;
     kind?: 'task-complete' | 'approval' | 'ask-questions' | 'generic';
+    context?: {
+      approvalId?: string;
+      questionToolCallId?: string;
+      questionId?: string;
+    };
   }) {
     return ipcRenderer.invoke('desktop:show-notification', request);
   },

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -646,6 +646,40 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
       ipcRenderer.removeListener('desktop:approval-from-notification', onApproval);
     };
   },
+  subscribeNotificationReply(callback: (payload: {
+    kind: 'approval' | 'ask-questions';
+    text: string;
+    context?: {
+      approvalId?: string;
+      questionToolCallId?: string;
+      questionId?: string;
+    };
+  }) => void) {
+    const onReply = (
+      _event: Electron.IpcRendererEvent,
+      payload: {
+        kind?: string;
+        text?: string;
+        context?: {
+          approvalId?: string;
+          questionToolCallId?: string;
+          questionId?: string;
+        };
+      },
+    ) => {
+      if ((payload?.kind === 'approval' || payload?.kind === 'ask-questions') && typeof payload.text === 'string') {
+        callback({
+          kind: payload.kind,
+          text: payload.text,
+          context: payload.context,
+        });
+      }
+    };
+    ipcRenderer.on('desktop:notification-reply', onReply);
+    return () => {
+      ipcRenderer.removeListener('desktop:notification-reply', onReply);
+    };
+  },
   subscribeNewSession(callback: () => void) {
     const onNewSession = () => {
       callback();

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -294,6 +294,13 @@ declare global {
     subscribeApprovalFromNotification(
       callback: (payload: { decision: 'allow' | 'deny' }) => void,
     ): () => void;
+    subscribeNotificationReply(
+      callback: (payload: {
+        kind: 'approval' | 'ask-questions';
+        text: string;
+        context?: import('./lib/desktop-notification-types.js').DesktopNotificationContext;
+      }) => void,
+    ): () => void;
     subscribeNewSession(callback: () => void): () => void;
   }
 

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -2379,8 +2379,9 @@ export function useDesktopRuntime() {
       if (payload.kind !== 'approval') {
         return;
       }
+      const current = snapshotRef.current?.conversation.pendingToolApproval;
       const userMessage = payload.text.trim();
-      if (!userMessage) {
+      if (!current || !userMessage) {
         return;
       }
       void submitApproval({ kind: 'guidance', userMessage });

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import i18n from '@/lib/i18n';
+import { buildSingleTextQuestionNotificationReplyResult } from "@/lib/ask-questions-notification-reply";
+import i18n from "@/lib/i18n";
 
 import type { SettingsFormState } from "@/components/settings/types";
 import { useHostApi } from "@/hooks/useHostApi";
@@ -2395,36 +2396,17 @@ export function useDesktopRuntime() {
       if (payload.kind !== 'ask-questions') {
         return;
       }
-      const current = snapshotRef.current?.conversation.pendingQuestions;
-      if (!current || payload.context?.questionToolCallId !== current.toolCallId) {
-        return;
-      }
-      const question = current.request.questions[0];
-      const text = payload.text.trim();
-      if (
-        current.request.questions.length !== 1 ||
-        !question ||
-        question.kind !== 'text' ||
-        payload.context?.questionId !== question.id ||
-        !text
-      ) {
+      const result = buildSingleTextQuestionNotificationReplyResult(
+        snapshotRef.current?.conversation.pendingQuestions,
+        payload,
+      );
+      if (!result) {
         return;
       }
       void (async () => {
         setBusyAction('questions');
         try {
-          const next = await api.replyPendingQuestions({
-            status: 'answered',
-            answers: [
-              {
-                questionId: question.id,
-                title: question.title,
-                kind: question.kind,
-                answered: true,
-                text,
-              },
-            ],
-          });
+          const next = await api.replyPendingQuestions(result);
           applySnapshot(next);
           setQuestionError('');
           setRuntimeError('');

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -2386,6 +2386,57 @@ export function useDesktopRuntime() {
     });
   }, [submitApproval]);
 
+  useEffect(() => {
+    const bridge = window.spiritDesktop;
+    if (!api || !bridge?.subscribeNotificationReply) {
+      return;
+    }
+    return bridge.subscribeNotificationReply((payload) => {
+      if (payload.kind !== 'ask-questions') {
+        return;
+      }
+      const current = snapshotRef.current?.conversation.pendingQuestions;
+      if (!current || payload.context?.questionToolCallId !== current.toolCallId) {
+        return;
+      }
+      const question = current.request.questions[0];
+      const text = payload.text.trim();
+      if (
+        current.request.questions.length !== 1 ||
+        !question ||
+        question.kind !== 'text' ||
+        payload.context?.questionId !== question.id ||
+        !text
+      ) {
+        return;
+      }
+      void (async () => {
+        setBusyAction('questions');
+        try {
+          const next = await api.replyPendingQuestions({
+            status: 'answered',
+            answers: [
+              {
+                questionId: question.id,
+                title: question.title,
+                kind: question.kind,
+                answered: true,
+                text,
+              },
+            ],
+          });
+          applySnapshot(next);
+          setQuestionError('');
+          setRuntimeError('');
+        } catch (error) {
+          setRuntimeError(describeError(error));
+        } finally {
+          setBusyAction('');
+        }
+      })();
+    });
+  }, [api, applySnapshot]);
+
   const submitQuestions = useCallback(async () => {
     if (!api || !pendingQuestions) {
       return;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -2369,6 +2369,23 @@ export function useDesktopRuntime() {
     });
   }, [submitApproval]);
 
+  useEffect(() => {
+    const bridge = window.spiritDesktop;
+    if (!bridge?.subscribeNotificationReply) {
+      return;
+    }
+    return bridge.subscribeNotificationReply((payload) => {
+      if (payload.kind !== 'approval') {
+        return;
+      }
+      const userMessage = payload.text.trim();
+      if (!userMessage) {
+        return;
+      }
+      void submitApproval({ kind: 'guidance', userMessage });
+    });
+  }, [submitApproval]);
+
   const submitQuestions = useCallback(async () => {
     if (!api || !pendingQuestions) {
       return;

--- a/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
+++ b/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
@@ -79,11 +79,32 @@ function askQuestionsNotificationPayload(
       ? i18n.t('notification.askQuestions.nQuestions', { count: questionCount })
       : i18n.t('notification.askQuestions.fallback'));
 
+  const singleTextQuestion =
+    pending.request.questions.length === 1 && pending.request.questions[0]?.kind === 'text'
+      ? pending.request.questions[0]
+      : undefined;
+
   return {
     kind: 'ask-questions',
     tag: `spirit-ask-${pending.toolCallId}`,
     title: formatSessionPrefixedTitle(sessionName, i18n.t('notification.askQuestions.title')),
     body: detail,
+    ...(singleTextQuestion && window.spiritDesktop?.platform === 'darwin'
+      ? {
+          actions: [
+            {
+              type: 'text' as const,
+              text: i18n.t('notification.askQuestions.reply'),
+              placeholder: singleTextQuestion.title,
+              action: 'reply' as const,
+            },
+          ],
+          context: {
+            questionToolCallId: pending.toolCallId,
+            questionId: singleTextQuestion.id,
+          },
+        }
+      : {}),
   };
 }
 

--- a/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
+++ b/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
@@ -54,11 +54,14 @@ function approvalNotificationPayload(
     tag: 'spirit-approval',
     title: formatSessionPrefixedTitle(sessionName, i18n.t('notification.approval.title')),
     body: isWindows ? body : `${body}\n${i18n.t('notification.approval.returnToApp')}`,
-    ...(isWindows
+    ...(isWindows || window.spiritDesktop?.platform === 'darwin'
       ? {
           actions: [
-            { type: 'button' as const, text: i18n.t('app.allow') },
-            { type: 'button' as const, text: i18n.t('app.deny') },
+            { type: 'button' as const, text: i18n.t('app.allow'), action: 'allow' as const },
+            { type: 'button' as const, text: i18n.t('app.deny'), action: 'deny' as const },
+            ...(window.spiritDesktop?.platform === 'darwin'
+              ? [{ type: 'text' as const, text: i18n.t('notification.approval.reply'), action: 'reply' as const }]
+              : []),
           ],
         }
       : {}),

--- a/apps/desktop/src/lib/ask-questions-notification-reply.ts
+++ b/apps/desktop/src/lib/ask-questions-notification-reply.ts
@@ -1,0 +1,42 @@
+import type { AskQuestionsResult, PendingQuestionsSnapshot } from '../types';
+
+export function buildSingleTextQuestionNotificationReplyResult(
+  pendingQuestions: PendingQuestionsSnapshot | null | undefined,
+  payload: {
+    text: string;
+    context?: {
+      questionToolCallId?: string;
+      questionId?: string;
+    };
+  },
+): AskQuestionsResult | undefined {
+  const current = pendingQuestions;
+  if (!current || payload.context?.questionToolCallId !== current.toolCallId) {
+    return undefined;
+  }
+
+  const question = current.request.questions[0];
+  const text = payload.text.trim();
+  if (
+    current.request.questions.length !== 1 ||
+    !question ||
+    question.kind !== 'text' ||
+    payload.context?.questionId !== question.id ||
+    !text
+  ) {
+    return undefined;
+  }
+
+  return {
+    status: 'answered',
+    answers: [
+      {
+        questionId: question.id,
+        title: question.title,
+        kind: question.kind,
+        answered: true,
+        text,
+      },
+    ],
+  };
+}

--- a/apps/desktop/src/lib/desktop-notification-types.ts
+++ b/apps/desktop/src/lib/desktop-notification-types.ts
@@ -1,8 +1,22 @@
 export type DesktopNotificationKind = 'task-complete' | 'approval' | 'ask-questions' | 'generic';
 
-export type DesktopNotificationAction = {
-  type: 'button';
-  text: string;
+export type DesktopNotificationAction =
+  | {
+      type: 'button';
+      text: string;
+      action?: 'allow' | 'deny' | 'focus';
+    }
+  | {
+      type: 'text';
+      text: string;
+      placeholder?: string;
+      action: 'reply';
+    };
+
+export type DesktopNotificationContext = {
+  approvalId?: string;
+  questionToolCallId?: string;
+  questionId?: string;
 };
 
 export type DesktopShowNotificationRequest = {
@@ -12,4 +26,5 @@ export type DesktopShowNotificationRequest = {
   silent?: boolean;
   actions?: DesktopNotificationAction[];
   kind?: DesktopNotificationKind;
+  context?: DesktopNotificationContext;
 };

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1074,7 +1074,8 @@
     "askQuestions": {
       "title": "Questions pending",
       "nQuestions": "{{count}} questions to answer",
-      "fallback": "Return to the app to answer questions."
+      "fallback": "Return to the app to answer questions.",
+      "reply": "Answer here"
     }
   },
   "tool": {

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1068,7 +1068,8 @@
     },
     "approval": {
       "title": "Approval required",
-      "returnToApp": "Return to the app to handle approval."
+      "returnToApp": "Return to the app to handle approval.",
+      "reply": "Reply with guidance"
     },
     "askQuestions": {
       "title": "Questions pending",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -1071,7 +1071,8 @@
     "askQuestions": {
       "title": "待回答问题",
       "nQuestions": "{{count}} 个问题待回答",
-      "fallback": "请返回应用回答问题。"
+      "fallback": "请返回应用回答问题。",
+      "reply": "在此回答"
     }
   },
   "tool": {

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -1065,7 +1065,8 @@
     },
     "approval": {
       "title": "待审批",
-      "returnToApp": "返回应用以处理审批。"
+      "returnToApp": "返回应用以处理审批。",
+      "reply": "回复指引"
     },
     "askQuestions": {
       "title": "待回答问题",

--- a/apps/desktop/test/lib/ask-questions-notification-reply.test.mjs
+++ b/apps/desktop/test/lib/ask-questions-notification-reply.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildSingleTextQuestionNotificationReplyResult } from '../../src/lib/ask-questions-notification-reply.ts';
+
+function pendingQuestions(overrides = {}) {
+  return {
+    toolCallId: 'tool-1',
+    request: {
+      questions: [
+        {
+          id: 'question-1',
+          kind: 'text',
+          title: 'What should happen next?',
+          required: true,
+          options: [],
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+test('buildSingleTextQuestionNotificationReplyResult maps matching text reply', () => {
+  assert.deepEqual(
+    buildSingleTextQuestionNotificationReplyResult(pendingQuestions(), {
+      text: '  Proceed carefully  ',
+      context: {
+        questionToolCallId: 'tool-1',
+        questionId: 'question-1',
+      },
+    }),
+    {
+      status: 'answered',
+      answers: [
+        {
+          questionId: 'question-1',
+          title: 'What should happen next?',
+          kind: 'text',
+          answered: true,
+          text: 'Proceed carefully',
+        },
+      ],
+    },
+  );
+});
+
+test('buildSingleTextQuestionNotificationReplyResult ignores stale tool call', () => {
+  assert.equal(
+    buildSingleTextQuestionNotificationReplyResult(pendingQuestions(), {
+      text: 'Proceed',
+      context: {
+        questionToolCallId: 'old-tool',
+        questionId: 'question-1',
+      },
+    }),
+    undefined,
+  );
+});
+
+test('buildSingleTextQuestionNotificationReplyResult ignores non-text or multi-question prompts', () => {
+  assert.equal(
+    buildSingleTextQuestionNotificationReplyResult(
+      pendingQuestions({
+        request: {
+          questions: [
+            {
+              id: 'question-1',
+              kind: 'text',
+              title: 'First?',
+              required: true,
+              options: [],
+            },
+            {
+              id: 'question-2',
+              kind: 'text',
+              title: 'Second?',
+              required: true,
+              options: [],
+            },
+          ],
+        },
+      }),
+      {
+        text: 'Proceed',
+        context: {
+          questionToolCallId: 'tool-1',
+          questionId: 'question-1',
+        },
+      },
+    ),
+    undefined,
+  );
+});


### PR DESCRIPTION
## Summary

- 扩展桌面通知载荷，支持 macOS 按钮操作、文本回复和通知上下文
- 支持审批通知直接允许、拒绝或回复指引
- 支持单个文本 askQuestions 在通知内回答，复杂问卷继续回到应用处理
- 在用户离开应用且任务被阻挡或完成时触发 macOS Dock 弹跳

## Test plan

- [x] npm --prefix apps/desktop run build:electron
- [x] npm --prefix apps/desktop run build:renderer
- [x] node --experimental-strip-types --test test/lib/ask-questions-notification-reply.test.mjs
- [x] npx --yes tsx --test test/lib/ask-questions-notification-reply.test.mjs test/lib/windows-toast-xml.test.mjs