### PR TITLE
feat(agent-core): OpenRouter Claude 思考与 Gateway 对齐

### DIFF
--- a/apps/desktop/src/host/model-catalog-metadata.ts
+++ b/apps/desktop/src/host/model-catalog-metadata.ts
@@ -1,5 +1,5 @@
 import { formatModelDisplayNameFromId } from '@spirit-agent/core/model-display-name';
-import { gatewayAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
+import { routedAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
 import type { ProviderListedModelEntry } from '@spirit-agent/host-internal';
 
 import type {
@@ -179,11 +179,11 @@ function resolvePreviewSupportedReasoningEffortsForEntry(
     };
   }
 
-  if (provider !== 'vercel-ai-gateway') {
+  if (provider !== 'vercel-ai-gateway' && provider !== 'openrouter') {
     return {};
   }
 
-  const inferred = gatewayAnthropicClaudeSupportedEfforts(entry.id);
+  const inferred = routedAnthropicClaudeSupportedEfforts(entry.id);
   if (inferred === undefined) {
     return {};
   }

--- a/apps/desktop/test/host/model-catalog-metadata.test.mjs
+++ b/apps/desktop/test/host/model-catalog-metadata.test.mjs
@@ -140,6 +140,7 @@ test('openrouter provider passes through display metadata and pricing', () => {
         outputPerTokenUsd: '0.000015',
       },
       capabilities: ['chat'],
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
     },
   ]);
 
@@ -221,6 +222,33 @@ test('vercel-ai-gateway provider maps language and image model types to catalog 
 test('vercel-ai-gateway infers supportedReasoningEfforts for anthropic claude catalog entries', () => {
   const preview = previewModelCatalogForTransport({
     provider: 'vercel-ai-gateway',
+    transportKind: 'openai-compatible',
+    listedModels: [
+      {
+        id: 'anthropic/claude-sonnet-4.6',
+      },
+      {
+        id: 'openai/gpt-5',
+      },
+    ],
+  });
+
+  assert.deepEqual(preview, [
+    {
+      id: 'anthropic/claude-sonnet-4.6',
+      capabilities: ['chat'],
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
+    },
+    {
+      id: 'openai/gpt-5',
+      capabilities: ['chat'],
+    },
+  ]);
+});
+
+test('openrouter infers supportedReasoningEfforts for anthropic claude catalog entries', () => {
+  const preview = previewModelCatalogForTransport({
+    provider: 'openrouter',
     transportKind: 'openai-compatible',
     listedModels: [
       {
@@ -422,6 +450,7 @@ test('openrouter provider passes contextLength through catalog metadata', () => 
       id: 'anthropic/claude-sonnet-4',
       capabilities: ['chat'],
       contextLength: 200000,
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
     },
   ]);
 });

--- a/apps/desktop/test/host/model-catalog-metadata.test.mjs
+++ b/apps/desktop/test/host/model-catalog-metadata.test.mjs
@@ -273,6 +273,27 @@ test('openrouter infers supportedReasoningEfforts for anthropic claude catalog e
   ]);
 });
 
+test('openrouter keeps explicit empty supportedReasoningEfforts without claude inference', () => {
+  const preview = previewModelCatalogForTransport({
+    provider: 'openrouter',
+    transportKind: 'openai-compatible',
+    listedModels: [
+      {
+        id: 'anthropic/claude-sonnet-4.6',
+        supportedReasoningEfforts: [],
+      },
+    ],
+  });
+
+  assert.deepEqual(preview, [
+    {
+      id: 'anthropic/claude-sonnet-4.6',
+      capabilities: ['chat'],
+      supportedReasoningEfforts: [],
+    },
+  ]);
+});
+
 test('moonshot-ai video input maps to video capability not videoGeneration', () => {
   const preview = previewModelCatalogForTransport({
     provider: 'moonshot-ai',

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -162,6 +162,19 @@ test('buildResponsesProviderOptions maps gateway anthropic opus 4.8 to summarize
   );
 });
 
+test('buildResponsesProviderOptions omits openrouter providerOptions for anthropic claude', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'anthropic/claude-sonnet-4.6',
+      llmVendor: 'openrouter',
+      reasoningEffort: 'medium',
+    }),
+    {},
+  );
+});
+
 test('buildResponsesProviderOptions maps azure provider options', () => {
   const options = buildResponsesProviderOptions({
     transportKind: 'open-responses',

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -11,6 +11,7 @@ import { getLlmFetch } from '../llm-fetch.js';
 import type { JsonObject } from '../ports.js';
 import { createAlibabaResponsesAwareFetch } from './alibaba-responses-fetch.js';
 import { createApplyPatchAwareFetch } from './apply-patch-responses-fetch.js';
+import { createOpenRouterReasoningAwareFetch } from './openrouter-reasoning-responses-fetch.js';
 import {
   resolveBedrockMantleOpenResponsesApiKey,
   wrapFetchForBedrockMantleIamAuth,
@@ -30,6 +31,7 @@ import {
   buildGatewayAnthropicProviderOptions,
   isGatewayAnthropicClaudeModel,
 } from '../openai/gateway-anthropic-thinking.js';
+import { isOpenRouterAnthropicClaudeModel } from '../openai/openrouter-anthropic-reasoning.js';
 import { buildGatewayWebSearchTool, shouldUseGatewayWebSearch } from './gateway-web-search.js';
 import { resolveProviderWebSearchMode } from './web-search-eligibility.js';
 import {
@@ -68,6 +70,7 @@ function responsesFetchForConfig(config: OpenResponsesTransportConfig): typeof f
   if (shouldUseAlibabaResponsesBuiltInTools(config)) {
     fetchFn = createAlibabaResponsesAwareFetch(config, fetchFn);
   }
+  fetchFn = createOpenRouterReasoningAwareFetch(config, fetchFn);
   if (shouldUseApplyPatchFileTools(config)) {
     fetchFn = createApplyPatchAwareFetch(config, fetchFn);
   }
@@ -249,6 +252,10 @@ export function buildResponsesProviderOptions(
   }
 
   if (provider !== 'openai') {
+    if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {
+      return {};
+    }
+
     const providerOptions: JsonObject = {
       ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
       ...(reasoningSummary !== undefined ? { reasoningSummary } : {}),

--- a/packages/agent-core/src/open-responses/openrouter-reasoning-responses-fetch.test.ts
+++ b/packages/agent-core/src/open-responses/openrouter-reasoning-responses-fetch.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createOpenRouterReasoningAwareFetch } from './openrouter-reasoning-responses-fetch.js';
+
+test('createOpenRouterReasoningAwareFetch patches openrouter claude responses body', async () => {
+  let capturedBody: unknown;
+  const fetchFn = createOpenRouterReasoningAwareFetch(
+    {
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'anthropic/claude-sonnet-4.6',
+      llmVendor: 'openrouter',
+      reasoningEffort: 'high',
+    },
+    async (_input, init) => {
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : undefined;
+      return new Response('{}', { status: 200 });
+    },
+  );
+
+  await fetchFn('https://openrouter.ai/api/v1/responses', {
+    method: 'POST',
+    body: JSON.stringify({ model: 'anthropic/claude-sonnet-4.6', input: [] }),
+  });
+
+  assert.deepEqual(capturedBody, {
+    model: 'anthropic/claude-sonnet-4.6',
+    input: [],
+    reasoning: { enabled: true, effort: 'high' },
+  });
+});
+
+test('createOpenRouterReasoningAwareFetch is noop for non-claude openrouter models', async () => {
+  let capturedBody: unknown;
+  const fetchFn = createOpenRouterReasoningAwareFetch(
+    {
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'openai/gpt-5',
+      llmVendor: 'openrouter',
+      reasoningEffort: 'medium',
+    },
+    async (_input, init) => {
+      capturedBody = init?.body ? JSON.parse(String(init.body)) : undefined;
+      return new Response('{}', { status: 200 });
+    },
+  );
+
+  await fetchFn('https://openrouter.ai/api/v1/responses', {
+    method: 'POST',
+    body: JSON.stringify({ model: 'openai/gpt-5', input: [] }),
+  });
+
+  assert.deepEqual(capturedBody, {
+    model: 'openai/gpt-5',
+    input: [],
+  });
+});

--- a/packages/agent-core/src/open-responses/openrouter-reasoning-responses-fetch.ts
+++ b/packages/agent-core/src/open-responses/openrouter-reasoning-responses-fetch.ts
@@ -1,0 +1,48 @@
+import { getLlmFetch } from '../llm-fetch.js';
+import type { JsonObject, JsonValue } from '../ports.js';
+import { isJsonObject } from '../tool-agent.js';
+import {
+  patchResponsesRequestBodyForOpenRouterReasoning,
+  shouldInjectOpenRouterClaudeReasoning,
+} from '../openai/openrouter-anthropic-reasoning.js';
+import type { OpenResponsesTransportConfig } from './responses-compat.js';
+
+type FetchFn = typeof fetch;
+
+export function createOpenRouterReasoningAwareFetch(
+  config: OpenResponsesTransportConfig,
+  baseFetch: FetchFn = getLlmFetch(),
+): FetchFn {
+  if (!shouldInjectOpenRouterClaudeReasoning(config)) {
+    return baseFetch;
+  }
+
+  return async (input, init) => {
+    const patchedInit = patchRequestInitBody(init, config);
+    return baseFetch(input, patchedInit);
+  };
+}
+
+function patchRequestInitBody(
+  init: RequestInit | undefined,
+  config: OpenResponsesTransportConfig,
+): RequestInit | undefined {
+  if (!init?.body || typeof init.body !== 'string') {
+    return init;
+  }
+
+  try {
+    const body = JSON.parse(init.body) as JsonObject;
+    if (!isJsonObject(body as JsonValue)) {
+      return init;
+    }
+
+    patchResponsesRequestBodyForOpenRouterReasoning(body, config);
+    return {
+      ...init,
+      body: JSON.stringify(body),
+    };
+  } catch {
+    return init;
+  }
+}

--- a/packages/agent-core/src/open-responses/responses-compat.ts
+++ b/packages/agent-core/src/open-responses/responses-compat.ts
@@ -6,6 +6,10 @@ import type {
   OpenAiVideoGenerationConfig,
 } from '../openai/openai-compat.js';
 import { isGatewayAnthropicClaudeModel } from '../openai/gateway-anthropic-thinking.js';
+import {
+  buildOpenRouterClaudeReasoningBody,
+  isOpenRouterAnthropicClaudeModel,
+} from '../openai/openrouter-anthropic-reasoning.js';
 import { resolveOpenAiTransportReasoningEffortForContext } from '../reasoning-effort.js';
 import { extractAzureResourceNameFromApiBase } from '../azure-resource.js';
 import { cloneJsonValue } from '../tool-agent.js';
@@ -211,6 +215,11 @@ export function openResponsesReasoningTrace(
 ): JsonObject | undefined {
   if (isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
     return undefined;
+  }
+
+  if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {
+    const reasoning = buildOpenRouterClaudeReasoningBody(config);
+    return reasoning;
   }
 
   const effort = openResponsesReasoningEffort(config);

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -85,6 +85,7 @@ import {
   buildGatewayAnthropicProviderOptions,
   isGatewayAnthropicClaudeModel,
 } from './gateway-anthropic-thinking.js';
+import { isOpenRouterAnthropicClaudeModel } from './openrouter-anthropic-reasoning.js';
 import { generateSiliconFlowImage } from '../image-generation/siliconflow-backend.js';
 import { generateVideoWithRouter } from '../video-generation/router.js';
 import { getLlmFetch } from '../llm-fetch.js';
@@ -901,6 +902,10 @@ function buildAiSdkProviderOptions(
 ): Record<string, JsonObject> {
   if (isVercelAiGatewayProvider(config) && isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
     return buildGatewayAnthropicProviderOptions(config);
+  }
+
+  if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {
+    return {};
   }
 
   if (isAlibabaOfficialAiSdkProvider(config)) {

--- a/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
@@ -1,22 +1,17 @@
 import type { JsonObject, JsonValue } from '../ports.js';
 import type { AnthropicEffort, AnthropicThinkingConfig } from '../anthropic/anthropic-compat.js';
 import type { OpenAiLlmVendor, OpenAiTransportConfig } from './openai-compat.js';
+import {
+  isRoutedAnthropicClaudeModel,
+  resolveRoutedAnthropicClaudeCapabilities,
+  routedAnthropicClaudeSupportedEfforts,
+  routedAnthropicEffortFromReasoningEffort,
+  ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT,
+  type RoutedAnthropicClaudeCapabilities,
+} from './routed-anthropic-claude-capabilities.js';
 
-export type GatewayAnthropicThinkingMode = 'adaptive' | 'budget' | 'none';
-
-export interface GatewayAnthropicClaudeCapabilities {
-  thinkingMode: GatewayAnthropicThinkingMode;
-  supportedEfforts: readonly AnthropicEffort[];
-  adaptiveDisplay?: 'summarized';
-}
-
-const LEGACY_BUDGET_EFFORTS: readonly AnthropicEffort[] = ['low', 'medium', 'high'];
-
-const BUDGET_TOKENS_BY_EFFORT: Record<'low' | 'medium' | 'high', number> = {
-  low: 4_000,
-  medium: 8_000,
-  high: 12_000,
-};
+export type GatewayAnthropicThinkingMode = RoutedAnthropicClaudeCapabilities['thinkingMode'];
+export type GatewayAnthropicClaudeCapabilities = RoutedAnthropicClaudeCapabilities;
 
 export function normalizeGatewayAnthropicClaudeModelId(model: string): string {
   return model
@@ -34,90 +29,19 @@ export function isGatewayAnthropicClaudeModel(
     return false;
   }
 
-  const normalized = model.trim().toLowerCase();
-  return normalized.startsWith('anthropic/claude-');
+  return isRoutedAnthropicClaudeModel(model);
 }
 
 export function resolveGatewayAnthropicClaudeCapabilities(
   model: string,
 ): GatewayAnthropicClaudeCapabilities {
-  const modelId = normalizeGatewayAnthropicClaudeModelId(model);
-
-  if (modelId.includes('claude-opus-4-7') || modelId.includes('claude-opus-4-8')) {
-    return {
-      thinkingMode: 'adaptive',
-      supportedEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
-      adaptiveDisplay: 'summarized',
-    };
-  }
-
-  if (modelId.includes('claude-opus-4-6')) {
-    return {
-      thinkingMode: 'adaptive',
-      supportedEfforts: ['low', 'medium', 'high', 'max'],
-    };
-  }
-
-  if (modelId.includes('claude-sonnet-4-6')) {
-    return {
-      thinkingMode: 'adaptive',
-      supportedEfforts: ['low', 'medium', 'high'],
-    };
-  }
-
-  if (isLegacyGatewayAnthropicClaudeModel(modelId)) {
-    return {
-      thinkingMode: 'budget',
-      supportedEfforts: LEGACY_BUDGET_EFFORTS,
-    };
-  }
-
-  return {
-    thinkingMode: 'none',
-    supportedEfforts: [],
-  };
+  return resolveRoutedAnthropicClaudeCapabilities(model);
 }
 
 export function gatewayAnthropicClaudeSupportedEfforts(
   model: string,
 ): AnthropicEffort[] | undefined {
-  if (!model.trim().toLowerCase().startsWith('anthropic/claude-')) {
-    return undefined;
-  }
-
-  const capabilities = resolveGatewayAnthropicClaudeCapabilities(model);
-  if (capabilities.supportedEfforts.length === 0) {
-    return undefined;
-  }
-
-  return [...capabilities.supportedEfforts];
-}
-
-function isLegacyGatewayAnthropicClaudeModel(modelId: string): boolean {
-  if (!modelId.includes('claude')) {
-    return false;
-  }
-
-  return (
-    modelId.includes('haiku-4-5')
-    || modelId.includes('opus-4-5')
-    || modelId.includes('sonnet-4-5')
-    || /claude-opus-4(?:-|$)/.test(modelId)
-    || /claude-sonnet-4(?:-|$)/.test(modelId)
-    || modelId.includes('claude-opus-4-1')
-  );
-}
-
-function anthropicEffortFromConfigReasoningEffort(
-  reasoningEffort: OpenAiTransportConfig['reasoningEffort'],
-  supportedEfforts: readonly AnthropicEffort[],
-): AnthropicEffort | undefined {
-  if (reasoningEffort === undefined || reasoningEffort === 'default') {
-    return undefined;
-  }
-
-  const effort = reasoningEffort as AnthropicEffort;
-  return supportedEfforts.includes(effort) ? effort : undefined;
+  return routedAnthropicClaudeSupportedEfforts(model);
 }
 
 function buildAdaptiveThinkingConfig(
@@ -133,7 +57,7 @@ function buildBudgetThinkingConfig(effort: AnthropicEffort): AnthropicThinkingCo
   const budgetKey = effort === 'low' || effort === 'medium' || effort === 'high' ? effort : 'high';
   return {
     type: 'enabled',
-    budgetTokens: BUDGET_TOKENS_BY_EFFORT[budgetKey],
+    budgetTokens: ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT[budgetKey],
   };
 }
 
@@ -145,7 +69,7 @@ export function buildGatewayAnthropicProviderOptions(
   }
 
   const capabilities = resolveGatewayAnthropicClaudeCapabilities(config.model);
-  const effort = anthropicEffortFromConfigReasoningEffort(
+  const effort = routedAnthropicEffortFromReasoningEffort(
     config.reasoningEffort,
     capabilities.supportedEfforts,
   );

--- a/packages/agent-core/src/openai/index.ts
+++ b/packages/agent-core/src/openai/index.ts
@@ -11,6 +11,16 @@ export {
   isGatewayAnthropicClaudeModel,
   resolveGatewayAnthropicClaudeCapabilities,
 } from './gateway-anthropic-thinking.js';
+export {
+  buildOpenRouterClaudeReasoningBody,
+  isOpenRouterAnthropicClaudeModel,
+  shouldInjectOpenRouterClaudeReasoning,
+} from './openrouter-anthropic-reasoning.js';
+export {
+  isRoutedAnthropicClaudeModel,
+  routedAnthropicClaudeSupportedEfforts,
+  resolveRoutedAnthropicClaudeCapabilities,
+} from './routed-anthropic-claude-capabilities.js';
 export type {
   OpenAiLlmVendor,
   OpenAiModelCapabilities,

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -2,6 +2,10 @@ import type { JsonObject, JsonValue } from '../ports.js';
 import type { LlmModelCapabilities } from '../llm-provider-shared.js';
 import { resolveOpenAiTransportReasoningEffortForContext } from '../reasoning-effort.js';
 import { cloneJsonValue } from '../tool-agent.js';
+import {
+  buildOpenRouterClaudeReasoningBody,
+  isOpenRouterAnthropicClaudeModel,
+} from './openrouter-anthropic-reasoning.js';
 
 /** 与宿主 `ModelProfile.provider` 对齐；用于在 OpenAI 形态 API 上附加厂商扩展字段。 */
 export type OpenAiLlmVendor =
@@ -196,12 +200,17 @@ export function openAiReasoningEffort(
  * Moonshot 已改用 `@ai-sdk/moonshotai` 的 `providerOptions.moonshotai.thinking`。
  */
 export function openAiVendorChatCompletionBodyExtras(
-  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'vendorExtendedThinking'>,
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'>,
 ): Record<string, unknown> {
   const extras: Record<string, unknown> = {};
   if (config.llmVendor === 'deepseek') {
     const enabled = config.vendorExtendedThinking !== false;
     extras.thinking = { type: enabled ? 'enabled' : 'disabled' };
+  }
+
+  const openRouterReasoning = buildOpenRouterClaudeReasoningBody(config);
+  if (openRouterReasoning !== undefined) {
+    extras.reasoning = openRouterReasoning;
   }
 
   return extras;
@@ -214,7 +223,8 @@ export function buildOpenAiRequestTrace(
   tools: readonly unknown[],
   stream = false,
 ): JsonValue[] {
-  const reasoningEffort = openAiReasoningEffort(config);
+  const openRouterClaude = isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model);
+  const reasoningEffort = openRouterClaude ? undefined : openAiReasoningEffort(config);
   const vendorExtras = openAiVendorChatCompletionBodyExtras(config);
   const trace: OpenAiRequestTrace = {
     kind: 'openai_sdk_chat_completions',
@@ -222,6 +232,9 @@ export function buildOpenAiRequestTrace(
     model: config.model,
     stream,
     ...(reasoningEffort === undefined ? {} : { reasoning_effort: reasoningEffort }),
+    ...(openRouterClaude && vendorExtras.reasoning !== undefined
+      ? { reasoning: vendorExtras.reasoning as JsonValue }
+      : {}),
     messages: messages.map((message) => cloneJsonValue(message)),
     ...(tools.length > 0
       ? {

--- a/packages/agent-core/src/openai/openrouter-anthropic-reasoning.test.ts
+++ b/packages/agent-core/src/openai/openrouter-anthropic-reasoning.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildOpenRouterClaudeReasoningBody,
+  isOpenRouterAnthropicClaudeModel,
+  patchResponsesRequestBodyForOpenRouterReasoning,
+  shouldInjectOpenRouterClaudeReasoning,
+} from './openrouter-anthropic-reasoning.js';
+import { openAiVendorChatCompletionBodyExtras } from './openai-compat.js';
+
+test('isOpenRouterAnthropicClaudeModel matches openrouter anthropic routes only', () => {
+  assert.equal(
+    isOpenRouterAnthropicClaudeModel('openrouter', 'anthropic/claude-sonnet-4.6'),
+    true,
+  );
+  assert.equal(
+    isOpenRouterAnthropicClaudeModel('vercel-ai-gateway', 'anthropic/claude-sonnet-4.6'),
+    false,
+  );
+  assert.equal(
+    isOpenRouterAnthropicClaudeModel('openrouter', 'openai/gpt-5'),
+    false,
+  );
+});
+
+test('buildOpenRouterClaudeReasoningBody sends adaptive enabled for sonnet 4.6 default effort', () => {
+  assert.deepEqual(
+    buildOpenRouterClaudeReasoningBody({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-sonnet-4.6',
+      reasoningEffort: 'default',
+    }),
+    { enabled: true },
+  );
+});
+
+test('buildOpenRouterClaudeReasoningBody maps effort for opus 4.8', () => {
+  assert.deepEqual(
+    buildOpenRouterClaudeReasoningBody({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-opus-4.8',
+      reasoningEffort: 'medium',
+    }),
+    { enabled: true, effort: 'medium' },
+  );
+});
+
+test('buildOpenRouterClaudeReasoningBody uses budget max_tokens for legacy claude', () => {
+  assert.deepEqual(
+    buildOpenRouterClaudeReasoningBody({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-sonnet-4-5',
+      reasoningEffort: 'medium',
+    }),
+    { enabled: true, max_tokens: 8_000 },
+  );
+});
+
+test('buildOpenRouterClaudeReasoningBody omits thinking for legacy claude at default effort', () => {
+  assert.equal(
+    buildOpenRouterClaudeReasoningBody({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-sonnet-4-5',
+      reasoningEffort: 'default',
+    }),
+    undefined,
+  );
+});
+
+test('buildOpenRouterClaudeReasoningBody maps none to effort none', () => {
+  assert.deepEqual(
+    buildOpenRouterClaudeReasoningBody({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-sonnet-4.6',
+      reasoningEffort: 'none',
+    }),
+    { effort: 'none' },
+  );
+});
+
+test('shouldInjectOpenRouterClaudeReasoning follows buildOpenRouterClaudeReasoningBody', () => {
+  assert.equal(
+    shouldInjectOpenRouterClaudeReasoning({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-sonnet-4.6',
+      reasoningEffort: 'medium',
+    }),
+    true,
+  );
+  assert.equal(
+    shouldInjectOpenRouterClaudeReasoning({
+      llmVendor: 'openrouter',
+      model: 'openai/gpt-5',
+      reasoningEffort: 'medium',
+    }),
+    false,
+  );
+});
+
+test('patchResponsesRequestBodyForOpenRouterReasoning writes reasoning and strips reasoning_effort', () => {
+  const body = {
+    model: 'anthropic/claude-sonnet-4.6',
+    reasoning_effort: 'medium',
+  };
+
+  patchResponsesRequestBodyForOpenRouterReasoning(body, {
+    llmVendor: 'openrouter',
+    model: 'anthropic/claude-sonnet-4.6',
+    reasoningEffort: 'medium',
+  });
+
+  assert.deepEqual(body, {
+    model: 'anthropic/claude-sonnet-4.6',
+    reasoning: { enabled: true, effort: 'medium' },
+  });
+});
+
+test('openAiVendorChatCompletionBodyExtras injects reasoning for openrouter claude', () => {
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-sonnet-4.6',
+      reasoningEffort: 'medium',
+    }),
+    {
+      reasoning: { enabled: true, effort: 'medium' },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openrouter-anthropic-reasoning.ts
+++ b/packages/agent-core/src/openai/openrouter-anthropic-reasoning.ts
@@ -1,0 +1,95 @@
+import type { JsonObject } from '../ports.js';
+import { isJsonObject } from '../tool-agent.js';
+import type { OpenAiLlmVendor, OpenAiTransportConfig } from './openai-compat.js';
+import {
+  isRoutedAnthropicClaudeModel,
+  resolveRoutedAnthropicClaudeCapabilities,
+  ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT,
+  routedAnthropicEffortFromReasoningEffort,
+} from './routed-anthropic-claude-capabilities.js';
+import type { OpenResponsesTransportConfig } from '../open-responses/responses-compat.js';
+
+export type OpenRouterClaudeReasoningConfig = Pick<
+  OpenAiTransportConfig,
+  'llmVendor' | 'model' | 'reasoningEffort'
+>;
+
+export function isOpenRouterAnthropicClaudeModel(
+  llmVendor: OpenAiLlmVendor | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'openrouter' && isRoutedAnthropicClaudeModel(model);
+}
+
+export function buildOpenRouterClaudeReasoningBody(
+  config: OpenRouterClaudeReasoningConfig,
+): JsonObject | undefined {
+  if (!isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {
+    return undefined;
+  }
+
+  if (config.reasoningEffort === 'none') {
+    return { effort: 'none' };
+  }
+
+  const capabilities = resolveRoutedAnthropicClaudeCapabilities(config.model);
+  const effort = routedAnthropicEffortFromReasoningEffort(
+    config.reasoningEffort,
+    capabilities.supportedEfforts,
+  );
+
+  if (capabilities.thinkingMode === 'adaptive') {
+    if (effort !== undefined) {
+      return { enabled: true, effort };
+    }
+    return { enabled: true };
+  }
+
+  if (capabilities.thinkingMode === 'budget' && effort !== undefined) {
+    const budgetKey = effort === 'low' || effort === 'medium' || effort === 'high' ? effort : 'high';
+    return {
+      enabled: true,
+      max_tokens: ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT[budgetKey],
+    };
+  }
+
+  return undefined;
+}
+
+export function shouldInjectOpenRouterClaudeReasoning(
+  config: Pick<OpenResponsesTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort'>,
+): boolean {
+  return buildOpenRouterClaudeReasoningBody(config) !== undefined;
+}
+
+export function patchResponsesRequestBodyForOpenRouterReasoning(
+  body: JsonObject,
+  config: Pick<OpenResponsesTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort'>,
+): void {
+  const reasoning = buildOpenRouterClaudeReasoningBody(config);
+  if (reasoning === undefined) {
+    return;
+  }
+
+  body.reasoning = reasoning;
+  delete body.reasoning_effort;
+}
+
+export function tryPatchOpenRouterClaudeChatCompletionBody(
+  body: unknown,
+  config: OpenRouterClaudeReasoningConfig,
+): boolean {
+  if (!isJsonObject(body as JsonObject)) {
+    return false;
+  }
+
+  const reasoning = buildOpenRouterClaudeReasoningBody(config);
+  if (reasoning === undefined) {
+    return false;
+  }
+
+  const record = body as JsonObject;
+  record.reasoning = reasoning;
+  delete record.reasoning_effort;
+  return true;
+}

--- a/packages/agent-core/src/openai/routed-anthropic-claude-capabilities.ts
+++ b/packages/agent-core/src/openai/routed-anthropic-claude-capabilities.ts
@@ -1,0 +1,112 @@
+import type { AnthropicEffort } from '../anthropic/anthropic-compat.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+
+export type RoutedAnthropicThinkingMode = 'adaptive' | 'budget' | 'none';
+
+export interface RoutedAnthropicClaudeCapabilities {
+  thinkingMode: RoutedAnthropicThinkingMode;
+  supportedEfforts: readonly AnthropicEffort[];
+  adaptiveDisplay?: 'summarized';
+}
+
+const LEGACY_BUDGET_EFFORTS: readonly AnthropicEffort[] = ['low', 'medium', 'high'];
+
+export const ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT: Record<'low' | 'medium' | 'high', number> = {
+  low: 4_000,
+  medium: 8_000,
+  high: 12_000,
+};
+
+export function normalizeRoutedAnthropicClaudeModelId(model: string): string {
+  return model
+    .trim()
+    .toLowerCase()
+    .replace(/^anthropic\//, '')
+    .replace(/(\d)\.(\d)/g, '$1-$2');
+}
+
+export function isRoutedAnthropicClaudeModel(model: string): boolean {
+  return model.trim().toLowerCase().startsWith('anthropic/claude-');
+}
+
+export function resolveRoutedAnthropicClaudeCapabilities(
+  model: string,
+): RoutedAnthropicClaudeCapabilities {
+  const modelId = normalizeRoutedAnthropicClaudeModelId(model);
+
+  if (modelId.includes('claude-opus-4-7') || modelId.includes('claude-opus-4-8')) {
+    return {
+      thinkingMode: 'adaptive',
+      supportedEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+      adaptiveDisplay: 'summarized',
+    };
+  }
+
+  if (modelId.includes('claude-opus-4-6')) {
+    return {
+      thinkingMode: 'adaptive',
+      supportedEfforts: ['low', 'medium', 'high', 'max'],
+    };
+  }
+
+  if (modelId.includes('claude-sonnet-4-6')) {
+    return {
+      thinkingMode: 'adaptive',
+      supportedEfforts: ['low', 'medium', 'high'],
+    };
+  }
+
+  if (isLegacyRoutedAnthropicClaudeModel(modelId)) {
+    return {
+      thinkingMode: 'budget',
+      supportedEfforts: LEGACY_BUDGET_EFFORTS,
+    };
+  }
+
+  return {
+    thinkingMode: 'none',
+    supportedEfforts: [],
+  };
+}
+
+export function routedAnthropicClaudeSupportedEfforts(
+  model: string,
+): AnthropicEffort[] | undefined {
+  if (!isRoutedAnthropicClaudeModel(model)) {
+    return undefined;
+  }
+
+  const capabilities = resolveRoutedAnthropicClaudeCapabilities(model);
+  if (capabilities.supportedEfforts.length === 0) {
+    return undefined;
+  }
+
+  return [...capabilities.supportedEfforts];
+}
+
+function isLegacyRoutedAnthropicClaudeModel(modelId: string): boolean {
+  if (!modelId.includes('claude')) {
+    return false;
+  }
+
+  return (
+    modelId.includes('haiku-4-5')
+    || modelId.includes('opus-4-5')
+    || modelId.includes('sonnet-4-5')
+    || /claude-opus-4(?:-|$)/.test(modelId)
+    || /claude-sonnet-4(?:-|$)/.test(modelId)
+    || modelId.includes('claude-opus-4-1')
+  );
+}
+
+export function routedAnthropicEffortFromReasoningEffort(
+  reasoningEffort: OpenAiTransportConfig['reasoningEffort'],
+  supportedEfforts: readonly AnthropicEffort[],
+): AnthropicEffort | undefined {
+  if (reasoningEffort === undefined || reasoningEffort === 'default') {
+    return undefined;
+  }
+
+  const effort = reasoningEffort as AnthropicEffort;
+  return supportedEfforts.includes(effort) ? effort : undefined;
+}

--- a/packages/agent-core/src/reasoning-effort.test.ts
+++ b/packages/agent-core/src/reasoning-effort.test.ts
@@ -168,3 +168,24 @@ test('gateway claude models use anthropic effort options filtered by model capab
     'max',
   );
 });
+
+test('openrouter claude models use anthropic effort options filtered by model capabilities', () => {
+  const sonnetOptions = modelReasoningEffortOptions({
+    provider: 'openrouter',
+    model: 'anthropic/claude-sonnet-4.6',
+    transportKind: 'open-responses',
+  });
+  assert.deepEqual(
+    sonnetOptions.map((option) => option.value),
+    ['default', 'low', 'medium', 'high'],
+  );
+
+  assert.equal(
+    resolveModelReasoningEffortForContext('medium', {
+      provider: 'openrouter',
+      model: 'anthropic/claude-opus-4.8',
+      transportKind: 'open-responses',
+    }),
+    'medium',
+  );
+});

--- a/packages/agent-core/src/reasoning-effort.ts
+++ b/packages/agent-core/src/reasoning-effort.ts
@@ -4,6 +4,8 @@ import {
   isGatewayAnthropicClaudeModel,
   resolveGatewayAnthropicClaudeCapabilities,
 } from './openai/gateway-anthropic-thinking.js';
+import { isOpenRouterAnthropicClaudeModel } from './openai/openrouter-anthropic-reasoning.js';
+import { resolveRoutedAnthropicClaudeCapabilities } from './openai/routed-anthropic-claude-capabilities.js';
 import type { OpenAiTransportConfig } from './openai/openai-compat.js';
 
 export type ModelReasoningProvider =
@@ -206,6 +208,10 @@ export function defaultModelReasoningEffort(
     return 'default';
   }
 
+  if (isOpenRouterAnthropicClaudeReasoningModel(context)) {
+    return 'default';
+  }
+
   return DEFAULT_MODEL_REASONING_EFFORT;
 }
 
@@ -241,6 +247,12 @@ export function modelReasoningEffortOptions(
   if (isGatewayAnthropicClaudeReasoningModel(context)) {
     const supportedEfforts = context?.supportedEfforts
       ?? resolveGatewayAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts;
+    return anthropicReasoningEffortOptionsForSupportedEfforts(supportedEfforts);
+  }
+
+  if (isOpenRouterAnthropicClaudeReasoningModel(context)) {
+    const supportedEfforts = context?.supportedEfforts
+      ?? resolveRoutedAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts;
     return anthropicReasoningEffortOptionsForSupportedEfforts(supportedEfforts);
   }
 
@@ -344,6 +356,15 @@ export function isGatewayAnthropicClaudeReasoningModel(
   );
 }
 
+export function isOpenRouterAnthropicClaudeReasoningModel(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  return isOpenRouterAnthropicClaudeModel(
+    context?.provider === 'openrouter' ? 'openrouter' : undefined,
+    context?.model ?? '',
+  );
+}
+
 function normalizeModelId(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
@@ -427,6 +448,20 @@ function resolveCompatibleModelReasoningEffort(
     const supportedEfforts = normalizeSupportedReasoningEfforts(
       context?.supportedEfforts
         ?? resolveGatewayAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts,
+    );
+    switch (normalized) {
+      case 'none':
+      case 'minimal':
+        return 'default';
+      default:
+        return anthropicReasoningEffortValueForContext(normalized, supportedEfforts) ?? 'default';
+    }
+  }
+
+  if (isOpenRouterAnthropicClaudeReasoningModel(context)) {
+    const supportedEfforts = normalizeSupportedReasoningEfforts(
+      context?.supportedEfforts
+        ?? resolveRoutedAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts,
     );
     switch (normalized) {
       case 'none':

--- a/packages/host-internal/src/openai-models.test.ts
+++ b/packages/host-internal/src/openai-models.test.ts
@@ -307,8 +307,41 @@ test('parseOpenRouterModelEntriesPayload extracts display metadata and pricing',
         outputPerTokenUsd: '0.000015',
         requestPerCallUsd: '0',
       },
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
     },
   ]);
+});
+
+test('parseOpenRouterModelEntriesPayload reads reasoning supported_efforts from api', () => {
+  const entries = parseOpenRouterModelEntriesPayload({
+    data: [
+      {
+        id: 'anthropic/claude-sonnet-4.6',
+        architecture: { output_modalities: ['text'] },
+        reasoning: { supported_efforts: ['high', 'medium', 'low'] },
+      },
+    ],
+  });
+
+  assert.deepEqual(entries, [
+    {
+      id: 'anthropic/claude-sonnet-4.6',
+      supportedReasoningEfforts: ['high', 'medium', 'low'],
+    },
+  ]);
+});
+
+test('parseOpenRouterModelEntriesPayload infers claude efforts when api omits reasoning', () => {
+  const entries = parseOpenRouterModelEntriesPayload({
+    data: [
+      {
+        id: 'anthropic/claude-opus-4.8',
+        architecture: { output_modalities: ['text'] },
+      },
+    ],
+  });
+
+  assert.deepEqual(entries[0]?.supportedReasoningEfforts, ['low', 'medium', 'high', 'xhigh', 'max']);
 });
 
 test('parseXiaomiModelEntriesPayload marks multimodal allowlist models', () => {
@@ -500,7 +533,10 @@ test('parseOpenAiCompatibleModelEntriesPayload routes openrouter to typed parser
   }, 'openrouter');
 
   assert.deepEqual(entries, [
-    { id: 'anthropic/claude-sonnet-4' },
+    {
+      id: 'anthropic/claude-sonnet-4',
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
+    },
     { id: 'stability/sdxl', supportsImageGeneration: true },
   ]);
 });
@@ -520,6 +556,7 @@ test('parseOpenRouterModelEntriesPayload maps context_length', () => {
     {
       id: 'anthropic/claude-sonnet-4',
       contextLength: 200000,
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
     },
   ]);
 });

--- a/packages/host-internal/src/openai-models.test.ts
+++ b/packages/host-internal/src/openai-models.test.ts
@@ -331,6 +331,25 @@ test('parseOpenRouterModelEntriesPayload reads reasoning supported_efforts from 
   ]);
 });
 
+test('parseOpenRouterModelEntriesPayload keeps explicit empty supported_efforts without claude fallback', () => {
+  const entries = parseOpenRouterModelEntriesPayload({
+    data: [
+      {
+        id: 'anthropic/claude-sonnet-4.6',
+        architecture: { output_modalities: ['text'] },
+        reasoning: { supported_efforts: [] },
+      },
+    ],
+  });
+
+  assert.deepEqual(entries, [
+    {
+      id: 'anthropic/claude-sonnet-4.6',
+      supportedReasoningEfforts: [],
+    },
+  ]);
+});
+
 test('parseOpenRouterModelEntriesPayload infers claude efforts when api omits reasoning', () => {
   const entries = parseOpenRouterModelEntriesPayload({
     data: [

--- a/packages/host-internal/src/openai-models.ts
+++ b/packages/host-internal/src/openai-models.ts
@@ -2,7 +2,7 @@
  * OpenAI-compatible `GET /v1/models` listing (host-side; no secrets stored here).
  */
 
-import { gatewayAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
+import { gatewayAnthropicClaudeSupportedEfforts, routedAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
 
 import type { ModelProviderId, ProviderModelTransportKind } from './model-provider-presets.js';
 import { resolveProviderConnectApiBase } from './model-provider-presets.js';
@@ -493,6 +493,47 @@ function attachGatewayAnthropicReasoningEfforts(
   };
 }
 
+function readOpenRouterSupportedReasoningEfforts(
+  record: Record<string, unknown>,
+): string[] | undefined {
+  const reasoning = record.reasoning;
+  if (typeof reasoning !== 'object' || reasoning === null) {
+    return undefined;
+  }
+
+  const supportedEfforts = (reasoning as Record<string, unknown>).supported_efforts;
+  if (!Array.isArray(supportedEfforts)) {
+    return undefined;
+  }
+
+  const efforts: string[] = [];
+  for (const item of supportedEfforts) {
+    if (typeof item === 'string' && item.trim().length > 0) {
+      efforts.push(item.trim().toLowerCase());
+    }
+  }
+
+  return efforts.length > 0 ? efforts : undefined;
+}
+
+function attachOpenRouterAnthropicReasoningEfforts(
+  modelEntry: ProviderListedModelEntry,
+): ProviderListedModelEntry {
+  if (modelEntry.supportedReasoningEfforts !== undefined) {
+    return modelEntry;
+  }
+
+  const supportedReasoningEfforts = routedAnthropicClaudeSupportedEfforts(modelEntry.id);
+  if (supportedReasoningEfforts === undefined) {
+    return modelEntry;
+  }
+
+  return {
+    ...modelEntry,
+    supportedReasoningEfforts,
+  };
+}
+
 export function parseVercelAiGatewayModelEntriesPayload(body: unknown): ProviderListedModelEntry[] {
   if (typeof body !== 'object' || body === null || !('data' in body)) {
     return [];
@@ -623,18 +664,28 @@ export function parseOpenRouterModelEntriesPayload(body: unknown): ProviderListe
       }
       if (hasImage && !hasText) {
         entries.push(
-          attachListedModelMetadata(
-            { id: id.trim(), supportsImageGeneration: true },
-            record,
-            readOpenRouterPricing(record),
+          attachOpenRouterAnthropicReasoningEfforts(
+            attachListedModelMetadata(
+              { id: id.trim(), supportsImageGeneration: true },
+              record,
+              readOpenRouterPricing(record),
+            ),
           ),
         );
         continue;
       }
     }
 
+    const modelEntry: ProviderListedModelEntry = { id: id.trim() };
+    const supportedReasoningEfforts = readOpenRouterSupportedReasoningEfforts(record);
+    if (supportedReasoningEfforts !== undefined) {
+      modelEntry.supportedReasoningEfforts = supportedReasoningEfforts;
+    }
+
     entries.push(
-      attachListedModelMetadata({ id: id.trim() }, record, readOpenRouterPricing(record)),
+      attachOpenRouterAnthropicReasoningEfforts(
+        attachListedModelMetadata(modelEntry, record, readOpenRouterPricing(record)),
+      ),
     );
   }
   return entries;

--- a/packages/host-internal/src/openai-models.ts
+++ b/packages/host-internal/src/openai-models.ts
@@ -513,7 +513,8 @@ function readOpenRouterSupportedReasoningEfforts(
     }
   }
 
-  return efforts.length > 0 ? efforts : undefined;
+  // OpenRouter 显式返回 [] 表示不支持 effort 选择，须与字段缺失（undefined → 可兜底）区分。
+  return efforts;
 }
 
 function attachOpenRouterAnthropicReasoningEfforts(


### PR DESCRIPTION
## Summary

- OpenRouter 上 anthropic/claude-* 通过顶层 reasoning 对象注入 adaptive/budget 思考，与 Gateway 行为一致
- Chat Completions 与 Open Responses 双 transport 覆盖；reasoning-effort UI 复用 Anthropic effort 选项
- 目录解析 OpenRouter reasoning.supported_efforts，Claude 模型无 API 字段时用共享能力表兜底

## Test plan

- [x] agent-core 单测：openrouter-anthropic-reasoning、model-factory、reasoning-effort、fetch patch
- [x] host-internal openai-models 单测
- [x] desktop model-catalog-metadata 单测
- [ ] 手动：OpenRouter + claude-sonnet-4.6，Chat Completions 与 Open Responses 各测 Medium effort，确认 UI 可展开思考且 trace 含 reasoning.enabled
- [ ] 手动：Legacy claude-sonnet-4.5 Medium 走 max_tokens budget