### PR TITLE
feat(desktop): 错误提示迁移至 Sonner toast

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -47,6 +47,7 @@
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "shadcn": "^4.4.0",
+        "sonner": "^2.0.7",
         "streamdown": "^2.5.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
@@ -16373,6 +16374,16 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -78,6 +78,7 @@
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.4.0",
+    "sonner": "^2.0.7",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -26,6 +26,7 @@ import { useConversationViewState } from "@/hooks/useConversationViewState";
 import { useUiLayoutScale } from "@/hooks/useUiLayoutScale";
 import { useDesktopKeyboardShortcuts } from "@/hooks/useDesktopKeyboardShortcuts";
 import { useDesktopRuntime } from "@/hooks/useDesktopRuntime";
+import { useDesktopRuntimeErrorToast } from "@/hooks/use-desktop-runtime-error-toast";
 import { useDesktopShellEffects } from "@/hooks/useDesktopShellEffects";
 import { useFont } from "@/hooks/useFont";
 import { useMessageRewind } from "@/hooks/useMessageRewind";
@@ -57,6 +58,7 @@ export default function App() {
   const { clickablePointerCursor, setClickablePointerCursor } = useClickablePointerCursor();
   const uiLayoutScale = useUiLayoutScale();
   const runtime = useDesktopRuntime();
+  useDesktopRuntimeErrorToast(runtime.runtimeError);
   const snapshot = runtime.snapshot;
   /** 与 Host API 的 `kind` 解耦：壳可能是 Electron，但仍通过 Vite 代理走 Web Host（侧栏会显示 Localhost Web Host）。Mica 与 `spirit-desktop-native` 仍应对 Electron 窗口生效。 */
   const isElectronShell = isElectronChrome();
@@ -222,7 +224,6 @@ export default function App() {
     return (
       <WebHostPairingGate
         busy={runtime.busyAction === "bootstrap"}
-        error={runtime.runtimeError}
         onPair={runtime.pairWebHost}
       />
     );
@@ -353,7 +354,6 @@ export default function App() {
               onClickablePointerCursorChange={setClickablePointerCursor}
               settings={runtime.settings}
               snapshot={snapshot}
-              runtimeError={runtime.runtimeError}
               apiReady={runtime.apiReady}
               busyAction={runtime.busyAction}
               modelsBusy={runtime.busyAction === "models"}
@@ -680,7 +680,6 @@ export default function App() {
         onOpenChange={composer.handleBranchCheckoutDialogOpenChange}
         branchCheckoutBlockedByChanges={composer.branchCheckoutBlockedByChanges}
         git={snapshot?.git}
-        runtimeError={runtime.runtimeError}
         commitBusy={composer.commitBusy}
         onCancel={composer.cancelBranchCheckoutDialog}
         onConfirmCheckout={composer.confirmBranchCheckoutAndSend}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -490,7 +490,6 @@ export default function App() {
               snapshot={snapshot}
               apiReady={runtime.apiReady}
               busyAction={runtime.busyAction}
-              runtimeError={runtime.runtimeError}
               onListMarketplaceExtensions={runtime.listMarketplaceExtensions}
               onGetMarketplaceExtensionDetail={runtime.getMarketplaceExtensionDetail}
               onGetMarketplaceExtensionReadme={runtime.getMarketplaceExtensionReadme}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -27,6 +27,7 @@ import { useUiLayoutScale } from "@/hooks/useUiLayoutScale";
 import { useDesktopKeyboardShortcuts } from "@/hooks/useDesktopKeyboardShortcuts";
 import { useDesktopRuntime } from "@/hooks/useDesktopRuntime";
 import { useDesktopRuntimeErrorToast } from "@/hooks/use-desktop-runtime-error-toast";
+import { useDesktopQuestionErrorToast } from "@/hooks/use-desktop-question-error-toast";
 import { useDesktopShellEffects } from "@/hooks/useDesktopShellEffects";
 import { useFont } from "@/hooks/useFont";
 import { useMessageRewind } from "@/hooks/useMessageRewind";
@@ -59,6 +60,7 @@ export default function App() {
   const uiLayoutScale = useUiLayoutScale();
   const runtime = useDesktopRuntime();
   useDesktopRuntimeErrorToast(runtime.runtimeError);
+  useDesktopQuestionErrorToast(runtime.questionError);
   const snapshot = runtime.snapshot;
   /** 与 Host API 的 `kind` 解耦：壳可能是 Electron，但仍通过 Vite 代理走 Web Host（侧栏会显示 Localhost Web Host）。Mica 与 `spirit-desktop-native` 仍应对 Electron 窗口生效。 */
   const isElectronShell = isElectronChrome();

--- a/apps/desktop/src/components/branch-checkout-dialog.tsx
+++ b/apps/desktop/src/components/branch-checkout-dialog.tsx
@@ -17,7 +17,6 @@ export type BranchCheckoutDialogProps = {
   onOpenChange: (open: boolean) => void;
   branchCheckoutBlockedByChanges: boolean;
   git: DesktopSnapshot["git"] | undefined;
-  runtimeError: string;
   commitBusy: boolean;
   onCancel: () => void;
   onConfirmCheckout: () => void;
@@ -29,7 +28,6 @@ export function BranchCheckoutDialog({
   onOpenChange,
   branchCheckoutBlockedByChanges,
   git,
-  runtimeError,
   commitBusy,
   onCancel,
   onConfirmCheckout,
@@ -59,9 +57,6 @@ export function BranchCheckoutDialog({
             )}
           </DialogDescription>
         </DialogHeader>
-        {runtimeError ? (
-          <p className="text-sm leading-relaxed text-destructive">{runtimeError}</p>
-        ) : null}
         <DialogFooter className="gap-2 sm:justify-end">
           <Button
             type="button"

--- a/apps/desktop/src/components/conversation/composer-dock.tsx
+++ b/apps/desktop/src/components/conversation/composer-dock.tsx
@@ -233,11 +233,6 @@ export const ComposerDock = forwardRef<HTMLDivElement, ComposerDockProps>(functi
               ) : null}
             </div>
           ) : null}
-          {runtime.runtimeError ? (
-            <div className="rounded-md border border-destructive/35 bg-destructive/10 px-2.5 py-2 text-xs leading-relaxed text-destructive">
-              {runtime.runtimeError}
-            </div>
-          ) : null}
 
           {rewindWarnings.length > 0 ? (
             <div className="rounded-md border border-amber-500/35 bg-amber-500/10 px-2.5 py-2 text-xs leading-relaxed text-amber-900 dark:text-amber-100">

--- a/apps/desktop/src/components/conversation/composer-dock.tsx
+++ b/apps/desktop/src/components/conversation/composer-dock.tsx
@@ -273,7 +273,6 @@ export const ComposerDock = forwardRef<HTMLDivElement, ComposerDockProps>(functi
             <PendingQuestionsCard
               pendingQuestions={runtime.pendingQuestions}
               questionDrafts={runtime.questionDrafts}
-              questionError={runtime.questionError}
               questionsBusy={runtime.busyAction === "questions"}
               onUpdateDraft={runtime.updateQuestionDraft}
               onSubmitQuestions={() => void runtime.submitQuestions()}

--- a/apps/desktop/src/components/marketplace-view.tsx
+++ b/apps/desktop/src/components/marketplace-view.tsx
@@ -21,6 +21,7 @@ import {
   instantHoverMotionClass,
 } from "@/lib/desktop-chrome";
 import { desktopMicaTintClass, desktopMicaTintInnerClass } from "@/lib/desktop-mica-surface";
+import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
 import { cn } from "@/lib/utils";
 import type {
   DesktopExtensionListItem,
@@ -40,7 +41,6 @@ type MarketplaceViewProps = {
   } | null;
   apiReady: boolean;
   busyAction: string;
-  runtimeError: string;
   onListMarketplaceExtensions: () => Promise<DesktopMarketplaceCatalogItem[]>;
   onGetMarketplaceExtensionDetail: (extensionId: string) => Promise<DesktopMarketplaceDetail>;
   onGetMarketplaceExtensionReadme: (extensionId: string) => Promise<string>;
@@ -109,7 +109,6 @@ export function MarketplaceView({
   snapshot,
   apiReady,
   busyAction,
-  runtimeError,
   onListMarketplaceExtensions,
   onGetMarketplaceExtensionDetail,
   onGetMarketplaceExtensionReadme,
@@ -133,7 +132,10 @@ export function MarketplaceView({
 
   const installedExtensions = snapshot?.extensionsList ?? [];
   const marketplaceBusy = busyAction === "marketplace";
-  const effectiveError = runtimeError || localError;
+
+  useEffect(() => {
+    showDesktopErrorToast(localError, "marketplace-local-error");
+  }, [localError]);
 
   const filteredCatalog = catalog.filter((item) => {
     const query = searchText.trim().toLowerCase();
@@ -548,11 +550,6 @@ export function MarketplaceView({
           ) : (
             <ScrollArea className="min-h-0 flex-1" type="hover" scrollHideDelay={450}>
               <div className={cn("mx-auto w-full space-y-4 px-3 pb-12 pt-5", MARKETPLACE_READING_W)}>
-                {effectiveError ? (
-                  <div className="rounded-md border border-destructive/35 bg-destructive/10 px-3 py-2 text-xs leading-relaxed text-destructive">
-                    {effectiveError}
-                  </div>
-                ) : null}
 
                 {/* 详情顶栏：图标与文本垂直居中；正文压缩为标题行 + 单行摘要（作者并入摘要前缀） */}
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">

--- a/apps/desktop/src/components/pending-questions-card.tsx
+++ b/apps/desktop/src/components/pending-questions-card.tsx
@@ -26,7 +26,6 @@ const questionOptionClass = cn(
 type PendingQuestionsCardProps = {
   pendingQuestions: PendingQuestionsSnapshot;
   questionDrafts: Record<string, QuestionDraft>;
-  questionError: string;
   questionsBusy: boolean;
   onUpdateDraft(
     questionId: string,
@@ -58,7 +57,6 @@ function isQuestionDraftAnswered(
 export function PendingQuestionsCard({
   pendingQuestions,
   questionDrafts,
-  questionError,
   questionsBusy,
   onUpdateDraft,
   onSubmitQuestions,
@@ -281,12 +279,6 @@ export function PendingQuestionsCard({
               placeholder={question.customInputPlaceholder ?? t("app.supplementOption")}
               disabled={questionsBusy}
             />
-          </div>
-        ) : null}
-
-        {questionError ? (
-          <div className="rounded-md border border-destructive/40 bg-destructive/10 px-2.5 py-2 text-xs text-destructive">
-            {questionError}
           </div>
         ) : null}
 

--- a/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { GitHubDeviceLoginDialog } from "@/components/github-device-login-dialog";
 import { GitHubMarkIcon } from "@/components/github-mark-icon";
 import { Button } from "@/components/ui/button";
+import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
 import {
   useGitHubDeviceLogin,
   type GitHubDeviceLoginRuntime,
@@ -41,6 +42,13 @@ export function IntegrationsSettingsPanel({
     void refreshAuthStatus();
   }, [isElectronShell, refreshAuthStatus, dialogOpen, loadingAuth]);
 
+  useEffect(() => {
+    if (!isElectronShell || dialogOpen) {
+      return;
+    }
+    showDesktopErrorToast(error ?? "", "github-integration-error");
+  }, [isElectronShell, dialogOpen, error]);
+
   const openExternalUrl = useCallback((url: string) => {
     void window.spiritDesktop?.openExternalUrl(url);
   }, []);
@@ -72,12 +80,6 @@ export function IntegrationsSettingsPanel({
 
       {!isElectronShell ? (
         <p className="text-sm text-muted-foreground">{t("settings.integrationsDesktopOnly")}</p>
-      ) : null}
-
-      {error && isElectronShell && !dialogOpen ? (
-        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-          {error}
-        </div>
       ) : null}
 
       <div className="divide-y divide-border/35 rounded-lg border border-border/40 bg-background/80">

--- a/apps/desktop/src/components/settings/settings-view.tsx
+++ b/apps/desktop/src/components/settings/settings-view.tsx
@@ -34,7 +34,6 @@ export function SettingsView({
   onClickablePointerCursorChange,
   settings,
   snapshot,
-  runtimeError,
   apiReady,
   modelsBusy,
   modelsPreviewBusy,
@@ -109,12 +108,6 @@ export function SettingsView({
                 {t(settingsPageTitleKey[tab])}
                 {tab === "dreams" ? <Badge variant="outline">Beta</Badge> : null}
               </h1>
-            ) : null}
-
-            {runtimeError ? (
-              <div className="mb-4 rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-                {runtimeError}
-              </div>
             ) : null}
 
             {extensionSettingsItem ? (

--- a/apps/desktop/src/components/settings/types.ts
+++ b/apps/desktop/src/components/settings/types.ts
@@ -58,7 +58,6 @@ export type SettingsViewProps = {
   onClickablePointerCursorChange: (enabled: boolean) => void;
   settings: SettingsFormState;
   snapshot: DesktopSnapshot | null;
-  runtimeError: string;
   apiReady: boolean;
   busyAction: string;
   modelsBusy: boolean;

--- a/apps/desktop/src/components/ui/sonner.tsx
+++ b/apps/desktop/src/components/ui/sonner.tsx
@@ -28,6 +28,8 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       style={
         {
+          // sonner 注入样式硬编码 Segoe UI 等系统栈，须显式接应用 --font-sans（Geist / 用户自选）
+          fontFamily: "var(--font-sans)",
           "--normal-bg": "var(--popover)",
           "--normal-text": "var(--popover-foreground)",
           "--normal-border": "var(--border)",

--- a/apps/desktop/src/components/ui/sonner.tsx
+++ b/apps/desktop/src/components/ui/sonner.tsx
@@ -1,0 +1,47 @@
+import { useTheme } from "@/hooks/useTheme"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/apps/desktop/src/components/web-host-pairing-gate.tsx
+++ b/apps/desktop/src/components/web-host-pairing-gate.tsx
@@ -13,29 +13,27 @@ import {
 } from "@/components/ui/card";
 import { DesktopFormInput } from "@/components/ui/desktop-form-field";
 import { Label } from "@/components/ui/label";
+import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
 
 export function WebHostPairingGate({
   busy,
-  error,
   onPair,
 }: {
   busy: boolean;
-  error: string;
   onPair(code: string): Promise<boolean>;
 }) {
   const { t } = useTranslation();
   const [code, setCode] = useState("");
-  const [localError, setLocalError] = useState("");
 
   const submit = () => {
     const normalized = code.trim();
     if (!normalized) {
-      setLocalError(t('app.enterPairingCode'));
+      showDesktopErrorToast(t("app.enterPairingCode"), "web-host-pairing-local");
       return;
     }
     void onPair(normalized).then((ok) => {
       if (!ok) {
-        setLocalError(t('app.pairingFailed'));
+        showDesktopErrorToast(t("app.pairingFailed"), "web-host-pairing-local");
       }
     });
   };
@@ -56,7 +54,6 @@ export function WebHostPairingGate({
               inputMode="numeric"
               autoComplete="one-time-code"
               onChange={(event) => {
-                setLocalError("");
                 setCode(event.target.value);
               }}
               onKeyDown={(event) => {
@@ -66,9 +63,6 @@ export function WebHostPairingGate({
               }}
             />
           </div>
-          {localError || (error && !error.includes('需要完成首次配对')) ? (
-            <p className="text-sm text-destructive">{localError || error}</p>
-          ) : null}
           <Button type="button" className="w-full" disabled={busy} onClick={submit}>
             {busy ? <LoaderCircle className="size-4 animate-spin" /> : null}
             {t('app.pair')}

--- a/apps/desktop/src/hooks/use-desktop-question-error-toast.ts
+++ b/apps/desktop/src/hooks/use-desktop-question-error-toast.ts
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
+
+export function useDesktopQuestionErrorToast(questionError: string) {
+  useEffect(() => {
+    showDesktopErrorToast(questionError, "question-error");
+  }, [questionError]);
+}

--- a/apps/desktop/src/hooks/use-desktop-runtime-error-toast.ts
+++ b/apps/desktop/src/hooks/use-desktop-runtime-error-toast.ts
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
+
+export function useDesktopRuntimeErrorToast(runtimeError: string) {
+  useEffect(() => {
+    showDesktopErrorToast(runtimeError, "desktop-runtime-error");
+  }, [runtimeError]);
+}

--- a/apps/desktop/src/lib/desktop-error-toast.ts
+++ b/apps/desktop/src/lib/desktop-error-toast.ts
@@ -1,0 +1,9 @@
+import { toast } from "sonner";
+
+export function showDesktopErrorToast(message: string, id = "desktop-error") {
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return;
+  }
+  toast.error(trimmed, { id });
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 
 import './lib/i18n';
 import App from './App';
+import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { WorkspaceToolsChromeProvider } from '@/contexts/workspace-tools-chrome-context';
 import { ThemeProvider } from './hooks/useTheme';
@@ -46,6 +47,7 @@ if (!rootElement) {
 createRoot(rootElement).render(
   <StrictMode>
     <ThemeProvider>
+      <Toaster position="bottom-right" />
       <TooltipProvider delayDuration={300}>
         <WorkspaceToolsChromeProvider>
           <App />


### PR DESCRIPTION
## Summary

- 通过 shadcn CLI 安装 Sonner，在右下角以 `toast.error` 展示 Desktop 错误
- `runtimeError` 在 App 层集中监听，移除 composer、settings、分支切换、Web Host 配对等内联红条
- Marketplace `localError`、Integrations GitHub 错误、问卷 `questionError` 同步改 toast
- 修复 Sonner 注入样式硬编码系统字体，toast 接应用 `--font-sans`（Geist / 用户自选）

## Test plan

- [x] Marketplace 详情拉取失败（如 502）：右下角 toast，详情页无红色 banner
- [x] Composer / Settings 操作失败：`runtimeError` 以 toast 展示，无内联红条
- [x] 分支切换 Dialog 失败：toast 展示，Dialog 内无 `text-destructive`
- [x] Web Host 首次配对：校验与 `runtimeError` 均以 toast 展示
- [x] Settings → Integrations GitHub 错误（Dialog 关闭时）：toast 展示，面板无红卡
- [x] Pending questions 校验失败：toast 展示，卡片内无红条
- [x] Toast 字体与主界面 Geist 一致（非 Segoe UI / 微软雅黑）
- [x] `npm run build:renderer` 通过