### PR TITLE
fix(agent-core): Vercel Gateway Gemini 注入思考摘要配置

### DIFF
--- a/apps/desktop/src/host/model-catalog-metadata.ts
+++ b/apps/desktop/src/host/model-catalog-metadata.ts
@@ -1,5 +1,8 @@
 import { formatModelDisplayNameFromId } from '@spirit-agent/core/model-display-name';
-import { routedAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
+import {
+  gatewayGoogleGeminiSupportedEfforts,
+  routedAnthropicClaudeSupportedEfforts,
+} from '@spirit-agent/core';
 import type { ProviderListedModelEntry } from '@spirit-agent/host-internal';
 
 import type {
@@ -183,14 +186,21 @@ function resolvePreviewSupportedReasoningEffortsForEntry(
     return {};
   }
 
-  const inferred = routedAnthropicClaudeSupportedEfforts(entry.id);
-  if (inferred === undefined) {
-    return {};
+  const inferredAnthropic = routedAnthropicClaudeSupportedEfforts(entry.id);
+  if (inferredAnthropic !== undefined) {
+    return {
+      supportedReasoningEfforts: normalizePreviewSupportedReasoningEfforts(inferredAnthropic),
+    };
   }
 
-  return {
-    supportedReasoningEfforts: normalizePreviewSupportedReasoningEfforts(inferred),
-  };
+  const inferredGemini = gatewayGoogleGeminiSupportedEfforts(entry.id);
+  if (inferredGemini !== undefined) {
+    return {
+      supportedReasoningEfforts: normalizePreviewSupportedReasoningEfforts(inferredGemini),
+    };
+  }
+
+  return {};
 }
 
 function normalizePreviewSupportedReasoningEfforts(

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -143,6 +143,46 @@ test('buildResponsesProviderOptions maps gateway anthropic claude to adaptive th
   );
 });
 
+test('buildResponsesProviderOptions maps gateway google gemini 3 to google thinkingConfig', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'google/gemini-3.1-pro-preview',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'high',
+    }),
+    {
+      google: {
+        thinkingConfig: {
+          thinkingLevel: 'high',
+          includeThoughts: true,
+        },
+      },
+    },
+  );
+});
+
+test('buildResponsesProviderOptions maps gateway google gemini 2.5 to google thinkingConfig', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'google/gemini-2.5-flash',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'low',
+    }),
+    {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: 1024,
+          includeThoughts: true,
+        },
+      },
+    },
+  );
+});
+
 test('buildResponsesProviderOptions maps gateway anthropic opus 4.8 to summarized adaptive thinking', () => {
   assert.deepEqual(
     buildResponsesProviderOptions({

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -31,6 +31,10 @@ import {
   buildGatewayAnthropicProviderOptions,
   isGatewayAnthropicClaudeModel,
 } from '../openai/gateway-anthropic-thinking.js';
+import {
+  buildGatewayGoogleProviderOptions,
+  isGatewayGoogleGeminiModel,
+} from '../openai/gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from '../openai/openrouter-anthropic-reasoning.js';
 import { buildGatewayWebSearchTool, shouldUseGatewayWebSearch } from './gateway-web-search.js';
 import { resolveProviderWebSearchMode } from './web-search-eligibility.js';
@@ -208,6 +212,10 @@ export function buildResponsesProviderOptions(
   if (shouldUseGatewayWebSearch(config)) {
     if (isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
       return buildGatewayAnthropicProviderOptions(config);
+    }
+
+    if (isGatewayGoogleGeminiModel(config.llmVendor, config.model)) {
+      return buildGatewayGoogleProviderOptions(config, reasoningEffort);
     }
 
     // Gateway v3 language-model 原样转发 providerOptions；OpenAI 路由模型须用 openai 命名空间（见 Vercel AI Gateway reasoning 文档）。

--- a/packages/agent-core/src/open-responses/streaming-gateway-gemini-thinking.test.ts
+++ b/packages/agent-core/src/open-responses/streaming-gateway-gemini-thinking.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { TextStreamPart } from 'ai';
+
+import type { ToolAgentRoundCompletion } from '../ports.js';
+import type { ToolAgentState } from '../tool-agent.js';
+import { createDeferred, responsesEventStreamToRuntimeEvents } from './streaming.js';
+import type { OpenResponsesTransportConfig } from './responses-compat.js';
+
+const gatewayGeminiConfig: OpenResponsesTransportConfig = {
+  transportKind: 'open-responses',
+  apiKey: 'test',
+  model: 'google/gemini-3.1-pro-preview',
+  llmVendor: 'vercel-ai-gateway',
+};
+
+async function collectThinkingChunks(
+  config: OpenResponsesTransportConfig,
+  stream: AsyncIterable<TextStreamPart<any>>,
+): Promise<string[]> {
+  const state: ToolAgentState = { messages: [], steps: 0 };
+  const completion = createDeferred<ToolAgentRoundCompletion<ToolAgentState>>();
+  const chunks: string[] = [];
+
+  for await (const event of responsesEventStreamToRuntimeEvents(
+    config,
+    stream,
+    {},
+    state,
+    [],
+    completion,
+  )) {
+    if (event.kind === 'thinking-chunk') {
+      chunks.push(event.text);
+    }
+  }
+
+  await completion.promise;
+  return chunks;
+}
+
+test('gateway gemini streaming maps reasoning-delta to thinking-chunk', async () => {
+  async function* stream(): AsyncGenerator<TextStreamPart<any>> {
+    yield { type: 'reasoning-delta', id: 'thought_1', text: 'Sum primes.' };
+    yield { type: 'reasoning-delta', id: 'thought_1', text: ' Check list.' };
+    yield { type: 'text-delta', id: 't1', text: 'The answer is 129.' };
+    yield {
+      type: 'raw',
+      rawValue: {
+        type: 'response.completed',
+        response: { id: 'resp-gateway-gemini' },
+      },
+    };
+  }
+
+  const chunks = await collectThinkingChunks(gatewayGeminiConfig, stream());
+  assert.deepEqual(chunks, ['Sum primes.', ' Check list.']);
+});

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -86,7 +86,9 @@ import {
   isGatewayAnthropicClaudeModel,
 } from './gateway-anthropic-thinking.js';
 import {
+  buildGatewayGoogleProviderOptions,
   buildGoogleThinkingConfigForEffort,
+  isGatewayGoogleGeminiModel,
 } from './gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openrouter-anthropic-reasoning.js';
 import { generateSiliconFlowImage } from '../image-generation/siliconflow-backend.js';
@@ -905,6 +907,10 @@ function buildAiSdkProviderOptions(
 ): Record<string, JsonObject> {
   if (isVercelAiGatewayProvider(config) && isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
     return buildGatewayAnthropicProviderOptions(config);
+  }
+
+  if (isVercelAiGatewayProvider(config) && isGatewayGoogleGeminiModel(config.llmVendor, config.model)) {
+    return buildGatewayGoogleProviderOptions(config, openAiReasoningEffort(config));
   }
 
   if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -85,6 +85,9 @@ import {
   buildGatewayAnthropicProviderOptions,
   isGatewayAnthropicClaudeModel,
 } from './gateway-anthropic-thinking.js';
+import {
+  buildGoogleThinkingConfigForEffort,
+} from './gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openrouter-anthropic-reasoning.js';
 import { generateSiliconFlowImage } from '../image-generation/siliconflow-backend.js';
 import { generateVideoWithRouter } from '../video-generation/router.js';
@@ -964,7 +967,10 @@ function buildAiSdkProviderOptions(
   }
 
   if (isGoogleOfficialAiSdkProvider(config)) {
-    const thinkingConfig = buildGoogleThinkingConfig(config);
+    const thinkingConfig = buildGoogleThinkingConfigForEffort(
+      config.model,
+      openAiReasoningEffort(config),
+    );
     if (thinkingConfig === undefined) {
       return {};
     }
@@ -979,7 +985,10 @@ function buildAiSdkProviderOptions(
   }
 
   if (isGoogleVertexOfficialAiSdkProvider(config)) {
-    const thinkingConfig = buildGoogleThinkingConfig(config);
+    const thinkingConfig = buildGoogleThinkingConfigForEffort(
+      config.model,
+      openAiReasoningEffort(config),
+    );
     if (thinkingConfig === undefined) {
       return {};
     }
@@ -1746,64 +1755,6 @@ function isGoogleOfficialAiSdkProvider(config: OpenAiTransportConfig): boolean {
 
 function isGoogleVertexOfficialAiSdkProvider(config: OpenAiTransportConfig): boolean {
   return config.llmVendor === 'google-vertex-ai';
-}
-
-function isGoogleGemini3Model(model: string): boolean {
-  const normalized = model.trim().toLowerCase();
-  return normalized.includes('gemini-3');
-}
-
-function buildGoogleThinkingConfig(
-  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort'>,
-): GoogleGenerativeAIProviderOptions['thinkingConfig'] | undefined {
-  const effort = openAiReasoningEffort(config);
-  if (effort === undefined) {
-    return undefined;
-  }
-
-  if (effort === 'none') {
-    if (isGoogleGemini3Model(config.model)) {
-      return { thinkingLevel: 'minimal' };
-    }
-
-    return { thinkingBudget: 0 };
-  }
-
-  if (isGoogleGemini3Model(config.model)) {
-    if (effort === 'low' || effort === 'medium' || effort === 'high') {
-      return {
-        thinkingLevel: effort,
-        includeThoughts: true,
-      };
-    }
-
-    return undefined;
-  }
-
-  const thinkingBudget = googleGemini25ThinkingBudgetForEffort(effort);
-  if (thinkingBudget === undefined) {
-    return undefined;
-  }
-
-  return {
-    thinkingBudget,
-    includeThoughts: thinkingBudget > 0,
-  };
-}
-
-function googleGemini25ThinkingBudgetForEffort(
-  effort: string,
-): number | undefined {
-  switch (effort) {
-    case 'low':
-      return 1024;
-    case 'medium':
-      return 4096;
-    case 'high':
-      return 8192;
-    default:
-      return undefined;
-  }
 }
 
 function xaiChatReasoningEffort(

--- a/packages/agent-core/src/openai/gateway-google-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-google-thinking.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayGoogleProviderOptions,
+  buildGoogleThinkingConfigForEffort,
+  gatewayGoogleGeminiSupportedEfforts,
+  isGatewayGoogleGeminiModel,
+} from './gateway-google-thinking.js';
+
+test('isGatewayGoogleGeminiModel matches vercel-ai-gateway google gemini routes only', () => {
+  assert.equal(
+    isGatewayGoogleGeminiModel('vercel-ai-gateway', 'google/gemini-3.1-pro-preview'),
+    true,
+  );
+  assert.equal(
+    isGatewayGoogleGeminiModel('vercel-ai-gateway', 'google/gemini-2.5-flash'),
+    true,
+  );
+  assert.equal(
+    isGatewayGoogleGeminiModel('vercel-ai-gateway', 'openai/gpt-5'),
+    false,
+  );
+  assert.equal(
+    isGatewayGoogleGeminiModel('vercel-ai-gateway', 'google/imagen-4'),
+    false,
+  );
+  assert.equal(
+    isGatewayGoogleGeminiModel('google', 'google/gemini-3.1-pro-preview'),
+    false,
+  );
+});
+
+test('buildGoogleThinkingConfigForEffort maps Gemini 3 and 2.5 effort levels', () => {
+  assert.deepEqual(
+    buildGoogleThinkingConfigForEffort('google/gemini-3.1-pro-preview', 'high'),
+    {
+      thinkingLevel: 'high',
+      includeThoughts: true,
+    },
+  );
+  assert.deepEqual(
+    buildGoogleThinkingConfigForEffort('google/gemini-2.5-flash', 'medium'),
+    {
+      thinkingBudget: 4096,
+      includeThoughts: true,
+    },
+  );
+  assert.deepEqual(
+    buildGoogleThinkingConfigForEffort('google/gemini-3.1-pro-preview', 'none'),
+    {
+      thinkingLevel: 'minimal',
+    },
+  );
+});
+
+test('buildGatewayGoogleProviderOptions sends google thinkingConfig for gateway gemini', () => {
+  assert.deepEqual(
+    buildGatewayGoogleProviderOptions(
+      {
+        llmVendor: 'vercel-ai-gateway',
+        model: 'google/gemini-3.1-pro-preview',
+        reasoningEffort: 'medium',
+      },
+      'medium',
+    ),
+    {
+      google: {
+        thinkingConfig: {
+          thinkingLevel: 'medium',
+          includeThoughts: true,
+        },
+      },
+    },
+  );
+});
+
+test('gatewayGoogleGeminiSupportedEfforts exports effort vocabulary for catalog metadata', () => {
+  assert.deepEqual(
+    gatewayGoogleGeminiSupportedEfforts('google/gemini-3.1-pro-preview'),
+    ['low', 'medium', 'high'],
+  );
+  assert.equal(gatewayGoogleGeminiSupportedEfforts('openai/gpt-5'), undefined);
+});

--- a/packages/agent-core/src/openai/gateway-google-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-google-thinking.ts
@@ -6,7 +6,8 @@ import type { OpenAiLlmVendor, OpenAiTransportConfig } from './openai-compat.js'
 export function isGatewayGoogleGeminiModel(
   llmVendor: OpenAiLlmVendor | undefined,
   model: string,
-): boolean {  if (llmVendor !== 'vercel-ai-gateway') {
+): boolean {
+  if (llmVendor !== 'vercel-ai-gateway') {
     return false;
   }
 

--- a/packages/agent-core/src/openai/gateway-google-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-google-thinking.ts
@@ -1,0 +1,105 @@
+import type { GoogleGenerativeAIProviderOptions } from '@ai-sdk/google';
+
+import type { JsonObject } from '../ports.js';
+import type { OpenAiLlmVendor, OpenAiTransportConfig } from './openai-compat.js';
+
+export function isGatewayGoogleGeminiModel(
+  llmVendor: OpenAiLlmVendor | undefined,
+  model: string,
+): boolean {  if (llmVendor !== 'vercel-ai-gateway') {
+    return false;
+  }
+
+  return model.trim().toLowerCase().startsWith('google/gemini-');
+}
+
+export function isGoogleGemini3Model(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return normalized.includes('gemini-3');
+}
+
+function googleGemini25ThinkingBudgetForEffort(
+  effort: string,
+): number | undefined {
+  switch (effort) {
+    case 'low':
+      return 1024;
+    case 'medium':
+      return 4096;
+    case 'high':
+      return 8192;
+    default:
+      return undefined;
+  }
+}
+
+export function buildGoogleThinkingConfigForEffort(
+  model: string,
+  effort: string | undefined,
+): GoogleGenerativeAIProviderOptions['thinkingConfig'] | undefined {
+  if (effort === undefined) {
+    return undefined;
+  }
+
+  if (effort === 'none') {
+    if (isGoogleGemini3Model(model)) {
+      return { thinkingLevel: 'minimal' };
+    }
+
+    return { thinkingBudget: 0 };
+  }
+
+  if (isGoogleGemini3Model(model)) {
+    if (effort === 'low' || effort === 'medium' || effort === 'high') {
+      return {
+        thinkingLevel: effort,
+        includeThoughts: true,
+      };
+    }
+
+    return undefined;
+  }
+
+  const thinkingBudget = googleGemini25ThinkingBudgetForEffort(effort);
+  if (thinkingBudget === undefined) {
+    return undefined;
+  }
+
+  return {
+    thinkingBudget,
+    includeThoughts: thinkingBudget > 0,
+  };
+}
+
+export function gatewayGoogleGeminiSupportedEfforts(
+  model: string,
+): readonly string[] | undefined {
+  const normalized = model.trim().toLowerCase();
+  if (!normalized.startsWith('google/gemini-')) {
+    return undefined;
+  }
+
+  return ['low', 'medium', 'high'];
+}
+
+export function buildGatewayGoogleProviderOptions(
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort'>,
+  effort: string | undefined,
+): Record<string, JsonObject> {
+  if (!isGatewayGoogleGeminiModel(config.llmVendor, config.model)) {
+    return {};
+  }
+
+  const thinkingConfig = buildGoogleThinkingConfigForEffort(config.model, effort);
+  if (thinkingConfig === undefined) {
+    return {};
+  }
+
+  const googleOptions = {
+    thinkingConfig,
+  } satisfies GoogleGenerativeAIProviderOptions;
+
+  return {
+    google: googleOptions as JsonObject,
+  };
+}

--- a/packages/agent-core/src/openai/index.ts
+++ b/packages/agent-core/src/openai/index.ts
@@ -12,6 +12,12 @@ export {
   resolveGatewayAnthropicClaudeCapabilities,
 } from './gateway-anthropic-thinking.js';
 export {
+  buildGatewayGoogleProviderOptions,
+  buildGoogleThinkingConfigForEffort,
+  gatewayGoogleGeminiSupportedEfforts,
+  isGatewayGoogleGeminiModel,
+} from './gateway-google-thinking.js';
+export {
   buildOpenRouterClaudeReasoningBody,
   isOpenRouterAnthropicClaudeModel,
   shouldInjectOpenRouterClaudeReasoning,

--- a/packages/agent-core/src/reasoning-effort.test.ts
+++ b/packages/agent-core/src/reasoning-effort.test.ts
@@ -132,6 +132,35 @@ test('anthropic supported efforts restrict unavailable levels', () => {
   );
 });
 
+test('gateway gemini models use google effort options', () => {
+  const geminiOptions = modelReasoningEffortOptions({
+    provider: 'vercel-ai-gateway',
+    model: 'google/gemini-3.1-pro-preview',
+    transportKind: 'open-responses',
+  });
+  assert.deepEqual(
+    geminiOptions.map((option) => option.value),
+    ['default', 'none', 'low', 'medium', 'high'],
+  );
+
+  assert.equal(
+    resolveModelReasoningEffortForContext('minimal', {
+      provider: 'vercel-ai-gateway',
+      model: 'google/gemini-3.1-pro-preview',
+      transportKind: 'open-responses',
+    }),
+    'low',
+  );
+  assert.equal(
+    resolveOpenAiTransportReasoningEffortForContext('medium', {
+      provider: 'vercel-ai-gateway',
+      model: 'google/gemini-2.5-flash',
+      transportKind: 'openai-compatible',
+    }),
+    'medium',
+  );
+});
+
 test('gateway claude models use anthropic effort options filtered by model capabilities', () => {
   const sonnetOptions = modelReasoningEffortOptions({
     provider: 'vercel-ai-gateway',

--- a/packages/agent-core/src/reasoning-effort.ts
+++ b/packages/agent-core/src/reasoning-effort.ts
@@ -4,6 +4,7 @@ import {
   isGatewayAnthropicClaudeModel,
   resolveGatewayAnthropicClaudeCapabilities,
 } from './openai/gateway-anthropic-thinking.js';
+import { isGatewayGoogleGeminiModel } from './openai/gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openai/openrouter-anthropic-reasoning.js';
 import { resolveRoutedAnthropicClaudeCapabilities } from './openai/routed-anthropic-claude-capabilities.js';
 import type { OpenAiTransportConfig } from './openai/openai-compat.js';
@@ -338,7 +339,12 @@ export function isXaiReasoningEffortModel(
 export function isGoogleReasoningEffortModel(
   context?: ModelReasoningEffortContext,
 ): boolean {
-  return context?.provider === 'google' || context?.provider === 'google-vertex-ai';
+  return context?.provider === 'google'
+    || context?.provider === 'google-vertex-ai'
+    || isGatewayGoogleGeminiModel(
+      context?.provider === 'vercel-ai-gateway' ? 'vercel-ai-gateway' : undefined,
+      context?.model ?? '',
+    );
 }
 
 export function isAnthropicReasoningEffortModel(

--- a/packages/host-internal/src/openai-models.test.ts
+++ b/packages/host-internal/src/openai-models.test.ts
@@ -201,6 +201,40 @@ test('parseVercelAiGatewayModelEntriesPayload infers supportedReasoningEfforts f
   ]);
 });
 
+test('parseVercelAiGatewayModelEntriesPayload infers supportedReasoningEfforts for google gemini models', () => {
+  const entries = parseVercelAiGatewayModelEntriesPayload({
+    data: [
+      {
+        id: 'google/gemini-3.1-pro-preview',
+        type: 'language',
+      },
+      {
+        id: 'google/gemini-2.5-flash',
+        type: 'language',
+      },
+      {
+        id: 'google/imagen-4',
+        type: 'image',
+      },
+    ],
+  });
+
+  assert.deepEqual(entries, [
+    {
+      id: 'google/gemini-3.1-pro-preview',
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
+    },
+    {
+      id: 'google/gemini-2.5-flash',
+      supportedReasoningEfforts: ['low', 'medium', 'high'],
+    },
+    {
+      id: 'google/imagen-4',
+      supportsImageGeneration: true,
+    },
+  ]);
+});
+
 test('parseOpenAiCompatibleModelEntriesPayload routes vercel-ai-gateway to typed parser', () => {
   const entries = parseOpenAiCompatibleModelEntriesPayload({
     data: [

--- a/packages/host-internal/src/openai-models.ts
+++ b/packages/host-internal/src/openai-models.ts
@@ -2,7 +2,11 @@
  * OpenAI-compatible `GET /v1/models` listing (host-side; no secrets stored here).
  */
 
-import { gatewayAnthropicClaudeSupportedEfforts, routedAnthropicClaudeSupportedEfforts } from '@spirit-agent/core';
+import {
+  gatewayAnthropicClaudeSupportedEfforts,
+  gatewayGoogleGeminiSupportedEfforts,
+  routedAnthropicClaudeSupportedEfforts,
+} from '@spirit-agent/core';
 
 import type { ModelProviderId, ProviderModelTransportKind } from './model-provider-presets.js';
 import { resolveProviderConnectApiBase } from './model-provider-presets.js';
@@ -493,6 +497,28 @@ function attachGatewayAnthropicReasoningEfforts(
   };
 }
 
+function attachGatewayGeminiReasoningEfforts(
+  modelEntry: ProviderListedModelEntry,
+): ProviderListedModelEntry {
+  const supportedReasoningEfforts = gatewayGoogleGeminiSupportedEfforts(modelEntry.id);
+  if (supportedReasoningEfforts === undefined) {
+    return modelEntry;
+  }
+
+  return {
+    ...modelEntry,
+    supportedReasoningEfforts: [...supportedReasoningEfforts],
+  };
+}
+
+function attachGatewayModelReasoningEfforts(
+  modelEntry: ProviderListedModelEntry,
+): ProviderListedModelEntry {
+  return attachGatewayGeminiReasoningEfforts(
+    attachGatewayAnthropicReasoningEfforts(modelEntry),
+  );
+}
+
 function readOpenRouterSupportedReasoningEfforts(
   record: Record<string, unknown>,
 ): string[] | undefined {
@@ -605,7 +631,7 @@ export function parseVercelAiGatewayModelEntriesPayload(body: unknown): Provider
       attachListedModelMetadata({ id: id.trim() }, record, readVercelGatewayPricing(record)),
     );
   }
-  return entries.map(attachGatewayAnthropicReasoningEfforts);
+  return entries.map(attachGatewayModelReasoningEfforts);
 }
 
 function readOpenRouterModalities(value: unknown): string[] {


### PR DESCRIPTION
## Summary

- 新增 `gateway-google-thinking` 模块，为 Vercel AI Gateway 的 `google/gemini-*` 注入 `providerOptions.google.thinkingConfig`（含 `includeThoughts: true`）
- Open Responses 与 Chat Completions 两条 transport 路径均接入，修复此前误用 `openai.reasoningEffort` 导致 UI 无思考摘要的问题
- Gateway Gemini 模型走 Google reasoning effort 归一化，并在模型目录推断 `supportedReasoningEfforts`
- 补充 provider options、reasoning-effort、流式 `reasoning-delta` → `thinking-chunk` 单测

## Test plan

- [x] `packages/agent-core`：`gateway-google-thinking`、`model-factory`、`streaming-gateway-gemini-thinking`、`reasoning-effort`、`ai-sdk-transport-google` 相关单测通过
- [x] `packages/host-internal`：`openai-models` Gateway Gemini `supportedReasoningEfforts` 单测通过
- [x] Desktop 手动：Vercel AI Gateway + `google/gemini-3.1-pro-preview`，Reasoning = Medium，UI 可见思考折叠块