### PR TITLE
refactor(desktop, cli): Chat Schema v2 会话落盘仅持久化 timeline

### DIFF
--- a/apps/cli/src/chat_store.rs
+++ b/apps/cli/src/chat_store.rs
@@ -7,7 +7,12 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::rewind::{ConversationMessageRole, ConversationMessageSnapshot, MessageAuxSnapshot};
+use crate::chat_timeline::{
+    CHAT_SCHEMA_VERSION, PersistedTimelineTurn, build_persisted_timeline,
+    derive_archive_projection, hydrate_desktop_messages_from_timeline,
+    normalize_desktop_messages_for_persistence,
+};
+use crate::rewind::ConversationMessageSnapshot;
 
 use crate::mcp::spirit_agent_data_dir;
 
@@ -17,14 +22,12 @@ fn default_chat_approval_level() -> String {
     "default".to_string()
 }
 
-/// Desktop 会话 JSON 可能含 `sessionTitleSource`（seed/llm）；CLI 读取时忽略该字段。
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ChatFile {
+    chat_schema_version: i32,
     saved_at_unix_ms: u128,
-    messages: Vec<StoredChatMessage>,
-    #[serde(default)]
-    assistant_aux: Vec<StoredAssistantAux>,
+    desktop_message_timeline: Vec<PersistedTimelineTurn>,
     llm_history: Vec<crate::ports::ArchivedLlmMessage>,
     #[serde(default)]
     loop_enabled: bool,
@@ -40,27 +43,6 @@ struct ChatFile {
     workspace_root: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     git_branch: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    desktop_messages: Option<Vec<ConversationMessageSnapshot>>,
-}
-
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct StoredChatMessage {
-    role: String,
-    content: String,
-}
-
-#[derive(Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct StoredAssistantAux {
-    message_index: usize,
-    #[serde(default)]
-    thinking: Option<String>,
-    #[serde(default)]
-    compaction: Option<String>,
-    #[serde(default)]
-    finish_task_notice: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -86,12 +68,7 @@ struct StoredSubagentSessionSummary {
     error: Option<String>,
 }
 
-struct SanitizedChatData {
-    messages: Vec<StoredChatMessage>,
-    assistant_aux: Vec<StoredAssistantAux>,
-    desktop_messages: Vec<ConversationMessageSnapshot>,
-}
-
+#[derive(Debug)]
 pub struct LoadedChat {
     pub messages: Vec<(String, String)>,
     pub assistant_aux: Vec<crate::ports::AssistantAuxArchiveEntry>,
@@ -144,13 +121,20 @@ pub fn save_chat(
             .with_context(|| format!("创建对话目录失败: {}", parent.display()))?;
     }
 
-    let sanitized = sanitize_chat_data(messages, assistant_aux, desktop_messages);
+    let desktop_messages = desktop_messages
+        .map(normalize_desktop_messages_for_persistence)
+        .filter(|messages| !messages.is_empty())
+        .unwrap_or_else(|| build_fallback_desktop_messages(messages, assistant_aux));
+    let desktop_message_timeline = build_persisted_timeline(&desktop_messages);
+    if desktop_message_timeline.is_empty() {
+        return Err(anyhow!("chat schema v2 拒绝写入空会话 timeline"));
+    }
     let workspace_root = current_workspace_root();
 
     let file = ChatFile {
+        chat_schema_version: CHAT_SCHEMA_VERSION,
         saved_at_unix_ms: current_unix_millis(),
-        messages: sanitized.messages,
-        assistant_aux: sanitized.assistant_aux,
+        desktop_message_timeline,
         llm_history: llm_history.to_vec(),
         loop_enabled,
         approval_level: crate::ports::normalize_approval_level(approval_level),
@@ -175,15 +159,13 @@ pub fn save_chat(
         rewind: rewind.cloned(),
         session_display_name: session_display_name_override
             .map(str::to_string)
-            .or_else(|| derive_session_display_name(&sanitized.desktop_messages)),
+            .or_else(|| derive_session_display_name(&desktop_messages)),
         workspace_root: workspace_root
             .as_ref()
             .map(|path| path.to_string_lossy().to_string()),
         git_branch: workspace_root
             .as_ref()
             .and_then(|path| detect_git_branch(path)),
-        desktop_messages: (!sanitized.desktop_messages.is_empty())
-            .then_some(sanitized.desktop_messages),
     };
 
     let content = serde_json::to_string_pretty(&file)?;
@@ -195,73 +177,32 @@ pub fn load_chat(path_arg: &str) -> Result<LoadedChat> {
     let path = resolve_load_path(path_arg)?;
     let text = fs::read_to_string(&path)
         .with_context(|| format!("读取对话文件失败: {}", path.display()))?;
-    let parsed: ChatFile = serde_json::from_str(&text)
+    let parsed: Value = serde_json::from_str(&text)
         .with_context(|| format!("解析对话文件失败: {}", path.display()))?;
 
-    let ChatFile {
-        messages: parsed_messages,
-        assistant_aux: parsed_assistant_aux,
-        llm_history,
-        loop_enabled,
-        approval_level,
-        subagent_sessions,
-        rewind,
-        desktop_messages,
-        session_display_name,
-        ..
-    } = parsed;
+    ensure_chat_schema_v2(&parsed)?;
+    reject_legacy_conversation_fields(&parsed)?;
 
-    let messages = parsed_messages
-        .into_iter()
-        .map(|m| (m.role, m.content))
-        .collect::<Vec<_>>();
-    let assistant_aux = parsed_assistant_aux
-        .into_iter()
-        .filter(|entry| {
-            entry
-                .thinking
-                .as_ref()
-                .is_some_and(|value| !value.trim().is_empty())
-                || entry
-                    .compaction
-                    .as_ref()
-                    .is_some_and(|value| !value.trim().is_empty())
-                || entry
-                    .finish_task_notice
-                    .as_ref()
-                    .is_some_and(|value| !value.trim().is_empty())
-        })
-        .map(|entry| crate::ports::AssistantAuxArchiveEntry {
-            message_index: entry.message_index,
-            thinking: entry.thinking.filter(|value| !value.trim().is_empty()),
-            compaction: entry.compaction.filter(|value| !value.trim().is_empty()),
-            finish_task_notice: entry
-                .finish_task_notice
-                .filter(|value| !value.trim().is_empty()),
-        })
-        .collect::<Vec<_>>();
-    let sanitized = sanitize_chat_data(&messages, &assistant_aux, desktop_messages.as_deref());
+    let parsed: ChatFile = serde_json::from_value(parsed)
+        .with_context(|| format!("解析 chat schema v2 失败: {}", path.display()))?;
+    if parsed.desktop_message_timeline.is_empty() {
+        return Err(anyhow!("chat schema v2 要求非空 desktopMessageTimeline"));
+    }
+
+    let desktop_messages = hydrate_desktop_messages_from_timeline(&parsed.desktop_message_timeline);
+    if desktop_messages.is_empty() {
+        return Err(anyhow!("chat schema v2 timeline 未还原出任何消息"));
+    }
+    let (messages, assistant_aux) = derive_archive_projection(&desktop_messages);
 
     Ok(LoadedChat {
-        messages: sanitized
-            .messages
-            .into_iter()
-            .map(|m| (m.role, m.content))
-            .collect(),
-        assistant_aux: sanitized
-            .assistant_aux
-            .into_iter()
-            .map(|entry| crate::ports::AssistantAuxArchiveEntry {
-                message_index: entry.message_index,
-                thinking: entry.thinking,
-                compaction: entry.compaction,
-                finish_task_notice: entry.finish_task_notice,
-            })
-            .collect(),
-        llm_history,
-        loop_enabled,
-        approval_level: crate::ports::normalize_approval_level(&approval_level),
-        subagent_sessions: subagent_sessions
+        messages,
+        assistant_aux,
+        llm_history: parsed.llm_history,
+        loop_enabled: parsed.loop_enabled,
+        approval_level: crate::ports::normalize_approval_level(&parsed.approval_level),
+        subagent_sessions: parsed
+            .subagent_sessions
             .into_iter()
             .map(|entry| crate::ports::SubagentSessionArchiveEntry {
                 summary: crate::ports::SubagentSessionSummary {
@@ -279,11 +220,35 @@ pub fn load_chat(path_arg: &str) -> Result<LoadedChat> {
                 llm_history: entry.llm_history,
             })
             .collect(),
-        desktop_messages: (!sanitized.desktop_messages.is_empty())
-            .then_some(sanitized.desktop_messages),
-        rewind,
-        session_display_name,
+        desktop_messages: Some(desktop_messages),
+        rewind: parsed.rewind,
+        session_display_name: parsed.session_display_name,
     })
+}
+
+fn ensure_chat_schema_v2(parsed: &Value) -> Result<()> {
+    match parsed.get("chatSchemaVersion").and_then(Value::as_i64) {
+        Some(version) if version == CHAT_SCHEMA_VERSION as i64 => Ok(()),
+        Some(version) => Err(anyhow!(
+            "chat schema v2 required (chatSchemaVersion={CHAT_SCHEMA_VERSION}), got {version}"
+        )),
+        None => Err(anyhow!(
+            "chat schema v2 required (chatSchemaVersion={CHAT_SCHEMA_VERSION}), got none"
+        )),
+    }
+}
+
+fn reject_legacy_conversation_fields(parsed: &Value) -> Result<()> {
+    if parsed.get("messages").is_some() {
+        return Err(anyhow!("chat schema v2 must not include messages"));
+    }
+    if parsed.get("assistantAux").is_some() {
+        return Err(anyhow!("chat schema v2 must not include assistantAux"));
+    }
+    if parsed.get("desktopMessages").is_some() {
+        return Err(anyhow!("chat schema v2 must not include desktopMessages"));
+    }
+    Ok(())
 }
 
 fn current_unix_millis() -> u128 {
@@ -293,147 +258,44 @@ fn current_unix_millis() -> u128 {
         .unwrap_or(0)
 }
 
-fn sanitize_chat_data(
+fn build_fallback_desktop_messages(
     messages: &[(String, String)],
     assistant_aux: &[crate::ports::AssistantAuxArchiveEntry],
-    desktop_messages: Option<&[ConversationMessageSnapshot]>,
-) -> SanitizedChatData {
-    let normalized_aux = assistant_aux
-        .iter()
-        .filter_map(|entry| {
-            let thinking = entry
-                .thinking
-                .clone()
-                .filter(|value| !value.trim().is_empty());
-            let compaction = entry
-                .compaction
-                .clone()
-                .filter(|value| !value.trim().is_empty());
-            let finish_task_notice = entry
-                .finish_task_notice
-                .clone()
-                .filter(|value| !value.trim().is_empty());
-            if thinking.is_none() && compaction.is_none() && finish_task_notice.is_none() {
-                None
-            } else {
-                Some((
-                    entry.message_index,
-                    StoredAssistantAux {
-                        message_index: 0,
-                        thinking,
-                        compaction,
-                        finish_task_notice,
-                    },
-                ))
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let mut persisted_messages = Vec::new();
-    let mut persisted_aux = Vec::new();
-
-    for (original_index, (role, content)) in messages.iter().enumerate() {
-        let aux = normalized_aux
-            .iter()
-            .find(|(index, _)| *index == original_index)
-            .map(|(_, entry)| entry.clone());
-        if role == "assistant" && content.trim().is_empty() && aux.is_none() {
-            continue;
-        }
-
-        let message_index = persisted_messages.len();
-        persisted_messages.push(StoredChatMessage {
-            role: role.clone(),
-            content: content.clone(),
-        });
-
-        aux.map(|mut entry| {
-            entry.message_index = message_index;
-            persisted_aux.push(entry.clone());
-        });
-    }
-
-    let desktop_messages = sanitize_desktop_messages(desktop_messages)
-        .unwrap_or_else(|| build_fallback_desktop_messages(&persisted_messages, &persisted_aux));
-
-    SanitizedChatData {
-        messages: persisted_messages,
-        assistant_aux: persisted_aux,
-        desktop_messages,
-    }
-}
-
-fn sanitize_desktop_messages(
-    desktop_messages: Option<&[ConversationMessageSnapshot]>,
-) -> Option<Vec<ConversationMessageSnapshot>> {
-    let sanitized = desktop_messages?
-        .iter()
-        .filter_map(|message| {
-            let aux = sanitize_message_aux_snapshot(message.aux.as_ref());
-            if message.role == ConversationMessageRole::Assistant
-                && message.content.trim().is_empty()
-                && message.tool.is_none()
-                && aux.is_none()
-            {
-                return None;
-            }
-            Some(ConversationMessageSnapshot {
-                id: message.id,
-                role: message.role,
-                content: message.content.clone(),
-                tool: message.tool.clone(),
-                aux,
-                pending: message.pending,
-            })
-        })
-        .collect::<Vec<_>>();
-    (!sanitized.is_empty()).then_some(sanitized)
-}
-
-fn sanitize_message_aux_snapshot(aux: Option<&MessageAuxSnapshot>) -> Option<MessageAuxSnapshot> {
-    let aux = aux?;
-    let thinking = aux
-        .thinking
-        .clone()
-        .filter(|value| !value.trim().is_empty());
-    let compaction = aux
-        .compaction
-        .clone()
-        .filter(|value| !value.trim().is_empty());
-    if thinking.is_none() && compaction.is_none() {
-        None
-    } else {
-        Some(MessageAuxSnapshot {
-            thinking,
-            compaction,
-        })
-    }
-}
-
-fn build_fallback_desktop_messages(
-    messages: &[StoredChatMessage],
-    assistant_aux: &[StoredAssistantAux],
 ) -> Vec<ConversationMessageSnapshot> {
+    use crate::rewind::{ConversationMessageRole, MessageAuxSnapshot};
+
     messages
         .iter()
         .enumerate()
-        .map(|(index, message)| ConversationMessageSnapshot {
+        .map(|(index, (role, content))| ConversationMessageSnapshot {
             id: index + 1,
-            role: if message.role == "user" {
+            role: if role == "user" {
                 ConversationMessageRole::User
             } else {
                 ConversationMessageRole::Assistant
             },
-            content: message.content.clone(),
+            content: content.clone(),
             tool: None,
             aux: assistant_aux
                 .iter()
                 .find(|entry| entry.message_index == index)
                 .and_then(|entry| {
-                    sanitize_message_aux_snapshot(Some(&MessageAuxSnapshot {
-                        thinking: entry.thinking.clone(),
-                        compaction: entry.compaction.clone(),
-                    }))
+                    let thinking = entry
+                        .thinking
+                        .clone()
+                        .filter(|value| !value.trim().is_empty());
+                    let compaction = entry
+                        .compaction
+                        .clone()
+                        .filter(|value| !value.trim().is_empty());
+                    if thinking.is_none() && compaction.is_none() {
+                        None
+                    } else {
+                        Some(MessageAuxSnapshot {
+                            thinking,
+                            compaction,
+                        })
+                    }
                 }),
             pending: false,
         })
@@ -441,6 +303,8 @@ fn build_fallback_desktop_messages(
 }
 
 fn derive_session_display_name(messages: &[ConversationMessageSnapshot]) -> Option<String> {
+    use crate::rewind::ConversationMessageRole;
+
     let seed = messages
         .iter()
         .find(|message| {
@@ -555,11 +419,12 @@ pub fn display_name(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rewind::{ConversationMessageRole, MessageAuxSnapshot};
     use serde_json::json;
 
     #[test]
-    fn save_chat_writes_desktop_compatible_schema_and_reloads() {
-        let file_path = test_file_path("desktop-compatible-save");
+    fn save_chat_writes_v2_schema_and_reloads() {
+        let file_path = test_file_path("v2-save");
         let messages = vec![
             ("user".to_string(), "hello".to_string()),
             ("assistant".to_string(), "".to_string()),
@@ -577,6 +442,35 @@ mod tests {
             "hello".to_string(),
             Vec::new(),
         )];
+        let desktop_messages = vec![
+            ConversationMessageSnapshot {
+                id: 1,
+                role: ConversationMessageRole::User,
+                content: "hello".to_string(),
+                tool: None,
+                aux: None,
+                pending: false,
+            },
+            ConversationMessageSnapshot {
+                id: 2,
+                role: ConversationMessageRole::Assistant,
+                content: String::new(),
+                tool: None,
+                aux: Some(MessageAuxSnapshot {
+                    thinking: Some("reasoning".to_string()),
+                    compaction: None,
+                }),
+                pending: false,
+            },
+            ConversationMessageSnapshot {
+                id: 3,
+                role: ConversationMessageRole::Assistant,
+                content: "answer".to_string(),
+                tool: None,
+                aux: None,
+                pending: false,
+            },
+        ];
 
         let saved = save_chat(
             Some(file_path.to_string_lossy().as_ref()),
@@ -587,30 +481,19 @@ mod tests {
             "default",
             &[],
             None,
-            None,
+            Some(&desktop_messages),
             None,
         )
         .expect("save chat");
 
         let raw = fs::read_to_string(&saved).expect("read saved chat");
         let parsed: Value = serde_json::from_str(&raw).expect("parse saved chat json");
-        assert!(parsed.get("savedAtUnixMs").is_some());
-        assert!(parsed.get("saved_at_unix_ms").is_none());
-        assert!(parsed.get("assistantAux").is_some());
-        assert!(parsed.get("assistant_aux").is_none());
-        assert!(parsed.get("llmHistory").is_some());
+        assert_eq!(parsed["chatSchemaVersion"], json!(2));
+        assert!(parsed.get("messages").is_none());
+        assert!(parsed.get("assistantAux").is_none());
+        assert!(parsed.get("desktopMessages").is_none());
+        assert!(parsed["desktopMessageTimeline"].is_array());
         assert_eq!(parsed["loopEnabled"], json!(true));
-        assert!(parsed["llmHistory"][0]["content"].is_array());
-        assert!(parsed["llmHistory"][0].get("imagePaths").is_none());
-
-        let stored_messages = parsed["messages"].as_array().expect("messages array");
-        assert_eq!(stored_messages.len(), 3);
-        let desktop_messages = parsed["desktopMessages"]
-            .as_array()
-            .expect("desktop messages array");
-        assert_eq!(desktop_messages.len(), 3);
-        assert_eq!(parsed["assistantAux"][0]["messageIndex"], json!(1));
-        assert_eq!(desktop_messages[1]["aux"]["thinking"], json!("reasoning"));
 
         let loaded = load_chat(saved.to_string_lossy().as_ref()).expect("reload chat");
         assert_eq!(loaded.messages.len(), 3);
@@ -624,29 +507,18 @@ mod tests {
                 .len(),
             3
         );
-        assert_eq!(loaded.assistant_aux[0].message_index, 1);
-        assert_eq!(
-            loaded.assistant_aux[0].thinking.as_deref(),
-            Some("reasoning")
-        );
 
         let _ = fs::remove_file(saved);
     }
 
     #[test]
-    fn load_chat_upgrades_legacy_llm_history_shape() {
-        let file_path = test_file_path("legacy-llm-history");
+    fn load_chat_rejects_legacy_schema() {
+        let file_path = test_file_path("legacy-schema");
         let raw = json!({
             "savedAtUnixMs": current_unix_millis(),
             "messages": [{ "role": "user", "content": "hello" }],
             "assistantAux": [],
-            "llmHistory": [
-                {
-                    "role": "user",
-                    "content": "hello",
-                    "imagePaths": ["demo.png"]
-                }
-            ],
+            "llmHistory": [],
             "subagentSessions": [],
         });
         fs::write(
@@ -655,73 +527,74 @@ mod tests {
         )
         .expect("write legacy chat");
 
-        let loaded = load_chat(file_path.to_string_lossy().as_ref()).expect("load legacy chat");
-        assert_eq!(loaded.llm_history.len(), 1);
-        assert_eq!(loaded.llm_history[0].text_content(), "hello");
-        assert_eq!(
-            loaded.llm_history[0].image_paths(),
-            vec!["demo.png".to_string()]
-        );
-        assert_eq!(
-            loaded
-                .desktop_messages
-                .as_ref()
-                .expect("fallback desktop messages")
-                .len(),
-            1
-        );
+        let error = load_chat(file_path.to_string_lossy().as_ref()).expect_err("legacy load");
+        assert!(error.to_string().contains("chat schema v2"));
 
         let _ = fs::remove_file(file_path);
     }
 
     #[test]
-    fn load_chat_preserves_desktop_tool_snapshots() {
-        let file_path = test_file_path("desktop-tool-snapshot");
+    fn load_chat_preserves_v2_tool_timeline_rows() {
+        let file_path = test_file_path("v2-tool-snapshot");
         let raw = json!({
+            "chatSchemaVersion": 2,
             "savedAtUnixMs": current_unix_millis(),
-            "messages": [{ "role": "user", "content": "画一张图" }],
-            "assistantAux": [],
-            "llmHistory": [],
-            "subagentSessions": [],
-            "desktopMessages": [
-                {
-                    "id": 1,
-                    "role": "user",
+            "desktopMessageTimeline": [{
+                "turnId": 1,
+                "createdOrder": 0,
+                "userRow": {
+                    "rowId": "row-user",
+                    "messageId": 1,
+                    "turnId": 1,
+                    "kind": "user",
+                    "createdOrder": 0,
                     "content": "画一张图",
                     "pending": false
                 },
-                {
-                    "id": 2,
-                    "role": "assistant",
-                    "content": "",
-                    "pending": false,
-                    "tool": {
-                        "toolName": "generate_image",
-                        "phase": "succeeded",
-                        "headline": "图片生成完成",
-                        "detailLines": [
-                            "path: C:\\Users\\pc\\AppData\\Roaming\\SpiritAgent\\generated-images\\demo.png"
-                        ],
-                        "outputExcerpt": "[generated image]\npath: C:\\Users\\pc\\AppData\\Roaming\\SpiritAgent\\generated-images\\demo.png",
-                        "imagePaths": [
-                            "C:\\Users\\pc\\AppData\\Roaming\\SpiritAgent\\generated-images\\demo.png"
-                        ]
-                    }
-                }
-            ]
+                "segments": [{
+                    "segmentId": 1,
+                    "turnId": 1,
+                    "kind": "initial",
+                    "status": "completed",
+                    "createdOrder": 1,
+                    "rows": [{
+                        "rowId": "row-tool",
+                        "messageId": 2,
+                        "turnId": 1,
+                        "segmentId": 1,
+                        "kind": "tool",
+                        "section": "tools",
+                        "createdOrder": 2,
+                        "pending": false,
+                        "tool": {
+                            "toolName": "generate_image",
+                            "phase": "succeeded",
+                            "headline": "图片生成完成",
+                            "detailLines": [
+                                "path: C:\\\\Users\\\\pc\\\\AppData\\\\Roaming\\\\SpiritAgent\\\\generated-images\\\\demo.png"
+                            ],
+                            "outputExcerpt": "[generated image]",
+                            "imagePaths": [
+                                "C:\\\\Users\\\\pc\\\\AppData\\\\Roaming\\\\SpiritAgent\\\\generated-images\\\\demo.png"
+                            ]
+                        }
+                    }]
+                }]
+            }],
+            "llmHistory": [],
+            "subagentSessions": []
         });
         fs::write(
             &file_path,
-            serde_json::to_string_pretty(&raw).expect("serialize desktop json"),
+            serde_json::to_string_pretty(&raw).expect("serialize v2 json"),
         )
-        .expect("write desktop chat");
+        .expect("write v2 chat");
 
-        let loaded = load_chat(file_path.to_string_lossy().as_ref()).expect("load desktop chat");
+        let loaded = load_chat(file_path.to_string_lossy().as_ref()).expect("load v2 chat");
         let desktop_messages = loaded
             .desktop_messages
             .as_ref()
             .expect("desktop tool snapshots");
-        assert_eq!(loaded.messages.len(), 1);
         assert_eq!(desktop_messages.len(), 2);
         assert_eq!(
             desktop_messages[1]
@@ -730,14 +603,6 @@ mod tests {
                 .expect("tool snapshot")
                 .tool_name,
             "generate_image"
-        );
-        assert_eq!(
-            desktop_messages[1]
-                .tool
-                .as_ref()
-                .expect("tool snapshot")
-                .image_paths,
-            vec!["C:\\Users\\pc\\AppData\\Roaming\\SpiritAgent\\generated-images\\demo.png"]
         );
 
         let _ = fs::remove_file(file_path);

--- a/apps/cli/src/chat_timeline.rs
+++ b/apps/cli/src/chat_timeline.rs
@@ -1,0 +1,428 @@
+use crate::rewind::{
+    ConversationMessageRole, ConversationMessageSnapshot, MessageAuxSnapshot, ToolBlockSnapshot,
+};
+
+pub const CHAT_SCHEMA_VERSION: i32 = 2;
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedTimelineRow {
+    pub row_id: String,
+    pub message_id: usize,
+    pub turn_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segment_id: Option<u64>,
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    pub created_order: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    pub pending: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<ToolBlockSnapshot>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub aux: Option<MessageAuxSnapshot>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedTimelineSegment {
+    pub segment_id: u64,
+    pub turn_id: u64,
+    pub kind: String,
+    pub status: String,
+    pub created_order: u64,
+    pub rows: Vec<PersistedTimelineRow>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PersistedTimelineTurn {
+    pub turn_id: u64,
+    pub created_order: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_row: Option<PersistedTimelineRow>,
+    pub segments: Vec<PersistedTimelineSegment>,
+}
+
+pub fn normalize_desktop_messages_for_persistence(
+    messages: &[ConversationMessageSnapshot],
+) -> Vec<ConversationMessageSnapshot> {
+    messages
+        .iter()
+        .filter(|message| {
+            let aux = sanitize_aux(message.aux.as_ref());
+            !(message.role == ConversationMessageRole::Assistant
+                && message.content.trim().is_empty()
+                && message.tool.is_none()
+                && aux.is_none())
+        })
+        .map(|message| ConversationMessageSnapshot {
+            id: message.id,
+            role: message.role,
+            content: message.content.clone(),
+            tool: message.tool.clone(),
+            aux: sanitize_aux(message.aux.as_ref()),
+            pending: false,
+        })
+        .collect()
+}
+
+pub fn build_persisted_timeline(
+    messages: &[ConversationMessageSnapshot],
+) -> Vec<PersistedTimelineTurn> {
+    let normalized = normalize_desktop_messages_for_persistence(messages);
+    let mut turns = Vec::new();
+    let mut current_turn: Option<PersistedTimelineTurn> = None;
+    let mut current_segment: Option<PersistedTimelineSegment> = None;
+    let mut next_turn_id = 1u64;
+    let mut next_segment_id = 1u64;
+    let mut next_row_id = 1u64;
+    let mut next_created_order = 0u64;
+
+    let push_segment = |turn: &mut PersistedTimelineTurn, segment: PersistedTimelineSegment| {
+        if !segment.rows.is_empty() {
+            turn.segments.push(segment);
+        }
+    };
+
+    for message in normalized {
+        if message.role == ConversationMessageRole::User {
+            if let Some(mut turn) = current_turn.take() {
+                if let Some(segment) = current_segment.take() {
+                    push_segment(&mut turn, segment);
+                }
+                turns.push(turn);
+            }
+            current_turn = Some(PersistedTimelineTurn {
+                turn_id: next_turn_id,
+                created_order: next_created_order,
+                user_row: Some(PersistedTimelineRow {
+                    row_id: format!("row-{next_row_id}"),
+                    message_id: message.id,
+                    turn_id: next_turn_id,
+                    segment_id: None,
+                    kind: "user".to_string(),
+                    section: None,
+                    created_order: next_created_order,
+                    content: Some(message.content.clone()),
+                    pending: false,
+                    tool: None,
+                    aux: None,
+                }),
+                segments: Vec::new(),
+            });
+            next_turn_id += 1;
+            next_row_id += 1;
+            next_created_order += 1;
+            continue;
+        }
+
+        if current_segment.is_none() {
+            let turn_id = if let Some(turn) = current_turn.as_ref() {
+                turn.turn_id
+            } else {
+                let turn = PersistedTimelineTurn {
+                    turn_id: next_turn_id,
+                    created_order: next_created_order,
+                    user_row: None,
+                    segments: Vec::new(),
+                };
+                next_turn_id += 1;
+                next_created_order += 1;
+                current_turn = Some(turn);
+                current_turn.as_ref().expect("turn inserted").turn_id
+            };
+            current_segment = Some(PersistedTimelineSegment {
+                segment_id: next_segment_id,
+                turn_id,
+                kind: "initial".to_string(),
+                status: "completed".to_string(),
+                created_order: next_created_order,
+                rows: Vec::new(),
+            });
+            next_segment_id += 1;
+            next_created_order += 1;
+        }
+
+        let turn = current_turn.as_mut().expect("assistant turn");
+        let segment = current_segment.as_mut().expect("assistant segment");
+        if let Some(row) =
+            row_from_assistant_message(message, turn.turn_id, segment.segment_id, next_created_order, next_row_id)
+        {
+            segment.rows.push(row);
+            next_row_id += 1;
+            next_created_order += 1;
+        }
+    }
+
+    if let Some(mut turn) = current_turn.take() {
+        if let Some(segment) = current_segment.take() {
+            push_segment(&mut turn, segment);
+        }
+        if turn.user_row.is_some() || !turn.segments.is_empty() {
+            turns.push(turn);
+        }
+    }
+
+    turns
+}
+
+fn row_from_assistant_message(
+    message: ConversationMessageSnapshot,
+    turn_id: u64,
+    segment_id: u64,
+    created_order: u64,
+    row_id_num: u64,
+) -> Option<PersistedTimelineRow> {
+    let base = |kind: &str, section: Option<&str>| PersistedTimelineRow {
+        row_id: format!("row-{row_id_num}"),
+        message_id: message.id,
+        turn_id,
+        segment_id: Some(segment_id),
+        kind: kind.to_string(),
+        section: section.map(str::to_string),
+        created_order,
+        content: None,
+        pending: false,
+        tool: None,
+        aux: None,
+    };
+
+    if let Some(tool) = message.tool.clone() {
+        let mut row = base("tool", Some("tools"));
+        row.tool = Some(tool);
+        return Some(row);
+    }
+
+    let aux = sanitize_aux(message.aux.as_ref());
+    if message.content.trim().is_empty() {
+        if let Some(thinking) = aux.as_ref().and_then(|value| value.thinking.clone()) {
+            return Some(PersistedTimelineRow {
+                aux: Some(MessageAuxSnapshot {
+                    thinking: Some(thinking),
+                    compaction: None,
+                }),
+                section: Some("before-tools".to_string()),
+                ..base("assistant-thinking", Some("before-tools"))
+            });
+        }
+        if let Some(compaction) = aux.as_ref().and_then(|value| value.compaction.clone()) {
+            return Some(PersistedTimelineRow {
+                aux: Some(MessageAuxSnapshot {
+                    thinking: None,
+                    compaction: Some(compaction),
+                }),
+                ..base("assistant-compaction", None)
+            });
+        }
+        return None;
+    }
+
+    Some(PersistedTimelineRow {
+        content: Some(message.content),
+        aux,
+        section: Some("after-tools".to_string()),
+        ..base("assistant-text", Some("after-tools"))
+    })
+}
+
+pub fn hydrate_desktop_messages_from_timeline(
+    timeline: &[PersistedTimelineTurn],
+) -> Vec<ConversationMessageSnapshot> {
+    let mut messages = Vec::new();
+    for turn in timeline {
+        if let Some(user_row) = turn.user_row.as_ref() {
+            if let Some(message) = row_to_message(user_row) {
+                messages.push(message);
+            }
+        }
+        for segment in &turn.segments {
+            for row in &segment.rows {
+                if let Some(message) = row_to_message(row) {
+                    messages.push(message);
+                }
+            }
+        }
+    }
+    messages
+}
+
+fn row_to_message(row: &PersistedTimelineRow) -> Option<ConversationMessageSnapshot> {
+    if row.pending {
+        return None;
+    }
+    match row.kind.as_str() {
+        "user" => {
+            let content = row.content.as_deref()?.trim();
+            if content.is_empty() {
+                return None;
+            }
+            Some(ConversationMessageSnapshot {
+                id: row.message_id,
+                role: ConversationMessageRole::User,
+                content: content.to_string(),
+                tool: None,
+                aux: None,
+                pending: false,
+            })
+        }
+        "assistant-text" => {
+            let content = row.content.as_deref()?.trim();
+            if content.is_empty() {
+                return None;
+            }
+            Some(ConversationMessageSnapshot {
+                id: row.message_id,
+                role: ConversationMessageRole::Assistant,
+                content: content.to_string(),
+                tool: None,
+                aux: sanitize_aux(row.aux.as_ref()),
+                pending: false,
+            })
+        }
+        "assistant-thinking" => Some(ConversationMessageSnapshot {
+            id: row.message_id,
+            role: ConversationMessageRole::Assistant,
+            content: String::new(),
+            tool: None,
+            aux: sanitize_aux(row.aux.as_ref()),
+            pending: false,
+        }),
+        "assistant-compaction" => Some(ConversationMessageSnapshot {
+            id: row.message_id,
+            role: ConversationMessageRole::Assistant,
+            content: String::new(),
+            tool: None,
+            aux: sanitize_aux(row.aux.as_ref()),
+            pending: false,
+        }),
+        "tool" => Some(ConversationMessageSnapshot {
+            id: row.message_id,
+            role: ConversationMessageRole::Assistant,
+            content: String::new(),
+            tool: row.tool.clone(),
+            aux: None,
+            pending: false,
+        }),
+        _ => None,
+    }
+}
+
+pub fn derive_archive_projection(
+    messages: &[ConversationMessageSnapshot],
+) -> (Vec<(String, String)>, Vec<crate::ports::AssistantAuxArchiveEntry>) {
+    let mut archive_messages = Vec::new();
+    let mut assistant_aux = Vec::new();
+    for message in messages {
+        if message.role == ConversationMessageRole::User {
+            archive_messages.push(("user".to_string(), message.content.clone()));
+            continue;
+        }
+        if message.tool.is_some() {
+            continue;
+        }
+        let aux = sanitize_aux(message.aux.as_ref());
+        if message.content.trim().is_empty() && aux.is_none() {
+            continue;
+        }
+        let index = archive_messages.len();
+        archive_messages.push(("assistant".to_string(), message.content.clone()));
+        if let Some(aux) = aux {
+            assistant_aux.push(crate::ports::AssistantAuxArchiveEntry {
+                message_index: index,
+                thinking: aux.thinking,
+                compaction: aux.compaction,
+                finish_task_notice: None,
+            });
+        }
+    }
+    (archive_messages, assistant_aux)
+}
+
+fn sanitize_aux(aux: Option<&MessageAuxSnapshot>) -> Option<MessageAuxSnapshot> {
+    let aux = aux?;
+    let thinking = aux
+        .thinking
+        .clone()
+        .filter(|value| !value.trim().is_empty());
+    let compaction = aux
+        .compaction
+        .clone()
+        .filter(|value| !value.trim().is_empty());
+    if thinking.is_none() && compaction.is_none() {
+        None
+    } else {
+        Some(MessageAuxSnapshot {
+            thinking,
+            compaction,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rewind::{ToolBlockSnapshotPhase};
+
+    #[test]
+    fn build_persisted_timeline_omits_empty_assistant_content_for_tool_and_thinking() {
+        let messages = vec![
+            ConversationMessageSnapshot {
+                id: 1,
+                role: ConversationMessageRole::User,
+                content: "hello".to_string(),
+                tool: None,
+                aux: None,
+                pending: false,
+            },
+            ConversationMessageSnapshot {
+                id: 2,
+                role: ConversationMessageRole::Assistant,
+                content: String::new(),
+                tool: None,
+                aux: Some(MessageAuxSnapshot {
+                    thinking: Some("reasoning".to_string()),
+                    compaction: None,
+                }),
+                pending: false,
+            },
+            ConversationMessageSnapshot {
+                id: 3,
+                role: ConversationMessageRole::Assistant,
+                content: String::new(),
+                tool: Some(crate::rewind::ToolBlockSnapshot {
+                    tool_call_id: Some("call-1".to_string()),
+                    tool_name: "read_file".to_string(),
+                    phase: ToolBlockSnapshotPhase::Succeeded,
+                    headline: "Read".to_string(),
+                    detail_lines: Vec::new(),
+                    image_paths: Vec::new(),
+                    video_paths: Vec::new(),
+                    args_excerpt: None,
+                    output_excerpt: None,
+                }),
+                aux: None,
+                pending: false,
+            },
+            ConversationMessageSnapshot {
+                id: 4,
+                role: ConversationMessageRole::Assistant,
+                content: "answer".to_string(),
+                tool: None,
+                aux: None,
+                pending: false,
+            },
+        ];
+
+        let timeline = build_persisted_timeline(&messages);
+        let rows = &timeline[0].segments[0].rows;
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].kind, "assistant-thinking");
+        assert!(rows[0].content.is_none());
+        assert_eq!(rows[1].kind, "tool");
+        assert!(rows[1].content.is_none());
+        assert_eq!(rows[2].content.as_deref(), Some("answer"));
+    }
+}

--- a/apps/cli/src/lib.rs
+++ b/apps/cli/src/lib.rs
@@ -2,6 +2,7 @@ pub mod adapters;
 pub mod ask_questions;
 pub mod bedrock_mantle;
 pub mod chat_store;
+pub mod chat_timeline;
 pub mod cli;
 #[cfg(feature = "tui")]
 pub mod conversation_select;

--- a/apps/desktop/src/host/automation-runner.ts
+++ b/apps/desktop/src/host/automation-runner.ts
@@ -281,7 +281,6 @@ async function persistAutomationSession(
   approvalLevel: HostAutomationDefinition['approvalLevel'];
   },
 ): Promise<void> {
-  const desktopMessages = input.projection.toMessages();
   const archivePayload = input.projection.buildArchivePayload();
   const archive = input.runtime.toArchive(archivePayload.messages, archivePayload.assistantAux);
   const timelineSnapshot = input.projection.timelineSnapshot();
@@ -289,13 +288,13 @@ async function persistAutomationSession(
   await saveStoredSession(
     input.sessionPath,
     buildStoredDesktopSession({
-      archive,
+      llmHistory: archive.llmHistory,
+      subagentSessions: archive.subagentSessions,
       savedAtUnixMs: Date.now(),
       sessionDisplayName: input.sessionDisplayName,
       sessionTitleSource: 'seed',
       workspaceRoot: input.workspaceRoot,
       ...(input.gitBranch ? { gitBranch: input.gitBranch } : {}),
-      desktopMessages,
       desktopMessageTimeline: timelineSnapshot,
       rewind: createDesktopRewindMetadata(),
       loopEnabled: archive.loopEnabled === true,

--- a/apps/desktop/src/host/chat-schema.ts
+++ b/apps/desktop/src/host/chat-schema.ts
@@ -1,0 +1,375 @@
+import type { ConversationMessageSnapshot, MessageAuxSnapshot, ToolBlockSnapshot } from '../types.js';
+import {
+  DesktopMessageTimeline,
+  type DesktopTimelineRowKind,
+  type DesktopTimelineRowSnapshot,
+  type DesktopTimelineSegmentSnapshot,
+  type DesktopTimelineTurnSnapshot,
+} from './message-timeline.js';
+import {
+  normalizeMessageAuxSnapshot,
+  normalizeToolBlockSnapshot,
+} from './message-ordering.js';
+
+export const CHAT_SCHEMA_VERSION = 2 as const;
+
+export type ChatSchemaVersion = typeof CHAT_SCHEMA_VERSION;
+
+export class ChatSessionSchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ChatSessionSchemaError';
+  }
+}
+
+export type PersistedDesktopTimelineRowSnapshot = Omit<DesktopTimelineRowSnapshot, 'content'> & {
+  content?: string;
+};
+
+export type PersistedDesktopTimelineSegmentSnapshot = Omit<DesktopTimelineSegmentSnapshot, 'rows'> & {
+  rows: PersistedDesktopTimelineRowSnapshot[];
+};
+
+export type PersistedDesktopTimelineTurnSnapshot = Omit<DesktopTimelineTurnSnapshot, 'userRow' | 'segments'> & {
+  userRow?: PersistedDesktopTimelineRowSnapshot;
+  segments: PersistedDesktopTimelineSegmentSnapshot[];
+};
+
+const ROW_KINDS_WITHOUT_CONTENT: ReadonlySet<DesktopTimelineRowKind> = new Set([
+  'assistant-thinking',
+  'assistant-compaction',
+  'tool',
+]);
+
+function rowPath(turnIndex: number, segmentIndex: number | undefined, rowIndex: number | undefined): string {
+  if (segmentIndex === undefined) {
+    return `desktopMessageTimeline[${turnIndex}].userRow`;
+  }
+  if (rowIndex === undefined) {
+    return `desktopMessageTimeline[${turnIndex}].segments[${segmentIndex}]`;
+  }
+  return `desktopMessageTimeline[${turnIndex}].segments[${segmentIndex}].rows[${rowIndex}]`;
+}
+
+function hasPersistedContent(content: string | undefined): boolean {
+  return typeof content === 'string' && content.length > 0;
+}
+
+function hasTrimmedContent(content: string | undefined): boolean {
+  return typeof content === 'string' && content.trim().length > 0;
+}
+
+function cloneAux(aux: MessageAuxSnapshot | undefined): MessageAuxSnapshot | undefined {
+  if (!aux) {
+    return undefined;
+  }
+  return {
+    ...(aux.thinking ? { thinking: aux.thinking } : {}),
+    ...(aux.compaction ? { compaction: aux.compaction } : {}),
+    ...(aux.finishTaskNotice ? { finishTaskNotice: aux.finishTaskNotice } : {}),
+  };
+}
+
+function cloneRowForPersistence(row: DesktopTimelineRowSnapshot): PersistedDesktopTimelineRowSnapshot | undefined {
+  const tool = normalizeToolBlockSnapshot(row.tool);
+  const aux = normalizeMessageAuxSnapshot(row.aux);
+  const base = {
+    rowId: row.rowId,
+    messageId: row.messageId,
+    turnId: row.turnId,
+    ...(row.segmentId !== undefined ? { segmentId: row.segmentId } : {}),
+    kind: row.kind,
+    ...(row.section ? { section: row.section } : {}),
+    createdOrder: row.createdOrder,
+    pending: false as const,
+    ...(row.canContinue ? { canContinue: true as const } : {}),
+  };
+
+  if (row.kind === 'assistant-text') {
+    if (!hasTrimmedContent(row.content)) {
+      return undefined;
+    }
+    return {
+      ...base,
+      content: row.content,
+      ...(row.localFileAttachments?.length
+        ? { localFileAttachments: row.localFileAttachments.map((attachment) => ({ ...attachment })) }
+        : {}),
+      ...(aux ? { aux } : {}),
+    };
+  }
+
+  if (row.kind === 'user') {
+    if (!hasTrimmedContent(row.content)) {
+      return undefined;
+    }
+    return {
+      ...base,
+      content: row.content,
+      ...(row.localFileAttachments?.length
+        ? { localFileAttachments: row.localFileAttachments.map((attachment) => ({ ...attachment })) }
+        : {}),
+    };
+  }
+
+  if (row.kind === 'assistant-thinking') {
+    if (!aux?.thinking?.trim()) {
+      return undefined;
+    }
+    return {
+      ...base,
+      aux: { thinking: aux.thinking },
+    };
+  }
+
+  if (row.kind === 'assistant-compaction') {
+    if (!aux?.compaction?.trim()) {
+      return undefined;
+    }
+    return {
+      ...base,
+      aux: { compaction: aux.compaction },
+    };
+  }
+
+  if (row.kind === 'tool') {
+    if (!tool) {
+      return undefined;
+    }
+    return {
+      ...base,
+      tool,
+    };
+  }
+
+  if (row.kind === 'standalone-subagent-status') {
+    const hasContent = hasTrimmedContent(row.content);
+    const hasAux = Boolean(aux?.finishTaskNotice?.trim());
+    if (!hasContent && !hasAux) {
+      return undefined;
+    }
+    return {
+      ...base,
+      ...(hasContent ? { content: row.content } : {}),
+      ...(aux ? { aux: cloneAux(aux) } : {}),
+    };
+  }
+
+  return undefined;
+}
+
+function normalizeSegmentForPersistence(
+  segment: DesktopTimelineSegmentSnapshot,
+): PersistedDesktopTimelineSegmentSnapshot | undefined {
+  const rows = segment.rows
+    .map((row) => cloneRowForPersistence(row))
+    .filter((row): row is PersistedDesktopTimelineRowSnapshot => row !== undefined);
+  if (rows.length === 0) {
+    return undefined;
+  }
+  return {
+    segmentId: segment.segmentId,
+    turnId: segment.turnId,
+    kind: segment.kind,
+    status: segment.status === 'streaming' ? 'completed' : segment.status,
+    createdOrder: segment.createdOrder,
+    rows,
+  };
+}
+
+export function normalizeTimelineSnapshotForPersistence(
+  snapshot: DesktopTimelineTurnSnapshot[],
+): PersistedDesktopTimelineTurnSnapshot[] {
+  return snapshot.flatMap((turn) => {
+    const userRow = turn.userRow ? cloneRowForPersistence(turn.userRow) : undefined;
+    const segments = turn.segments
+      .map((segment) => normalizeSegmentForPersistence(segment))
+      .filter((segment): segment is PersistedDesktopTimelineSegmentSnapshot => segment !== undefined);
+    if (!userRow && segments.length === 0) {
+      return [];
+    }
+    return [{
+      turnId: turn.turnId,
+      createdOrder: turn.createdOrder,
+      ...(userRow ? { userRow } : {}),
+      segments,
+    }];
+  });
+}
+
+function validatePersistedTimelineRowV2(
+  row: PersistedDesktopTimelineRowSnapshot,
+  path: string,
+): void {
+  if (row.pending) {
+    throw new ChatSessionSchemaError(`${path}: pending rows are not allowed in chat schema v2`);
+  }
+
+  if (ROW_KINDS_WITHOUT_CONTENT.has(row.kind) && row.content !== undefined) {
+    throw new ChatSessionSchemaError(`${path}: ${row.kind} rows must not include content in chat schema v2`);
+  }
+
+  const tool = normalizeToolBlockSnapshot(row.tool);
+  const aux = normalizeMessageAuxSnapshot(row.aux);
+
+  switch (row.kind) {
+    case 'user':
+      if (!hasTrimmedContent(row.content)) {
+        throw new ChatSessionSchemaError(`${path}: user rows require non-empty content`);
+      }
+      return;
+    case 'assistant-text':
+      if (!hasTrimmedContent(row.content)) {
+        throw new ChatSessionSchemaError(`${path}: assistant-text rows require non-empty content`);
+      }
+      if (tool) {
+        throw new ChatSessionSchemaError(`${path}: assistant-text rows must not include tool`);
+      }
+      return;
+    case 'assistant-thinking':
+      if (!aux?.thinking?.trim()) {
+        throw new ChatSessionSchemaError(`${path}: assistant-thinking rows require aux.thinking`);
+      }
+      return;
+    case 'assistant-compaction':
+      if (!aux?.compaction?.trim()) {
+        throw new ChatSessionSchemaError(`${path}: assistant-compaction rows require aux.compaction`);
+      }
+      return;
+    case 'tool':
+      if (!tool) {
+        throw new ChatSessionSchemaError(`${path}: tool rows require tool`);
+      }
+      return;
+    case 'standalone-subagent-status':
+      if (!hasTrimmedContent(row.content) && !aux?.finishTaskNotice?.trim()) {
+        throw new ChatSessionSchemaError(
+          `${path}: standalone-subagent-status rows require content or aux.finishTaskNotice`,
+        );
+      }
+      return;
+    default:
+      throw new ChatSessionSchemaError(`${path}: unknown row kind`);
+  }
+}
+
+export function validateTimelineSnapshotV2(snapshot: PersistedDesktopTimelineTurnSnapshot[]): void {
+  if (!Array.isArray(snapshot) || snapshot.length === 0) {
+    throw new ChatSessionSchemaError('desktopMessageTimeline must be a non-empty array in chat schema v2');
+  }
+
+  snapshot.forEach((turn, turnIndex) => {
+    if (turn.userRow) {
+      validatePersistedTimelineRowV2(turn.userRow, rowPath(turnIndex, undefined, undefined));
+    }
+    turn.segments.forEach((segment, segmentIndex) => {
+      segment.rows.forEach((row, rowIndex) => {
+        validatePersistedTimelineRowV2(row, rowPath(turnIndex, segmentIndex, rowIndex));
+      });
+    });
+    if (!turn.userRow && turn.segments.every((segment) => segment.rows.length === 0)) {
+      throw new ChatSessionSchemaError(`desktopMessageTimeline[${turnIndex}] has no persistable rows`);
+    }
+  });
+}
+
+export function assertChatSchemaVersionV2(version: unknown): asserts version is ChatSchemaVersion {
+  if (version !== CHAT_SCHEMA_VERSION) {
+    throw new ChatSessionSchemaError(
+      `chat schema v2 required (chatSchemaVersion=${CHAT_SCHEMA_VERSION}), got ${String(version)}`,
+    );
+  }
+}
+
+export function assertNoLegacyConversationFields(parsed: Record<string, unknown>): void {
+  if ('messages' in parsed) {
+    throw new ChatSessionSchemaError('chat schema v2 must not include messages');
+  }
+  if ('assistantAux' in parsed) {
+    throw new ChatSessionSchemaError('chat schema v2 must not include assistantAux');
+  }
+  if ('desktopMessages' in parsed) {
+    throw new ChatSessionSchemaError('chat schema v2 must not include desktopMessages');
+  }
+}
+
+function hydratePersistedRow(row: PersistedDesktopTimelineRowSnapshot): DesktopTimelineRowSnapshot {
+  const tool = row.tool ? cloneTool(row.tool) : undefined;
+  const aux = row.aux ? cloneAux(row.aux) : undefined;
+  return {
+    rowId: row.rowId,
+    messageId: row.messageId,
+    turnId: row.turnId,
+    ...(row.segmentId !== undefined ? { segmentId: row.segmentId } : {}),
+    kind: row.kind,
+    ...(row.section ? { section: row.section } : {}),
+    createdOrder: row.createdOrder,
+    content: row.content ?? '',
+    pending: false,
+    ...(row.canContinue ? { canContinue: true } : {}),
+    ...(row.localFileAttachments?.length
+      ? { localFileAttachments: row.localFileAttachments.map((attachment) => ({ ...attachment })) }
+      : {}),
+    ...(tool ? { tool } : {}),
+    ...(aux ? { aux } : {}),
+  };
+}
+
+function cloneTool(tool: ToolBlockSnapshot): ToolBlockSnapshot {
+  const normalized = normalizeToolBlockSnapshot(tool) ?? tool;
+  return {
+    ...normalized,
+    detailLines: [...normalized.detailLines],
+    ...(normalized.imagePaths ? { imagePaths: [...normalized.imagePaths] } : {}),
+    ...(normalized.videoPaths ? { videoPaths: [...normalized.videoPaths] } : {}),
+  };
+}
+
+export function hydrateTimelineSnapshotFromPersistence(
+  snapshot: PersistedDesktopTimelineTurnSnapshot[],
+): DesktopTimelineTurnSnapshot[] {
+  return snapshot.map((turn) => ({
+    turnId: turn.turnId,
+    createdOrder: turn.createdOrder,
+    ...(turn.userRow ? { userRow: hydratePersistedRow(turn.userRow) } : {}),
+    segments: turn.segments.map((segment) => ({
+      segmentId: segment.segmentId,
+      turnId: segment.turnId,
+      kind: segment.kind,
+      status: segment.status,
+      createdOrder: segment.createdOrder,
+      rows: segment.rows.map(hydratePersistedRow),
+    })),
+  }));
+}
+
+export function timelinePersistedSnapshotToMessages(
+  snapshot: PersistedDesktopTimelineTurnSnapshot[],
+): ConversationMessageSnapshot[] {
+  const runtimeSnapshot = hydrateTimelineSnapshotFromPersistence(snapshot);
+  let nextMessageId = 1;
+  const timeline = DesktopMessageTimeline.fromSnapshot(runtimeSnapshot, {
+    allocateMessageId: () => nextMessageId++,
+    reserveMessageId: (messageId) => {
+      if (messageId >= nextMessageId) {
+        nextMessageId = messageId + 1;
+      }
+    },
+  });
+  return timeline.toMessages();
+}
+
+export function timelineRuntimeSnapshotToMessages(
+  snapshot: DesktopTimelineTurnSnapshot[],
+): ConversationMessageSnapshot[] {
+  let nextMessageId = 1;
+  const timeline = DesktopMessageTimeline.fromSnapshot(snapshot, {
+    allocateMessageId: () => nextMessageId++,
+    reserveMessageId: (messageId) => {
+      if (messageId >= nextMessageId) {
+        nextMessageId = messageId + 1;
+      }
+    },
+  });
+  return timeline.toMessages();
+}

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -1,13 +1,12 @@
 import type { ChatArchive } from '@spirit-agent/core';
 import type { HostToolRequest, ApprovalLevel } from '@spirit-agent/host-internal';
-import type { DesktopTimelineTurnSnapshot } from './message-timeline.js';
+import type { PersistedDesktopTimelineTurnSnapshot } from './chat-schema.js';
 import type { StoredDesktopRewindMetadata } from './rewind.js';
 
 import type {
   CommitChangesRequest,
   AskQuestionsQuestionSpec,
   ConversationContextUsageSnapshot,
-  ConversationMessageSnapshot,
 } from '../types.js';
 
 export type HostCommandName =
@@ -121,20 +120,22 @@ export type DesktopToolRequest = HostToolRequest<AskQuestionsQuestionSpec>;
 
 export type SessionTitleSource = 'seed' | 'llm';
 
-export interface StoredDesktopSession extends ChatArchive {
-  chatSchemaVersion?: 2;
+export interface StoredDesktopSession {
+  chatSchemaVersion: 2;
+  llmHistory: ChatArchive['llmHistory'];
+  subagentSessions?: ChatArchive['subagentSessions'];
+  loopEnabled?: boolean;
+  approvalLevel?: ApprovalLevel;
+  desktopMessageTimeline: PersistedDesktopTimelineTurnSnapshot[];
   savedAtUnixMs: number;
   sessionDisplayName?: string;
   sessionTitleSource?: SessionTitleSource;
   workspaceRoot?: string;
   gitBranch?: string;
   activePlanPath?: string;
-  desktopMessages?: ConversationMessageSnapshot[];
-  desktopMessageTimeline?: DesktopTimelineTurnSnapshot[];
   rewind?: StoredDesktopRewindMetadata;
-  approvalLevel?: ApprovalLevel;
   contextUsage?: ConversationContextUsageSnapshot;
-  subagentDesktopMessages?: Record<string, ConversationMessageSnapshot[]>;
+  subagentDesktopTimelines?: Record<string, PersistedDesktopTimelineTurnSnapshot[]>;
   queuedUserTurns?: import('./message-queue.js').QueuedUserTurn[];
   automationId?: string;
   automationRunId?: string;

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -122,6 +122,7 @@ export type DesktopToolRequest = HostToolRequest<AskQuestionsQuestionSpec>;
 export type SessionTitleSource = 'seed' | 'llm';
 
 export interface StoredDesktopSession extends ChatArchive {
+  chatSchemaVersion?: 2;
   savedAtUnixMs: number;
   sessionDisplayName?: string;
   sessionTitleSource?: SessionTitleSource;

--- a/apps/desktop/src/host/dreams.ts
+++ b/apps/desktop/src/host/dreams.ts
@@ -40,6 +40,10 @@ import {
   type DesktopConfigFile,
 } from './storage.js';
 import { DesktopToolExecutor } from './tool-executor.js';
+import { DesktopMessageTimeline } from './message-timeline.js';
+import { createDesktopRewindMetadata } from './rewind.js';
+import { buildStoredDesktopSession } from './sessions.js';
+import { timelinePersistedSnapshotToMessages } from './chat-schema.js';
 import {
   currentApiBase,
   sameWorkspaceRoot,
@@ -448,7 +452,7 @@ function normalizeDreamCollectorMessages(
           content: llmMessageTextContent(normalized.content),
         };
       })
-    : archive.messages.map((message) => ({
+    : timelinePersistedSnapshotToMessages(archive.desktopMessageTimeline).map((message) => ({
         role: message.role,
         content: message.content,
       }));
@@ -606,22 +610,25 @@ async function persistDreamCollectorDebugSession(input: {
     },
   ];
   const sessionFile = path.join(chatsDirPath(), `${DREAM_DEBUG_SESSION_FILE_PREFIX}${now}-${input.runId}.json`);
-  await saveStoredSession(sessionFile, {
-    messages,
-    assistantAux: [],
+  let nextMessageId = 1;
+  const timeline = DesktopMessageTimeline.fromMessages(messages, {
+    allocateMessageId: () => nextMessageId++,
+  });
+  await saveStoredSession(sessionFile, buildStoredDesktopSession({
     llmHistory: messages.map((message) => ({
       role: message.role,
       content: message.content,
       imagePaths: [],
-      videoPaths: [],
     })),
-    subagentSessions: [],
     savedAtUnixMs: now,
     sessionDisplayName: i18n.t('error.dreamSessionDisplayName', { name: input.sourceSession.displayName }),
     workspaceRoot: input.workspaceRoot,
     gitBranch: input.gitBranch,
-    desktopMessages: messages,
-  });
+    desktopMessageTimeline: timeline.snapshot(),
+    rewind: createDesktopRewindMetadata(),
+    loopEnabled: false,
+    approvalLevel: 'default',
+  }));
 }
 
 export function isDreamCollectorDebugSessionPath(filePath: string): boolean {

--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -53,7 +53,7 @@ import type {
   PendingAssistantAux,
   ToolBlockSnapshot,
 } from '../types.js';
-import type { DesktopToolRequest, StoredDesktopSession } from './contracts.js';
+import type { DesktopToolRequest } from './contracts.js';
 
 export {
   hasActiveRunSubagentToolInMessages,
@@ -1224,27 +1224,6 @@ function displayPathForReadFile(path: string): string {
 
   const segments = normalized.split('/').filter(Boolean);
   return segments[segments.length - 1] || normalized;
-}
-
-export function restoreMessagesFromArchive(
-  archive: StoredDesktopSession,
-): ConversationMessageSnapshot[] {
-  const auxByIndex = new Map<number, MessageAuxSnapshot>();
-  for (const entry of archive.assistantAux) {
-    auxByIndex.set(entry.messageIndex, {
-      ...(entry.thinking ? { thinking: entry.thinking } : {}),
-      ...(entry.compaction ? { compaction: entry.compaction } : {}),
-      ...(entry.finishTaskNotice ? { finishTaskNotice: entry.finishTaskNotice } : {}),
-    });
-  }
-
-  return archive.messages.map((message, index) => ({
-    id: index + 1,
-    role: message.role,
-    content: message.content,
-    ...(auxByIndex.get(index) ? { aux: auxByIndex.get(index) } : {}),
-    pending: false,
-  }));
 }
 
 export function toolMessageKey(

--- a/apps/desktop/src/host/rewind-host.ts
+++ b/apps/desktop/src/host/rewind-host.ts
@@ -20,7 +20,11 @@ import {
   type DesktopRewindCheckpointSnapshot,
 } from './rewind.js';
 import type { DesktopMessageTimeline } from './message-timeline.js';
-import { sanitizeConversationMessagesForPersistence } from './sessions.js';
+import {
+  hydrateTimelineSnapshotFromPersistence,
+  normalizeTimelineSnapshotForPersistence,
+  timelinePersistedSnapshotToMessages,
+} from './chat-schema.js';
 import {
   archiveBeforeLastUser,
   cloneArchiveHistory,
@@ -53,7 +57,10 @@ export interface RewindHostContext {
   resolveTodoSessionKeyForBundle(bundle: SessionBundle): string;
   cancelTodoClearing(sessionKey: string): void;
   refreshTodoSnapshotForBundle(bundle: SessionBundle): Promise<void>;
-  createMessageTimelineFromMessages(messages: ConversationMessageSnapshot[]): DesktopMessageTimeline;
+  createMessageTimelineFromMessages(
+    messages: ConversationMessageSnapshot[],
+    timelineSnapshot?: import('./message-timeline.js').DesktopTimelineTurnSnapshot[],
+  ): DesktopMessageTimeline;
   resetStreamingPlacementState(full: boolean): void;
 }
 
@@ -157,18 +164,21 @@ export async function recordRewindCheckpoint(
       } satisfies ChatArchive;
   const sessionKey = ctx.resolveTodoSessionKeyForBundle(ctx.activeBundle());
   const currentTodos = cloneHostTodoRecords(await listSessionTodos(sessionKey));
+  const desktopMessageTimeline = normalizeTimelineSnapshotForPersistence(
+    ctx.activeBundle().messageTimeline.snapshot(),
+  );
   await saveRewindCheckpointSnapshot(
     spiritAgentDataDir(),
     ctx.activeBundle().rewind.sessionId,
     checkpoint.id,
     {
       archive,
-      desktopMessages: sanitizeConversationMessagesForPersistence(desktopMessages),
+      desktopMessageTimeline,
       todos: currentTodos,
       ...(beforeUserCheckpoint
         ? {
             beforeArchive: cloneChatArchive(beforeUserCheckpoint.archive),
-            beforeDesktopMessages: beforeUserCheckpoint.desktopMessages.map((message) => ({ ...message })),
+            beforeDesktopMessageTimeline: beforeUserCheckpoint.desktopMessageTimeline,
             ...(beforeUserCheckpoint.todos
               ? { beforeTodos: cloneHostTodoRecords(beforeUserCheckpoint.todos) }
               : {}),
@@ -211,7 +221,9 @@ export async function buildRewindCheckpointSnapshot(
   const todos = cloneHostTodoRecords(await listSessionTodos(sessionKey));
   return {
     archive,
-    desktopMessages: sanitizeConversationMessagesForPersistence(desktopMessages),
+    desktopMessageTimeline: normalizeTimelineSnapshotForPersistence(
+      ctx.activeBundle().messageTimeline.snapshot(),
+    ),
     todos,
   };
 }
@@ -223,10 +235,15 @@ export function restoreBeforeRewindCheckpoint(
 ): void {
   ctx.requireState();
   const archive = snapshot.beforeArchive ?? archiveBeforeLastUser(snapshot.archive);
-  const desktopMessages = snapshot.beforeDesktopMessages ?? snapshot.desktopMessages.slice(0, -1);
+  const timeline = snapshot.beforeDesktopMessageTimeline
+    ?? snapshot.desktopMessageTimeline.slice(0, -1);
+  const desktopMessages = timelinePersistedSnapshotToMessages(timeline);
 
   ctx.activeBundle().messages = desktopMessages.map((message) => ({ ...message }));
-  ctx.activeBundle().messageTimeline = ctx.createMessageTimelineFromMessages(ctx.activeBundle().messages);
+  ctx.activeBundle().messageTimeline = ctx.createMessageTimelineFromMessages(
+    ctx.activeBundle().messages,
+    hydrateTimelineSnapshotFromPersistence(timeline),
+  );
   ctx.activeBundle().archiveHistory = cloneArchiveHistory(archive.llmHistory);
   ctx.activeBundle().archiveSubagentSessions = cloneArchiveSubagentSessions(archive.subagentSessions ?? []);
   ctx.activeBundle().loopEnabled = archive.loopEnabled === true;

--- a/apps/desktop/src/host/rewind.ts
+++ b/apps/desktop/src/host/rewind.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 import type { ChatArchive } from '@spirit-agent/core';
 import type { HostRecordedFileChange, HostTodoRecord } from '@spirit-agent/host-internal';
 
+import type { PersistedDesktopTimelineTurnSnapshot } from './chat-schema.js';
 import type { ConversationMessageSnapshot } from '../types.js';
 
 const REWIND_DIR_NAME = 'rewind';
@@ -45,9 +46,9 @@ export interface DesktopStoredFileChange extends HostRecordedFileChange {
 
 export interface DesktopRewindCheckpointSnapshot {
   archive: ChatArchive;
-  desktopMessages: ConversationMessageSnapshot[];
+  desktopMessageTimeline: PersistedDesktopTimelineTurnSnapshot[];
   beforeArchive?: ChatArchive;
-  beforeDesktopMessages?: ConversationMessageSnapshot[];
+  beforeDesktopMessageTimeline?: PersistedDesktopTimelineTurnSnapshot[];
   todos?: HostTodoRecord[];
   beforeTodos?: HostTodoRecord[];
 }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -430,7 +430,6 @@ import { DesktopConversationSnapshotView } from './conversation-snapshot.js';
 import { buildDesktopSnapshot, buildModelCatalogHints } from './snapshot.js';
 import {
   applyToolCallSummaryCopy,
-  restoreMessagesFromArchive,
 } from './message-ordering.js';
 import {
   mapPendingAuxState,
@@ -2466,7 +2465,6 @@ class DesktopHostService {
     const restored = restoreStoredSessionState({
       filePath: sessionPath,
       loaded,
-      fallbackMessages: restoreMessagesFromArchive(loaded),
     });
     const synced = this.sessionRegistry.reloadWarmBundleFromRestoredIfIdle(
       sessionPath,

--- a/apps/desktop/src/host/session-activation.ts
+++ b/apps/desktop/src/host/session-activation.ts
@@ -20,7 +20,6 @@ import {
   type EphemeralSessionRecord,
 } from './sessions.js';
 import type { DesktopTimelineTurnSnapshot, DesktopMessageTimeline } from './message-timeline.js';
-import { restoreMessagesFromArchive } from './message-ordering.js';
 import { currentApiBase, sameWorkspaceRoot } from './service-utils.js';
 import type { HostExtensionEvent } from '@spirit-agent/host-internal';
 import { cancelPendingWorktreeBootstrapOnBundle } from './worktree-bootstrap-orchestrator.js';
@@ -198,7 +197,6 @@ export async function openSessionCommand(
     const restored = restoreStoredSessionState({
       filePath,
       loaded,
-      fallbackMessages: restoreMessagesFromArchive(loaded),
     });
     const bundle = ctx.sessionRegistry().upsertFromRestored(
       workspaceRoot,

--- a/apps/desktop/src/host/session-persistence.ts
+++ b/apps/desktop/src/host/session-persistence.ts
@@ -7,9 +7,8 @@ import {
   buildArchiveMessagesFromConversation,
   buildStoredDesktopSession,
   cloneQueuedUserTurns,
-  sanitizeConversationMessagesForPersistence,
+  serializeSubagentTimelinesFromMessages,
 } from './sessions.js';
-import { serializeSubagentDesktopMessagesRecord } from './subagent-conversation-projection.js';
 import type { SessionBundle } from './session-bundle.js';
 import type { DesktopRuntime } from './runtime.js';
 import { saveStoredSession } from './storage.js';
@@ -64,22 +63,22 @@ export async function persistDesktopSessionBundle(
   const sessionTitleSource = bundle.sessionTitleSource ?? 'seed';
   bundle.sessionTitleSource = sessionTitleSource;
   const stored = buildStoredDesktopSession({
-    archive,
+    llmHistory: archive.llmHistory,
+    subagentSessions: archive.subagentSessions,
     savedAtUnixMs,
     sessionDisplayName: activeSession.displayName,
     sessionTitleSource,
     workspaceRoot: input.workspaceRoot,
     gitBranch: input.gitBranch,
     ...(bundle.activePlanPath ? { activePlanPath: bundle.activePlanPath } : {}),
-    desktopMessages: sanitizeConversationMessagesForPersistence(desktopMessages),
     desktopMessageTimeline: bundle.messageTimeline.snapshot(),
     rewind: bundle.rewind,
     loopEnabled: bundle.loopEnabled,
     approvalLevel: bundle.approvalLevel,
     ...(bundle.contextUsage ? { contextUsage: { ...bundle.contextUsage } } : {}),
-    ...(serializeSubagentDesktopMessagesRecord(bundle.subagentDesktopMessagesBySessionId)
+    ...(serializeSubagentTimelinesFromMessages(bundle.subagentDesktopMessagesBySessionId)
       ? {
-          subagentDesktopMessages: serializeSubagentDesktopMessagesRecord(
+          subagentDesktopTimelines: serializeSubagentTimelinesFromMessages(
             bundle.subagentDesktopMessagesBySessionId,
           ),
         }

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -248,6 +248,7 @@ export function cloneQueuedUserTurns(queued: readonly QueuedUserTurn[]): QueuedU
   }));
 }
 
+/** 运行时消息投影清洗；chat schema v2 落盘边界见 chat-schema.ts。 */
 export function sanitizeConversationMessagesForPersistence(
   messages: ConversationMessageSnapshot[],
 ): ConversationMessageSnapshot[] {
@@ -386,80 +387,6 @@ export function serializeSubagentTimelinesFromMessages(
     }
   }
   return Object.keys(serialized).length > 0 ? serialized : undefined;
-}
-
-function tryCloneDesktopMessageTimeline(
-  timeline: DesktopTimelineTurnSnapshot[] | undefined,
-): DesktopTimelineTurnSnapshot[] | undefined {
-  if (!timeline) {
-    return undefined;
-  }
-  try {
-    return cloneDesktopMessageTimeline(timeline);
-  } catch {
-    return undefined;
-  }
-}
-
-function cloneDesktopMessageTimeline(
-  timeline: DesktopTimelineTurnSnapshot[],
-): DesktopTimelineTurnSnapshot[] {
-  return timeline.map((turn) => ({
-    ...turn,
-    ...(turn.userRow
-      ? {
-          userRow: {
-            ...turn.userRow,
-            ...(turn.userRow.localFileAttachments?.length
-              ? {
-                  localFileAttachments: turn.userRow.localFileAttachments.map((attachment) => ({
-                    ...attachment,
-                  })),
-                }
-              : {}),
-            ...(turn.userRow.tool
-              ? {
-                  tool: {
-                    ...turn.userRow.tool,
-                    detailLines: [...turn.userRow.tool.detailLines],
-                    ...(turn.userRow.tool.imagePaths
-                      ? { imagePaths: [...turn.userRow.tool.imagePaths] }
-                      : {}),
-                    ...(turn.userRow.tool.videoPaths
-                      ? { videoPaths: [...turn.userRow.tool.videoPaths] }
-                      : {}),
-                  },
-                }
-              : {}),
-            ...(turn.userRow.aux ? { aux: { ...turn.userRow.aux } } : {}),
-          },
-        }
-      : {}),
-    segments: turn.segments.map((segment) => ({
-      ...segment,
-      rows: segment.rows.map((row) => ({
-        ...row,
-        ...(row.localFileAttachments?.length
-          ? {
-              localFileAttachments: row.localFileAttachments.map((attachment) => ({
-                ...attachment,
-              })),
-            }
-          : {}),
-        ...(row.tool
-          ? {
-              tool: {
-                ...row.tool,
-                detailLines: [...row.tool.detailLines],
-                ...(row.tool.imagePaths ? { imagePaths: [...row.tool.imagePaths] } : {}),
-                ...(row.tool.videoPaths ? { videoPaths: [...row.tool.videoPaths] } : {}),
-              },
-            }
-          : {}),
-        ...(row.aux ? { aux: { ...row.aux } } : {}),
-      })),
-    })),
-  }));
 }
 
 function archiveProjectableConversationMessages(

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -1,7 +1,16 @@
 import path from 'node:path';
 
 import type { ChatArchive } from '@spirit-agent/core';
-import { timelineRuntimeSnapshotToMessages } from './chat-schema.js';
+import {
+  CHAT_SCHEMA_VERSION,
+  hydrateTimelineSnapshotFromPersistence,
+  normalizeTimelineSnapshotForPersistence,
+  timelinePersistedSnapshotToMessages,
+  timelineRuntimeSnapshotToMessages,
+  type PersistedDesktopTimelineTurnSnapshot,
+  validateTimelineSnapshotV2,
+} from './chat-schema.js';
+import type { StoredDesktopSession } from './contracts.js';
 
 import type {
   ActiveSessionSnapshot,
@@ -12,8 +21,9 @@ import type {
 import { extractActivePlanPathFromLlmHistory, normalizeApprovalLevel } from '@spirit-agent/host-internal';
 import type { ApprovalLevel } from '@spirit-agent/host-internal';
 import type { QueuedUserTurn } from './message-queue.js';
-import type { SessionTitleSource, StoredDesktopSession } from './contracts.js';
+import type { SessionTitleSource } from './contracts.js';
 import type { DesktopTimelineTurnSnapshot } from './message-timeline.js';
+import { DesktopMessageTimeline } from './message-timeline.js';
 import type { SessionBundle } from './session-bundle.js';
 import { isSessionBundleBusy } from './direct-media-turn.js';
 import {
@@ -23,7 +33,6 @@ import {
   shouldHideEmptyPendingAssistantSnapshot,
 } from './message-ordering.js';
 import { cloneArchiveHistory, cloneArchiveSubagentSessions } from './service-utils.js';
-import { cloneSubagentDesktopMessagesRecord } from './subagent-conversation-projection.js';
 import { createDesktopRewindMetadata, type StoredDesktopRewindMetadata } from './rewind.js';
 
 export const EPHEMERAL_COMMIT_SESSION_PREFIX = 'ephemeral://commit-message/';
@@ -141,12 +150,10 @@ export function restoreEphemeralSessionState(record: EphemeralSessionRecord): Re
 export function restoreStoredSessionState(input: {
   filePath: string;
   loaded: StoredDesktopSession;
-  fallbackMessages: ConversationMessageSnapshot[];
 }): RestoredSessionState {
-  const messages = input.loaded.desktopMessages
-    ? cloneConversationMessages(input.loaded.desktopMessages)
-    : cloneConversationMessages(input.fallbackMessages);
-  const desktopMessageTimeline = tryCloneDesktopMessageTimeline(input.loaded.desktopMessageTimeline);
+  validateTimelineSnapshotV2(input.loaded.desktopMessageTimeline);
+  const runtimeTimeline = hydrateTimelineSnapshotFromPersistence(input.loaded.desktopMessageTimeline);
+  const messages = timelinePersistedSnapshotToMessages(input.loaded.desktopMessageTimeline);
   const storedActivePlanPath = typeof input.loaded.activePlanPath === 'string'
     ? input.loaded.activePlanPath.trim()
     : '';
@@ -155,7 +162,7 @@ export function restoreStoredSessionState(input: {
     : extractActivePlanPathFromLlmHistory(input.loaded.llmHistory);
   return {
     messages,
-    ...(desktopMessageTimeline ? { desktopMessageTimeline } : {}),
+    desktopMessageTimeline: runtimeTimeline,
     activeSession: {
       filePath: path.resolve(input.filePath),
       displayName: input.loaded.sessionDisplayName ?? deriveDisplayNameFromMessages(messages),
@@ -171,10 +178,10 @@ export function restoreStoredSessionState(input: {
       ? { sessionTitleSource: input.loaded.sessionTitleSource }
       : {}),
     ...(input.loaded.contextUsage ? { contextUsage: { ...input.loaded.contextUsage } } : {}),
-    ...(input.loaded.subagentDesktopMessages
+    ...(input.loaded.subagentDesktopTimelines
       ? {
-          subagentDesktopMessagesBySessionId: cloneSubagentDesktopMessagesRecord(
-            input.loaded.subagentDesktopMessages,
+          subagentDesktopMessagesBySessionId: cloneSubagentTimelinesRecord(
+            input.loaded.subagentDesktopTimelines,
           ),
         }
       : {}),
@@ -185,28 +192,33 @@ export function restoreStoredSessionState(input: {
 }
 
 export function buildStoredDesktopSession(input: {
-  archive: ChatArchive;
+  llmHistory: ChatArchive['llmHistory'];
+  subagentSessions?: ChatArchive['subagentSessions'];
   savedAtUnixMs?: number;
   sessionDisplayName: string;
   sessionTitleSource?: SessionTitleSource;
   workspaceRoot: string;
   gitBranch?: string;
   activePlanPath?: string;
-  desktopMessages: ConversationMessageSnapshot[];
-  desktopMessageTimeline?: DesktopTimelineTurnSnapshot[];
+  desktopMessageTimeline: DesktopTimelineTurnSnapshot[];
   rewind: StoredDesktopRewindMetadata;
   loopEnabled: boolean;
   approvalLevel: ApprovalLevel;
   contextUsage?: ConversationContextUsageSnapshot;
-  subagentDesktopMessages?: Record<string, ConversationMessageSnapshot[]>;
+  subagentDesktopTimelines?: Record<string, PersistedDesktopTimelineTurnSnapshot[]>;
   queuedUserTurns?: QueuedUserTurn[];
   automationId?: string;
   automationRunId?: string;
 }): StoredDesktopSession {
+  const desktopMessageTimeline = normalizeTimelineSnapshotForPersistence(input.desktopMessageTimeline);
+  validateTimelineSnapshotV2(desktopMessageTimeline);
   return {
-    ...input.archive,
+    chatSchemaVersion: CHAT_SCHEMA_VERSION,
+    llmHistory: input.llmHistory,
+    ...(input.subagentSessions?.length ? { subagentSessions: input.subagentSessions } : {}),
     loopEnabled: input.loopEnabled,
     approvalLevel: input.approvalLevel,
+    desktopMessageTimeline,
     savedAtUnixMs: input.savedAtUnixMs ?? Date.now(),
     sessionDisplayName: input.sessionDisplayName,
     ...(input.sessionTitleSource ? { sessionTitleSource: input.sessionTitleSource } : {}),
@@ -215,13 +227,9 @@ export function buildStoredDesktopSession(input: {
     ...(input.automationId ? { automationId: input.automationId } : {}),
     ...(input.automationRunId ? { automationRunId: input.automationRunId } : {}),
     ...(input.activePlanPath ? { activePlanPath: input.activePlanPath } : {}),
-    desktopMessages: sanitizeConversationMessagesForPersistence(input.desktopMessages),
-    ...(input.desktopMessageTimeline
-      ? { desktopMessageTimeline: cloneDesktopMessageTimeline(input.desktopMessageTimeline) }
-      : {}),
     rewind: input.rewind,
     ...(input.contextUsage ? { contextUsage: { ...input.contextUsage } } : {}),
-    ...(input.subagentDesktopMessages ? { subagentDesktopMessages: input.subagentDesktopMessages } : {}),
+    ...(input.subagentDesktopTimelines ? { subagentDesktopTimelines: input.subagentDesktopTimelines } : {}),
     ...(input.queuedUserTurns?.length
       ? { queuedUserTurns: cloneQueuedUserTurns(input.queuedUserTurns) }
       : {}),
@@ -315,6 +323,12 @@ export function nextMessageIdFromMessages(messages: ConversationMessageSnapshot[
   return Math.max(0, ...messages.map((message) => message.id)) + 1;
 }
 
+export function restoreMessagesFromArchive(
+  archive: StoredDesktopSession,
+): ConversationMessageSnapshot[] {
+  return timelinePersistedSnapshotToMessages(archive.desktopMessageTimeline);
+}
+
 export function deriveDisplayNameFromSeed(seed: string): string {
   const trimmed = seed.trim();
   if (!trimmed) {
@@ -334,6 +348,44 @@ function cloneConversationMessages(
   messages: ConversationMessageSnapshot[],
 ): ConversationMessageSnapshot[] {
   return messages.map((message) => ({ ...message }));
+}
+
+function cloneSubagentTimelinesRecord(
+  record: Record<string, PersistedDesktopTimelineTurnSnapshot[]>,
+): Map<string, ConversationMessageSnapshot[]> {
+  const next = new Map<string, ConversationMessageSnapshot[]>();
+  for (const [sessionId, timeline] of Object.entries(record)) {
+    next.set(sessionId, timelinePersistedSnapshotToMessages(timeline));
+  }
+  return next;
+}
+
+export function serializeSubagentTimelinesFromMessages(
+  record: Map<string, ConversationMessageSnapshot[]>,
+): Record<string, PersistedDesktopTimelineTurnSnapshot[]> | undefined {
+  if (record.size === 0) {
+    return undefined;
+  }
+  const serialized: Record<string, PersistedDesktopTimelineTurnSnapshot[]> = {};
+  for (const [sessionId, messages] of record.entries()) {
+    if (messages.length === 0) {
+      continue;
+    }
+    let nextMessageId = 1;
+    const timeline = DesktopMessageTimeline.fromMessages(messages, {
+      allocateMessageId: () => nextMessageId++,
+      reserveMessageId: (messageId) => {
+        if (messageId >= nextMessageId) {
+          nextMessageId = messageId + 1;
+        }
+      },
+    });
+    const persisted = normalizeTimelineSnapshotForPersistence(timeline.snapshot());
+    if (persisted.length > 0) {
+      serialized[sessionId] = persisted;
+    }
+  }
+  return Object.keys(serialized).length > 0 ? serialized : undefined;
 }
 
 function tryCloneDesktopMessageTimeline(

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 
 import type { ChatArchive } from '@spirit-agent/core';
+import { timelineRuntimeSnapshotToMessages } from './chat-schema.js';
 
 import type {
   ActiveSessionSnapshot,
@@ -297,6 +298,17 @@ export function buildArchiveAssistantAuxFromConversation(
       ...(message.aux.finishTaskNotice ? { finishTaskNotice: message.aux.finishTaskNotice } : {}),
     }];
   });
+}
+
+/** Runtime archive projection from a persisted v2 timeline snapshot. */
+export function buildChatArchiveFromTimeline(
+  timeline: DesktopTimelineTurnSnapshot[],
+): Pick<ChatArchive, 'messages' | 'assistantAux'> {
+  const messages = timelineRuntimeSnapshotToMessages(timeline);
+  return {
+    messages: buildArchiveMessagesFromConversation(messages),
+    assistantAux: buildArchiveAssistantAuxFromConversation(messages),
+  };
 }
 
 export function nextMessageIdFromMessages(messages: ConversationMessageSnapshot[]): number {

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -56,6 +56,14 @@ import type {
 } from '../types.js';
 import type { StoredDesktopSession } from './contracts.js';
 import {
+  assertChatSchemaVersionV2,
+  assertNoLegacyConversationFields,
+  ChatSessionSchemaError,
+  timelinePersistedSnapshotToMessages,
+  validateTimelineSnapshotV2,
+  type PersistedDesktopTimelineTurnSnapshot,
+} from './chat-schema.js';
+import {
   buildModelSecretKeyPresence,
   hasBedrockRuntimeCredentials,
   hasGoogleVertexRuntimeCredentials,
@@ -593,16 +601,32 @@ export async function loadHostMetadata(
 }
 
 function normalizeStoredSession(parsed: Partial<StoredDesktopSession>): StoredDesktopSession {
+  const raw = parsed as Record<string, unknown>;
+  assertChatSchemaVersionV2(parsed.chatSchemaVersion);
+  assertNoLegacyConversationFields(raw);
+  if ('subagentDesktopMessages' in raw) {
+    throw new ChatSessionSchemaError('chat schema v2 must not include subagentDesktopMessages');
+  }
+  if (!Array.isArray(parsed.desktopMessageTimeline)) {
+    throw new ChatSessionSchemaError('desktopMessageTimeline is required in chat schema v2');
+  }
+  const desktopMessageTimeline = parsed.desktopMessageTimeline as PersistedDesktopTimelineTurnSnapshot[];
+  validateTimelineSnapshotV2(desktopMessageTimeline);
+
   const contextUsage = normalizeContextUsageSnapshot(parsed.contextUsage);
   return {
-    savedAtUnixMs:
-      typeof parsed.savedAtUnixMs === 'number' ? parsed.savedAtUnixMs : Date.now(),
-    messages: Array.isArray(parsed.messages) ? parsed.messages : [],
-    assistantAux: Array.isArray(parsed.assistantAux) ? parsed.assistantAux : [],
+    chatSchemaVersion: 2,
     llmHistory: Array.isArray(parsed.llmHistory) ? parsed.llmHistory : [],
     subagentSessions: Array.isArray(parsed.subagentSessions)
       ? parsed.subagentSessions
       : [],
+    loopEnabled: parsed.loopEnabled === true,
+    ...(parsed.approvalLevel === 'default' || parsed.approvalLevel === 'full-approval'
+      ? { approvalLevel: parsed.approvalLevel }
+      : {}),
+    desktopMessageTimeline,
+    savedAtUnixMs:
+      typeof parsed.savedAtUnixMs === 'number' ? parsed.savedAtUnixMs : Date.now(),
     ...(normalizeDisplayName(parsed.sessionDisplayName)
       ? { sessionDisplayName: normalizeDisplayName(parsed.sessionDisplayName) }
       : {}),
@@ -616,16 +640,10 @@ function normalizeStoredSession(parsed: Partial<StoredDesktopSession>): StoredDe
     ...(typeof parsed.activePlanPath === 'string' && parsed.activePlanPath.trim()
       ? { activePlanPath: parsed.activePlanPath.trim() }
       : {}),
-    ...(Array.isArray(parsed.desktopMessages)
-      ? { desktopMessages: parsed.desktopMessages as ConversationMessageSnapshot[] }
-      : {}),
-    ...(Array.isArray(parsed.desktopMessageTimeline)
-      ? { desktopMessageTimeline: parsed.desktopMessageTimeline }
-      : {}),
     ...(contextUsage ? { contextUsage } : {}),
     rewind: normalizeDesktopRewindMetadata(parsed.rewind),
-    ...(parsed.subagentDesktopMessages && typeof parsed.subagentDesktopMessages === 'object'
-      ? { subagentDesktopMessages: parsed.subagentDesktopMessages as Record<string, ConversationMessageSnapshot[]> }
+    ...(parsed.subagentDesktopTimelines && typeof parsed.subagentDesktopTimelines === 'object'
+      ? { subagentDesktopTimelines: parsed.subagentDesktopTimelines as Record<string, PersistedDesktopTimelineTurnSnapshot[]> }
       : {}),
     ...(typeof parsed.automationId === 'string' && parsed.automationId.trim()
       ? { automationId: parsed.automationId.trim() }
@@ -659,7 +677,7 @@ export async function listStoredSessions(): Promise<SessionListItem[]> {
           path: filePath,
           displayName:
             normalizeDisplayName(parsed.sessionDisplayName) ??
-            deriveDisplayName(parsed.desktopMessages, parsed.messages),
+            deriveDisplayNameFromTimeline(parsed.desktopMessageTimeline),
           workspaceRoot:
             resolveStoredWorkspaceRoot(parsed.workspaceRoot) ?? discoverWorkspaceRoot(),
           ...(gitBranch ? { gitBranch } : {}),
@@ -1141,19 +1159,17 @@ function resolveSessionPath(filePath: string | undefined): string {
   return absolute.toLowerCase().endsWith('.json') ? absolute : `${absolute}.json`;
 }
 
-function deriveDisplayName(
-  desktopMessages: ConversationMessageSnapshot[] | undefined,
-  archiveMessages:
-    | Array<{ role: 'user' | 'assistant'; content: string }>
-    | undefined,
+function deriveDisplayNameFromTimeline(
+  timeline: PersistedDesktopTimelineTurnSnapshot[] | undefined,
 ): string {
-  const fromDesktop = desktopMessages?.find(
+  if (!timeline?.length) {
+    return 'New conversation';
+  }
+  const messages = timelinePersistedSnapshotToMessages(timeline);
+  const firstUser = messages.find(
     (message) => message.role === 'user' && message.content.trim().length > 0,
-  )?.content;
-  const fromArchive = archiveMessages?.find(
-    (message) => message.role === 'user' && message.content.trim().length > 0,
-  )?.content;
-  const seed = fromDesktop ?? fromArchive ?? 'New conversation';
+  );
+  const seed = firstUser?.content ?? 'New conversation';
   return seed.length > 28 ? `${seed.slice(0, 28)}…` : seed;
 }
 

--- a/apps/desktop/test/host/chat-schema-fixture.mjs
+++ b/apps/desktop/test/host/chat-schema-fixture.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  CHAT_SCHEMA_VERSION,
+  normalizeTimelineSnapshotForPersistence,
+} from '../../dist-electron/src/host/chat-schema.js';
+import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
+
+export function buildV2TimelineFromUserMessage(content) {
+  let nextMessageId = 1;
+  const timeline = new DesktopMessageTimeline({
+    allocateMessageId: () => nextMessageId++,
+  });
+  timeline.beginUserTurn(content);
+  return normalizeTimelineSnapshotForPersistence(timeline.snapshot());
+}
+
+export function buildV2StoredSession(overrides = {}) {
+  const desktopMessageTimeline = overrides.desktopMessageTimeline
+    ?? buildV2TimelineFromUserMessage(overrides.userContent ?? 'hello');
+  return {
+    chatSchemaVersion: CHAT_SCHEMA_VERSION,
+    llmHistory: overrides.llmHistory ?? [],
+    subagentSessions: [],
+    loopEnabled: false,
+    approvalLevel: 'default',
+    desktopMessageTimeline,
+    savedAtUnixMs: overrides.savedAtUnixMs ?? Date.now(),
+    sessionDisplayName: overrides.sessionDisplayName ?? 'hello',
+    workspaceRoot: overrides.workspaceRoot ?? 'D:/SpiritAgent',
+    rewind: overrides.rewind,
+    contextUsage: overrides.contextUsage,
+    ...overrides,
+  };
+}
+
+test('buildV2StoredSession helper produces valid v2 shape', () => {
+  const stored = buildV2StoredSession();
+  assert.equal(stored.chatSchemaVersion, 2);
+  assert.equal(stored.desktopMessageTimeline.length, 1);
+  assert.equal(stored.desktopMessageTimeline[0].userRow.content, 'hello');
+});

--- a/apps/desktop/test/host/chat-schema.test.mjs
+++ b/apps/desktop/test/host/chat-schema.test.mjs
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { test } from 'node:test';
 
 import {
@@ -10,6 +13,8 @@ import {
   timelinePersistedSnapshotToMessages,
   validateTimelineSnapshotV2,
 } from '../../dist-electron/src/host/chat-schema.js';
+import { loadStoredSession } from '../../dist-electron/src/host/storage.js';
+import { buildV2StoredSession } from './chat-schema-fixture.mjs';
 
 function toolRow(toolCallId) {
   return {
@@ -160,6 +165,44 @@ test('timelineSnapshotToMessages round-trips normalized thinking and tool rows',
   assert.equal(messages[1].aux?.thinking, 'reasoning');
   assert.equal(messages[2].tool?.toolCallId, 'call-1');
   assert.equal(messages[3].content, 'answer');
+});
+
+test('loadStoredSession rejects legacy chat files without chatSchemaVersion', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'spirit-chat-schema-'));
+  const filePath = path.join(dir, 'legacy-chat.json');
+  try {
+    await writeFile(filePath, JSON.stringify({
+      messages: [{ role: 'user', content: 'hello' }],
+      assistantAux: [],
+      llmHistory: [],
+      subagentSessions: [],
+      savedAtUnixMs: Date.now(),
+    }, null, 2));
+    await assert.rejects(
+      () => loadStoredSession(filePath),
+      (error) => error instanceof ChatSessionSchemaError,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('loadStoredSession round-trips v2 stored session', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'spirit-chat-schema-'));
+  const filePath = path.join(dir, 'v2-chat.json');
+  try {
+    const stored = buildV2StoredSession({ userContent: 'round trip' });
+    await writeFile(filePath, JSON.stringify(stored, null, 2));
+    const loaded = await loadStoredSession(filePath);
+    assert.equal(loaded.chatSchemaVersion, CHAT_SCHEMA_VERSION);
+    assert.equal(loaded.desktopMessageTimeline.length, 1);
+    assert.equal(
+      timelinePersistedSnapshotToMessages(loaded.desktopMessageTimeline)[0].content,
+      'round trip',
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('assertChatSchemaVersionV2 and assertNoLegacyConversationFields enforce v2 shape', () => {

--- a/apps/desktop/test/host/chat-schema.test.mjs
+++ b/apps/desktop/test/host/chat-schema.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  CHAT_SCHEMA_VERSION,
+  ChatSessionSchemaError,
+  assertChatSchemaVersionV2,
+  assertNoLegacyConversationFields,
+  normalizeTimelineSnapshotForPersistence,
+  timelinePersistedSnapshotToMessages,
+  validateTimelineSnapshotV2,
+} from '../../dist-electron/src/host/chat-schema.js';
+
+function toolRow(toolCallId) {
+  return {
+    rowId: `row-${toolCallId}`,
+    messageId: 1,
+    turnId: 1,
+    segmentId: 1,
+    kind: 'tool',
+    section: 'tools',
+    createdOrder: 2,
+    pending: false,
+    tool: {
+      toolCallId,
+      toolName: 'read_file',
+      phase: 'succeeded',
+      headline: 'Read file',
+      detailLines: [],
+      argsExcerpt: '{}',
+    },
+  };
+}
+
+function thinkingRow(thinking) {
+  return {
+    rowId: 'row-thinking',
+    messageId: 2,
+    turnId: 1,
+    segmentId: 1,
+    kind: 'assistant-thinking',
+    section: 'before-tools',
+    createdOrder: 1,
+    pending: false,
+    aux: { thinking },
+  };
+}
+
+function textRow(content) {
+  return {
+    rowId: 'row-text',
+    messageId: 3,
+    turnId: 1,
+    segmentId: 1,
+    kind: 'assistant-text',
+    section: 'after-tools',
+    createdOrder: 3,
+    content,
+    pending: false,
+  };
+}
+
+function sampleTurn(rows) {
+  return [{
+    turnId: 1,
+    createdOrder: 1,
+    userRow: {
+      rowId: 'row-user',
+      messageId: 1,
+      turnId: 1,
+      kind: 'user',
+      createdOrder: 0,
+      content: 'hello',
+      pending: false,
+    },
+    segments: [{
+      segmentId: 1,
+      turnId: 1,
+      kind: 'initial',
+      status: 'completed',
+      createdOrder: 1,
+      rows,
+    }],
+  }];
+}
+
+test('normalizeTimelineSnapshotForPersistence omits empty content for tool and thinking rows', () => {
+  const normalized = normalizeTimelineSnapshotForPersistence(sampleTurn([
+    thinkingRow('reasoning'),
+    toolRow('call-1'),
+    textRow('answer'),
+    {
+      rowId: 'row-empty-text',
+      messageId: 4,
+      turnId: 1,
+      segmentId: 1,
+      kind: 'assistant-text',
+      section: 'after-tools',
+      createdOrder: 4,
+      content: '',
+      pending: false,
+    },
+  ]));
+
+  const rows = normalized[0].segments[0].rows;
+  assert.equal(rows.length, 3);
+  assert.equal(rows[0].kind, 'assistant-thinking');
+  assert.equal('content' in rows[0], false);
+  assert.equal(rows[0].aux.thinking, 'reasoning');
+  assert.equal(rows[1].kind, 'tool');
+  assert.equal('content' in rows[1], false);
+  assert.equal(rows[2].content, 'answer');
+});
+
+test('validateTimelineSnapshotV2 rejects empty assistant-text and legacy content on tool rows', () => {
+  const valid = normalizeTimelineSnapshotForPersistence(sampleTurn([
+    thinkingRow('reasoning'),
+    toolRow('call-1'),
+    textRow('answer'),
+  ]));
+  assert.doesNotThrow(() => validateTimelineSnapshotV2(valid));
+
+  assert.throws(
+    () => validateTimelineSnapshotV2(sampleTurn([
+      {
+        rowId: 'row-empty',
+        messageId: 2,
+        turnId: 1,
+        segmentId: 1,
+        kind: 'assistant-text',
+        section: 'after-tools',
+        createdOrder: 1,
+        content: '',
+        pending: false,
+      },
+    ])),
+    ChatSessionSchemaError,
+  );
+
+  assert.throws(
+    () => validateTimelineSnapshotV2(sampleTurn([
+      {
+        ...toolRow('call-1'),
+        content: '',
+      },
+    ])),
+    ChatSessionSchemaError,
+  );
+});
+
+test('timelineSnapshotToMessages round-trips normalized thinking and tool rows', () => {
+  const normalized = normalizeTimelineSnapshotForPersistence(sampleTurn([
+    thinkingRow('reasoning'),
+    toolRow('call-1'),
+    textRow('answer'),
+  ]));
+  const messages = timelinePersistedSnapshotToMessages(normalized);
+  assert.equal(messages.length, 4);
+  assert.equal(messages[1].content, '');
+  assert.equal(messages[1].aux?.thinking, 'reasoning');
+  assert.equal(messages[2].tool?.toolCallId, 'call-1');
+  assert.equal(messages[3].content, 'answer');
+});
+
+test('assertChatSchemaVersionV2 and assertNoLegacyConversationFields enforce v2 shape', () => {
+  assert.equal(CHAT_SCHEMA_VERSION, 2);
+  assert.throws(() => assertChatSchemaVersionV2(1), ChatSessionSchemaError);
+  assert.throws(() => assertNoLegacyConversationFields({ messages: [] }), ChatSessionSchemaError);
+  assert.throws(() => assertNoLegacyConversationFields({ assistantAux: [] }), ChatSessionSchemaError);
+  assert.throws(() => assertNoLegacyConversationFields({ desktopMessages: [] }), ChatSessionSchemaError);
+  assert.doesNotThrow(() => assertNoLegacyConversationFields({ chatSchemaVersion: 2 }));
+});

--- a/apps/desktop/test/host/finish-task-notice-rehydrate.test.mjs
+++ b/apps/desktop/test/host/finish-task-notice-rehydrate.test.mjs
@@ -6,8 +6,8 @@ import {
   rehydrateFinishTaskNoticesInTimeline,
 } from '../../dist-electron/src/host/finish-task-notice-rehydrate.js';
 import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
-import { restoreMessagesFromArchive } from '../../dist-electron/src/host/message-ordering.js';
-import { buildArchiveAssistantAuxFromConversation } from '../../dist-electron/src/host/sessions.js';
+import { buildArchiveAssistantAuxFromConversation, restoreMessagesFromArchive } from '../../dist-electron/src/host/sessions.js';
+import { buildV2StoredSession } from './chat-schema-fixture.mjs';
 
 test('buildArchiveAssistantAuxFromConversation persists finishTaskNotice', () => {
   const messages = [
@@ -29,21 +29,41 @@ test('buildArchiveAssistantAuxFromConversation persists finishTaskNotice', () =>
   ]);
 });
 
-test('restoreMessagesFromArchive restores finishTaskNotice from assistantAux', () => {
-  const restored = restoreMessagesFromArchive({
-    messages: [
-      { role: 'user', content: 'hello' },
-      { role: 'assistant', content: 'hi there' },
-    ],
-    assistantAux: [
-      {
-        messageIndex: 1,
-        finishTaskNotice: '任务以 已问候 完成。',
+test('restoreMessagesFromArchive restores finishTaskNotice from v2 timeline', () => {
+  const restored = restoreMessagesFromArchive(buildV2StoredSession({
+    desktopMessageTimeline: [{
+      turnId: 1,
+      createdOrder: 1,
+      userRow: {
+        rowId: 'row-user',
+        messageId: 1,
+        turnId: 1,
+        kind: 'user',
+        createdOrder: 0,
+        content: 'hello',
+        pending: false,
       },
-    ],
-    llmHistory: [],
-    subagentSessions: [],
-  });
+      segments: [{
+        segmentId: 1,
+        turnId: 1,
+        kind: 'initial',
+        status: 'completed',
+        createdOrder: 1,
+        rows: [{
+          rowId: 'row-assistant',
+          messageId: 2,
+          turnId: 1,
+          segmentId: 1,
+          kind: 'assistant-text',
+          section: 'after-tools',
+          createdOrder: 2,
+          content: 'hi there',
+          pending: false,
+          aux: { finishTaskNotice: '任务以 已问候 完成。' },
+        }],
+      }],
+    }],
+  }));
 
   assert.equal(restored[1]?.aux?.finishTaskNotice, '任务以 已问候 完成。');
 });

--- a/apps/desktop/test/host/session-registry.test.mjs
+++ b/apps/desktop/test/host/session-registry.test.mjs
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 
 import { SessionRegistry } from '../../dist-electron/src/host/session-registry.js';
 import { restoreStoredSessionState } from '../../dist-electron/src/host/sessions.js';
+import { buildV2StoredSession } from './chat-schema-fixture.mjs';
 import {
   isProvisionalSessionPath,
   provisionalNewSessionPath,
@@ -13,14 +14,7 @@ test('SessionRegistry tracks active bundle after upsertFromRestored', () => {
   const registry = new SessionRegistry();
   const restored = restoreStoredSessionState({
     filePath: 'D:/SpiritAgent/chats/test-session.json',
-    loaded: {
-      llmHistory: [],
-      subagentSessions: [],
-      desktopMessages: [
-        { id: 1, role: 'user', content: 'hello', pending: false },
-      ],
-    },
-    fallbackMessages: [],
+    loaded: buildV2StoredSession({ userContent: 'hello' }),
   });
 
   const bundle = registry.upsertFromRestored(
@@ -121,12 +115,7 @@ test('SessionRegistry upsertFromRestored finds bundle after rekey and keeps runt
 
   const stale = restoreStoredSessionState({
     filePath: sessionPath,
-    loaded: {
-      llmHistory: [],
-      subagentSessions: [],
-      desktopMessages: [{ id: 1, role: 'user', content: 'stale', pending: false }],
-    },
-    fallbackMessages: [],
+    loaded: buildV2StoredSession({ userContent: 'stale' }),
   });
   registry.upsertFromRestored(
     'D:/SpiritAgent/repo',
@@ -147,12 +136,7 @@ test('SessionRegistry upsertFromRestored does not clobber bundle with attached r
   const filePath = 'D:/SpiritAgent/chats/session-live.json';
   const live = restoreStoredSessionState({
     filePath,
-    loaded: {
-      llmHistory: [],
-      subagentSessions: [],
-      desktopMessages: [{ id: 1, role: 'user', content: 'live turn', pending: false }],
-    },
-    fallbackMessages: [],
+    loaded: buildV2StoredSession({ userContent: 'live turn' }),
   });
   const bundle = registry.upsertFromRestored(
     'D:/SpiritAgent/repo',
@@ -172,12 +156,7 @@ test('SessionRegistry upsertFromRestored does not clobber bundle with attached r
 
   const staleDisk = restoreStoredSessionState({
     filePath,
-    loaded: {
-      llmHistory: [],
-      subagentSessions: [],
-      desktopMessages: [{ id: 1, role: 'user', content: 'stale from disk', pending: false }],
-    },
-    fallbackMessages: [],
+    loaded: buildV2StoredSession({ userContent: 'stale from disk' }),
   });
   registry.upsertFromRestored(
     'D:/SpiritAgent/repo',
@@ -201,12 +180,7 @@ test('SessionRegistry beginNewActive keeps prior bundle in memory', () => {
   const filePath = 'D:/SpiritAgent/chats/session-a.json';
   const restored = restoreStoredSessionState({
     filePath,
-    loaded: {
-      llmHistory: [],
-      subagentSessions: [],
-      desktopMessages: [{ id: 1, role: 'user', content: 'keep me', pending: false }],
-    },
-    fallbackMessages: [],
+    loaded: buildV2StoredSession({ userContent: 'keep me' }),
   });
   registry.upsertFromRestored(
     'D:/SpiritAgent/repo',

--- a/apps/desktop/test/host/sessions.test.mjs
+++ b/apps/desktop/test/host/sessions.test.mjs
@@ -2,75 +2,58 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import {
+  normalizeTimelineSnapshotForPersistence,
+} from '../../dist-electron/src/host/chat-schema.js';
+import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
+import {
   buildStoredDesktopSession,
   restoreStoredSessionState,
   sessionListActivityFromBundle,
 } from '../../dist-electron/src/host/sessions.js';
 import { createDesktopRewindMetadata } from '../../dist-electron/src/host/rewind.js';
+import { buildV2StoredSession, buildV2TimelineFromUserMessage } from './chat-schema-fixture.mjs';
 
-test('restoreStoredSessionState ignores malformed desktop timeline snapshots', () => {
-  const desktopMessages = [
-    {
-      id: 1,
-      role: 'user',
-      content: 'Inspect this file',
-      pending: false,
-    },
-  ];
+test('restoreStoredSessionState hydrates messages from v2 timeline', () => {
+  const loaded = buildV2StoredSession({
+    userContent: 'Inspect this file',
+    sessionDisplayName: 'Inspect this file',
+  });
 
   const restored = restoreStoredSessionState({
     filePath: 'D:/SpiritAgent/test-session.json',
-    loaded: {
-      llmHistory: [],
-      subagentSessions: [],
-      desktopMessages,
-      desktopMessageTimeline: [
-        {
-          turnId: 1,
-          createdOrder: 1,
-          segments: null,
-        },
-      ],
-    },
-    fallbackMessages: [],
+    loaded,
   });
 
-  assert.deepEqual(restored.messages, desktopMessages);
-  assert.equal(restored.desktopMessageTimeline, undefined);
+  assert.equal(restored.messages.length, 1);
+  assert.equal(restored.messages[0].content, 'Inspect this file');
+  assert.equal(restored.desktopMessageTimeline?.length, 1);
 });
 
 test('buildStoredDesktopSession and restoreStoredSessionState roundtrip contextUsage', () => {
   const contextUsage = { inputTokens: 1200, contextLength: 128000, percent: 1 };
-  const desktopMessages = [
-    {
-      id: 1,
-      role: 'user',
-      content: 'hello',
-      pending: false,
-    },
-  ];
+  let nextMessageId = 1;
+  const timeline = new DesktopMessageTimeline({
+    allocateMessageId: () => nextMessageId++,
+  });
+  timeline.beginUserTurn('hello');
   const stored = buildStoredDesktopSession({
-    archive: {
-      messages: [],
-      assistantAux: [],
-      llmHistory: [],
-      subagentSessions: [],
-    },
+    llmHistory: [],
     sessionDisplayName: 'hello',
     workspaceRoot: 'D:/SpiritAgent',
-    desktopMessages,
+    desktopMessageTimeline: timeline.snapshot(),
     rewind: createDesktopRewindMetadata(),
     loopEnabled: false,
     approvalLevel: 'default',
     contextUsage,
   });
 
+  assert.equal(stored.chatSchemaVersion, 2);
   assert.deepEqual(stored.contextUsage, contextUsage);
+  assert.equal('messages' in stored, false);
 
   const restored = restoreStoredSessionState({
     filePath: 'D:/SpiritAgent/test-session.json',
     loaded: stored,
-    fallbackMessages: [],
   });
 
   assert.deepEqual(restored.contextUsage, contextUsage);
@@ -78,40 +61,53 @@ test('buildStoredDesktopSession and restoreStoredSessionState roundtrip contextU
 
 test('sessionListActivityFromBundle maps runtime busy states', () => {
   assert.deepEqual(sessionListActivityFromBundle(undefined), {});
-  assert.deepEqual(
-    sessionListActivityFromBundle({
-      runtime: { isBusy: () => false },
-    }),
-    {},
-  );
+
   assert.deepEqual(
     sessionListActivityFromBundle({
       runtime: {
         isBusy: () => true,
-        hasPendingApproval: () => false,
-        hasPendingQuestions: () => false,
+        hasPendingApproval() {
+          return true;
+        },
+        hasPendingQuestions() {
+          return false;
+        },
+      },
+    }),
+    { isBusy: true, isBlocked: true },
+  );
+
+  assert.deepEqual(
+    sessionListActivityFromBundle({
+      runtime: {
+        isBusy: () => true,
+        hasPendingApproval() {
+          return false;
+        },
+        hasPendingQuestions() {
+          return false;
+        },
       },
     }),
     { isBusy: true },
   );
-  assert.deepEqual(
-    sessionListActivityFromBundle({
-      runtime: {
-        isBusy: () => true,
-        hasPendingApproval: () => true,
-        hasPendingQuestions: () => false,
-      },
-    }),
-    { isBusy: true, isBlocked: true },
-  );
-  assert.deepEqual(
-    sessionListActivityFromBundle({
-      runtime: {
-        isBusy: () => true,
-        hasPendingApproval: () => false,
-        hasPendingQuestions: () => true,
-      },
-    }),
-    { isBusy: true, isBlocked: true },
-  );
+});
+
+test('normalizeTimelineSnapshotForPersistence omits empty assistant content on disk', () => {
+  let nextMessageId = 1;
+  const timeline = new DesktopMessageTimeline({
+    allocateMessageId: () => nextMessageId++,
+  });
+  timeline.beginUserTurn('hello');
+  timeline.beginAssistantSegment('initial');
+  timeline.finalizeThinkingSegment('hidden reasoning');
+  timeline.appendAssistantTextChunk('visible answer');
+  timeline.completeActiveAssistantSegment();
+
+  const fromConversation = normalizeTimelineSnapshotForPersistence(timeline.snapshot());
+  const thinkingRow = fromConversation[0].segments[0].rows.find((row) => row.kind === 'assistant-thinking');
+  const textRow = fromConversation[0].segments[0].rows.find((row) => row.kind === 'assistant-text');
+  assert.equal('content' in thinkingRow, false);
+  assert.equal(textRow.content, 'visible answer');
+  assert.equal(buildV2TimelineFromUserMessage('hello')[0].userRow.content, 'hello');
 });


### PR DESCRIPTION
## Summary

- Desktop/CLI 会话 JSON 升级至 `chatSchemaVersion: 2`，UI 唯一落盘来源为 `desktopMessageTimeline`
- `assistant-thinking` / `tool` 行不再写入空 `content`；`assistant-text` / `user` 必须非空 `content`
- 移除 `messages`、`assistantAux`、`desktopMessages` 落盘路径；旧格式或无版本会话加载直接失败（不做向后兼容）
- CLI `chat_store` 与 Desktop 对齐，补齐 v2 round-trip 与拒绝旧格式单测

## Test plan

- [x] `apps/desktop/test/host/chat-schema.test.mjs`
- [x] `apps/desktop/test/host/sessions.test.mjs`
- [x] `apps/desktop/test/host/session-registry.test.mjs`
- [x] `apps/desktop/test/host/finish-task-notice-rehydrate.test.mjs`
- [x] CLI `chat_store` / `chat_timeline` 单测
- [x] 实机会话落盘 JSON 验证 v2 形态（无 legacy 字段、无空 content 占位）