### PR TITLE
feat(host-internal): grep 全端切换 @vscode/ripgrep

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -14,6 +14,10 @@ files:
   - '!node_modules/spirit-agent-repo/**/*'
   - '!node_modules/**/spirit-agent-repo/**/*'
   - '!**/target/**/*'
+  - from: ../../node_modules/@vscode/ripgrep
+    to: node_modules/@vscode/ripgrep
+    filter:
+      - '**/*'
   - ../../packages/agent-core/dist/**/*
   - ../../packages/agent-core/package.json
   - ../../packages/host-internal/dist/**/*
@@ -24,6 +28,7 @@ asarUnpack:
   - node_modules/node-pty/**/*
   - node_modules/koffi/**/*
   - node_modules/@napi-rs/keyring/**/*
+  - node_modules/@vscode/ripgrep/**/*
 npmRebuild: true
 buildDependenciesFromSource: false
 publish: null

--- a/package-lock.json
+++ b/package-lock.json
@@ -1344,6 +1344,182 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/abbrev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -4367,6 +4543,7 @@
       "dependencies": {
         "@aws-sdk/client-bedrock": "^3.1068.0",
         "@spirit-agent/core": "0.2.6",
+        "@vscode/ripgrep": "^1.18.0",
         "fast-glob": "^3.3.3",
         "fflate": "^0.8.2",
         "glob": "^13.0.6",

--- a/packages/agent-core/src/host-tools.ts
+++ b/packages/agent-core/src/host-tools.ts
@@ -224,7 +224,7 @@ export function buildBuiltinHostToolDefinitions(
     ),
     functionTool(
       'grep',
-      'Search text within workspace file contents. By default query is matched as case-insensitive literal text; set is_regexp to true for a regular expression. Optionally pass glob to limit which files are searched. Use the glob tool to list paths only and list_directory_files for a single directory inventory.',
+      'Search text within workspace file contents. Respects .gitignore. By default query is matched as case-insensitive literal text; set is_regexp to true for a regular expression. Optionally pass glob to limit which files are searched. Use the glob tool to list paths only and list_directory_files for a single directory inventory.',
       {
         type: 'object',
         properties: {

--- a/packages/host-internal/NOTICE.md
+++ b/packages/host-internal/NOTICE.md
@@ -6,20 +6,24 @@ Scope constraint: exclude workspace-local/internal dependencies resolved via `wo
 
 ## Summary
 
-- MIT: 6 package(s)
+- MIT: 8 package(s)
 - Apache-2.0: 3 package(s)
 - BlueOak-1.0.0: 2 package(s)
 - BSD-3-Clause: 1 package(s)
 
 ## Components
 
-- **@aws-sdk/client-bedrock** 3.1068.0 — Apache-2.0
+- **@aws-sdk/client-bedrock** 3.1075.0 — Apache-2.0
   - https://github.com/aws/aws-sdk-js-v3
-- **@types/node** 25.6.0 — MIT
+- **@spirit-agent/core** 0.2.6 — MIT
+  - https://github.com/N123999/SpiritAgent
+- **@types/node** 25.9.4 — MIT
   - https://github.com/DefinitelyTyped/DefinitelyTyped
+- **@vscode/ripgrep** 1.18.0 — MIT
+  - https://github.com/microsoft/vscode-ripgrep
 - **fast-glob** 3.3.3 — MIT
   - https://github.com/mrmlnc/fast-glob
-- **fflate** 0.8.2 — MIT
+- **fflate** 0.8.3 — MIT
   - https://github.com/101arrowz/fflate
 - **glob** 13.0.6 — BlueOak-1.0.0
   - https://github.com/isaacs/node-glob
@@ -29,13 +33,13 @@ Scope constraint: exclude workspace-local/internal dependencies resolved via `wo
   - https://github.com/kaelzhang/node-ignore
 - **license-checker-rseidelsohn** 4.4.2 — BSD-3-Clause
   - https://github.com/RSeidelsohn/license-checker-rseidelsohn
-- **tar** 7.5.13 — BlueOak-1.0.0
+- **tar** 7.5.16 — BlueOak-1.0.0
   - https://github.com/isaacs/node-tar
 - **typescript** 5.9.3 — Apache-2.0
   - https://github.com/microsoft/TypeScript
 - **vscode-jsonrpc** 8.2.1 — MIT
   - https://github.com/Microsoft/vscode-languageserver-node
-- **vscode-languageserver-protocol** 3.18.0 — MIT
+- **vscode-languageserver-protocol** 3.18.1 — MIT
   - https://github.com/Microsoft/vscode-languageserver-node
 
 ## License texts
@@ -43,7 +47,7 @@ Scope constraint: exclude workspace-local/internal dependencies resolved via `wo
 ### Apache-2.0
 
 **Used by:**
-- @aws-sdk/client-bedrock 3.1068.0
+- @aws-sdk/client-bedrock 3.1075.0
 
 ```
                                 Apache License
@@ -596,7 +600,7 @@ software or this license, under any kind of legal claim.***
 ### BlueOak-1.0.0
 
 **Used by:**
-- tar 7.5.13
+- tar 7.5.16
 
 ```
 # Blue Oak Model License
@@ -690,7 +694,36 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### MIT
 
 **Used by:**
-- @types/node 25.6.0
+- @spirit-agent/core 0.2.6
+
+```
+MIT License
+
+Copyright (c) 2026 Spirit Studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### MIT
+
+**Used by:**
+- @types/node 25.9.4
 
 ```
     MIT License
@@ -714,6 +747,27 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE
+```
+
+### MIT
+
+**Used by:**
+- @vscode/ripgrep 1.18.0
+
+```
+vscode-ripgrep
+
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ### MIT
@@ -748,12 +802,12 @@ SOFTWARE.
 ### MIT
 
 **Used by:**
-- fflate 0.8.2
+- fflate 0.8.3
 
 ```
 MIT License
 
-Copyright (c) 2023 Arjun Barrett
+Copyright (c) 2026 Arjun Barrett
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -807,7 +861,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 **Used by:**
 - vscode-jsonrpc 8.2.1
-- vscode-languageserver-protocol 3.18.0
+- vscode-languageserver-protocol 3.18.1
 
 ```
 Copyright (c) Microsoft Corporation

--- a/packages/host-internal/package.json
+++ b/packages/host-internal/package.json
@@ -140,6 +140,8 @@
   "dependencies": {
     "@aws-sdk/client-bedrock": "^3.1068.0",
     "@spirit-agent/core": "0.2.6",
+    "@spirit-agent/host-internal": "file:",
+    "@vscode/ripgrep": "^1.18.0",
     "fast-glob": "^3.3.3",
     "fflate": "^0.8.2",
     "glob": "^13.0.6",

--- a/packages/host-internal/package.json
+++ b/packages/host-internal/package.json
@@ -140,7 +140,6 @@
   "dependencies": {
     "@aws-sdk/client-bedrock": "^3.1068.0",
     "@spirit-agent/core": "0.2.6",
-    "@spirit-agent/host-internal": "file:",
     "@vscode/ripgrep": "^1.18.0",
     "fast-glob": "^3.3.3",
     "fflate": "^0.8.2",

--- a/packages/host-internal/src/ripgrep-search.test.ts
+++ b/packages/host-internal/src/ripgrep-search.test.ts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+
+import {
+  buildRipgrepArgs,
+  formatGrepToolOutput,
+  runRipgrepSearch,
+} from './ripgrep-search.js';
+
+const execFileAsync = promisify(execFile);
+
+async function withTempWorkspace(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'spirit-ripgrep-search-'));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function initGitRepo(root: string): Promise<void> {
+  await execFileAsync('git', ['init'], { cwd: root, windowsHide: true });
+}
+
+test('buildRipgrepArgs maps text query to fixed-string case-insensitive search', () => {
+  const args = buildRipgrepArgs({
+    workspaceRoot: '/workspace',
+    query: 'needle',
+    isRegexp: false,
+  });
+
+  assert.deepEqual(args, [
+    '--json',
+    '--no-heading',
+    '--color=never',
+    '--line-number',
+    '--max-filesize',
+    '1M',
+    '--hidden',
+    '-F',
+    '-i',
+    'needle',
+    '/workspace',
+  ]);
+});
+
+test('buildRipgrepArgs maps regexp query without --hidden when glob is set', () => {
+  const args = buildRipgrepArgs({
+    workspaceRoot: 'C:\\repo',
+    query: 'runtime\\s+parity',
+    isRegexp: true,
+    globPattern: 'src/**/*.ts',
+  });
+
+  assert.deepEqual(args, [
+    '--json',
+    '--no-heading',
+    '--color=never',
+    '--line-number',
+    '--max-filesize',
+    '1M',
+    '-g',
+    'src/**/*.ts',
+    '-i',
+    '--regexp',
+    'runtime\\s+parity',
+    'C:\\repo',
+  ]);
+});
+
+test('runRipgrepSearch finds case-insensitive text matches', async () => {
+  await withTempWorkspace(async (root) => {
+    await writeFile(join(root, 'alpha.txt'), 'NEEDLE here\n', 'utf8');
+
+    const matches = await runRipgrepSearch({
+      workspaceRoot: root,
+      query: 'needle',
+      isRegexp: false,
+    });
+
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0]?.relativePath, 'alpha.txt');
+    assert.equal(matches[0]?.lineNumber, 1);
+    assert.equal(matches[0]?.lineText, 'NEEDLE here');
+  });
+});
+
+test('runRipgrepSearch supports case-insensitive regular expressions', async () => {
+  await withTempWorkspace(async (root) => {
+    await writeFile(join(root, 'alpha.txt'), 'Runtime    parity\n', 'utf8');
+    await writeFile(join(root, 'beta.txt'), 'no match here\n', 'utf8');
+
+    const matches = await runRipgrepSearch({
+      workspaceRoot: root,
+      query: 'runtime\\s+parity',
+      isRegexp: true,
+    });
+
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0]?.relativePath, 'alpha.txt');
+    assert.match(matches[0]?.lineText ?? '', /Runtime\s+parity/u);
+  });
+});
+
+test('runRipgrepSearch limits search to glob pattern', async () => {
+  await withTempWorkspace(async (root) => {
+    await mkdir(join(root, 'src'), { recursive: true });
+    await mkdir(join(root, 'docs'), { recursive: true });
+    await writeFile(join(root, 'src', 'app.ts'), 'needle here\n', 'utf8');
+    await writeFile(join(root, 'docs', 'readme.md'), 'needle here\n', 'utf8');
+
+    const matches = await runRipgrepSearch({
+      workspaceRoot: root,
+      query: 'needle',
+      globPattern: 'src/**/*.ts',
+    });
+
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0]?.relativePath, 'src/app.ts');
+  });
+});
+
+test('runRipgrepSearch returns no matches for missing query hits', async () => {
+  await withTempWorkspace(async (root) => {
+    await writeFile(join(root, 'alpha.txt'), 'nothing here\n', 'utf8');
+
+    const matches = await runRipgrepSearch({
+      workspaceRoot: root,
+      query: 'needle',
+    });
+
+    assert.deepEqual(matches, []);
+  });
+});
+
+test('runRipgrepSearch rejects invalid regular expressions', async () => {
+  await withTempWorkspace(async (root) => {
+    await writeFile(join(root, 'alpha.txt'), 'value\n', 'utf8');
+
+    await assert.rejects(
+      () =>
+        runRipgrepSearch({
+          workspaceRoot: root,
+          query: '(',
+          isRegexp: true,
+        }),
+      /无效正则/u,
+    );
+  });
+});
+
+test('runRipgrepSearch skips files matched by .gitignore', async () => {
+  await withTempWorkspace(async (root) => {
+    await initGitRepo(root);
+    await writeFile(join(root, '.gitignore'), 'ignored.txt\n', 'utf8');
+    await writeFile(join(root, 'ignored.txt'), 'needle here\n', 'utf8');
+    await writeFile(join(root, 'tracked.txt'), 'needle here\n', 'utf8');
+
+    const matches = await runRipgrepSearch({
+      workspaceRoot: root,
+      query: 'needle',
+    });
+
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0]?.relativePath, 'tracked.txt');
+  });
+});
+
+test('runRipgrepSearch searches hidden directories in full-workspace mode', async () => {
+  await withTempWorkspace(async (root) => {
+    await mkdir(join(root, '.cursor'), { recursive: true });
+    await writeFile(join(root, '.cursor', 'rules.md'), 'needle in hidden dir\n', 'utf8');
+
+    const matches = await runRipgrepSearch({
+      workspaceRoot: root,
+      query: 'needle',
+    });
+
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0]?.relativePath, '.cursor/rules.md');
+  });
+});
+
+test('formatGrepToolOutput preserves grep tool summary shape', () => {
+  const output = formatGrepToolOutput({
+    query: 'needle',
+    isRegexp: false,
+    globPattern: 'src/**/*.ts',
+    matches: [
+      {
+        relativePath: 'src/app.ts',
+        lineNumber: 1,
+        lineText: 'needle here',
+      },
+    ],
+  });
+
+  assert.match(output, /^\[tool\] 搜索\(文本\): needle\n/u);
+  assert.match(output, /glob: src\/\*\*\/\*\.ts/u);
+  assert.match(output, /命中片段\nsrc\/app\.ts:1 \| needle here\n/u);
+  assert.match(output, /涉及文件\nsrc\/app\.ts\n/u);
+});
+
+test('formatGrepToolOutput reports empty results', () => {
+  const output = formatGrepToolOutput({
+    query: 'needle',
+    isRegexp: true,
+    globPattern: null,
+    matches: [],
+  });
+
+  assert.equal(output, '[tool] 搜索(正则): needle\n未搜索到文件');
+});

--- a/packages/host-internal/src/ripgrep-search.ts
+++ b/packages/host-internal/src/ripgrep-search.ts
@@ -1,0 +1,180 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import path from 'node:path';
+import { rgPath } from '@vscode/ripgrep';
+
+const MAX_SEARCH_FILE_SIZE = '1M';
+
+export type RipgrepSearchOptions = {
+  workspaceRoot: string;
+  query: string;
+  isRegexp?: boolean;
+  globPattern?: string | null;
+};
+
+export type RipgrepMatch = {
+  relativePath: string;
+  lineNumber: number;
+  lineText: string;
+};
+
+type RipgrepMatchLine = {
+  path: { text: string };
+  lines: { text: string };
+  line_number: number;
+};
+
+type RipgrepJsonLine =
+  | {
+      type: 'match';
+      data: RipgrepMatchLine;
+    }
+  | {
+      type: string;
+      data?: unknown;
+    };
+
+export function normalizeSearchLine(line: string): string {
+  return line.replace(/\r?\n$/u, '').trim();
+}
+
+export function buildRipgrepArgs(options: RipgrepSearchOptions): string[] {
+  const { query, isRegexp = false, globPattern, workspaceRoot } = options;
+  const args: string[] = [
+    '--json',
+    '--no-heading',
+    '--color=never',
+    '--line-number',
+    '--max-filesize',
+    MAX_SEARCH_FILE_SIZE,
+  ];
+
+  if (globPattern === null || globPattern === undefined) {
+    args.push('--hidden');
+  }
+
+  if (globPattern !== null && globPattern !== undefined) {
+    args.push('-g', globPattern);
+  }
+
+  if (isRegexp) {
+    args.push('-i', '--regexp', query);
+  } else if (query.startsWith('-')) {
+    args.push('-F', '-i', '--', query);
+  } else {
+    args.push('-F', '-i', query);
+  }
+
+  args.push(workspaceRoot);
+  return args;
+}
+
+function toRelativePath(workspaceRoot: string, filePath: string): string {
+  const rel = path.relative(workspaceRoot, filePath).replace(/\\/gu, '/');
+  return rel || '.';
+}
+
+function mapRipgrepRegexError(stderr: string): Error {
+  const trimmed = stderr.trim();
+  if (!trimmed) {
+    return new Error('无效正则');
+  }
+  const message = trimmed.split(/\r?\n/u).find((line) => line.trim().length > 0) ?? trimmed;
+  return new Error(`无效正则: ${message}`);
+}
+
+export async function runRipgrepSearch(options: RipgrepSearchOptions): Promise<RipgrepMatch[]> {
+  const args = buildRipgrepArgs(options);
+  const child = spawn(rgPath, args, {
+    cwd: options.workspaceRoot,
+    windowsHide: true,
+  });
+
+  const matches: RipgrepMatch[] = [];
+  let stdout = '';
+  let stderr = '';
+
+  child.stdout.on('data', (chunk: Buffer | string) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on('data', (chunk: Buffer | string) => {
+    stderr += chunk.toString();
+  });
+
+  const [exitCode] = await once(child, 'close');
+
+  if (exitCode === 2) {
+    if (options.isRegexp) {
+      throw mapRipgrepRegexError(stderr);
+    }
+    throw new Error(stderr.trim() || `ripgrep failed with exit code ${exitCode}`);
+  }
+
+  if (exitCode !== 0 && exitCode !== 1) {
+    throw new Error(stderr.trim() || `ripgrep failed with exit code ${exitCode}`);
+  }
+
+  for (const line of stdout.split(/\r?\n/u)) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    let parsed: RipgrepJsonLine;
+    try {
+      parsed = JSON.parse(line) as RipgrepJsonLine;
+    } catch {
+      continue;
+    }
+
+    if (parsed.type !== 'match') {
+      continue;
+    }
+
+    const matchData = (parsed as { type: 'match'; data: RipgrepMatchLine }).data;
+    matches.push({
+      relativePath: toRelativePath(options.workspaceRoot, matchData.path.text),
+      lineNumber: matchData.line_number,
+      lineText: normalizeSearchLine(matchData.lines.text),
+    });
+  }
+
+  return matches;
+}
+
+export function formatGrepToolOutput(params: {
+  query: string;
+  isRegexp: boolean;
+  globPattern: string | null;
+  matches: RipgrepMatch[];
+}): string {
+  const { query, isRegexp, globPattern, matches } = params;
+  const searchMode = isRegexp ? '正则' : '文本';
+  const files = new Set<string>();
+
+  for (const match of matches) {
+    files.add(match.relativePath);
+  }
+
+  if (files.size === 0) {
+    let out = `[tool] 搜索(${searchMode}): ${query}`;
+    if (globPattern !== null) {
+      out += `\nglob: ${globPattern}`;
+    }
+    out += '\n未搜索到文件';
+    return out;
+  }
+
+  let out = `[tool] 搜索(${searchMode}): ${query}`;
+  if (globPattern !== null) {
+    out += `\nglob: ${globPattern}`;
+  }
+  out += '\n命中片段\n';
+  for (const match of matches) {
+    out += `${match.relativePath}:${match.lineNumber} | ${match.lineText}\n`;
+  }
+  out += '\n涉及文件\n';
+  for (const file of [...files].sort((left, right) => left.localeCompare(right))) {
+    out += `${file}\n`;
+  }
+  return out;
+}

--- a/packages/host-internal/src/ripgrep-search.ts
+++ b/packages/host-internal/src/ripgrep-search.ts
@@ -1,5 +1,4 @@
 import { spawn } from 'node:child_process';
-import { once } from 'node:events';
 import path from 'node:path';
 import { rgPath } from '@vscode/ripgrep';
 
@@ -83,6 +82,17 @@ function mapRipgrepRegexError(stderr: string): Error {
   return new Error(`无效正则: ${message}`);
 }
 
+function waitForChildClose(child: ReturnType<typeof spawn>): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    child.once('error', (error: Error) => {
+      reject(error);
+    });
+    child.once('close', (code) => {
+      resolve(code);
+    });
+  });
+}
+
 export async function runRipgrepSearch(options: RipgrepSearchOptions): Promise<RipgrepMatch[]> {
   const args = buildRipgrepArgs(options);
   const child = spawn(rgPath, args, {
@@ -101,7 +111,7 @@ export async function runRipgrepSearch(options: RipgrepSearchOptions): Promise<R
     stderr += chunk.toString();
   });
 
-  const [exitCode] = await once(child, 'close');
+  const exitCode = await waitForChildClose(child);
 
   if (exitCode === 2) {
     if (options.isRegexp) {

--- a/packages/host-internal/src/tools.test.ts
+++ b/packages/host-internal/src/tools.test.ts
@@ -1,13 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
+import { promisify } from 'node:util';
 
 import {
   NodeHostToolService,
   type HostToolExecutionOutput,
 } from './tools.js';
+
+const execFileAsync = promisify(execFile);
 
 const ONE_PIXEL_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Zp1cAAAAASUVORK5CYII=';
@@ -541,6 +545,31 @@ test('grep rejects invalid regular expressions with a clear error', async () => 
         }),
       /无效正则/u,
     );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('grep skips files matched by .gitignore', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-host-tools-search-gitignore-'));
+  const spiritDataDir = join(workspaceRoot, '.spirit-data');
+
+  try {
+    await mkdir(spiritDataDir, { recursive: true });
+    await execFileAsync('git', ['init'], { cwd: workspaceRoot, windowsHide: true });
+    await writeFile(join(workspaceRoot, '.gitignore'), 'ignored.txt\n', 'utf8');
+    await writeFile(join(workspaceRoot, 'ignored.txt'), 'needle here\n', 'utf8');
+    await writeFile(join(workspaceRoot, 'tracked.txt'), 'needle here\n', 'utf8');
+
+    const service = new NodeHostToolService({ workspaceRoot, spiritDataDir });
+    const output = await service.execute({
+      name: 'grep',
+      query: 'needle',
+    });
+
+    assertTextToolOutput(output);
+    assert.match(output, /tracked\.txt:1 \| needle here/u);
+    assert.doesNotMatch(output, /ignored\.txt/u);
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -22,6 +22,10 @@ import {
 } from '@spirit-agent/core';
 
 import { applyDiff } from './apply-diff.js';
+import {
+  formatGrepToolOutput,
+  runRipgrepSearch,
+} from './ripgrep-search.js';
 import { resolveCompactionArchivesDir } from './compaction-archive.js';
 import {
   defaultShellForPty,
@@ -92,28 +96,10 @@ const WEB_FETCH_TIMEOUT_MS = 20_000;
 const WEB_FETCH_IMAGE_CACHE_DIR = 'tool-web-fetch-images';
 const WEB_FETCH_IMAGE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const WEB_FETCH_IMAGE_CACHE_MAX_FILES = 128;
-const MAX_SEARCH_FILE_BYTES = 1_000_000;
 const BROWSER_USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36';
 
 const SEARCH_IGNORE_DIR_NAMES = new Set(['.git', 'target', 'node_modules']);
-const BINARY_EXTENSIONS = new Set([
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-  '.ico',
-  '.zip',
-  '.gz',
-  '.7z',
-  '.pdf',
-  '.exe',
-  '.dll',
-  '.so',
-  '.dylib',
-  '.class',
-]);
 
 export type HostJsonPrimitive = string | number | boolean | null;
 export type HostJsonValue = HostJsonPrimitive | HostJsonObject | HostJsonValue[];
@@ -1617,113 +1603,19 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
         ? normalizeWorkspaceGlobPattern(inputGlob)
         : null;
 
-    const searchMode = isRegexp ? '正则' : '文本';
-    const matchesLine = createSearchLineMatcher(needle, isRegexp);
-    const files = new Set<string>();
-    const hits: string[] = [];
+    const matches = await runRipgrepSearch({
+      workspaceRoot: this.workspaceRoot,
+      query: needle,
+      isRegexp,
+      globPattern,
+    });
 
-    const visitFile = async (filePath: string): Promise<void> => {
-      const ext = path.extname(filePath).toLowerCase();
-      if (BINARY_EXTENSIONS.has(ext)) {
-        return;
-      }
-
-      let st;
-      try {
-        st = await lstat(filePath);
-      } catch {
-        return;
-      }
-      if (!st.isFile() || st.size > MAX_SEARCH_FILE_BYTES) {
-        return;
-      }
-
-      let content: string;
-      try {
-        content = await readFile(filePath, 'utf8');
-      } catch {
-        return;
-      }
-
-      const rel = path.relative(this.workspaceRoot, filePath).replace(/\\/gu, '/');
-      const relDisplay = rel || '.';
-      const lines = content.split(/\r?\n/u);
-
-      for (let index = 0; index < lines.length; index += 1) {
-        const line = lines[index] ?? '';
-        if (!matchesLine(line)) {
-          continue;
-        }
-
-        files.add(relDisplay);
-        hits.push(`${relDisplay}:${index + 1} | ${normalizeSearchLine(line)}`);
-      }
-    };
-
-    if (globPattern !== null) {
-      const relativePaths = (
-        await globPaths(globPattern, {
-          cwd: this.workspaceRoot,
-          absolute: false,
-          nodir: true,
-          dot: true,
-          windowsPathsNoEscape: true,
-          ignore: [...SEARCH_IGNORE_DIR_NAMES].map((name) => `**/${name}/**`),
-        })
-      )
-        .map((value) => value.replace(/\\/gu, '/'))
-        .sort((left, right) => left.localeCompare(right));
-
-      for (const relPath of relativePaths) {
-        await visitFile(path.join(this.workspaceRoot, relPath));
-      }
-    } else {
-      const walk = async (dir: string): Promise<void> => {
-        let entries;
-        try {
-          entries = await readdir(dir, { withFileTypes: true });
-        } catch {
-          return;
-        }
-
-        for (const entry of entries) {
-          const full = path.join(dir, entry.name);
-          if (entry.isDirectory()) {
-            if (SEARCH_IGNORE_DIR_NAMES.has(entry.name)) {
-              continue;
-            }
-            await walk(full);
-          } else if (entry.isFile()) {
-            await visitFile(full);
-          }
-        }
-      };
-
-      await walk(this.workspaceRoot);
-    }
-
-    if (files.size === 0) {
-      let out = `[tool] 搜索(${searchMode}): ${query}`;
-      if (globPattern !== null) {
-        out += `\nglob: ${globPattern}`;
-      }
-      out += '\n未搜索到文件';
-      return out;
-    }
-
-    let out = `[tool] 搜索(${searchMode}): ${query}`;
-    if (globPattern !== null) {
-      out += `\nglob: ${globPattern}`;
-    }
-    out += '\n命中片段\n';
-    for (const hit of hits) {
-      out += `${hit}\n`;
-    }
-    out += '\n涉及文件\n';
-    for (const file of [...files].sort((left, right) => left.localeCompare(right))) {
-      out += `${file}\n`;
-    }
-    return out;
+    return formatGrepToolOutput({
+      query,
+      isRegexp,
+      globPattern,
+      matches,
+    });
   }
 
   private async executeShell(
@@ -2341,22 +2233,6 @@ function normalizeWorkspaceGlobPattern(input: string): string {
   return normalized;
 }
 
-function createSearchLineMatcher(query: string, isRegexp: boolean): (line: string) => boolean {
-  if (!isRegexp) {
-    const needleLower = query.toLowerCase();
-    return (line: string) => line.toLowerCase().includes(needleLower);
-  }
-
-  let regexp: RegExp;
-  try {
-    regexp = new RegExp(query, 'i');
-  } catch (error) {
-    throw new Error(`无效正则: ${error instanceof Error ? error.message : String(error)}`);
-  }
-
-  return (line: string) => regexp.test(line);
-}
-
 function isImageInputBlocked(
   profile: HostToolModelCompatibilityProfile | undefined,
 ): boolean {
@@ -2484,10 +2360,6 @@ function validateQuestions(questions: HostAskQuestionsQuestionSpec[]): void {
       }
     }
   }
-}
-
-function normalizeSearchLine(line: string): string {
-  return line.replace(/\r?\n$/u, '').trim();
 }
 
 function countSubstringOccurrences(haystack: string, needle: string): number {

--- a/scripts/release/bundle-cli.mjs
+++ b/scripts/release/bundle-cli.mjs
@@ -190,6 +190,9 @@ async function ensureNodeRuntime(targetInfo) {
 
 async function copyHoistedHostInternalRipgrep(destinationRoot) {
   const destination = path.join(destinationRoot, 'packages', 'host-internal', 'node_modules', '@vscode', 'ripgrep');
+  if (await pathExists(destination)) {
+    return;
+  }
   const hoistedRipgrep = path.join(repoRoot, 'node_modules', '@vscode', 'ripgrep');
   if (!(await pathExists(hoistedRipgrep))) {
     return;
@@ -206,7 +209,6 @@ async function copyPackageDist(packageName, destinationRoot) {
   const nodeModules = path.join(sourceRoot, 'node_modules');
   if (await pathExists(nodeModules)) {
     await cp(nodeModules, path.join(destination, 'node_modules'), { recursive: true });
-    return;
   }
   if (packageName === 'host-internal') {
     await copyHoistedHostInternalRipgrep(destinationRoot);

--- a/scripts/release/bundle-cli.mjs
+++ b/scripts/release/bundle-cli.mjs
@@ -188,6 +188,16 @@ async function ensureNodeRuntime(targetInfo) {
   return extractedRoot;
 }
 
+async function copyHoistedHostInternalRipgrep(destinationRoot) {
+  const destination = path.join(destinationRoot, 'packages', 'host-internal', 'node_modules', '@vscode', 'ripgrep');
+  const hoistedRipgrep = path.join(repoRoot, 'node_modules', '@vscode', 'ripgrep');
+  if (!(await pathExists(hoistedRipgrep))) {
+    return;
+  }
+  await mkdir(path.dirname(destination), { recursive: true });
+  await cp(hoistedRipgrep, destination, { recursive: true });
+}
+
 async function copyPackageDist(packageName, destinationRoot) {
   const sourceRoot = path.join(repoRoot, 'packages', packageName);
   const destination = path.join(destinationRoot, 'packages', packageName);
@@ -196,6 +206,10 @@ async function copyPackageDist(packageName, destinationRoot) {
   const nodeModules = path.join(sourceRoot, 'node_modules');
   if (await pathExists(nodeModules)) {
     await cp(nodeModules, path.join(destination, 'node_modules'), { recursive: true });
+    return;
+  }
+  if (packageName === 'host-internal') {
+    await copyHoistedHostInternalRipgrep(destinationRoot);
   }
 }
 


### PR DESCRIPTION
## Summary

- 在 `host-internal` 用 `@vscode/ripgrep` 替换原 JS `readFile` 全仓扫描，CLI 与 Desktop 共用 `ripgrep-search` 模块
- 尊重 `.gitignore`、全仓启用 `--hidden`、保留 `--max-filesize 1M` 与既有 grep 工具输出格式
- Desktop 打包解包 ripgrep 原生二进制；CLI bundle 在 workspace hoist 场景下复制 `@vscode/ripgrep`
- 更新 `agent-core` grep 工具描述，注明 respects `.gitignore`

## Test plan

- [x] `npm --prefix packages/host-internal run build:tsc`
- [x] `node --test dist/ripgrep-search.test.js dist/tools.test.js`（42/42 通过）
- [x] 全仓 grep `disableHoverableContent` 冒烟（~404ms，明显快于旧 JS 实现）
- [x] `npm --prefix apps/desktop run build:host-internal` 构建通过
- [x] NOTICE 含 `@vscode/ripgrep` 许可条目