### PR TITLE
feat(desktop): 设置页支持 Mod+Comma 打开与 ESC 返回

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -133,20 +133,9 @@ export default function App() {
   );
 
   const openIntegrationsSettings = useCallback(() => {
-    surfaceNav.sessionSidebarChromeApiRef.current?.openSidebar();
-    if (surfaceNav.activeSurface !== "settings") {
-      surfaceNav.setLastNonSettingsSurface(
-        surfaceNav.activeSurface === "marketplace"
-          ? "marketplace"
-          : surfaceNav.activeSurface === "automations" ||
-              surfaceNav.activeSurface === "automation-detail"
-            ? "automations"
-            : "conversation",
-      );
-    }
+    surfaceNav.handleOpenSettings();
     surfaceNav.setExtensionSettingsId(null);
     surfaceNav.setSettingsTab("integrations");
-    surfaceNav.setActiveSurface("settings");
   }, [surfaceNav]);
 
   const composer = useComposerController({
@@ -186,6 +175,8 @@ export default function App() {
     conversationAbortShortcutEligibleRef: conversation.conversationAbortShortcutEligibleRef,
     sessionSidebarChromeApiRef: surfaceNav.sessionSidebarChromeApiRef,
     handleNewSession: surfaceNav.handleNewSession,
+    handleOpenSettings: surfaceNav.handleOpenSettings,
+    handleCloseSettings: surfaceNav.handleCloseSettings,
     setActionPickerOpen: composer.setActionPickerOpen,
     setFilePickerOpen: composer.setFilePickerOpen,
     uiLayoutScaleApi: uiLayoutScale,
@@ -303,20 +294,8 @@ export default function App() {
               surfaceNav.setSelectedAutomationId(null);
               surfaceNav.setActiveSurface("automations");
             }}
-            onOpenSettings={() => {
-              surfaceNav.sessionSidebarChromeApiRef.current?.openSidebar();
-              if (surfaceNav.activeSurface !== "settings") {
-                surfaceNav.setLastNonSettingsSurface(
-                  surfaceNav.activeSurface === "marketplace"
-                    ? "marketplace"
-                    : surfaceNav.activeSurface === "automations" || surfaceNav.activeSurface === "automation-detail"
-                      ? "automations"
-                      : "conversation",
-                );
-              }
-              surfaceNav.setActiveSurface("settings");
-            }}
-            onBackToSessions={() => surfaceNav.setActiveSurface(surfaceNav.lastNonSettingsSurface)}
+            onOpenSettings={surfaceNav.handleOpenSettings}
+            onBackToSessions={surfaceNav.handleCloseSettings}
             marketplaceActive={surfaceNav.marketplaceMode}
             automationsActive={surfaceNav.automationsMode}
             settingsTab={surfaceNav.settingsTab}

--- a/apps/desktop/src/components/layout/desktop-shortcut-kbds.tsx
+++ b/apps/desktop/src/components/layout/desktop-shortcut-kbds.tsx
@@ -2,6 +2,7 @@ import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import {
   isMacDesktopPlatform,
   modAltLetterShortcutKbdKeys,
+  modCommaShortcutKbdKeys,
   modLetterShortcutKbdKeys,
 } from "@/lib/desktop-shell";
 
@@ -55,6 +56,24 @@ export function WorkspaceToolsShortcutKbd() {
           <Kbd>Alt</Kbd>
           <span>+</span>
           <Kbd>B</Kbd>
+        </>
+      )}
+    </KbdGroup>
+  );
+}
+
+export function SettingsShortcutKbd() {
+  const keys = modCommaShortcutKbdKeys();
+
+  return (
+    <KbdGroup>
+      {isMacDesktopPlatform() ? (
+        keys.map((key) => <Kbd key={key}>{key}</Kbd>)
+      ) : (
+        <>
+          <Kbd>Ctrl</Kbd>
+          <span>+</span>
+          <Kbd>,</Kbd>
         </>
       )}
     </KbdGroup>

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -75,7 +75,8 @@ import { resolveWorkspaceGroupingRoot } from "@/lib/workspace-grouping";
 import { runAfterRadixOverlayClose } from "@/lib/overlay-motion";
 import { isViteDev } from "@/lib/vite-dev";
 import { cn } from "@/lib/utils";
-import { shortcutLabel } from "@/lib/desktop-shell";
+import { SettingsShortcutKbd } from "@/components/layout/desktop-shortcut-kbds";
+import { shortcutLabel, settingsShortcutLabel } from "@/lib/desktop-shell";
 import i18n from "@/lib/i18n";
 import { useHostApi } from "@/hooks/useHostApi";
 import type { SessionListItem } from "@/types";
@@ -87,6 +88,7 @@ import {
 
 /** 平台快捷键提示，模块加载时计算（平台不会运行时变化）。 */
 const newSessionShortcutLabel = shortcutLabel("N");
+const settingsShortcutLabelText = settingsShortcutLabel();
 
 
 function samePath(a: string, b: string): boolean {
@@ -1734,21 +1736,50 @@ function SessionSidebarInner({
             narrow && "mt-auto flex flex-col items-center py-2",
           )}
         >
-          <Button
-            type="button"
-            variant="ghost"
-            size={narrow ? "icon" : "sm"}
-            className={cn(
-              sidebarItemDefaultTextClass,
-              sidebarInteractionMotionClass,
-              sidebarItemHoverClass(micaStyle),
-              narrow ? "size-8" : "h-8 w-full justify-start gap-2",
-            )}
-            onClick={onOpenSettings}
-          >
-            <Settings className="size-4" aria-hidden />
-            <span className={cn(narrow && "sr-only")}>{t('settings.title')}</span>
-          </Button>
+          {narrow ? (
+            <Tooltip delayDuration={300} disableHoverableContent>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className={cn(
+                    sidebarItemDefaultTextClass,
+                    sidebarInteractionMotionClass,
+                    sidebarItemHoverClass(micaStyle),
+                    "size-8",
+                  )}
+                  onClick={onOpenSettings}
+                  aria-label={t("settings.title")}
+                >
+                  <Settings className="size-4" aria-hidden />
+                  <span className="sr-only">{t("settings.title")}</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={4}>
+                {t("settings.title")} <SettingsShortcutKbd />
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className={cn(
+                sidebarItemDefaultTextClass,
+                sidebarInteractionMotionClass,
+                sidebarItemHoverClass(micaStyle),
+                "h-8 w-full justify-start gap-2",
+              )}
+              onClick={onOpenSettings}
+            >
+              <Settings className="size-4" aria-hidden />
+              <span>{t("settings.title")}</span>
+              <span className="ml-auto text-[0.65rem] text-sidebar-item-foreground" aria-hidden>
+                {settingsShortcutLabelText}
+              </span>
+            </Button>
+          )}
         </div>
       ) : null}
 

--- a/apps/desktop/src/hooks/useAppSurfaceNavigation.ts
+++ b/apps/desktop/src/hooks/useAppSurfaceNavigation.ts
@@ -167,6 +167,28 @@ export function useAppSurfaceNavigation({
     });
   }, [composerAutomationApiRef, runtime, t]);
 
+  const handleOpenSettings = useCallback(() => {
+    sessionSidebarChromeApiRef.current?.openSidebar();
+    const current = activeSurfaceRef.current;
+    if (current !== "settings") {
+      setLastNonSettingsSurface(
+        current === "marketplace"
+          ? "marketplace"
+          : current === "automations" || current === "automation-detail"
+            ? "automations"
+            : "conversation",
+      );
+    }
+    setActiveSurface("settings");
+  }, []);
+
+  const handleCloseSettings = useCallback(() => {
+    if (activeSurfaceRef.current !== "settings") {
+      return;
+    }
+    setActiveSurface(lastNonSettingsSurface);
+  }, [lastNonSettingsSurface]);
+
   const extensionSettingsItems = useMemo(
     () =>
       (snapshot?.extensionsList ?? [])
@@ -206,6 +228,8 @@ export function useAppSurfaceNavigation({
     handleNewSession,
     handleNewSessionInWorkspace,
     handleGenerateAutomation,
+    handleOpenSettings,
+    handleCloseSettings,
     extensionSettingsItems,
   };
 }

--- a/apps/desktop/src/hooks/useDesktopKeyboardShortcuts.ts
+++ b/apps/desktop/src/hooks/useDesktopKeyboardShortcuts.ts
@@ -10,8 +10,10 @@ import {
   isModShortcutPressed,
 } from "@/lib/desktop-shell";
 import {
+  resolveModCommaSettingsShortcutAction,
   resolveModPShortcutAction,
   shouldTriggerConversationAbortShortcut,
+  shouldTriggerSettingsEscapeShortcut,
 } from "@/lib/desktop-keyboard-shortcut-eligibility";
 import { resolveUiLayoutZoomShortcutAction } from "@/lib/ui-layout-scale";
 import type { AppSurface } from "@/hooks/useAppSurfaceNavigation";
@@ -30,6 +32,8 @@ export type UseDesktopKeyboardShortcutsOptions = {
   conversationAbortShortcutEligibleRef: MutableRefObject<boolean>;
   sessionSidebarChromeApiRef: MutableRefObject<SessionSidebarChromeApi | null>;
   handleNewSession: () => void;
+  handleOpenSettings: () => void;
+  handleCloseSettings: () => void;
   setActionPickerOpen: (open: boolean) => void;
   setFilePickerOpen: (open: boolean) => void;
   uiLayoutScaleApi: UiLayoutScaleShortcutApi;
@@ -41,6 +45,8 @@ export function useDesktopKeyboardShortcuts({
   conversationAbortShortcutEligibleRef,
   sessionSidebarChromeApiRef,
   handleNewSession,
+  handleOpenSettings,
+  handleCloseSettings,
   setActionPickerOpen,
   setFilePickerOpen,
   uiLayoutScaleApi,
@@ -155,6 +161,45 @@ export function useDesktopKeyboardShortcuts({
     }
     return bridge.subscribeNewSession(handleNewSession);
   }, [handleNewSession]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      const action = resolveModCommaSettingsShortcutAction(
+        {
+          defaultPrevented: event.defaultPrevented,
+          key: event.key,
+          shiftKey: event.shiftKey,
+          altKey: event.altKey,
+          modPressed: isModShortcutPressed(event),
+          target: event.target,
+        },
+        { activeSurface: activeSurfaceRef.current },
+      );
+      if (!action) {
+        return;
+      }
+      event.preventDefault();
+      handleOpenSettings();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeSurfaceRef, handleOpenSettings]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        !shouldTriggerSettingsEscapeShortcut(event, {
+          activeSurface: activeSurfaceRef.current,
+        })
+      ) {
+        return;
+      }
+      event.preventDefault();
+      handleCloseSettings();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [activeSurfaceRef, handleCloseSettings]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/apps/desktop/src/lib/desktop-keyboard-shortcut-eligibility.ts
+++ b/apps/desktop/src/lib/desktop-keyboard-shortcut-eligibility.ts
@@ -62,3 +62,77 @@ export function resolveModPShortcutAction(
   }
   return event.shiftKey ? "action-picker" : "file-picker";
 }
+
+export type SettingsShortcutSurfaceContext = {
+  activeSurface: ConversationAbortShortcutContext["activeSurface"];
+};
+
+function isEditableShortcutTarget(target: HTMLElement | null): boolean {
+  if (!target) {
+    return false;
+  }
+  return (
+    target.tagName === "TEXTAREA" ||
+    target.tagName === "INPUT" ||
+    target.tagName === "SELECT" ||
+    (target.isContentEditable &&
+      !target.closest("[data-spirit-surface='composer-surface']"))
+  );
+}
+
+function hasOpenDialogInDocument(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+  return document.querySelector('[role="dialog"][data-state="open"]') !== null;
+}
+
+/** Mod+, opens settings when not already on the settings surface. */
+export function resolveModCommaSettingsShortcutAction(
+  event: Pick<KeyboardEventLike, "defaultPrevented" | "key" | "shiftKey" | "altKey" | "target"> & {
+    modPressed: boolean;
+  },
+  context: SettingsShortcutSurfaceContext,
+): "open-settings" | null {
+  if (event.defaultPrevented || !event.modPressed || event.shiftKey || event.altKey) {
+    return null;
+  }
+  if (event.key !== "," && event.key !== "，") {
+    return null;
+  }
+  if (context.activeSurface === "settings") {
+    return null;
+  }
+  const target = event.target as HTMLElement | null;
+  if (isEditableShortcutTarget(target)) {
+    return null;
+  }
+  return "open-settings";
+}
+
+/** Escape returns from settings when no modal is open and focus is not in an editable field. */
+export function shouldTriggerSettingsEscapeShortcut(
+  event: KeyboardEventLike,
+  context: SettingsShortcutSurfaceContext,
+): boolean {
+  if (event.defaultPrevented) {
+    return false;
+  }
+  if (context.activeSurface !== "settings") {
+    return false;
+  }
+  if (event.key !== "Escape") {
+    return false;
+  }
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) {
+    return false;
+  }
+  if (hasOpenDialogInDocument()) {
+    return false;
+  }
+  const target = event.target as HTMLElement | null;
+  if (isEditableShortcutTarget(target)) {
+    return false;
+  }
+  return true;
+}

--- a/apps/desktop/src/lib/desktop-keyboard-shortcut-eligibility.ts
+++ b/apps/desktop/src/lib/desktop-keyboard-shortcut-eligibility.ts
@@ -84,7 +84,8 @@ function hasOpenDialogInDocument(): boolean {
   if (typeof document === "undefined") {
     return false;
   }
-  return document.querySelector('[role="dialog"][data-state="open"]') !== null;
+  // Radix Dialog（见 dialog.tsx / overlay-motion.ts）开放态为 data-open，非 data-state。
+  return document.querySelector('[data-slot="dialog-content"][data-open]') !== null;
 }
 
 /** Mod+, opens settings when not already on the settings surface. */

--- a/apps/desktop/src/lib/desktop-shell.ts
+++ b/apps/desktop/src/lib/desktop-shell.ts
@@ -120,6 +120,17 @@ export function modSlashShortcutLabel(): string {
   return isMacDesktopPlatform() ? keys.join("") : keys.join("+");
 }
 
+/** Cmd/Ctrl + , shortcut keys for tooltip Kbd chips. */
+export function modCommaShortcutKbdKeys(): readonly string[] {
+  return isMacDesktopPlatform() ? ["⌘", ","] : ["Ctrl", ","];
+}
+
+/** Cmd/Ctrl + , shortcut label for opening settings. */
+export function settingsShortcutLabel(): string {
+  const keys = modCommaShortcutKbdKeys();
+  return isMacDesktopPlatform() ? keys.join("") : keys.join("+");
+}
+
 type KeyboardModifierState = Pick<KeyboardEvent, "altKey" | "ctrlKey" | "metaKey">;
 
 /** Whether the platform primary shortcut modifier (⌘ on macOS, Ctrl elsewhere) is held. */

--- a/apps/desktop/test/lib/desktop-keyboard-shortcut-eligibility.test.mjs
+++ b/apps/desktop/test/lib/desktop-keyboard-shortcut-eligibility.test.mjs
@@ -254,3 +254,31 @@ test('shouldTriggerSettingsEscapeShortcut rejects textarea targets', () => {
     false,
   );
 });
+
+test('shouldTriggerSettingsEscapeShortcut rejects when a Radix dialog is open', () => {
+  const previousDocument = globalThis.document;
+  globalThis.document = {
+    querySelector: (selector) =>
+      selector.includes('data-slot="dialog-content"][data-open') ? {} : null,
+  };
+  try {
+    assert.equal(
+      shouldTriggerSettingsEscapeShortcut(
+        {
+          defaultPrevented: false,
+          ctrlKey: false,
+          metaKey: false,
+          altKey: false,
+          shiftKey: false,
+          code: 'Escape',
+          key: 'Escape',
+          target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
+        },
+        { activeSurface: 'settings' },
+      ),
+      false,
+    );
+  } finally {
+    globalThis.document = previousDocument;
+  }
+});

--- a/apps/desktop/test/lib/desktop-keyboard-shortcut-eligibility.test.mjs
+++ b/apps/desktop/test/lib/desktop-keyboard-shortcut-eligibility.test.mjs
@@ -2,8 +2,10 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  resolveModCommaSettingsShortcutAction,
   resolveModPShortcutAction,
   shouldTriggerConversationAbortShortcut,
+  shouldTriggerSettingsEscapeShortcut,
 } from '../../src/lib/desktop-keyboard-shortcut-eligibility.ts';
 
 const conversationContext = {
@@ -140,6 +142,114 @@ test('shouldTriggerConversationAbortShortcut rejects xterm targets', () => {
         },
       },
       conversationContext,
+    ),
+    false,
+  );
+});
+
+test('resolveModCommaSettingsShortcutAction opens settings from conversation', () => {
+  assert.equal(
+    resolveModCommaSettingsShortcutAction(
+      {
+        defaultPrevented: false,
+        key: ',',
+        shiftKey: false,
+        altKey: false,
+        modPressed: true,
+        target: { tagName: 'DIV' },
+      },
+      { activeSurface: 'conversation' },
+    ),
+    'open-settings',
+  );
+});
+
+test('resolveModCommaSettingsShortcutAction ignores when already on settings', () => {
+  assert.equal(
+    resolveModCommaSettingsShortcutAction(
+      {
+        defaultPrevented: false,
+        key: ',',
+        shiftKey: false,
+        altKey: false,
+        modPressed: true,
+        target: { tagName: 'DIV' },
+      },
+      { activeSurface: 'settings' },
+    ),
+    null,
+  );
+});
+
+test('resolveModCommaSettingsShortcutAction ignores textarea targets', () => {
+  assert.equal(
+    resolveModCommaSettingsShortcutAction(
+      {
+        defaultPrevented: false,
+        key: ',',
+        shiftKey: false,
+        altKey: false,
+        modPressed: true,
+        target: { tagName: 'TEXTAREA' },
+      },
+      { activeSurface: 'conversation' },
+    ),
+    null,
+  );
+});
+
+test('shouldTriggerSettingsEscapeShortcut accepts escape on settings surface', () => {
+  assert.equal(
+    shouldTriggerSettingsEscapeShortcut(
+      {
+        defaultPrevented: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        code: 'Escape',
+        key: 'Escape',
+        target: { tagName: 'DIV', isContentEditable: false, closest: () => null },
+      },
+      { activeSurface: 'settings' },
+    ),
+    true,
+  );
+});
+
+test('shouldTriggerSettingsEscapeShortcut rejects non-settings surface', () => {
+  assert.equal(
+    shouldTriggerSettingsEscapeShortcut(
+      {
+        defaultPrevented: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        code: 'Escape',
+        key: 'Escape',
+        target: null,
+      },
+      { activeSurface: 'conversation' },
+    ),
+    false,
+  );
+});
+
+test('shouldTriggerSettingsEscapeShortcut rejects textarea targets', () => {
+  assert.equal(
+    shouldTriggerSettingsEscapeShortcut(
+      {
+        defaultPrevented: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        shiftKey: false,
+        code: 'Escape',
+        key: 'Escape',
+        target: { tagName: 'TEXTAREA', isContentEditable: false, closest: () => null },
+      },
+      { activeSurface: 'settings' },
     ),
     false,
   );

--- a/apps/desktop/test/lib/desktop-shell.test.mjs
+++ b/apps/desktop/test/lib/desktop-shell.test.mjs
@@ -6,9 +6,11 @@ import {
   isModAltShortcutPressed,
   isModShortcutPressed,
   modAltLetterShortcutKbdKeys,
+  modCommaShortcutKbdKeys,
   modLetterShortcutKbdKeys,
   modSlashShortcutKbdKeys,
   modSlashShortcutLabel,
+  settingsShortcutLabel,
   shortcutLabel,
 } from "../../src/lib/desktop-shell.ts";
 
@@ -90,6 +92,30 @@ test("modSlashShortcutLabel formats slash shortcut per platform", () => {
   });
   withDesktopPlatform("linux", () => {
     assert.equal(modSlashShortcutLabel(), "Ctrl+/");
+  });
+});
+
+test("modCommaShortcutKbdKeys returns comma shortcut chips per platform", () => {
+  withDesktopPlatform("darwin", () => {
+    assert.deepEqual(modCommaShortcutKbdKeys(), ["⌘", ","]);
+  });
+  withDesktopPlatform("win32", () => {
+    assert.deepEqual(modCommaShortcutKbdKeys(), ["Ctrl", ","]);
+  });
+  withDesktopPlatform("linux", () => {
+    assert.deepEqual(modCommaShortcutKbdKeys(), ["Ctrl", ","]);
+  });
+});
+
+test("settingsShortcutLabel formats comma shortcut per platform", () => {
+  withDesktopPlatform("darwin", () => {
+    assert.equal(settingsShortcutLabel(), "⌘,");
+  });
+  withDesktopPlatform("win32", () => {
+    assert.equal(settingsShortcutLabel(), "Ctrl+,");
+  });
+  withDesktopPlatform("linux", () => {
+    assert.equal(settingsShortcutLabel(), "Ctrl+,");
   });
 });
 


### PR DESCRIPTION
## Summary

- 新增 Ctrl+, / ⌘, 全局快捷键打开设置，并在侧栏底部设置按钮展示平台化快捷键提示
- 设置页支持 ESC 返回进入设置前的表面，对话框打开或表单聚焦时不抢占 ESC
- 抽取 handleOpenSettings / handleCloseSettings 作为单一导航入口，快捷键资格判定可单测

## Test plan

- [x] npx --yes tsx --test test/lib/desktop-shell.test.mjs test/lib/desktop-keyboard-shortcut-eligibility.test.mjs
- [ ] 会话页 Ctrl+, / ⌘, 进入设置，侧栏按钮显示正确键位
- [ ] 设置页 ESC 返回上一表面；Hook 删除对话框打开时 ESC 先关对话框
- [ ] 设置表单 input/textarea 聚焦时 ESC 不触发全局返回