### PR TITLE
feat(agent-core): Gateway Claude 默认开启 adaptive thinking 并适配 effort 枚举

### DIFF
--- a/apps/desktop/src/host/model-catalog-metadata.ts
+++ b/apps/desktop/src/host/model-catalog-metadata.ts
@@ -1,4 +1,5 @@
 import { formatModelDisplayNameFromId } from '@spirit-agent/core/model-display-name';
+import { gatewayAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
 import type { ProviderListedModelEntry } from '@spirit-agent/host-internal';
 
 import type {
@@ -91,9 +92,7 @@ export function previewModelCatalogForTransport(input: {
     ...resolvePreviewCatalogDisplayName(input.provider, entry),
     ...(entry.description !== undefined ? { description: entry.description } : {}),
     ...(entry.pricing !== undefined ? { pricing: { ...entry.pricing } } : {}),
-    ...(entry.supportedReasoningEfforts !== undefined
-      ? { supportedReasoningEfforts: normalizePreviewSupportedReasoningEfforts(entry.supportedReasoningEfforts) }
-      : {}),
+    ...resolvePreviewSupportedReasoningEffortsForEntry(input.provider, entry),
     ...(entry.contextLength !== undefined ? { contextLength: entry.contextLength } : {}),
   }));
 }
@@ -168,6 +167,30 @@ function previewCapabilitiesFromListedEntry(
     capabilities.push('video');
   }
   return capabilities;
+}
+
+function resolvePreviewSupportedReasoningEffortsForEntry(
+  provider: DesktopModelProvider | undefined,
+  entry: ProviderListedModelEntry,
+): { supportedReasoningEfforts?: DesktopModelReasoningEffort[] } {
+  if (entry.supportedReasoningEfforts !== undefined) {
+    return {
+      supportedReasoningEfforts: normalizePreviewSupportedReasoningEfforts(entry.supportedReasoningEfforts),
+    };
+  }
+
+  if (provider !== 'vercel-ai-gateway') {
+    return {};
+  }
+
+  const inferred = gatewayAnthropicClaudeSupportedEfforts(entry.id);
+  if (inferred === undefined) {
+    return {};
+  }
+
+  return {
+    supportedReasoningEfforts: normalizePreviewSupportedReasoningEfforts(inferred),
+  };
 }
 
 function normalizePreviewSupportedReasoningEfforts(

--- a/apps/desktop/test/host/model-catalog-metadata.test.mjs
+++ b/apps/desktop/test/host/model-catalog-metadata.test.mjs
@@ -218,6 +218,33 @@ test('vercel-ai-gateway provider maps language and image model types to catalog 
   ]);
 });
 
+test('vercel-ai-gateway infers supportedReasoningEfforts for anthropic claude catalog entries', () => {
+  const preview = previewModelCatalogForTransport({
+    provider: 'vercel-ai-gateway',
+    transportKind: 'openai-compatible',
+    listedModels: [
+      {
+        id: 'anthropic/claude-sonnet-4.6',
+      },
+      {
+        id: 'openai/gpt-5',
+      },
+    ],
+  });
+
+  assert.deepEqual(preview, [
+    {
+      id: 'anthropic/claude-sonnet-4.6',
+      capabilities: ['chat'],
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
+    },
+    {
+      id: 'openai/gpt-5',
+      capabilities: ['chat'],
+    },
+  ]);
+});
+
 test('moonshot-ai video input maps to video capability not videoGeneration', () => {
   const preview = previewModelCatalogForTransport({
     provider: 'moonshot-ai',

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -124,6 +124,44 @@ test('buildResponsesProviderOptions maps gateway openai reasoning options', () =
   });
 });
 
+test('buildResponsesProviderOptions maps gateway anthropic claude to adaptive thinking', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'anthropic/claude-sonnet-4.6',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'medium',
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+        thinking: { type: 'adaptive' },
+        effort: 'medium',
+      },
+    },
+  );
+});
+
+test('buildResponsesProviderOptions maps gateway anthropic opus 4.8 to summarized adaptive thinking', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'anthropic/claude-opus-4.8',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'medium',
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+        thinking: { type: 'adaptive', display: 'summarized' },
+        effort: 'medium',
+      },
+    },
+  );
+});
+
 test('buildResponsesProviderOptions maps azure provider options', () => {
   const options = buildResponsesProviderOptions({
     transportKind: 'open-responses',

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -26,6 +26,10 @@ import {
   shouldUseApplyPatchFunctionTool,
   shouldUseOpenAiSdkApplyPatchTool,
 } from './apply-patch-eligibility.js';
+import {
+  buildGatewayAnthropicProviderOptions,
+  isGatewayAnthropicClaudeModel,
+} from '../openai/gateway-anthropic-thinking.js';
 import { buildGatewayWebSearchTool, shouldUseGatewayWebSearch } from './gateway-web-search.js';
 import { resolveProviderWebSearchMode } from './web-search-eligibility.js';
 import {
@@ -199,6 +203,10 @@ export function buildResponsesProviderOptions(
   const reasoningSummary = resolveOpenResponsesReasoningSummary(config);
 
   if (shouldUseGatewayWebSearch(config)) {
+    if (isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
+      return buildGatewayAnthropicProviderOptions(config);
+    }
+
     // Gateway v3 language-model 原样转发 providerOptions；OpenAI 路由模型须用 openai 命名空间（见 Vercel AI Gateway reasoning 文档）。
     const openaiOptions: JsonObject = {
       ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),

--- a/packages/agent-core/src/open-responses/responses-compat.ts
+++ b/packages/agent-core/src/open-responses/responses-compat.ts
@@ -5,6 +5,7 @@ import type {
   OpenAiLlmVendor,
   OpenAiVideoGenerationConfig,
 } from '../openai/openai-compat.js';
+import { isGatewayAnthropicClaudeModel } from '../openai/gateway-anthropic-thinking.js';
 import { resolveOpenAiTransportReasoningEffortForContext } from '../reasoning-effort.js';
 import { extractAzureResourceNameFromApiBase } from '../azure-resource.js';
 import { cloneJsonValue } from '../tool-agent.js';
@@ -208,6 +209,10 @@ export function openResponsesReasoningTrace(
     'llmVendor' | 'model' | 'reasoningEffort' | 'reasoningSummary'
   >,
 ): JsonObject | undefined {
+  if (isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
+    return undefined;
+  }
+
   const effort = openResponsesReasoningEffort(config);
   const summary = resolveOpenResponsesReasoningSummary(config);
   if (effort === undefined && summary === undefined) {

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -81,6 +81,10 @@ import {
   type OpenAiTransportConfig,
   type OpenAiVideoGenerationConfig,
 } from './openai-compat.js';
+import {
+  buildGatewayAnthropicProviderOptions,
+  isGatewayAnthropicClaudeModel,
+} from './gateway-anthropic-thinking.js';
 import { generateSiliconFlowImage } from '../image-generation/siliconflow-backend.js';
 import { generateVideoWithRouter } from '../video-generation/router.js';
 import { getLlmFetch } from '../llm-fetch.js';
@@ -895,6 +899,10 @@ function createAiSdkOpenAiProvider(config: OpenAiTransportConfig) {
 function buildAiSdkProviderOptions(
   config: OpenAiTransportConfig,
 ): Record<string, JsonObject> {
+  if (isVercelAiGatewayProvider(config) && isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
+    return buildGatewayAnthropicProviderOptions(config);
+  }
+
   if (isAlibabaOfficialAiSdkProvider(config)) {
     const extraBody = shouldUseAlibabaChatCompletionsBuiltInTools(config)
       ? buildAlibabaChatCompletionsExtraBody({ streaming: true })

--- a/packages/agent-core/src/openai/gateway-anthropic-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-anthropic-thinking.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayAnthropicProviderOptions,
+  gatewayAnthropicClaudeSupportedEfforts,
+  isGatewayAnthropicClaudeModel,
+  normalizeGatewayAnthropicClaudeModelId,
+  resolveGatewayAnthropicClaudeCapabilities,
+} from './gateway-anthropic-thinking.js';
+
+test('normalizeGatewayAnthropicClaudeModelId maps gateway ids to hyphen form', () => {
+  assert.equal(
+    normalizeGatewayAnthropicClaudeModelId('anthropic/claude-sonnet-4.6'),
+    'claude-sonnet-4-6',
+  );
+  assert.equal(
+    normalizeGatewayAnthropicClaudeModelId('anthropic/claude-opus-4.7'),
+    'claude-opus-4-7',
+  );
+});
+
+test('isGatewayAnthropicClaudeModel matches vercel-ai-gateway anthropic routes only', () => {
+  assert.equal(
+    isGatewayAnthropicClaudeModel('vercel-ai-gateway', 'anthropic/claude-sonnet-4.6'),
+    true,
+  );
+  assert.equal(
+    isGatewayAnthropicClaudeModel('vercel-ai-gateway', 'openai/gpt-5'),
+    false,
+  );
+  assert.equal(
+    isGatewayAnthropicClaudeModel('openrouter', 'anthropic/claude-sonnet-4.6'),
+    false,
+  );
+});
+
+test('resolveGatewayAnthropicClaudeCapabilities maps adaptive models and effort levels', () => {
+  assert.deepEqual(resolveGatewayAnthropicClaudeCapabilities('anthropic/claude-sonnet-4.6'), {
+    thinkingMode: 'adaptive',
+    supportedEfforts: ['low', 'medium', 'high'],
+  });
+  assert.deepEqual(resolveGatewayAnthropicClaudeCapabilities('anthropic/claude-opus-4.6'), {
+    thinkingMode: 'adaptive',
+    supportedEfforts: ['low', 'medium', 'high', 'max'],
+  });
+  assert.deepEqual(resolveGatewayAnthropicClaudeCapabilities('anthropic/claude-opus-4.7'), {
+    thinkingMode: 'adaptive',
+    supportedEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+    adaptiveDisplay: 'summarized',
+  });
+});
+
+test('resolveGatewayAnthropicClaudeCapabilities maps legacy claude models to budget thinking', () => {
+  assert.deepEqual(resolveGatewayAnthropicClaudeCapabilities('anthropic/claude-sonnet-4-5'), {
+    thinkingMode: 'budget',
+    supportedEfforts: ['low', 'medium', 'high'],
+  });
+});
+
+test('gatewayAnthropicClaudeSupportedEfforts exports effort vocabulary for catalog metadata', () => {
+  assert.deepEqual(
+    gatewayAnthropicClaudeSupportedEfforts('anthropic/claude-sonnet-4.6'),
+    ['low', 'medium', 'high'],
+  );
+  assert.equal(gatewayAnthropicClaudeSupportedEfforts('openai/gpt-5'), undefined);
+});
+
+test('buildGatewayAnthropicProviderOptions sends adaptive thinking for sonnet 4.6', () => {
+  assert.deepEqual(
+    buildGatewayAnthropicProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'anthropic/claude-sonnet-4.6',
+      reasoningEffort: 'default',
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+        thinking: { type: 'adaptive' },
+      },
+    },
+  );
+});
+
+test('buildGatewayAnthropicProviderOptions maps effort and summarized display for opus 4.7', () => {
+  assert.deepEqual(
+    buildGatewayAnthropicProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'anthropic/claude-opus-4.7',
+      reasoningEffort: 'high',
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+        thinking: { type: 'adaptive', display: 'summarized' },
+        effort: 'high',
+      },
+    },
+  );
+});
+
+test('buildGatewayAnthropicProviderOptions uses budget thinking for legacy claude when effort selected', () => {
+  assert.deepEqual(
+    buildGatewayAnthropicProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'anthropic/claude-sonnet-4-5',
+      reasoningEffort: 'medium',
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+        thinking: { type: 'enabled', budgetTokens: 8_000 },
+        effort: 'medium',
+      },
+    },
+  );
+});
+
+test('buildGatewayAnthropicProviderOptions omits budget thinking for legacy claude at default effort', () => {
+  assert.deepEqual(
+    buildGatewayAnthropicProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'anthropic/claude-sonnet-4-5',
+      reasoningEffort: 'default',
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
@@ -1,0 +1,172 @@
+import type { JsonObject, JsonValue } from '../ports.js';
+import type { AnthropicEffort, AnthropicThinkingConfig } from '../anthropic/anthropic-compat.js';
+import type { OpenAiLlmVendor, OpenAiTransportConfig } from './openai-compat.js';
+
+export type GatewayAnthropicThinkingMode = 'adaptive' | 'budget' | 'none';
+
+export interface GatewayAnthropicClaudeCapabilities {
+  thinkingMode: GatewayAnthropicThinkingMode;
+  supportedEfforts: readonly AnthropicEffort[];
+  adaptiveDisplay?: 'summarized';
+}
+
+const LEGACY_BUDGET_EFFORTS: readonly AnthropicEffort[] = ['low', 'medium', 'high'];
+
+const BUDGET_TOKENS_BY_EFFORT: Record<'low' | 'medium' | 'high', number> = {
+  low: 4_000,
+  medium: 8_000,
+  high: 12_000,
+};
+
+export function normalizeGatewayAnthropicClaudeModelId(model: string): string {
+  return model
+    .trim()
+    .toLowerCase()
+    .replace(/^anthropic\//, '')
+    .replace(/(\d)\.(\d)/g, '$1-$2');
+}
+
+export function isGatewayAnthropicClaudeModel(
+  llmVendor: OpenAiLlmVendor | undefined,
+  model: string,
+): boolean {
+  if (llmVendor !== 'vercel-ai-gateway') {
+    return false;
+  }
+
+  const normalized = model.trim().toLowerCase();
+  return normalized.startsWith('anthropic/claude-');
+}
+
+export function resolveGatewayAnthropicClaudeCapabilities(
+  model: string,
+): GatewayAnthropicClaudeCapabilities {
+  const modelId = normalizeGatewayAnthropicClaudeModelId(model);
+
+  if (modelId.includes('claude-opus-4-7') || modelId.includes('claude-opus-4-8')) {
+    return {
+      thinkingMode: 'adaptive',
+      supportedEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      adaptiveDisplay: 'summarized',
+    };
+  }
+
+  if (modelId.includes('claude-opus-4-6')) {
+    return {
+      thinkingMode: 'adaptive',
+      supportedEfforts: ['low', 'medium', 'high', 'max'],
+    };
+  }
+
+  if (modelId.includes('claude-sonnet-4-6')) {
+    return {
+      thinkingMode: 'adaptive',
+      supportedEfforts: ['low', 'medium', 'high'],
+    };
+  }
+
+  if (isLegacyGatewayAnthropicClaudeModel(modelId)) {
+    return {
+      thinkingMode: 'budget',
+      supportedEfforts: LEGACY_BUDGET_EFFORTS,
+    };
+  }
+
+  return {
+    thinkingMode: 'none',
+    supportedEfforts: [],
+  };
+}
+
+export function gatewayAnthropicClaudeSupportedEfforts(
+  model: string,
+): AnthropicEffort[] | undefined {
+  if (!model.trim().toLowerCase().startsWith('anthropic/claude-')) {
+    return undefined;
+  }
+
+  const capabilities = resolveGatewayAnthropicClaudeCapabilities(model);
+  if (capabilities.supportedEfforts.length === 0) {
+    return undefined;
+  }
+
+  return [...capabilities.supportedEfforts];
+}
+
+function isLegacyGatewayAnthropicClaudeModel(modelId: string): boolean {
+  if (!modelId.includes('claude')) {
+    return false;
+  }
+
+  return (
+    modelId.includes('haiku-4-5')
+    || modelId.includes('opus-4-5')
+    || modelId.includes('sonnet-4-5')
+    || /claude-opus-4(?:-|$)/.test(modelId)
+    || /claude-sonnet-4(?:-|$)/.test(modelId)
+    || modelId.includes('claude-opus-4-1')
+  );
+}
+
+function anthropicEffortFromConfigReasoningEffort(
+  reasoningEffort: OpenAiTransportConfig['reasoningEffort'],
+  supportedEfforts: readonly AnthropicEffort[],
+): AnthropicEffort | undefined {
+  if (reasoningEffort === undefined || reasoningEffort === 'default') {
+    return undefined;
+  }
+
+  const effort = reasoningEffort as AnthropicEffort;
+  return supportedEfforts.includes(effort) ? effort : undefined;
+}
+
+function buildAdaptiveThinkingConfig(
+  capabilities: GatewayAnthropicClaudeCapabilities,
+): AnthropicThinkingConfig {
+  return {
+    type: 'adaptive',
+    ...(capabilities.adaptiveDisplay ? { display: capabilities.adaptiveDisplay } : {}),
+  };
+}
+
+function buildBudgetThinkingConfig(effort: AnthropicEffort): AnthropicThinkingConfig {
+  const budgetKey = effort === 'low' || effort === 'medium' || effort === 'high' ? effort : 'high';
+  return {
+    type: 'enabled',
+    budgetTokens: BUDGET_TOKENS_BY_EFFORT[budgetKey],
+  };
+}
+
+export function buildGatewayAnthropicProviderOptions(
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort'>,
+): Record<string, JsonObject> {
+  if (!isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
+    return {};
+  }
+
+  const capabilities = resolveGatewayAnthropicClaudeCapabilities(config.model);
+  const effort = anthropicEffortFromConfigReasoningEffort(
+    config.reasoningEffort,
+    capabilities.supportedEfforts,
+  );
+
+  const anthropic: JsonObject = {
+    toolStreaming: true,
+  };
+
+  if (capabilities.thinkingMode === 'adaptive') {
+    anthropic.thinking = buildAdaptiveThinkingConfig(capabilities) as unknown as JsonValue;
+    if (effort !== undefined) {
+      anthropic.effort = effort;
+    }
+    return { anthropic };
+  }
+
+  if (capabilities.thinkingMode === 'budget' && effort !== undefined) {
+    anthropic.thinking = buildBudgetThinkingConfig(effort) as unknown as JsonValue;
+    anthropic.effort = effort;
+    return { anthropic };
+  }
+
+  return { anthropic };
+}

--- a/packages/agent-core/src/openai/index.ts
+++ b/packages/agent-core/src/openai/index.ts
@@ -5,6 +5,12 @@ export * from './transport-factory.js';
 export {
   resolveOpenAiModelCompatibilityProfile,
 } from './openai-compat.js';
+export {
+  buildGatewayAnthropicProviderOptions,
+  gatewayAnthropicClaudeSupportedEfforts,
+  isGatewayAnthropicClaudeModel,
+  resolveGatewayAnthropicClaudeCapabilities,
+} from './gateway-anthropic-thinking.js';
 export type {
   OpenAiLlmVendor,
   OpenAiModelCapabilities,

--- a/packages/agent-core/src/reasoning-effort.test.ts
+++ b/packages/agent-core/src/reasoning-effort.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  modelReasoningEffortOptions,
   resolveAnthropicTransportReasoningEffortForContext,
   resolveModelReasoningEffortForContext,
   resolveOpenAiTransportReasoningEffortForContext,
@@ -128,5 +129,42 @@ test('anthropic supported efforts restrict unavailable levels', () => {
       supportedEfforts: ['low', 'medium', 'high', 'xhigh'],
     }),
     'xhigh',
+  );
+});
+
+test('gateway claude models use anthropic effort options filtered by model capabilities', () => {
+  const sonnetOptions = modelReasoningEffortOptions({
+    provider: 'vercel-ai-gateway',
+    model: 'anthropic/claude-sonnet-4.6',
+    transportKind: 'openai-compatible',
+  });
+  assert.deepEqual(
+    sonnetOptions.map((option) => option.value),
+    ['default', 'low', 'medium', 'high'],
+  );
+
+  const opusOptions = modelReasoningEffortOptions({
+    provider: 'vercel-ai-gateway',
+    model: 'anthropic/claude-opus-4.7',
+    transportKind: 'openai-compatible',
+  });
+  assert.ok(opusOptions.some((option) => option.value === 'max'));
+  assert.ok(!opusOptions.some((option) => option.value === 'none'));
+
+  assert.equal(
+    resolveModelReasoningEffortForContext('max', {
+      provider: 'vercel-ai-gateway',
+      model: 'anthropic/claude-sonnet-4.6',
+      transportKind: 'openai-compatible',
+    }),
+    'default',
+  );
+  assert.equal(
+    resolveModelReasoningEffortForContext('max', {
+      provider: 'vercel-ai-gateway',
+      model: 'anthropic/claude-opus-4.7',
+      transportKind: 'openai-compatible',
+    }),
+    'max',
   );
 });

--- a/packages/agent-core/src/reasoning-effort.ts
+++ b/packages/agent-core/src/reasoning-effort.ts
@@ -1,5 +1,9 @@
 import type { AnthropicTransportConfig } from './anthropic/anthropic-compat.js';
 import type { LlmTransportKind } from './llm-provider-shared.js';
+import {
+  isGatewayAnthropicClaudeModel,
+  resolveGatewayAnthropicClaudeCapabilities,
+} from './openai/gateway-anthropic-thinking.js';
 import type { OpenAiTransportConfig } from './openai/openai-compat.js';
 
 export type ModelReasoningProvider =
@@ -198,6 +202,10 @@ export function defaultModelReasoningEffort(
     return 'default';
   }
 
+  if (isGatewayAnthropicClaudeReasoningModel(context)) {
+    return 'default';
+  }
+
   return DEFAULT_MODEL_REASONING_EFFORT;
 }
 
@@ -228,6 +236,12 @@ export function modelReasoningEffortOptions(
       return anthropicReasoningEffortOptionsForSupportedEfforts(context.supportedEfforts);
     }
     return ANTHROPIC_REASONING_EFFORT_OPTIONS;
+  }
+
+  if (isGatewayAnthropicClaudeReasoningModel(context)) {
+    const supportedEfforts = context?.supportedEfforts
+      ?? resolveGatewayAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts;
+    return anthropicReasoningEffortOptionsForSupportedEfforts(supportedEfforts);
   }
 
   return OPENAI_COMPATIBLE_REASONING_EFFORT_OPTIONS;
@@ -321,6 +335,15 @@ export function isAnthropicReasoningEffortModel(
   return context?.transportKind === 'anthropic' || context?.provider === 'anthropic';
 }
 
+export function isGatewayAnthropicClaudeReasoningModel(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  return isGatewayAnthropicClaudeModel(
+    context?.provider === 'vercel-ai-gateway' ? 'vercel-ai-gateway' : undefined,
+    context?.model ?? '',
+  );
+}
+
 function normalizeModelId(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
@@ -391,6 +414,20 @@ function resolveCompatibleModelReasoningEffort(
 
   if (isAnthropicReasoningEffortModel(context)) {
     const supportedEfforts = normalizeSupportedReasoningEfforts(context?.supportedEfforts);
+    switch (normalized) {
+      case 'none':
+      case 'minimal':
+        return 'default';
+      default:
+        return anthropicReasoningEffortValueForContext(normalized, supportedEfforts) ?? 'default';
+    }
+  }
+
+  if (isGatewayAnthropicClaudeReasoningModel(context)) {
+    const supportedEfforts = normalizeSupportedReasoningEfforts(
+      context?.supportedEfforts
+        ?? resolveGatewayAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts,
+    );
     switch (normalized) {
       case 'none':
       case 'minimal':

--- a/packages/host-internal/src/openai-models.test.ts
+++ b/packages/host-internal/src/openai-models.test.ts
@@ -168,6 +168,39 @@ test('parseVercelAiGatewayModelEntriesPayload maps language and image types', ()
   ]);
 });
 
+test('parseVercelAiGatewayModelEntriesPayload infers supportedReasoningEfforts for anthropic claude models', () => {
+  const entries = parseVercelAiGatewayModelEntriesPayload({
+    data: [
+      {
+        id: 'anthropic/claude-sonnet-4.6',
+        type: 'language',
+      },
+      {
+        id: 'anthropic/claude-opus-4.7',
+        type: 'language',
+      },
+      {
+        id: 'openai/gpt-5',
+        type: 'language',
+      },
+    ],
+  });
+
+  assert.deepEqual(entries, [
+    {
+      id: 'anthropic/claude-sonnet-4.6',
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
+    },
+    {
+      id: 'anthropic/claude-opus-4.7',
+      supportedReasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+    },
+    {
+      id: 'openai/gpt-5',
+    },
+  ]);
+});
+
 test('parseOpenAiCompatibleModelEntriesPayload routes vercel-ai-gateway to typed parser', () => {
   const entries = parseOpenAiCompatibleModelEntriesPayload({
     data: [

--- a/packages/host-internal/src/openai-models.ts
+++ b/packages/host-internal/src/openai-models.ts
@@ -2,6 +2,8 @@
  * OpenAI-compatible `GET /v1/models` listing (host-side; no secrets stored here).
  */
 
+import { gatewayAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
+
 import type { ModelProviderId, ProviderModelTransportKind } from './model-provider-presets.js';
 import { resolveProviderConnectApiBase } from './model-provider-presets.js';
 import {
@@ -477,6 +479,20 @@ export function parseGoogleModelEntriesPayload(body: unknown): ProviderListedMod
 
 const SKIPPED_VERCEL_GATEWAY_MODEL_TYPES = new Set(['embedding', 'reranking']);
 
+function attachGatewayAnthropicReasoningEfforts(
+  modelEntry: ProviderListedModelEntry,
+): ProviderListedModelEntry {
+  const supportedReasoningEfforts = gatewayAnthropicClaudeSupportedEfforts(modelEntry.id);
+  if (supportedReasoningEfforts === undefined) {
+    return modelEntry;
+  }
+
+  return {
+    ...modelEntry,
+    supportedReasoningEfforts,
+  };
+}
+
 export function parseVercelAiGatewayModelEntriesPayload(body: unknown): ProviderListedModelEntry[] {
   if (typeof body !== 'object' || body === null || !('data' in body)) {
     return [];
@@ -547,7 +563,7 @@ export function parseVercelAiGatewayModelEntriesPayload(body: unknown): Provider
       attachListedModelMetadata({ id: id.trim() }, record, readVercelGatewayPricing(record)),
     );
   }
-  return entries;
+  return entries.map(attachGatewayAnthropicReasoningEfforts);
 }
 
 function readOpenRouterModalities(value: unknown): string[] {


### PR DESCRIPTION
## Summary

- Gateway 上的 `anthropic/claude-*` 模型在请求中注入 `providerOptions.anthropic.thinking: { type: adaptive }`，不再误发 `openai.reasoningEffort`
- 按模型能力映射 effort（Sonnet 4.6: low/medium/high；Opus 4.6: +max；Opus 4.7+: +xhigh/max），Opus 4.7+ 附带 `display: summarized` 以返回可见 reasoning
- Legacy Claude 4.5 等仍走 budget thinking，仅在用户选择非 Default effort 时启用
- Vercel Gateway 列模型与 Desktop catalog preview 为 Claude 模型写入 `supportedReasoningEfforts`，模型选择器展示 Anthropic 风格 effort 枚举

## Test plan

- [x] `node --test` agent-core gateway-anthropic-thinking 与 reasoning-effort 单测
- [x] `node --test` host-internal openai-models 单测
- [x] `node --test` desktop model-catalog-metadata 单测
- [ ] Desktop 手动：Vercel AI Gateway + `anthropic/claude-sonnet-4.6`，确认 effort 为 Default/Low/Medium/High
- [ ] Desktop 手动：复杂任务应出现可展开 Thinking 内容（非仅 spinner）