### PR TITLE
fix(desktop): 对齐 Streamdown 围栏与 Mermaid 为 Void 自研样式

### DIFF
--- a/apps/desktop/src/components/agent-markdown-message.tsx
+++ b/apps/desktop/src/components/agent-markdown-message.tsx
@@ -16,7 +16,7 @@ import type { ReadManagedImagePreviewDataUrl } from "@/components/markdown-image
 import type { ReadManagedVideoPreviewUrl } from "@/components/markdown-video";
 import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 import {
-  createMarkdownMessageComponents,
+  createStreamdownMessageComponents,
   markdownMessageRootClassName,
   type MarkdownTone,
 } from "@/lib/markdown-message-components";
@@ -123,7 +123,7 @@ export function AgentMarkdownMessage({
   const onMarkdownLinkClick = useWorkspaceMarkdownLinkClick();
   const components = useMemo(
     () =>
-      createMarkdownMessageComponents(
+      createStreamdownMessageComponents(
         readManagedImagePreviewDataUrl,
         tone,
         readManagedVideoPreviewUrl,

--- a/apps/desktop/src/components/agent-markdown-message.tsx
+++ b/apps/desktop/src/components/agent-markdown-message.tsx
@@ -175,10 +175,11 @@ export function AgentMarkdownMessage({
         urlTransform={streamdownUrlTransform}
         rehypePlugins={streamdownRehypePlugins}
         controls={{
-          code: { copy: true, download: true },
+          code: { copy: false, download: false },
           mermaid: { copy: true, download: true, fullscreen: true, panZoom: true },
           table: { copy: true, download: true, fullscreen: true },
         }}
+        lineNumbers={false}
         parseIncompleteMarkdown={streaming}
         isAnimating={motionActive}
         animated={motionActive ? streamingAnimateOptions : false}

--- a/apps/desktop/src/components/agent-markdown-message.tsx
+++ b/apps/desktop/src/components/agent-markdown-message.tsx
@@ -8,13 +8,13 @@ import {
 } from "react";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
-import { mermaid } from "@streamdown/mermaid";
 import { Block, parseMarkdownIntoBlocks, Streamdown, type BlockProps } from "streamdown";
 import type { Pluggable } from "unified";
 
 import type { ReadManagedImagePreviewDataUrl } from "@/components/markdown-image";
 import type { ReadManagedVideoPreviewUrl } from "@/components/markdown-video";
 import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
+import { useTheme } from "@/hooks/useTheme";
 import {
   createStreamdownMessageComponents,
   markdownMessageRootClassName,
@@ -23,9 +23,13 @@ import {
 import { streamdownRehypePlugins } from "@/lib/markdown-streamdown-plugins";
 import { spiritRemarkPluginsForStreamdown } from "@/lib/markdown-remark-plugins";
 import { streamdownUrlTransform } from "@/lib/markdown-url-transform";
+import { createSpiritMermaidPlugin } from "@/lib/markdown-mermaid-theme";
+import { createMarkdownMermaidRenderer } from "@/components/markdown-mermaid-block";
 import { useWorkspaceMarkdownLinkClick } from "@/components/workspace-markdown-link-context";
 
-const streamdownPlugins = { code, math, mermaid };
+const streamdownMathPlugin = math;
+
+const streamdownPluginsBase = { code, math: streamdownMathPlugin };
 
 /** Char-level + zero stagger: each stream delta animates in parallel (not serial / per-paragraph batch). */
 const streamingAnimateOptions = {
@@ -120,7 +124,17 @@ export function AgentMarkdownMessage({
   readManagedVideoPreviewUrl?: ReadManagedVideoPreviewUrl;
 }) {
   const prefersReducedMotion = usePrefersReducedMotion();
+  const { resolvedDark } = useTheme();
   const onMarkdownLinkClick = useWorkspaceMarkdownLinkClick();
+  const streamdownPlugins = useMemo(
+    () => ({
+      ...streamdownPluginsBase,
+      mermaid: createSpiritMermaidPlugin(resolvedDark),
+      renderers: [createMarkdownMermaidRenderer(resolvedDark)],
+    }),
+    [resolvedDark],
+  );
+
   const components = useMemo(
     () =>
       createStreamdownMessageComponents(
@@ -176,7 +190,7 @@ export function AgentMarkdownMessage({
         rehypePlugins={streamdownRehypePlugins}
         controls={{
           code: { copy: false, download: false },
-          mermaid: { copy: true, download: true, fullscreen: true, panZoom: true },
+          mermaid: { copy: false, download: false, fullscreen: false, panZoom: true },
           table: { copy: true, download: true, fullscreen: true },
         }}
         lineNumbers={false}

--- a/apps/desktop/src/components/agent-markdown-message.tsx
+++ b/apps/desktop/src/components/agent-markdown-message.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   type MutableRefObject,
 } from "react";
-import { code } from "@streamdown/code";
+import { createCodePlugin } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { Block, parseMarkdownIntoBlocks, Streamdown, type BlockProps } from "streamdown";
 import type { Pluggable } from "unified";
@@ -29,7 +29,12 @@ import { useWorkspaceMarkdownLinkClick } from "@/components/workspace-markdown-l
 
 const streamdownMathPlugin = math;
 
-const streamdownPluginsBase = { code, math: streamdownMathPlugin };
+/** VS Code Default Light+ / Dark+（Shiki bundled） */
+const STREAMDOWN_SHIKI_THEMES = ["light-plus", "dark-plus"] as const;
+
+const spiritStreamdownCodePlugin = createCodePlugin({
+  themes: [...STREAMDOWN_SHIKI_THEMES],
+});
 
 /** Char-level + zero stagger: each stream delta animates in parallel (not serial / per-paragraph batch). */
 const streamingAnimateOptions = {
@@ -128,7 +133,8 @@ export function AgentMarkdownMessage({
   const onMarkdownLinkClick = useWorkspaceMarkdownLinkClick();
   const streamdownPlugins = useMemo(
     () => ({
-      ...streamdownPluginsBase,
+      code: spiritStreamdownCodePlugin,
+      math: streamdownMathPlugin,
       mermaid: createSpiritMermaidPlugin(resolvedDark),
       renderers: [createMarkdownMermaidRenderer(resolvedDark)],
     }),

--- a/apps/desktop/src/components/local-image-preview-dialog.tsx
+++ b/apps/desktop/src/components/local-image-preview-dialog.tsx
@@ -12,8 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 
 // backdrop-filter 在祖先 opacity 动画期间无法正确合成；卡片 hover 渐显须与 blur 写在同一元素上。
-export const LOCAL_IMAGE_FLOATING_ACTION_BUTTON_CLASS =
-  "size-8 rounded-full border border-border/50 bg-background/55 text-foreground shadow-sm backdrop-blur-xl transition-[opacity,background-color,border-color,box-shadow] duration-200 ease-out hover:border-border/60 hover:bg-background/72 dark:border-white/12 dark:bg-input/30 dark:hover:bg-input/40 supports-[backdrop-filter]:bg-background/40 dark:supports-[backdrop-filter]:bg-input/25";
+export const LOCAL_IMAGE_FLOATING_ACTION_BUTTON_CLASS = "spirit-floating-action-button";
 
 export function useImagePreviewAspectRatio(previewDataUrl: string | null): CSSProperties | undefined {
   const [previewAspectRatio, setPreviewAspectRatio] = useState<number | null>(null);

--- a/apps/desktop/src/components/markdown-mermaid-block.tsx
+++ b/apps/desktop/src/components/markdown-mermaid-block.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Maximize2, X } from "lucide-react";
 import type { MermaidConfig } from "mermaid";
@@ -94,7 +94,10 @@ export function MarkdownMermaidBlock({
 }: CustomRendererProps & { resolvedDark: boolean }) {
   const { t } = useTranslation();
   const [viewerOpen, setViewerOpen] = useState(false);
-  const mermaidConfig = getSpiritMermaidConfig(resolvedDark);
+  const mermaidConfig = useMemo(
+    () => getSpiritMermaidConfig(resolvedDark),
+    [resolvedDark],
+  );
   const expandLabel = t("app.viewLargeDiagram");
 
   if (isIncomplete) {

--- a/apps/desktop/src/components/markdown-mermaid-block.tsx
+++ b/apps/desktop/src/components/markdown-mermaid-block.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Maximize2, X } from "lucide-react";
+import type { MermaidConfig } from "mermaid";
+import type { CustomRendererProps } from "streamdown";
+
+import {
+  LOCAL_IMAGE_FLOATING_ACTION_BUTTON_CLASS,
+} from "@/components/local-image-preview-dialog";
+import { SpiritMermaidChart } from "@/components/spirit-mermaid-chart";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { getSpiritMermaidConfig } from "@/lib/markdown-mermaid-theme";
+import { cn } from "@/lib/utils";
+
+function MermaidChartSkeleton() {
+  return (
+    <div className="flex min-h-32 w-full items-center justify-center">
+      <Spinner className="size-4 text-muted-foreground" />
+    </div>
+  );
+}
+
+function MermaidPreviewDialog({
+  open,
+  onOpenChange,
+  chart,
+  mermaidConfig,
+  resolvedDark,
+}: {
+  open: boolean;
+  onOpenChange(open: boolean): void;
+  chart: string;
+  mermaidConfig: MermaidConfig;
+  resolvedDark: boolean;
+}) {
+  const { t } = useTranslation();
+  const closeLabel = t("app.closeDiagramPreview");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="bg-background/40 backdrop-blur-md"
+        className="w-auto max-w-none gap-0 border-0 bg-transparent p-0 shadow-none ring-0 sm:max-w-none"
+      >
+        <div
+          data-spirit-mermaid-preview
+          className={cn(
+            "pointer-events-auto relative inline-flex overflow-hidden rounded-[1.1rem] border border-border/45 bg-background",
+            "h-[min(calc(100dvh-4rem),48rem)] w-[min(calc(100dvw-4rem),70rem)] max-h-[calc(100dvh-2rem)] max-w-[calc(100dvw-2rem)]",
+          )}
+        >
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className={cn("absolute top-3 right-3 z-[1]", LOCAL_IMAGE_FLOATING_ACTION_BUTTON_CLASS)}
+              title={closeLabel}
+              aria-label={closeLabel}
+            >
+              <X className="size-4" aria-hidden />
+              <span className="sr-only">{closeLabel}</span>
+            </Button>
+          </DialogClose>
+          <div className="flex size-full flex-col p-4 pt-12">
+            <SpiritMermaidChart
+              chart={chart}
+              mermaidConfig={mermaidConfig}
+              resolvedDark={resolvedDark}
+              fullscreen
+              showControls
+              controlsAlwaysVisible
+              eager
+              className="min-h-0 flex-1"
+            />
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function MarkdownMermaidBlock({
+  code,
+  isIncomplete,
+  resolvedDark,
+}: CustomRendererProps & { resolvedDark: boolean }) {
+  const { t } = useTranslation();
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const mermaidConfig = getSpiritMermaidConfig(resolvedDark);
+  const expandLabel = t("app.viewLargeDiagram");
+
+  if (isIncomplete) {
+    return <MermaidChartSkeleton />;
+  }
+
+  const openPreview = () => {
+    setViewerOpen(true);
+  };
+
+  return (
+    <>
+      <div
+        className="group relative my-2 flex w-full flex-col gap-0 overflow-hidden rounded-md border border-border/40 bg-muted/30"
+        data-incomplete={isIncomplete || undefined}
+        data-streamdown="mermaid-block"
+      >
+        <div
+          className="pointer-events-none absolute top-2 right-2 z-[1]"
+          data-streamdown="mermaid-block-actions"
+        >
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className={cn(
+              "pointer-events-auto opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-within:opacity-100",
+              LOCAL_IMAGE_FLOATING_ACTION_BUTTON_CLASS,
+            )}
+            onClick={openPreview}
+            title={expandLabel}
+            aria-label={expandLabel}
+          >
+            <Maximize2 className="size-4" aria-hidden />
+          </Button>
+        </div>
+        <div className="min-w-0">
+          <SpiritMermaidChart
+            chart={code}
+            mermaidConfig={mermaidConfig}
+            resolvedDark={resolvedDark}
+            showControls
+          />
+        </div>
+      </div>
+
+      <MermaidPreviewDialog
+        open={viewerOpen}
+        onOpenChange={setViewerOpen}
+        chart={code}
+        mermaidConfig={mermaidConfig}
+        resolvedDark={resolvedDark}
+      />
+    </>
+  );
+}
+
+export function createMarkdownMermaidRenderer(resolvedDark: boolean) {
+  return {
+    language: "mermaid" as const,
+    component: (props: CustomRendererProps) => (
+      <MarkdownMermaidBlock {...props} resolvedDark={resolvedDark} />
+    ),
+  };
+}

--- a/apps/desktop/src/components/spirit-mermaid-chart.tsx
+++ b/apps/desktop/src/components/spirit-mermaid-chart.tsx
@@ -273,6 +273,7 @@ export function SpiritMermaidChart({
         }
       } catch (renderError) {
         if (!cancelled) {
+          setSvg("");
           setError(
             renderError instanceof Error
               ? renderError.message

--- a/apps/desktop/src/components/spirit-mermaid-chart.tsx
+++ b/apps/desktop/src/components/spirit-mermaid-chart.tsx
@@ -1,0 +1,351 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import { RotateCcw, ZoomIn, ZoomOut } from "lucide-react";
+import type { MermaidConfig } from "mermaid";
+
+import { useTranslation } from "react-i18next";
+
+import { Spinner } from "@/components/ui/spinner";
+import { createSpiritMermaidPlugin } from "@/lib/markdown-mermaid-theme";
+import { cn } from "@/lib/utils";
+
+const MERMAID_SVG_LAYOUT_CLASS_FULLSCREEN =
+  "[&_svg]:block [&_svg]:h-auto [&_svg]:max-h-full [&_svg]:w-auto [&_svg]:max-w-full";
+
+const MERMAID_SVG_LAYOUT_CLASS_INLINE =
+  "[&_svg]:block [&_svg]:h-auto [&_svg]:w-auto [&_svg]:max-w-full";
+
+function hashChart(source: string): number {
+  return source.split("").reduce((acc, ch) => (acc << 5) - acc + ch.charCodeAt(0), 0) | 0;
+}
+
+function MermaidPanZoom({
+  children,
+  className,
+  fullscreen = false,
+  showControls = true,
+  controlsAlwaysVisible = false,
+}: {
+  children: ReactNode;
+  className?: string;
+  fullscreen?: boolean;
+  showControls?: boolean;
+  controlsAlwaysVisible?: boolean;
+}) {
+  const { t } = useTranslation();
+  const zoomInLabel = t("app.diagramZoomIn");
+  const zoomOutLabel = t("app.diagramZoomOut");
+  const zoomResetLabel = t("app.diagramZoomReset");
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const panStartRef = useRef({ x: 0, y: 0 });
+
+  const minZoom = 0.5;
+  const maxZoom = 3;
+  const zoomStep = 0.1;
+
+  const adjustZoom = useCallback(
+    (delta: number) => {
+      setZoom((current) => Math.max(minZoom, Math.min(maxZoom, current + delta)));
+    },
+    [],
+  );
+
+  const resetView = useCallback(() => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  }, []);
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      event.preventDefault();
+      adjustZoom(event.deltaY > 0 ? -zoomStep : zoomStep);
+    },
+    [adjustZoom],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0 || event.isPrimary === false) {
+        return;
+      }
+      setIsDragging(true);
+      dragStartRef.current = { x: event.clientX, y: event.clientY };
+      panStartRef.current = pan;
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [pan],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!isDragging) {
+        return;
+      }
+      event.preventDefault();
+      const dx = event.clientX - dragStartRef.current.x;
+      const dy = event.clientY - dragStartRef.current.y;
+      setPan({
+        x: panStartRef.current.x + dx,
+        y: panStartRef.current.y + dy,
+      });
+    },
+    [isDragging],
+  );
+
+  const handlePointerEnd = useCallback((event: PointerEvent) => {
+    setIsDragging(false);
+    const target = contentRef.current;
+    if (target instanceof HTMLElement) {
+      target.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    return () => container.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || !isDragging) {
+      return;
+    }
+    document.body.style.userSelect = "none";
+    content.addEventListener("pointermove", handlePointerMove, { passive: false });
+    content.addEventListener("pointerup", handlePointerEnd);
+    content.addEventListener("pointercancel", handlePointerEnd);
+    return () => {
+      document.body.style.userSelect = "";
+      content.removeEventListener("pointermove", handlePointerMove);
+      content.removeEventListener("pointerup", handlePointerEnd);
+      content.removeEventListener("pointercancel", handlePointerEnd);
+    };
+  }, [handlePointerEnd, handlePointerMove, isDragging]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "spirit-mermaid-pan-zoom-host relative flex flex-col",
+        fullscreen ? "h-full w-full" : "min-h-28 w-full",
+        className,
+      )}
+      style={{ cursor: isDragging ? "grabbing" : "grab" }}
+    >
+      {showControls ? (
+        <div
+          className={cn(
+            "spirit-mermaid-pan-zoom-controls absolute z-[1] flex flex-col gap-1 rounded-md border border-border bg-background/80 p-1 supports-[backdrop-filter]:bg-background/70 supports-[backdrop-filter]:backdrop-blur-sm",
+            fullscreen ? "bottom-4 left-4" : "bottom-2 left-2",
+            controlsAlwaysVisible && "opacity-100",
+          )}
+        >
+          <button
+            type="button"
+            className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={zoom >= maxZoom}
+            onClick={() => adjustZoom(zoomStep)}
+            title={zoomInLabel}
+            aria-label={zoomInLabel}
+          >
+            <ZoomIn className="size-4" aria-hidden />
+          </button>
+          <button
+            type="button"
+            className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={zoom <= minZoom}
+            onClick={() => adjustZoom(-zoomStep)}
+            title={zoomOutLabel}
+            aria-label={zoomOutLabel}
+          >
+            <ZoomOut className="size-4" aria-hidden />
+          </button>
+          <button
+            type="button"
+            className="flex items-center justify-center rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={resetView}
+            title={zoomResetLabel}
+            aria-label={zoomResetLabel}
+          >
+            <RotateCcw className="size-4" aria-hidden />
+          </button>
+        </div>
+      ) : null}
+      <div
+        ref={contentRef}
+        role="application"
+        className={cn(
+          "flex w-full flex-1 origin-center items-center justify-center transition-transform duration-150 ease-out",
+          fullscreen && "h-full",
+        )}
+        style={{
+          transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+          transformOrigin: "center center",
+          touchAction: "none",
+          willChange: "transform",
+        }}
+        onPointerDown={handlePointerDown}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function SpiritMermaidChart({
+  chart,
+  mermaidConfig,
+  resolvedDark,
+  fullscreen = false,
+  showControls = true,
+  controlsAlwaysVisible = false,
+  className,
+  eager = false,
+}: {
+  chart: string;
+  mermaidConfig: MermaidConfig;
+  resolvedDark: boolean;
+  fullscreen?: boolean;
+  showControls?: boolean;
+  controlsAlwaysVisible?: boolean;
+  className?: string;
+  eager?: boolean;
+}) {
+  const plugin = useMemo(() => createSpiritMermaidPlugin(resolvedDark), [resolvedDark]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [shouldRender, setShouldRender] = useState(eager || fullscreen);
+  const [svg, setSvg] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    if (eager || fullscreen) {
+      setShouldRender(true);
+      return;
+    }
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting) {
+          setShouldRender(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "300px" },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [eager, fullscreen]);
+
+  useEffect(() => {
+    if (!shouldRender) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const mermaid = plugin.getMermaid(mermaidConfig);
+        const id = `spirit-mermaid-${Math.abs(hashChart(chart))}-${Date.now()}`;
+        const { svg: rendered } = await mermaid.render(id, chart);
+        if (!cancelled) {
+          setSvg(rendered);
+        }
+      } catch (renderError) {
+        if (!cancelled) {
+          setError(
+            renderError instanceof Error
+              ? renderError.message
+              : "Failed to render Mermaid chart",
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [chart, mermaidConfig, plugin, retryKey, shouldRender]);
+
+  if (!shouldRender && !svg) {
+    return <div className={cn("my-4 min-h-[200px]", className)} ref={containerRef} />;
+  }
+
+  if (loading && !svg) {
+    return (
+      <div
+        ref={containerRef}
+        className={cn(
+          "flex items-center justify-center",
+          fullscreen ? "size-full min-h-32" : "my-4 min-h-32 w-full p-4",
+          className,
+        )}
+      >
+        <Spinner className="size-4 shrink-0 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error && !svg) {
+    return (
+      <div className={cn("rounded-md bg-destructive/10 p-4", className)} ref={containerRef}>
+        <p className="font-mono text-destructive text-sm">Mermaid Error: {error}</p>
+        <button
+          type="button"
+          className="mt-2 text-muted-foreground text-xs underline"
+          onClick={() => setRetryKey((key) => key + 1)}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(fullscreen ? "size-full" : "w-full", className)}
+      data-streamdown="mermaid"
+      ref={containerRef}
+    >
+      <MermaidPanZoom
+        fullscreen={fullscreen}
+        showControls={showControls}
+        controlsAlwaysVisible={controlsAlwaysVisible}
+      >
+        <div
+          aria-label="Mermaid chart"
+          className={cn(
+            "flex w-full justify-center",
+            fullscreen && "size-full items-center",
+            fullscreen ? MERMAID_SVG_LAYOUT_CLASS_FULLSCREEN : MERMAID_SVG_LAYOUT_CLASS_INLINE,
+          )}
+          dangerouslySetInnerHTML={{ __html: svg }}
+          role="img"
+        />
+      </MermaidPanZoom>
+    </div>
+  );
+}

--- a/apps/desktop/src/lib/markdown-mermaid-theme.ts
+++ b/apps/desktop/src/lib/markdown-mermaid-theme.ts
@@ -1,0 +1,76 @@
+import { createMermaidPlugin } from "@streamdown/mermaid";
+import type { MermaidConfig } from "mermaid";
+
+import { DEFAULT_FONT_ID } from "@/lib/font";
+
+const MERMAID_FONT_FAMILY = `'${DEFAULT_FONT_ID === "geist" ? "Geist Variable" : "Geist Variable"}', sans-serif`;
+
+/** Void 语义色：与 styles.css 暗色 token 对齐，避免 Mermaid 默认黄/紫 subgraph */
+function buildVoidMermaidThemeVariables(resolvedDark: boolean): MermaidConfig["themeVariables"] {
+  if (resolvedDark) {
+    return {
+      darkMode: true,
+      background: "transparent",
+      fontFamily: MERMAID_FONT_FAMILY,
+      fontSize: "13px",
+      primaryColor: "#181818",
+      primaryTextColor: "#d4d4d4",
+      primaryBorderColor: "#272727",
+      secondaryColor: "#121212",
+      secondaryTextColor: "#d4d4d4",
+      secondaryBorderColor: "#272727",
+      tertiaryColor: "#090909",
+      tertiaryTextColor: "#a1a1a1",
+      tertiaryBorderColor: "#272727",
+      lineColor: "#525252",
+      textColor: "#d4d4d4",
+      mainBkg: "#181818",
+      nodeBorder: "#272727",
+      nodeTextColor: "#d4d4d4",
+      clusterBkg: "#090909",
+      clusterBorder: "#272727",
+      defaultLinkColor: "#717171",
+      titleColor: "#a1a1a1",
+      edgeLabelBackground: "#181818",
+    };
+  }
+
+  return {
+    darkMode: false,
+    background: "transparent",
+    fontFamily: MERMAID_FONT_FAMILY,
+    fontSize: "13px",
+    primaryColor: "#f4f4f5",
+    primaryTextColor: "#18181b",
+    primaryBorderColor: "#e4e4e7",
+    secondaryColor: "#fafafa",
+    secondaryTextColor: "#18181b",
+    secondaryBorderColor: "#e4e4e7",
+    tertiaryColor: "#f4f4f5",
+    tertiaryTextColor: "#52525b",
+    tertiaryBorderColor: "#d4d4d8",
+    lineColor: "#71717a",
+    textColor: "#18181b",
+    mainBkg: "#fafafa",
+    nodeBorder: "#e4e4e7",
+    nodeTextColor: "#18181b",
+    clusterBkg: "#f4f4f5",
+    clusterBorder: "#d4d4d8",
+    defaultLinkColor: "#71717a",
+    titleColor: "#52525b",
+    edgeLabelBackground: "#fafafa",
+  };
+}
+
+export function getSpiritMermaidConfig(resolvedDark: boolean): MermaidConfig {
+  return {
+    theme: "base",
+    themeVariables: buildVoidMermaidThemeVariables(resolvedDark),
+  };
+}
+
+export function createSpiritMermaidPlugin(resolvedDark: boolean) {
+  return createMermaidPlugin({
+    config: getSpiritMermaidConfig(resolvedDark),
+  });
+}

--- a/apps/desktop/src/lib/markdown-message-components.tsx
+++ b/apps/desktop/src/lib/markdown-message-components.tsx
@@ -254,6 +254,32 @@ export function createMarkdownMessageComponents(
   };
 }
 
+/**
+ * Streamdown 专用：不传 pre/code，避免覆盖内置 Mermaid / Shiki 围栏渲染；
+ * 行内 code 样式经 inlineCode 保留。
+ */
+export function createStreamdownMessageComponents(
+  readManagedImagePreviewDataUrl?: ReadManagedImagePreviewDataUrl,
+  tone: MarkdownTone = "default",
+  readManagedVideoPreviewUrl?: ReadManagedVideoPreviewUrl,
+  onLinkClick?: WorkspaceMarkdownLinkClickHandler,
+  size: MarkdownSize = "default",
+  allowHtml = false,
+): Record<string, ComponentType<Record<string, unknown>>> {
+  const { pre: _pre, code, ...rest } = createMarkdownMessageComponents(
+    readManagedImagePreviewDataUrl,
+    tone,
+    readManagedVideoPreviewUrl,
+    onLinkClick,
+    size,
+    allowHtml,
+  );
+  return {
+    ...rest,
+    inlineCode: code,
+  };
+}
+
 export function markdownMessageRootClassName(
   tone: MarkdownTone,
   className?: string,

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -595,6 +595,11 @@
     "downloadVideo": "Download Video",
     "viewLargeImage": "View Large Image",
     "closeImagePreview": "Close Image Preview",
+    "viewLargeDiagram": "View Large Diagram",
+    "closeDiagramPreview": "Close Diagram Preview",
+    "diagramZoomIn": "Zoom In",
+    "diagramZoomOut": "Zoom Out",
+    "diagramZoomReset": "Reset Zoom and Pan",
     "typeMessage": "Type a message\u2026",
     "emptySessionGreeting": {
       "startSomething": "Start something.",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -592,6 +592,11 @@
     "downloadVideo": "下载视频",
     "viewLargeImage": "查看大图",
     "closeImagePreview": "关闭图片预览",
+    "viewLargeDiagram": "查看图表",
+    "closeDiagramPreview": "关闭图表预览",
+    "diagramZoomIn": "放大",
+    "diagramZoomOut": "缩小",
+    "diagramZoomReset": "重置缩放与平移",
     "typeMessage": "输入消息\u2026",
     "emptySessionGreeting": {
       "startSomething": "开始点什么。",

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -5,8 +5,9 @@
 @source "../node_modules/streamdown/dist/*.js";
 @source "../node_modules/@streamdown/code/dist/*.js";
 @source "../node_modules/@streamdown/math/dist/*.js";
-@source "../node_modules/@streamdown/mermaid/dist/*.js";
+@import "./styles/markdown-mermaid.css";
 @import "./styles/markdown-code-block.css";
+@import "./styles/floating-action-button.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -6,6 +6,7 @@
 @source "../node_modules/@streamdown/code/dist/*.js";
 @source "../node_modules/@streamdown/math/dist/*.js";
 @source "../node_modules/@streamdown/mermaid/dist/*.js";
+@import "./styles/markdown-code-block.css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/desktop/src/styles/floating-action-button.css
+++ b/apps/desktop/src/styles/floating-action-button.css
@@ -1,0 +1,54 @@
+/* generate_image 等单钮浮动样式；blur 须写在按钮自身（祖先 opacity 会破坏 backdrop-filter） */
+.spirit-floating-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in oklab, var(--border) 50%, transparent);
+  background: color-mix(in oklab, var(--background) 55%, transparent);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  -webkit-backdrop-filter: blur(24px);
+  backdrop-filter: blur(24px);
+  cursor: pointer;
+  transition:
+    opacity 200ms ease-out,
+    background-color 200ms ease-out,
+    border-color 200ms ease-out,
+    box-shadow 200ms ease-out,
+    color 200ms ease-out;
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  .spirit-floating-action-button {
+    background: color-mix(in oklab, var(--background) 40%, transparent);
+  }
+}
+
+:is(.dark) .spirit-floating-action-button {
+  border-color: color-mix(in oklab, white 12%, transparent);
+  background: color-mix(in oklab, var(--input) 30%, transparent);
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  :is(.dark) .spirit-floating-action-button {
+    background: color-mix(in oklab, var(--input) 25%, transparent);
+  }
+}
+
+.spirit-floating-action-button:hover {
+  border-color: color-mix(in oklab, var(--border) 60%, transparent);
+  background: color-mix(in oklab, var(--background) 72%, transparent);
+  color: var(--foreground);
+}
+
+:is(.dark) .spirit-floating-action-button:hover {
+  background: color-mix(in oklab, var(--input) 40%, transparent);
+}
+
+.spirit-floating-action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/apps/desktop/src/styles/markdown-code-block.css
+++ b/apps/desktop/src/styles/markdown-code-block.css
@@ -1,0 +1,64 @@
+/* Streamdown 代码块：单层细边框对齐旧 pre */
+
+[data-streamdown="code-block"] {
+  position: relative;
+  isolation: isolate;
+  z-index: 0;
+  margin-block: 0.5rem;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in oklab, var(--border) 40%, transparent) !important;
+  background: color-mix(in oklab, var(--muted) 30%, transparent) !important;
+  padding: 0 !important;
+  gap: 0 !important;
+  content-visibility: visible;
+  contain-intrinsic-size: auto;
+}
+
+.text-muted-foreground [data-streamdown="code-block"] {
+  border-color: color-mix(in oklab, var(--border) 30%, transparent) !important;
+  background: color-mix(in oklab, var(--muted) 20%, transparent) !important;
+}
+
+[data-streamdown="code-block"]:last-child {
+  margin-bottom: 0;
+}
+
+[data-streamdown="code-block"].rounded-xl {
+  border-radius: var(--radius-md) !important;
+}
+
+[data-streamdown="code-block-header"] {
+  display: none !important;
+}
+
+/* copy/download 均关时 Streamdown 仍渲染空 actions 壳（带 border/padding），呈右侧黑点 */
+[data-streamdown="code-block"] > div:has(> [data-streamdown="code-block-actions"]:empty) {
+  display: none !important;
+}
+
+/* 去掉 Streamdown 内层第二道边框，对齐旧 pre 单层容器 */
+[data-streamdown="code-block-body"] {
+  border: none !important;
+  background: transparent !important;
+  border-radius: 0 !important;
+  padding: 0.75rem !important;
+  font-size: 0.75rem !important;
+  line-height: 1.625 !important;
+}
+
+[data-streamdown="code-block-body"] > pre {
+  margin: 0;
+  border: none !important;
+  background: transparent !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  white-space: pre;
+}
+
+/* lineNumbers=false 时 Streamdown 行 span 无 block 类，须强制每行独占一行 */
+[data-streamdown="code-block-body"] pre code > span {
+  display: block;
+}

--- a/apps/desktop/src/styles/markdown-mermaid.css
+++ b/apps/desktop/src/styles/markdown-mermaid.css
@@ -1,0 +1,248 @@
+/* Streamdown Mermaid：单层细边框对齐旧 pre 代码块；操作钮悬停浮现 */
+
+[data-streamdown="mermaid-block"] {
+  position: relative;
+  isolation: isolate;
+  z-index: 0;
+  margin-block: 0.5rem;
+  max-width: 100%;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in oklab, var(--border) 40%, transparent) !important;
+  background: color-mix(in oklab, var(--muted) 30%, transparent) !important;
+  padding: 0 !important;
+  gap: 0 !important;
+}
+
+.text-muted-foreground [data-streamdown="mermaid-block"] {
+  border-color: color-mix(in oklab, var(--border) 30%, transparent) !important;
+  background: color-mix(in oklab, var(--muted) 20%, transparent) !important;
+}
+
+[data-streamdown="mermaid-block"]:last-child {
+  margin-bottom: 0;
+}
+
+/* Streamdown 内层图表容器：加载中与渲染后均去掉第二层 border（:has(mermaid) 加载态匹配不到） */
+[data-streamdown="mermaid-block"] > div:last-child {
+  border: none !important;
+  background: transparent !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+}
+
+/* Mermaid chunk 懒加载骨架（Suspense fallback Oe）：对齐单层 pre 边框，去掉假顶栏 */
+.min-w-0.break-words > div.w-full.overflow-hidden.rounded-xl.border:has(> div.h-\[46px\]) {
+  margin-block: 0.5rem;
+  border-radius: var(--radius-md) !important;
+  border: 1px solid color-mix(in oklab, var(--border) 40%, transparent) !important;
+  background: color-mix(in oklab, var(--muted) 30%, transparent) !important;
+  padding: 0 !important;
+  --tw-divide-y-reverse: 0;
+}
+
+.min-w-0.break-words > div.w-full.overflow-hidden.rounded-xl.border:has(> div.h-\[46px\]) > div.h-\[46px\] {
+  display: none;
+}
+
+.min-w-0.break-words > div.w-full.overflow-hidden.rounded-xl.border:has(> div.h-\[46px\]) > div:last-child {
+  border-top: none !important;
+  padding: 1rem 0 0 !important;
+}
+
+.text-muted-foreground .min-w-0.break-words > div.w-full.overflow-hidden.rounded-xl.border:has(> div.h-\[46px\]) {
+  border-color: color-mix(in oklab, var(--border) 30%, transparent) !important;
+  background: color-mix(in oklab, var(--muted) 20%, transparent) !important;
+}
+
+/* 压掉 Streamdown 默认 rounded-xl，与旧 pre 的 rounded-md 一致 */
+[data-streamdown="mermaid-block"].rounded-xl {
+  border-radius: var(--radius-md) !important;
+}
+
+/* 隐藏 "mermaid" 语言顶栏（占布局且无信息量） */
+[data-streamdown="mermaid-block"] > div:first-child:has([class*="lowercase"]) {
+  display: none;
+}
+
+/* 放大：absolute 钉右上角（actions 即定位层，勿设 position: static） */
+[data-streamdown="mermaid-block"] > [data-streamdown="mermaid-block-actions"],
+[data-streamdown="mermaid-block"] > div:has([data-streamdown="mermaid-block-actions"]) {
+  position: absolute !important;
+  top: 0.5rem !important;
+  right: 0.5rem !important;
+  left: auto !important;
+  bottom: auto !important;
+  height: auto !important;
+  min-height: 0 !important;
+  margin: 0 !important;
+  width: auto !important;
+  z-index: 1;
+  pointer-events: none;
+}
+
+[data-streamdown="mermaid-block"]:hover > [data-streamdown="mermaid-block-actions"],
+[data-streamdown="mermaid-block"]:focus-within > [data-streamdown="mermaid-block-actions"],
+[data-streamdown="mermaid-block"]:hover > div:has([data-streamdown="mermaid-block-actions"]),
+[data-streamdown="mermaid-block"]:focus-within > div:has([data-streamdown="mermaid-block-actions"]) {
+  pointer-events: auto;
+}
+
+/* 放大：单枚圆形 FAB，hover 浮现（对齐预览关闭钮 spirit-floating-action-button） */
+[data-streamdown="mermaid-block-actions"] {
+  display: block !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+  opacity: 1;
+  pointer-events: none;
+}
+
+[data-streamdown="mermaid-block"]:hover [data-streamdown="mermaid-block-actions"],
+[data-streamdown="mermaid-block"]:focus-within [data-streamdown="mermaid-block-actions"] {
+  pointer-events: auto;
+}
+
+/* 缩放控件：合页竖条，同套边框/模糊 */
+[data-streamdown="mermaid-block"] [data-streamdown="mermaid"] .spirit-mermaid-pan-zoom-controls {
+  position: absolute !important;
+  bottom: 0.5rem !important;
+  left: 0.5rem !important;
+  top: auto !important;
+  right: auto !important;
+  z-index: 1;
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 0.25rem !important;
+  padding: 0.25rem !important;
+  border-radius: var(--radius-md) !important;
+  border: 1px solid color-mix(in oklab, var(--border) 50%, transparent) !important;
+  background: color-mix(in oklab, var(--background) 55%, transparent) !important;
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  -webkit-backdrop-filter: blur(24px);
+  backdrop-filter: blur(24px);
+  opacity: 0;
+  pointer-events: auto;
+  transition: opacity 200ms ease-out;
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  [data-streamdown="mermaid-block"] [data-streamdown="mermaid"] .spirit-mermaid-pan-zoom-controls {
+    background: color-mix(in oklab, var(--background) 40%, transparent) !important;
+  }
+}
+
+:is(.dark) [data-streamdown="mermaid-block"] [data-streamdown="mermaid"] .spirit-mermaid-pan-zoom-controls {
+  border-color: color-mix(in oklab, white 12%, transparent) !important;
+  background: color-mix(in oklab, var(--input) 30%, transparent) !important;
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  :is(.dark) [data-streamdown="mermaid-block"] [data-streamdown="mermaid"] .spirit-mermaid-pan-zoom-controls {
+    background: color-mix(in oklab, var(--input) 25%, transparent) !important;
+  }
+}
+
+[data-streamdown="mermaid-block"]:hover
+  [data-streamdown="mermaid"]
+  .spirit-mermaid-pan-zoom-controls,
+[data-streamdown="mermaid-block"]:focus-within
+  [data-streamdown="mermaid"]
+  .spirit-mermaid-pan-zoom-controls {
+  opacity: 1;
+}
+
+[data-streamdown="mermaid-block"] [data-streamdown="mermaid"] .spirit-mermaid-pan-zoom-controls > button {
+  width: auto;
+  height: auto;
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  padding: 0.375rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color 150ms ease, background-color 150ms ease;
+}
+
+[data-streamdown="mermaid-block"] [data-streamdown="mermaid"] .spirit-mermaid-pan-zoom-controls > button:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--muted) 50%, transparent);
+  color: var(--foreground);
+}
+
+[data-streamdown="mermaid-block"] [data-streamdown="mermaid"] .spirit-mermaid-pan-zoom-controls > button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+/* 预览 Dialog：pan-zoom 参照 preview 外框（勿相对 mermaid / pan-zoom-host），间距对齐关闭钮 top-3 */
+[data-spirit-mermaid-preview] .spirit-mermaid-pan-zoom-host {
+  position: static !important;
+}
+
+[data-spirit-mermaid-preview] .spirit-mermaid-pan-zoom-controls {
+  opacity: 1 !important;
+  bottom: 0.75rem !important;
+  left: 0.75rem !important;
+  border-radius: var(--radius-md) !important;
+  border: 1px solid color-mix(in oklab, var(--border) 50%, transparent) !important;
+  background: color-mix(in oklab, var(--background) 55%, transparent) !important;
+  -webkit-backdrop-filter: blur(24px);
+  backdrop-filter: blur(24px);
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  [data-spirit-mermaid-preview] .spirit-mermaid-pan-zoom-controls {
+    background: color-mix(in oklab, var(--background) 40%, transparent) !important;
+  }
+}
+
+:is(.dark) [data-spirit-mermaid-preview] .spirit-mermaid-pan-zoom-controls {
+  border-color: color-mix(in oklab, white 12%, transparent) !important;
+  background: color-mix(in oklab, var(--input) 30%, transparent) !important;
+}
+
+[data-spirit-mermaid-preview] .spirit-mermaid-pan-zoom-controls > button {
+  border: none;
+  border-radius: calc(var(--radius-md) - 2px);
+  background: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  padding: 0.375rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color 150ms ease, background-color 150ms ease;
+}
+
+[data-spirit-mermaid-preview] .spirit-mermaid-pan-zoom-controls > button:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--muted) 50%, transparent);
+  color: var(--foreground);
+}
+
+/* 勿设 relative：否则 pan-zoom 参照 mermaid 而非 mermaid-block，会多叠一层 padding */
+[data-streamdown="mermaid"] {
+  position: static;
+  min-height: 8rem;
+  font-family: var(--font-sans);
+}
+
+/* Mermaid SVG 默认易落宋体；强制跟应用 UI 栈 */
+[data-streamdown="mermaid"] svg,
+[data-streamdown="mermaid"] svg text,
+[data-streamdown="mermaid"] svg tspan,
+[data-streamdown="mermaid"] svg .label,
+[data-streamdown="mermaid"] svg .nodeLabel,
+[data-streamdown="mermaid"] svg .cluster-label {
+  font-family: var(--font-sans) !important;
+}
+
+[data-streamdown="mermaid"] svg .edgeLabel rect {
+  fill: color-mix(in oklab, var(--muted) 60%, transparent) !important;
+}


### PR DESCRIPTION
## Summary

- 围栏交回 Streamdown 内置 Mermaid/Shiki 渲染，自研 Mermaid 块、SpiritMermaidChart 与 Dialog 放大预览
- 新增 markdown-mermaid、markdown-code-block、floating-action-button 样式，压平双层边框与默认主题
- 代码块关闭复制/下载与行号，Shiki 改用 VS Code Light+/Dark+（createCodePlugin）
- 图表控件 diagram 专用 i18n，与生图文案区分

## Test plan

- [x] `npm run build:renderer`（各拆分提交均已通过）
- [ ] Desktop 对话输出 Mermaid 与 Python 代码块，确认渲染、放大预览与配色
- [ ] 悬停图表 pan-zoom / 放大 / 关闭钮，确认中文 Tooltip