### PR TITLE
fix(agent-core): 代码补全全预设提供商关闭 thinking/reasoning

### DIFF
--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -405,12 +405,27 @@ export function buildPrimaryTransportConfig(input: {
   };
 }
 
-/** 代码补全走轻量模型；DeepSeek 默认关闭 thinking 以降低延迟。 */
+/** DeepSeek / Moonshot 等 Anthropic 风格 thinking 默认开启；代码补全需显式 disabled 以降低延迟。 */
+const CODE_COMPLETION_DISABLE_VENDOR_EXTENDED_THINKING_PROVIDERS: readonly DesktopModelProvider[] = [
+  'deepseek',
+  'moonshot-ai',
+];
+
+export function codeCompletionShouldDisableVendorExtendedThinking(
+  provider: DesktopModelProvider | undefined,
+): boolean {
+  return provider !== undefined && CODE_COMPLETION_DISABLE_VENDOR_EXTENDED_THINKING_PROVIDERS.includes(provider);
+}
+
+/** 代码补全走轻量模型；DeepSeek / Moonshot AI 默认关闭 thinking 以降低延迟。 */
 export function buildCodeCompletionTransportConfig(
   input: Parameters<typeof buildPrimaryTransportConfig>[0],
 ): LlmTransportConfig {
   const transportConfig = buildPrimaryTransportConfig(input);
-  if (input.profile?.provider !== 'deepseek' || !isOpenAiCompatibleTransportConfig(transportConfig)) {
+  if (
+    !codeCompletionShouldDisableVendorExtendedThinking(input.profile?.provider) ||
+    !isOpenAiCompatibleTransportConfig(transportConfig)
+  ) {
     return transportConfig;
   }
   return {

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -1,10 +1,10 @@
 import {
+  applyCodeCompletionTransportProfile,
   resolveOpenResponsesReasoningSummary,
   type AnthropicTransportConfig,
   type LlmModelCapabilities,
   type LlmTransportConfig,
   type OpenResponsesSdkProvider,
-  isOpenAiCompatibleTransportConfig,
 } from '@spirit-agent/core';
 import {
   resolveAnthropicTransportReasoningEffortForContext,
@@ -405,33 +405,11 @@ export function buildPrimaryTransportConfig(input: {
   };
 }
 
-/** DeepSeek / Moonshot 等 Anthropic 风格 thinking 默认开启；代码补全需显式 disabled 以降低延迟。 */
-const CODE_COMPLETION_DISABLE_VENDOR_EXTENDED_THINKING_PROVIDERS: readonly DesktopModelProvider[] = [
-  'deepseek',
-  'moonshot-ai',
-];
-
-export function codeCompletionShouldDisableVendorExtendedThinking(
-  provider: DesktopModelProvider | undefined,
-): boolean {
-  return provider !== undefined && CODE_COMPLETION_DISABLE_VENDOR_EXTENDED_THINKING_PROVIDERS.includes(provider);
-}
-
-/** 代码补全走轻量模型；DeepSeek / Moonshot AI 默认关闭 thinking 以降低延迟。 */
+/** 代码补全走轻量模型；关闭思考策略由 agent-core transport-profile 统一处理。 */
 export function buildCodeCompletionTransportConfig(
   input: Parameters<typeof buildPrimaryTransportConfig>[0],
 ): LlmTransportConfig {
-  const transportConfig = buildPrimaryTransportConfig(input);
-  if (
-    !codeCompletionShouldDisableVendorExtendedThinking(input.profile?.provider) ||
-    !isOpenAiCompatibleTransportConfig(transportConfig)
-  ) {
-    return transportConfig;
-  }
-  return {
-    ...transportConfig,
-    vendorExtendedThinking: false,
-  };
+  return applyCodeCompletionTransportProfile(buildPrimaryTransportConfig(input));
 }
 
 export function modelCapabilitiesFromConfig(

--- a/apps/desktop/test/host/code-completion.test.mjs
+++ b/apps/desktop/test/host/code-completion.test.mjs
@@ -101,7 +101,23 @@ test('buildCodeCompletionTransportConfig disables DeepSeek thinking', () => {
   assert.equal(config.vendorExtendedThinking, false);
 });
 
-test('buildCodeCompletionTransportConfig leaves non-DeepSeek unchanged', () => {
+test('buildCodeCompletionTransportConfig disables Moonshot AI thinking', () => {
+  const config = buildCodeCompletionTransportConfig({
+    apiKey: 'test-key',
+    model: 'kimi-k2.5',
+    baseUrl: 'https://api.moonshot.ai/v1',
+    workspaceRoot,
+    profile: {
+      provider: 'moonshot-ai',
+      capabilities: ['chat'],
+      reasoningEffort: 'default',
+    },
+  });
+  assert.equal(config.llmVendor, 'moonshot-ai');
+  assert.equal(config.vendorExtendedThinking, false);
+});
+
+test('buildCodeCompletionTransportConfig leaves other providers unchanged', () => {
   const config = buildCodeCompletionTransportConfig({
     apiKey: 'test-key',
     model: 'gpt-4o-mini',

--- a/apps/desktop/test/host/code-completion.test.mjs
+++ b/apps/desktop/test/host/code-completion.test.mjs
@@ -94,10 +94,11 @@ test('buildCodeCompletionTransportConfig disables DeepSeek thinking', () => {
     profile: {
       provider: 'deepseek',
       capabilities: ['chat'],
-      reasoningEffort: 'default',
+      reasoningEffort: 'high',
     },
   });
   assert.equal(config.llmVendor, 'deepseek');
+  assert.equal(config.reasoningEffort, 'default');
   assert.equal(config.vendorExtendedThinking, false);
   assert.equal(config.transportRequestProfile, 'code-completion');
 });
@@ -111,10 +112,11 @@ test('buildCodeCompletionTransportConfig disables Moonshot AI thinking', () => {
     profile: {
       provider: 'moonshot-ai',
       capabilities: ['chat'],
-      reasoningEffort: 'default',
+      reasoningEffort: 'high',
     },
   });
   assert.equal(config.llmVendor, 'moonshot-ai');
+  assert.equal(config.reasoningEffort, 'default');
   assert.equal(config.vendorExtendedThinking, false);
   assert.equal(config.transportRequestProfile, 'code-completion');
 });

--- a/apps/desktop/test/host/code-completion.test.mjs
+++ b/apps/desktop/test/host/code-completion.test.mjs
@@ -99,6 +99,7 @@ test('buildCodeCompletionTransportConfig disables DeepSeek thinking', () => {
   });
   assert.equal(config.llmVendor, 'deepseek');
   assert.equal(config.vendorExtendedThinking, false);
+  assert.equal(config.transportRequestProfile, 'code-completion');
 });
 
 test('buildCodeCompletionTransportConfig disables Moonshot AI thinking', () => {
@@ -115,6 +116,7 @@ test('buildCodeCompletionTransportConfig disables Moonshot AI thinking', () => {
   });
   assert.equal(config.llmVendor, 'moonshot-ai');
   assert.equal(config.vendorExtendedThinking, false);
+  assert.equal(config.transportRequestProfile, 'code-completion');
 });
 
 test('buildCodeCompletionTransportConfig leaves other providers unchanged', () => {
@@ -130,4 +132,5 @@ test('buildCodeCompletionTransportConfig leaves other providers unchanged', () =
     },
   });
   assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.transportRequestProfile, 'code-completion');
 });

--- a/apps/desktop/test/host/code-completion.test.mjs
+++ b/apps/desktop/test/host/code-completion.test.mjs
@@ -119,7 +119,7 @@ test('buildCodeCompletionTransportConfig disables Moonshot AI thinking', () => {
   assert.equal(config.transportRequestProfile, 'code-completion');
 });
 
-test('buildCodeCompletionTransportConfig leaves other providers unchanged', () => {
+test('buildCodeCompletionTransportConfig disables OpenAI reasoning', () => {
   const config = buildCodeCompletionTransportConfig({
     apiKey: 'test-key',
     model: 'gpt-4o-mini',
@@ -132,5 +132,23 @@ test('buildCodeCompletionTransportConfig leaves other providers unchanged', () =
     },
   });
   assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, 'none');
+  assert.equal(config.transportRequestProfile, 'code-completion');
+});
+
+test('buildCodeCompletionTransportConfig disables custom provider reasoning', () => {
+  const config = buildCodeCompletionTransportConfig({
+    apiKey: 'test-key',
+    model: 'local-model',
+    baseUrl: 'https://llm.example/v1',
+    workspaceRoot,
+    profile: {
+      provider: 'custom',
+      capabilities: ['chat'],
+      reasoningEffort: 'high',
+    },
+  });
+  assert.equal(config.llmVendor, 'custom');
+  assert.equal(config.reasoningEffort, 'none');
   assert.equal(config.transportRequestProfile, 'code-completion');
 });

--- a/packages/agent-core/src/anthropic/anthropic-compat.test.ts
+++ b/packages/agent-core/src/anthropic/anthropic-compat.test.ts
@@ -44,6 +44,42 @@ test('resolveAnthropicThinkingConfig leaves unknown models undefined', () => {
   );
 });
 
+test('resolveAnthropicThinkingConfig disables thinking for code-completion profile', () => {
+  assert.deepEqual(
+    resolveAnthropicThinkingConfig({
+      model: 'claude-sonnet-4-6',
+      transportRequestProfile: 'code-completion',
+    }),
+    { type: 'disabled' },
+  );
+});
+
+test('resolveAnthropicThinkingConfig prefers explicit thinking over code-completion default', () => {
+  assert.deepEqual(
+    resolveAnthropicThinkingConfig({
+      model: 'claude-sonnet-4-6',
+      transportRequestProfile: 'code-completion',
+      thinking: { type: 'enabled', budgetTokens: 1024 },
+    }),
+    { type: 'enabled', budgetTokens: 1024 },
+  );
+});
+
+test('buildAnthropicProviderOptions emits disabled thinking for code-completion profile', () => {
+  assert.deepEqual(
+    buildAnthropicProviderOptions({
+      model: 'claude-sonnet-4-6',
+      transportRequestProfile: 'code-completion',
+    }),
+    {
+      anthropic: {
+        thinking: { type: 'disabled' },
+        toolStreaming: true,
+      },
+    },
+  );
+});
+
 test('buildAnthropicProviderOptions emits disabled thinking for unsupported models', () => {
   assert.deepEqual(
     buildAnthropicProviderOptions({

--- a/packages/agent-core/src/anthropic/anthropic-compat.ts
+++ b/packages/agent-core/src/anthropic/anthropic-compat.ts
@@ -53,7 +53,7 @@ export function resolveAnthropicThinkingConfig(
   }
 
   if (isCodeCompletionTransportProfile(config)) {
-    return undefined;
+    return { type: 'disabled' };
   }
 
   if (Array.isArray(config.supportedEfforts) && config.supportedEfforts.length === 0) {

--- a/packages/agent-core/src/anthropic/anthropic-compat.ts
+++ b/packages/agent-core/src/anthropic/anthropic-compat.ts
@@ -1,6 +1,7 @@
+import { isCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
 import type { JsonObject, JsonValue } from '../ports.js';
 import { cloneJsonValue } from '../tool-agent.js';
-import type { LlmModelCapabilities } from '../llm-provider-shared.js';
+import type { LlmModelCapabilities, TransportRequestProfile } from '../llm-provider-shared.js';
 
 export const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com/v1';
 
@@ -27,6 +28,8 @@ export interface AnthropicTransportConfig {
   sendReasoning?: boolean;
   disableParallelToolUse?: boolean;
   structuredOutputMode?: AnthropicStructuredOutputMode;
+  /** 代码补全等非 Agent 轻量请求的策略画像；缺省为 agent 路径默认行为。 */
+  transportRequestProfile?: TransportRequestProfile;
 }
 
 export interface AnthropicRequestTrace extends JsonObject {
@@ -40,10 +43,17 @@ export interface AnthropicRequestTrace extends JsonObject {
 }
 
 export function resolveAnthropicThinkingConfig(
-  config: Pick<AnthropicTransportConfig, 'model' | 'thinking' | 'effort' | 'supportedEfforts'>,
+  config: Pick<
+    AnthropicTransportConfig,
+    'model' | 'thinking' | 'effort' | 'supportedEfforts' | 'transportRequestProfile'
+  >,
 ): AnthropicThinkingConfig | undefined {
   if (config.thinking !== undefined) {
     return config.thinking;
+  }
+
+  if (isCodeCompletionTransportProfile(config)) {
+    return undefined;
   }
 
   if (Array.isArray(config.supportedEfforts) && config.supportedEfforts.length === 0) {
@@ -80,6 +90,7 @@ export function buildAnthropicProviderOptions(
     | 'sendReasoning'
     | 'disableParallelToolUse'
     | 'structuredOutputMode'
+    | 'transportRequestProfile'
   >,
 ): Record<string, JsonObject> {
   const thinking = resolveAnthropicThinkingConfig(config);

--- a/packages/agent-core/src/bedrock/bedrock-compat.ts
+++ b/packages/agent-core/src/bedrock/bedrock-compat.ts
@@ -1,6 +1,6 @@
 import type { JsonObject, JsonValue } from '../ports.js';
 import { cloneJsonValue } from '../tool-agent.js';
-import type { LlmModelCapabilities } from '../llm-provider-shared.js';
+import type { LlmModelCapabilities, TransportRequestProfile } from '../llm-provider-shared.js';
 
 /** Bedrock 推理强度；`default` 表示不注入 `reasoningConfig`。 */
 export type BedrockReasoningEffort =
@@ -31,6 +31,8 @@ export interface BedrockTransportConfig {
   modelCapabilities?: LlmModelCapabilities;
   reasoningEffort?: BedrockReasoningEffort;
   supportedReasoningEfforts?: readonly BedrockReasoningEffort[];
+  /** 代码补全等非 Agent 轻量请求的策略画像；缺省为 agent 路径默认行为。 */
+  transportRequestProfile?: TransportRequestProfile;
 }
 
 export interface BedrockRequestTrace extends JsonObject {

--- a/packages/agent-core/src/code-completion/index.ts
+++ b/packages/agent-core/src/code-completion/index.ts
@@ -5,3 +5,4 @@ export * from './validate.js';
 export * from './apply.js';
 export * from './to-monaco.js';
 export * from './delete-diff-preview.js';
+export * from './transport-profile.js';

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -18,14 +18,16 @@ test('isCodeCompletionTransportProfile matches code-completion only', () => {
   assert.equal(isCodeCompletionTransportProfile({}), false);
 });
 
-test('applyCodeCompletionTransportProfile tags openai-compatible and disables DeepSeek thinking', () => {
+test('applyCodeCompletionTransportProfile disables DeepSeek thinking', () => {
   const input: OpenAiTransportConfig = {
     apiKey: 'k',
     model: 'deepseek-v4-flash',
     llmVendor: 'deepseek',
+    reasoningEffort: 'high',
   };
   const result = applyCodeCompletionTransportProfile(input);
   assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'default');
   assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, false);
 });
 
@@ -34,9 +36,11 @@ test('applyCodeCompletionTransportProfile disables Moonshot thinking', () => {
     apiKey: 'k',
     model: 'kimi-k2.5',
     llmVendor: 'moonshot-ai',
+    reasoningEffort: 'high',
   };
   const result = applyCodeCompletionTransportProfile(input);
   assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'default');
   assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, false);
 });
 

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -78,6 +78,18 @@ test('applyCodeCompletionTransportProfile disables OpenAI reasoning on open-resp
   assert.equal((result as OpenResponsesTransportConfig).reasoningSummary, 'off');
 });
 
+test('applyCodeCompletionTransportProfile disables Anthropic extended thinking', () => {
+  const input: AnthropicTransportConfig = {
+    transportKind: 'anthropic',
+    apiKey: 'k',
+    model: 'claude-sonnet-4-6',
+    effort: 'high',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.deepEqual((result as AnthropicTransportConfig).thinking, { type: 'disabled' });
+});
+
 test('applyCodeCompletionTransportProfile tags anthropic, open-responses, and bedrock transports', () => {
   const anthropic: AnthropicTransportConfig = {
     transportKind: 'anthropic',

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -188,6 +188,20 @@ test('applyCodeCompletionTransportProfile disables Azure OpenAI reasoning on ope
   assert.equal((result as OpenResponsesTransportConfig).reasoningSummary, 'off');
 });
 
+test('applyCodeCompletionTransportProfile disables Gateway reasoning on open-responses transport', () => {
+  const input: OpenResponsesTransportConfig = {
+    transportKind: 'open-responses',
+    apiKey: 'k',
+    model: 'openai/gpt-5',
+    llmVendor: 'vercel-ai-gateway',
+    reasoningEffort: 'high',
+    reasoningSummary: 'detailed',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal((result as OpenResponsesTransportConfig).reasoningEffort, 'none');
+  assert.equal((result as OpenResponsesTransportConfig).reasoningSummary, 'off');
+});
+
 test('applyCodeCompletionTransportProfile disables Anthropic extended thinking', () => {
   const input: AnthropicTransportConfig = {
     transportKind: 'anthropic',

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -9,6 +9,7 @@ import type { AnthropicTransportConfig } from '../anthropic/anthropic-compat.js'
 import type { BedrockTransportConfig } from '../bedrock/bedrock-compat.js';
 import type { OpenAiTransportConfig } from '../openai/openai-compat.js';
 import type { OpenResponsesTransportConfig } from '../open-responses/responses-compat.js';
+import { openAiVendorChatCompletionBodyExtras } from '../openai/openai-compat.js';
 
 test('isCodeCompletionTransportProfile matches code-completion only', () => {
   assert.equal(isCodeCompletionTransportProfile({ transportRequestProfile: 'code-completion' }), true);
@@ -114,6 +115,33 @@ test('applyCodeCompletionTransportProfile disables xAI reasoning on open-respons
   assert.equal(result.transportRequestProfile, 'code-completion');
   assert.equal((result as OpenResponsesTransportConfig).reasoningEffort, 'none');
   assert.equal((result as OpenResponsesTransportConfig).reasoningSummary, 'off');
+});
+
+test('applyCodeCompletionTransportProfile disables OpenRouter Claude reasoning effort none', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'anthropic/claude-sonnet-4.6',
+    llmVendor: 'openrouter',
+    reasoningEffort: 'high',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(result as OpenAiTransportConfig),
+    { reasoning: { effort: 'none' } },
+  );
+});
+
+test('applyCodeCompletionTransportProfile disables OpenRouter non-Claude reasoning', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'openai/gpt-4o',
+    llmVendor: 'openrouter',
+    reasoningEffort: 'medium',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
+  assert.deepEqual(openAiVendorChatCompletionBodyExtras(result as OpenAiTransportConfig), {});
 });
 
 test('applyCodeCompletionTransportProfile disables Anthropic extended thinking', () => {

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -62,11 +62,23 @@ test('applyCodeCompletionTransportProfile disables Google Gemini thinking on ope
   assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
 });
 
+test('applyCodeCompletionTransportProfile disables xAI reasoning on openai-compatible transport', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'grok-4.3',
+    llmVendor: 'xai',
+    reasoningEffort: 'high',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
+});
+
 test('applyCodeCompletionTransportProfile leaves unrelated openai-compatible vendors unchanged except profile tag', () => {
   const input: OpenAiTransportConfig = {
     apiKey: 'k',
-    model: 'grok-4',
-    llmVendor: 'xai',
+    model: 'glm-4.7',
+    llmVendor: 'z-ai',
     reasoningEffort: 'medium',
   };
   const result = applyCodeCompletionTransportProfile(input);
@@ -83,6 +95,20 @@ test('applyCodeCompletionTransportProfile disables OpenAI reasoning on open-resp
     llmVendor: 'openai',
     reasoningEffort: 'high',
     reasoningSummary: 'detailed',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenResponsesTransportConfig).reasoningEffort, 'none');
+  assert.equal((result as OpenResponsesTransportConfig).reasoningSummary, 'off');
+});
+
+test('applyCodeCompletionTransportProfile disables xAI reasoning on open-responses transport', () => {
+  const input: OpenResponsesTransportConfig = {
+    transportKind: 'open-responses',
+    apiKey: 'k',
+    model: 'grok-4',
+    llmVendor: 'xai',
+    reasoningEffort: 'high',
   };
   const result = applyCodeCompletionTransportProfile(input);
   assert.equal(result.transportRequestProfile, 'code-completion');

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -78,8 +78,8 @@ test('applyCodeCompletionTransportProfile disables xAI reasoning on openai-compa
 test('applyCodeCompletionTransportProfile leaves unrelated openai-compatible vendors unchanged except profile tag', () => {
   const input: OpenAiTransportConfig = {
     apiKey: 'k',
-    model: 'glm-4.7',
-    llmVendor: 'z-ai',
+    model: 'local-model',
+    llmVendor: 'custom',
     reasoningEffort: 'medium',
   };
   const result = applyCodeCompletionTransportProfile(input);
@@ -142,6 +142,21 @@ test('applyCodeCompletionTransportProfile disables OpenRouter non-Claude reasoni
   const result = applyCodeCompletionTransportProfile(input);
   assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
   assert.deepEqual(openAiVendorChatCompletionBodyExtras(result as OpenAiTransportConfig), {});
+});
+
+test('applyCodeCompletionTransportProfile disables Azure OpenAI reasoning on open-responses transport', () => {
+  const input: OpenResponsesTransportConfig = {
+    transportKind: 'open-responses',
+    apiKey: 'k',
+    model: 'gpt-5',
+    llmVendor: 'azure',
+    responsesProvider: 'azure',
+    reasoningEffort: 'high',
+    reasoningSummary: 'detailed',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal((result as OpenResponsesTransportConfig).reasoningEffort, 'none');
+  assert.equal((result as OpenResponsesTransportConfig).reasoningSummary, 'off');
 });
 
 test('applyCodeCompletionTransportProfile disables Anthropic extended thinking', () => {

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -7,6 +7,7 @@ import {
 } from './transport-profile.js';
 import type { AnthropicTransportConfig } from '../anthropic/anthropic-compat.js';
 import type { BedrockTransportConfig } from '../bedrock/bedrock-compat.js';
+import { buildBedrockProviderOptions } from '../bedrock/bedrock-compat.js';
 import type { OpenAiTransportConfig } from '../openai/openai-compat.js';
 import type { OpenResponsesTransportConfig } from '../open-responses/responses-compat.js';
 import { openAiVendorChatCompletionBodyExtras } from '../openai/openai-compat.js';
@@ -169,6 +170,19 @@ test('applyCodeCompletionTransportProfile disables Anthropic extended thinking',
   const result = applyCodeCompletionTransportProfile(input);
   assert.equal(result.transportRequestProfile, 'code-completion');
   assert.deepEqual((result as AnthropicTransportConfig).thinking, { type: 'disabled' });
+});
+
+test('applyCodeCompletionTransportProfile disables Bedrock reasoning on code completion', () => {
+  const input: BedrockTransportConfig = {
+    transportKind: 'bedrock',
+    model: 'anthropic.claude-sonnet-4-6',
+    region: 'us-east-1',
+    reasoningEffort: 'high',
+  };
+  const result = applyCodeCompletionTransportProfile(input) as BedrockTransportConfig;
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal(result.reasoningEffort, 'none');
+  assert.deepEqual(buildBedrockProviderOptions(result), {});
 });
 
 test('applyCodeCompletionTransportProfile tags anthropic, open-responses, and bedrock transports', () => {

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -38,17 +38,44 @@ test('applyCodeCompletionTransportProfile disables Moonshot thinking', () => {
   assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, false);
 });
 
+test('applyCodeCompletionTransportProfile disables OpenAI reasoning on openai-compatible transport', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'gpt-5',
+    llmVendor: 'openai',
+    reasoningEffort: 'medium',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
+});
+
 test('applyCodeCompletionTransportProfile leaves unrelated openai-compatible vendors unchanged except profile tag', () => {
   const input: OpenAiTransportConfig = {
     apiKey: 'k',
-    model: 'gpt-4o-mini',
-    llmVendor: 'openai',
+    model: 'gemini-2.5-flash',
+    llmVendor: 'google',
     reasoningEffort: 'medium',
   };
   const result = applyCodeCompletionTransportProfile(input);
   assert.equal(result.transportRequestProfile, 'code-completion');
   assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, undefined);
   assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'medium');
+});
+
+test('applyCodeCompletionTransportProfile disables OpenAI reasoning on open-responses transport', () => {
+  const input: OpenResponsesTransportConfig = {
+    transportKind: 'open-responses',
+    apiKey: 'k',
+    model: 'gpt-5',
+    llmVendor: 'openai',
+    reasoningEffort: 'high',
+    reasoningSummary: 'detailed',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenResponsesTransportConfig).reasoningEffort, 'none');
+  assert.equal((result as OpenResponsesTransportConfig).reasoningSummary, 'off');
 });
 
 test('applyCodeCompletionTransportProfile tags anthropic, open-responses, and bedrock transports', () => {
@@ -61,7 +88,7 @@ test('applyCodeCompletionTransportProfile tags anthropic, open-responses, and be
     transportKind: 'open-responses',
     apiKey: 'k',
     model: 'gpt-5',
-    llmVendor: 'openai',
+    llmVendor: 'xai',
   };
   const bedrock: BedrockTransportConfig = {
     transportKind: 'bedrock',

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyCodeCompletionTransportProfile,
+  isCodeCompletionTransportProfile,
+} from './transport-profile.js';
+import type { AnthropicTransportConfig } from '../anthropic/anthropic-compat.js';
+import type { BedrockTransportConfig } from '../bedrock/bedrock-compat.js';
+import type { OpenAiTransportConfig } from '../openai/openai-compat.js';
+import type { OpenResponsesTransportConfig } from '../open-responses/responses-compat.js';
+
+test('isCodeCompletionTransportProfile matches code-completion only', () => {
+  assert.equal(isCodeCompletionTransportProfile({ transportRequestProfile: 'code-completion' }), true);
+  assert.equal(isCodeCompletionTransportProfile({ transportRequestProfile: 'agent' }), false);
+  assert.equal(isCodeCompletionTransportProfile({}), false);
+});
+
+test('applyCodeCompletionTransportProfile tags openai-compatible and disables DeepSeek thinking', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'deepseek-v4-flash',
+    llmVendor: 'deepseek',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, false);
+});
+
+test('applyCodeCompletionTransportProfile disables Moonshot thinking', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'kimi-k2.5',
+    llmVendor: 'moonshot-ai',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, false);
+});
+
+test('applyCodeCompletionTransportProfile leaves unrelated openai-compatible vendors unchanged except profile tag', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'gpt-4o-mini',
+    llmVendor: 'openai',
+    reasoningEffort: 'medium',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, undefined);
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'medium');
+});
+
+test('applyCodeCompletionTransportProfile tags anthropic, open-responses, and bedrock transports', () => {
+  const anthropic: AnthropicTransportConfig = {
+    transportKind: 'anthropic',
+    apiKey: 'k',
+    model: 'claude-sonnet-4-6',
+  };
+  const openResponses: OpenResponsesTransportConfig = {
+    transportKind: 'open-responses',
+    apiKey: 'k',
+    model: 'gpt-5',
+    llmVendor: 'openai',
+  };
+  const bedrock: BedrockTransportConfig = {
+    transportKind: 'bedrock',
+    model: 'anthropic.claude-sonnet-4-6',
+    region: 'us-east-1',
+  };
+
+  assert.equal(applyCodeCompletionTransportProfile(anthropic).transportRequestProfile, 'code-completion');
+  assert.equal(applyCodeCompletionTransportProfile(openResponses).transportRequestProfile, 'code-completion');
+  assert.equal(applyCodeCompletionTransportProfile(bedrock).transportRequestProfile, 'code-completion');
+});

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -64,6 +64,18 @@ test('applyCodeCompletionTransportProfile disables Google Gemini thinking on ope
   assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
 });
 
+test('applyCodeCompletionTransportProfile disables Google Vertex Gemini thinking on openai-compatible transport', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'gemini-2.5-flash',
+    llmVendor: 'google-vertex-ai',
+    reasoningEffort: 'high',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
+});
+
 test('applyCodeCompletionTransportProfile disables xAI reasoning on openai-compatible transport', () => {
   const input: OpenAiTransportConfig = {
     apiKey: 'k',

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -50,11 +50,23 @@ test('applyCodeCompletionTransportProfile disables OpenAI reasoning on openai-co
   assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
 });
 
-test('applyCodeCompletionTransportProfile leaves unrelated openai-compatible vendors unchanged except profile tag', () => {
+test('applyCodeCompletionTransportProfile disables Google Gemini thinking on openai-compatible transport', () => {
   const input: OpenAiTransportConfig = {
     apiKey: 'k',
     model: 'gemini-2.5-flash',
     llmVendor: 'google',
+    reasoningEffort: 'high',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
+});
+
+test('applyCodeCompletionTransportProfile leaves unrelated openai-compatible vendors unchanged except profile tag', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'grok-4',
+    llmVendor: 'xai',
     reasoningEffort: 'medium',
   };
   const result = applyCodeCompletionTransportProfile(input);

--- a/packages/agent-core/src/code-completion/transport-profile.test.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.test.ts
@@ -91,14 +91,26 @@ test('applyCodeCompletionTransportProfile disables xAI reasoning on openai-compa
 test('applyCodeCompletionTransportProfile leaves unrelated openai-compatible vendors unchanged except profile tag', () => {
   const input: OpenAiTransportConfig = {
     apiKey: 'k',
-    model: 'local-model',
-    llmVendor: 'custom',
+    model: 'Qwen/Qwen3-8B',
+    llmVendor: 'siliconflow',
     reasoningEffort: 'medium',
   };
   const result = applyCodeCompletionTransportProfile(input);
   assert.equal(result.transportRequestProfile, 'code-completion');
   assert.equal((result as OpenAiTransportConfig).vendorExtendedThinking, undefined);
   assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'medium');
+});
+
+test('applyCodeCompletionTransportProfile disables custom vendor reasoning on openai-compatible transport', () => {
+  const input: OpenAiTransportConfig = {
+    apiKey: 'k',
+    model: 'local-model',
+    llmVendor: 'custom',
+    reasoningEffort: 'high',
+  };
+  const result = applyCodeCompletionTransportProfile(input);
+  assert.equal(result.transportRequestProfile, 'code-completion');
+  assert.equal((result as OpenAiTransportConfig).reasoningEffort, 'none');
 });
 
 test('applyCodeCompletionTransportProfile disables OpenAI reasoning on open-responses transport', () => {

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -19,6 +19,7 @@ const OPENAI_COMPAT_THINKING_TYPE_VENDORS = new Set<OpenAiLlmVendor>([
   'zhipu-ai',
   'minimax',
   'xiaomi',
+  'volcengine',
 ]);
 
 export function isCodeCompletionTransportProfile(

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -18,6 +18,7 @@ const OPENAI_COMPAT_THINKING_TYPE_VENDORS = new Set<OpenAiLlmVendor>([
   'z-ai',
   'zhipu-ai',
   'minimax',
+  'xiaomi',
 ]);
 
 export function isCodeCompletionTransportProfile(

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -67,8 +67,10 @@ function applyOpenAiCompatibleCodeCompletionProfile(
   if (vendor !== undefined && OPENAI_COMPAT_THINKING_TYPE_VENDORS.has(vendor)) {
     // MiniMax：M3 默认关闭 thinking，可用 adaptive 开启；M2.x 无法关闭。
     // 文档：https://platform.minimaxi.com/docs/api-reference/text-openai-api
+    // Moonshot/DeepSeek 等与 thinking.type 互斥，补全路径不写 reasoning_effort（default → 不传）。
     return {
       ...profiled,
+      reasoningEffort: 'default',
       vendorExtendedThinking: false,
     };
   }

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -100,7 +100,10 @@ function applyOpenResponsesCodeCompletionProfile(
 function applyBedrockCodeCompletionProfile(
   config: BedrockTransportConfig,
 ): BedrockTransportConfig {
-  return withCodeCompletionProfile(config);
+  return {
+    ...withCodeCompletionProfile(config),
+    reasoningEffort: 'none',
+  };
 }
 
 /** 将任意 transport config 标记为代码补全请求画像，并按 transportKind / llmVendor 写入关闭思考所需字段。 */

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -53,7 +53,10 @@ function applyOpenAiCompatibleCodeCompletionProfile(
 function applyAnthropicCodeCompletionProfile(
   config: AnthropicTransportConfig,
 ): AnthropicTransportConfig {
-  return withCodeCompletionProfile(config);
+  return {
+    ...withCodeCompletionProfile(config),
+    thinking: { type: 'disabled' },
+  };
 }
 
 function applyOpenResponsesCodeCompletionProfile(

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -95,6 +95,7 @@ function applyOpenResponsesCodeCompletionProfile(
     || profiled.llmVendor === 'xai'
     || profiled.llmVendor === 'openrouter'
     || profiled.llmVendor === 'azure'
+    || profiled.llmVendor === 'vercel-ai-gateway'
   ) {
     return {
       ...profiled,

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -86,6 +86,7 @@ function applyOpenResponsesCodeCompletionProfile(
     profiled.llmVendor === 'openai'
     || profiled.llmVendor === 'xai'
     || profiled.llmVendor === 'openrouter'
+    || profiled.llmVendor === 'azure'
   ) {
     return {
       ...profiled,

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -41,7 +41,7 @@ function applyOpenAiCompatibleCodeCompletionProfile(
 ): OpenAiTransportConfig {
   const profiled = withCodeCompletionProfile(config);
   const vendor = profiled.llmVendor;
-  if (vendor === 'openai') {
+  if (vendor === 'openai' || vendor === 'xai') {
     return {
       ...profiled,
       reasoningEffort: 'none',
@@ -75,7 +75,7 @@ function applyOpenResponsesCodeCompletionProfile(
   config: OpenResponsesTransportConfig,
 ): OpenResponsesTransportConfig {
   const profiled = withCodeCompletionProfile(config);
-  if (profiled.llmVendor === 'openai') {
+  if (profiled.llmVendor === 'openai' || profiled.llmVendor === 'xai') {
     return {
       ...profiled,
       reasoningEffort: 'none',

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -35,6 +35,12 @@ function applyOpenAiCompatibleCodeCompletionProfile(
 ): OpenAiTransportConfig {
   const profiled = withCodeCompletionProfile(config);
   const vendor = profiled.llmVendor;
+  if (vendor === 'openai') {
+    return {
+      ...profiled,
+      reasoningEffort: 'none',
+    };
+  }
   if (vendor !== undefined && OPENAI_COMPAT_THINKING_TYPE_VENDORS.has(vendor)) {
     return {
       ...profiled,
@@ -53,7 +59,15 @@ function applyAnthropicCodeCompletionProfile(
 function applyOpenResponsesCodeCompletionProfile(
   config: OpenResponsesTransportConfig,
 ): OpenResponsesTransportConfig {
-  return withCodeCompletionProfile(config);
+  const profiled = withCodeCompletionProfile(config);
+  if (profiled.llmVendor === 'openai') {
+    return {
+      ...profiled,
+      reasoningEffort: 'none',
+      reasoningSummary: 'off',
+    };
+  }
+  return profiled;
 }
 
 function applyBedrockCodeCompletionProfile(

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -41,7 +41,7 @@ function applyOpenAiCompatibleCodeCompletionProfile(
 ): OpenAiTransportConfig {
   const profiled = withCodeCompletionProfile(config);
   const vendor = profiled.llmVendor;
-  if (vendor === 'openai' || vendor === 'xai') {
+  if (vendor === 'openai' || vendor === 'xai' || vendor === 'openrouter') {
     return {
       ...profiled,
       reasoningEffort: 'none',
@@ -75,7 +75,11 @@ function applyOpenResponsesCodeCompletionProfile(
   config: OpenResponsesTransportConfig,
 ): OpenResponsesTransportConfig {
   const profiled = withCodeCompletionProfile(config);
-  if (profiled.llmVendor === 'openai' || profiled.llmVendor === 'xai') {
+  if (
+    profiled.llmVendor === 'openai'
+    || profiled.llmVendor === 'xai'
+    || profiled.llmVendor === 'openrouter'
+  ) {
     return {
       ...profiled,
       reasoningEffort: 'none',

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -52,6 +52,12 @@ function applyOpenAiCompatibleCodeCompletionProfile(
       reasoningEffort: 'none',
     };
   }
+  if (vendor === 'custom') {
+    return {
+      ...profiled,
+      reasoningEffort: 'none',
+    };
+  }
   if (vendor !== undefined && OPENAI_COMPAT_GOOGLE_REASONING_NONE_VENDORS.has(vendor)) {
     return {
       ...profiled,

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -30,12 +30,24 @@ function withCodeCompletionProfile<T extends LlmTransportConfig>(config: T): T {
   };
 }
 
+/** 经 reasoningEffort none 关闭 Gemini thinking 的 OpenAI-compatible 直连厂商。 */
+const OPENAI_COMPAT_GOOGLE_REASONING_NONE_VENDORS = new Set<OpenAiLlmVendor>([
+  'google',
+  'google-vertex-ai',
+]);
+
 function applyOpenAiCompatibleCodeCompletionProfile(
   config: OpenAiTransportConfig,
 ): OpenAiTransportConfig {
   const profiled = withCodeCompletionProfile(config);
   const vendor = profiled.llmVendor;
   if (vendor === 'openai') {
+    return {
+      ...profiled,
+      reasoningEffort: 'none',
+    };
+  }
+  if (vendor !== undefined && OPENAI_COMPAT_GOOGLE_REASONING_NONE_VENDORS.has(vendor)) {
     return {
       ...profiled,
       reasoningEffort: 'none',

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -17,6 +17,7 @@ const OPENAI_COMPAT_THINKING_TYPE_VENDORS = new Set<OpenAiLlmVendor>([
   'moonshot-ai',
   'z-ai',
   'zhipu-ai',
+  'minimax',
 ]);
 
 export function isCodeCompletionTransportProfile(
@@ -56,6 +57,8 @@ function applyOpenAiCompatibleCodeCompletionProfile(
     };
   }
   if (vendor !== undefined && OPENAI_COMPAT_THINKING_TYPE_VENDORS.has(vendor)) {
+    // MiniMax：M3 默认关闭 thinking，可用 adaptive 开启；M2.x 无法关闭。
+    // 文档：https://platform.minimaxi.com/docs/api-reference/text-openai-api
     return {
       ...profiled,
       vendorExtendedThinking: false,

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -1,0 +1,82 @@
+import type { AnthropicTransportConfig } from '../anthropic/anthropic-compat.js';
+import type { BedrockTransportConfig } from '../bedrock/bedrock-compat.js';
+import type { OpenAiLlmVendor, OpenAiTransportConfig } from '../openai/openai-compat.js';
+import type { OpenResponsesTransportConfig } from '../open-responses/responses-compat.js';
+import type { TransportRequestProfile } from '../llm-provider-shared.js';
+import type { LlmTransportConfig } from '../provider-config.js';
+import {
+  isAnthropicTransportConfig,
+  isBedrockTransportConfig,
+  isOpenAiCompatibleTransportConfig,
+  isOpenResponsesTransportConfig,
+} from '../provider-config.js';
+
+/** 经 `thinking.type` 关闭 extended thinking 的 OpenAI-compatible 直连厂商（后续 Phase 逐步扩展）。 */
+const OPENAI_COMPAT_THINKING_TYPE_VENDORS = new Set<OpenAiLlmVendor>([
+  'deepseek',
+  'moonshot-ai',
+]);
+
+export function isCodeCompletionTransportProfile(
+  config: { transportRequestProfile?: TransportRequestProfile },
+): boolean {
+  return config.transportRequestProfile === 'code-completion';
+}
+
+function withCodeCompletionProfile<T extends LlmTransportConfig>(config: T): T {
+  return {
+    ...config,
+    transportRequestProfile: 'code-completion',
+  };
+}
+
+function applyOpenAiCompatibleCodeCompletionProfile(
+  config: OpenAiTransportConfig,
+): OpenAiTransportConfig {
+  const profiled = withCodeCompletionProfile(config);
+  const vendor = profiled.llmVendor;
+  if (vendor !== undefined && OPENAI_COMPAT_THINKING_TYPE_VENDORS.has(vendor)) {
+    return {
+      ...profiled,
+      vendorExtendedThinking: false,
+    };
+  }
+  return profiled;
+}
+
+function applyAnthropicCodeCompletionProfile(
+  config: AnthropicTransportConfig,
+): AnthropicTransportConfig {
+  return withCodeCompletionProfile(config);
+}
+
+function applyOpenResponsesCodeCompletionProfile(
+  config: OpenResponsesTransportConfig,
+): OpenResponsesTransportConfig {
+  return withCodeCompletionProfile(config);
+}
+
+function applyBedrockCodeCompletionProfile(
+  config: BedrockTransportConfig,
+): BedrockTransportConfig {
+  return withCodeCompletionProfile(config);
+}
+
+/** 将任意 transport config 标记为代码补全请求画像，并按 transportKind / llmVendor 写入关闭思考所需字段。 */
+export function applyCodeCompletionTransportProfile(
+  config: LlmTransportConfig,
+): LlmTransportConfig {
+  if (isAnthropicTransportConfig(config)) {
+    return applyAnthropicCodeCompletionProfile(config);
+  }
+  if (isOpenResponsesTransportConfig(config)) {
+    return applyOpenResponsesCodeCompletionProfile(config);
+  }
+  if (isBedrockTransportConfig(config)) {
+    return applyBedrockCodeCompletionProfile(config);
+  }
+  if (isOpenAiCompatibleTransportConfig(config)) {
+    return applyOpenAiCompatibleCodeCompletionProfile(config);
+  }
+  return withCodeCompletionProfile(config);
+}

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -16,6 +16,7 @@ const OPENAI_COMPAT_THINKING_TYPE_VENDORS = new Set<OpenAiLlmVendor>([
   'deepseek',
   'moonshot-ai',
   'z-ai',
+  'zhipu-ai',
 ]);
 
 export function isCodeCompletionTransportProfile(

--- a/packages/agent-core/src/code-completion/transport-profile.ts
+++ b/packages/agent-core/src/code-completion/transport-profile.ts
@@ -15,6 +15,7 @@ import {
 const OPENAI_COMPAT_THINKING_TYPE_VENDORS = new Set<OpenAiLlmVendor>([
   'deepseek',
   'moonshot-ai',
+  'z-ai',
 ]);
 
 export function isCodeCompletionTransportProfile(

--- a/packages/agent-core/src/llm-provider-shared.ts
+++ b/packages/agent-core/src/llm-provider-shared.ts
@@ -1,5 +1,8 @@
 export type LlmTransportKind = 'openai-compatible' | 'open-responses' | 'anthropic' | 'bedrock';
 
+/** 区分主 Agent 对话与代码补全等非 Agent 轻量 LLM 请求的策略画像。 */
+export type TransportRequestProfile = 'agent' | 'code-completion';
+
 export interface LlmModelCapabilities {
   chat?: true;
   imageInput?: true;

--- a/packages/agent-core/src/open-responses/alibaba-built-in-tools.ts
+++ b/packages/agent-core/src/open-responses/alibaba-built-in-tools.ts
@@ -1,4 +1,6 @@
 import type { JsonObject, JsonValue } from '../ports.js';
+import { isCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
+import type { OpenAiTransportConfig } from '../openai/openai-compat.js';
 import {
   isOpenAiCompatibleTransportConfig,
   isOpenResponsesTransportConfig,
@@ -35,6 +37,26 @@ export function shouldUseAlibabaBuiltInTools(config: LlmTransportConfig): boolea
 
 export function shouldUseAlibabaChatCompletionsBuiltInTools(config: LlmTransportConfig): boolean {
   return isOpenAiCompatibleTransportConfig(config) && alibabaLlmVendor(config) === 'alibaba';
+}
+
+export function shouldPatchAlibabaChatCompletionsExtraBody(
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'transportRequestProfile'>,
+): boolean {
+  return config.llmVendor === 'alibaba' && (
+    isCodeCompletionTransportProfile(config)
+    || shouldUseAlibabaChatCompletionsBuiltInTools(config as LlmTransportConfig)
+  );
+}
+
+export function buildAlibabaChatCompletionsExtraBodyForConfig(
+  config: Pick<OpenAiTransportConfig, 'transportRequestProfile'>,
+  options: AlibabaChatCompletionsExtraBodyOptions = {},
+): JsonObject {
+  if (isCodeCompletionTransportProfile(config)) {
+    return { enable_thinking: false };
+  }
+
+  return buildAlibabaChatCompletionsExtraBody(options);
 }
 
 export function shouldUseAlibabaResponsesBuiltInTools(config: LlmTransportConfig): boolean {

--- a/packages/agent-core/src/open-responses/alibaba-chat-completions-fetch.test.ts
+++ b/packages/agent-core/src/open-responses/alibaba-chat-completions-fetch.test.ts
@@ -48,6 +48,29 @@ test('alibaba chat fetch uses search-only extra_body when not streaming', async 
   assert.deepEqual(extraBody, { enable_search: true });
 });
 
+test('alibaba chat fetch disables enable_thinking for code-completion profile', async () => {
+  let capturedBody: Record<string, unknown> | undefined;
+  const baseFetch: typeof fetch = async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return new Response('{}', { status: 200 });
+  };
+
+  const fetch = createAlibabaChatCompletionsAwareFetch(
+    {
+      ...alibabaChatConfig,
+      transportRequestProfile: 'code-completion',
+    },
+    baseFetch,
+  );
+  await fetch('https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions', {
+    method: 'POST',
+    body: JSON.stringify({ model: 'qwen3-max', messages: [], stream: false }),
+  });
+
+  const extraBody = capturedBody?.extra_body as Record<string, unknown> | undefined;
+  assert.deepEqual(extraBody, { enable_thinking: false });
+});
+
 test('alibaba chat fetch is passthrough for non-alibaba vendor', async () => {
   let called = false;
   const baseFetch: typeof fetch = async () => {

--- a/packages/agent-core/src/open-responses/alibaba-chat-completions-fetch.ts
+++ b/packages/agent-core/src/open-responses/alibaba-chat-completions-fetch.ts
@@ -3,8 +3,8 @@ import type { JsonObject, JsonValue } from '../ports.js';
 import { isJsonObject } from '../tool-agent.js';
 import type { OpenAiTransportConfig } from '../openai/openai-compat.js';
 import {
-  buildAlibabaChatCompletionsExtraBody,
-  shouldUseAlibabaChatCompletionsBuiltInTools,
+  buildAlibabaChatCompletionsExtraBodyForConfig,
+  shouldPatchAlibabaChatCompletionsExtraBody,
 } from './alibaba-built-in-tools.js';
 
 type FetchFn = typeof fetch;
@@ -13,17 +13,18 @@ export function createAlibabaChatCompletionsAwareFetch(
   config: OpenAiTransportConfig,
   baseFetch: FetchFn = getLlmFetch(),
 ): FetchFn {
-  if (!shouldUseAlibabaChatCompletionsBuiltInTools(config)) {
+  if (!shouldPatchAlibabaChatCompletionsExtraBody(config)) {
     return baseFetch;
   }
 
   return async (input, init) => {
-    const patchedInit = patchAlibabaChatCompletionsRequestInit(init);
+    const patchedInit = patchAlibabaChatCompletionsRequestInit(config, init);
     return baseFetch(input, patchedInit);
   };
 }
 
 function patchAlibabaChatCompletionsRequestInit(
+  config: OpenAiTransportConfig,
   init: RequestInit | undefined,
 ): RequestInit | undefined {
   if (!init?.body || typeof init.body !== 'string') {
@@ -37,7 +38,7 @@ function patchAlibabaChatCompletionsRequestInit(
     }
 
     const streaming = body.stream === true;
-    const extraBody = buildAlibabaChatCompletionsExtraBody({ streaming });
+    const extraBody = buildAlibabaChatCompletionsExtraBodyForConfig(config, { streaming });
     const existingExtraBody = isJsonObject(body.extra_body as JsonValue)
       ? (body.extra_body as JsonObject)
       : {};

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -260,3 +260,24 @@ test('buildResponsesProviderOptions omits reasoning for code-completion OpenAI p
     },
   );
 });
+
+test('buildResponsesProviderOptions routes gateway code-completion by upstream slug', () => {
+  const config = applyCodeCompletionTransportProfile({
+    transportKind: 'open-responses',
+    apiKey: 'test-key',
+    model: 'anthropic/claude-sonnet-4-6',
+    llmVendor: 'vercel-ai-gateway',
+    reasoningEffort: 'high',
+    reasoningSummary: 'detailed',
+  });
+
+  assert.deepEqual(
+    buildResponsesProviderOptions(config as import('./responses-compat.js').OpenResponsesTransportConfig),
+    {
+      anthropic: {
+        thinking: { type: 'disabled' },
+        toolStreaming: true,
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildResponsesGenerateTools, buildResponsesProviderOptions } from './model-factory.js';
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
 
 const hostTool = {
   type: 'function',
@@ -235,4 +236,27 @@ test('buildResponsesProviderOptions maps azure provider options', () => {
       reasoningSummary: 'auto',
     },
   });
+});
+
+test('buildResponsesProviderOptions omits reasoning for code-completion OpenAI profile', () => {
+  const config = applyCodeCompletionTransportProfile({
+    transportKind: 'open-responses',
+    apiKey: 'test-key',
+    model: 'gpt-5',
+    llmVendor: 'openai',
+    responsesProvider: 'openai',
+    reasoningEffort: 'high',
+    reasoningSummary: 'detailed',
+  });
+
+  assert.deepEqual(
+    buildResponsesProviderOptions(config as import('./responses-compat.js').OpenResponsesTransportConfig),
+    {
+      openai: {
+        store: false,
+        truncation: 'disabled',
+        reasoningEffort: 'none',
+      },
+    },
+  );
 });

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -33,6 +33,10 @@ import {
   isGatewayAnthropicClaudeModel,
 } from '../openai/gateway-anthropic-thinking.js';
 import {
+  buildGatewayCodeCompletionProviderOptions,
+  shouldUseGatewayCodeCompletionProviderOptions,
+} from '../openai/gateway-code-completion-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   isGatewayGoogleGeminiModel,
 } from '../openai/gateway-google-thinking.js';
@@ -211,6 +215,10 @@ export function buildResponsesProviderOptions(
   const reasoningSummary = resolveOpenResponsesReasoningSummary(config);
 
   if (shouldUseGatewayWebSearch(config)) {
+    if (shouldUseGatewayCodeCompletionProviderOptions(config)) {
+      return buildGatewayCodeCompletionProviderOptions(config);
+    }
+
     if (isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
       return buildGatewayAnthropicProviderOptions(config);
     }

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -17,6 +17,7 @@ import {
   wrapFetchForBedrockMantleIamAuth,
 } from './bedrock-mantle-auth-fetch.js';
 import { shouldUseAlibabaResponsesBuiltInTools } from './alibaba-built-in-tools.js';
+import { isCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
 import {
   buildResponsesAiSdkTools,
   type OpenAiFunctionToolDefinition,
@@ -270,7 +271,7 @@ export function buildResponsesProviderOptions(
     };
 
     if (config.llmVendor === 'alibaba') {
-      providerOptions.enable_thinking = true;
+      providerOptions.enable_thinking = !isCodeCompletionTransportProfile(config);
     }
 
     if (Object.keys(providerOptions).length === 0) {

--- a/packages/agent-core/src/open-responses/responses-compat.ts
+++ b/packages/agent-core/src/open-responses/responses-compat.ts
@@ -1,5 +1,5 @@
 import type { JsonObject, JsonValue, SpiritAgentMode } from '../ports.js';
-import type { LlmModelCapabilities } from '../llm-provider-shared.js';
+import type { LlmModelCapabilities, TransportRequestProfile } from '../llm-provider-shared.js';
 import type {
   OpenAiImageGenerationConfig,
   OpenAiLlmVendor,
@@ -64,6 +64,8 @@ export interface OpenResponsesTransportConfig {
   };
   /** Azure 资源名；与 `@ai-sdk/azure` 的 `resourceName` 对齐。 */
   azureResourceName?: string;
+  /** 代码补全等非 Agent 轻量请求的策略画像；缺省为 agent 路径默认行为。 */
+  transportRequestProfile?: TransportRequestProfile;
 }
 
 export type OpenResponsesRequestTraceKind =

--- a/packages/agent-core/src/openai/ai-sdk-transport-google-vertex.test.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport-google-vertex.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { buildGoogleThinkingConfigForEffort } from './gateway-google-thinking.js';
+
+test('Google Vertex code-completion profile maps reasoningEffort none to thinkingBudget 0', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'gemini-2.5-flash',
+    llmVendor: 'google-vertex-ai',
+    reasoningEffort: 'high',
+  }) as OpenAiTransportConfig;
+
+  assert.equal(config.transportRequestProfile, 'code-completion');
+  assert.equal(config.reasoningEffort, 'none');
+  assert.deepEqual(
+    buildGoogleThinkingConfigForEffort(config.model, config.reasoningEffort),
+    { thinkingBudget: 0 },
+  );
+});

--- a/packages/agent-core/src/openai/ai-sdk-transport-google.test.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport-google.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { setLlmFetchTransportOverrideForTests } from '../llm-fetch.js';
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
 import { AiSdkOpenAiCompatibleTransport } from './ai-sdk-transport.js';
 
 function googleGenerateContentResponse(text: string) {
@@ -99,6 +100,44 @@ test('Google Gemini 3 models map reasoning effort to thinkingLevel', async () =>
     assert.deepEqual((generationConfig as Record<string, unknown>).thinkingConfig, {
       thinkingLevel: 'high',
       includeThoughts: true,
+    });
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
+});
+
+test('Google code-completion profile sends thinkingBudget 0 for Gemini 2.5', async () => {
+  let capturedBody: Record<string, unknown> | undefined;
+  setLlmFetchTransportOverrideForTests(async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return new Response(JSON.stringify(googleGenerateContentResponse('GOOGLE_CC_OK')), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  const transport = new AiSdkOpenAiCompatibleTransport();
+  try {
+    const config = applyCodeCompletionTransportProfile({
+      apiKey: 'test-key',
+      model: 'gemini-2.5-flash',
+      baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+      llmVendor: 'google',
+      reasoningEffort: 'high',
+      workspaceRoot: process.cwd(),
+    }) as import('./openai-compat.js').OpenAiTransportConfig;
+
+    const result = await transport.startToolAgentRound(
+      config,
+      { messages: [{ role: 'user', content: 'hello' }], steps: 0 },
+      [],
+    );
+
+    assert.equal(result.kind, 'success');
+    const generationConfig = capturedBody?.generationConfig;
+    assert.ok(generationConfig && typeof generationConfig === 'object' && !Array.isArray(generationConfig));
+    assert.deepEqual((generationConfig as Record<string, unknown>).thinkingConfig, {
+      thinkingBudget: 0,
     });
   } finally {
     setLlmFetchTransportOverrideForTests(undefined);

--- a/packages/agent-core/src/openai/ai-sdk-transport-moonshot.test.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport-moonshot.test.ts
@@ -99,7 +99,7 @@ test('Moonshot transport uses official provider trace kind and base URL', async 
   }
 });
 
-test('Moonshot code-completion profile sends thinking.type disabled via provider options', async () => {
+test('Moonshot code-completion profile sends thinking.type disabled without reasoning_effort', async () => {
   let capturedBody: Record<string, unknown> | undefined;
   setLlmFetchTransportOverrideForTests(async (_input, init) => {
     capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
@@ -123,6 +123,7 @@ test('Moonshot code-completion profile sends thinking.type disabled via provider
       model: 'kimi-k2.5',
       baseUrl: 'https://api.moonshot.cn/v1',
       llmVendor: 'moonshot-ai',
+      reasoningEffort: 'high',
       workspaceRoot: process.cwd(),
     }) as import('./openai-compat.js').OpenAiTransportConfig;
 
@@ -133,6 +134,7 @@ test('Moonshot code-completion profile sends thinking.type disabled via provider
     });
 
     assert.deepEqual(capturedBody?.thinking, { type: 'disabled' });
+    assert.equal(capturedBody?.reasoning_effort, undefined);
   } finally {
     setLlmFetchTransportOverrideForTests(undefined);
   }

--- a/packages/agent-core/src/openai/ai-sdk-transport-moonshot.test.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport-moonshot.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { setLlmFetchTransportOverrideForTests } from '../llm-fetch.js';
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
 import {
   clearMoonshotChatCompletionMessages,
   openAiMessagesContainVideoUrl,
@@ -93,6 +94,45 @@ test('Moonshot transport uses official provider trace kind and base URL', async 
       trace && typeof trace === 'object' && !Array.isArray(trace) ? trace.kind : undefined,
       'moonshot_sdk_chat_completions',
     );
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
+});
+
+test('Moonshot code-completion profile sends thinking.type disabled via provider options', async () => {
+  let capturedBody: Record<string, unknown> | undefined;
+  setLlmFetchTransportOverrideForTests(async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return new Response(JSON.stringify({
+      choices: [{
+        message: {
+          role: 'assistant',
+          content: '{"ok":true}',
+        },
+      }],
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  const transport = new AiSdkOpenAiCompatibleTransport();
+  try {
+    const config = applyCodeCompletionTransportProfile({
+      apiKey: 'test-key',
+      model: 'kimi-k2.5',
+      baseUrl: 'https://api.moonshot.cn/v1',
+      llmVendor: 'moonshot-ai',
+      workspaceRoot: process.cwd(),
+    }) as import('./openai-compat.js').OpenAiTransportConfig;
+
+    await transport.createJsonSchemaCompletion(config, {
+      schema: { type: 'object', properties: { ok: { type: 'boolean' } }, required: ['ok'] },
+      schemaName: 'test',
+      userPrompt: 'reply',
+    });
+
+    assert.deepEqual(capturedBody?.thinking, { type: 'disabled' });
   } finally {
     setLlmFetchTransportOverrideForTests(undefined);
   }

--- a/packages/agent-core/src/openai/ai-sdk-transport-xai.test.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport-xai.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
 import { setLlmFetchTransportOverrideForTests } from '../llm-fetch.js';
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
 import { AiSdkOpenAiCompatibleTransport } from './ai-sdk-transport.js';
 
 test('xAI chat transport uses official provider, base URL, reasoning options, and trace kind', async () => {
@@ -49,6 +50,50 @@ test('xAI chat transport uses official provider, base URL, reasoning options, an
       trace && typeof trace === 'object' && !Array.isArray(trace) ? trace.kind : undefined,
       'xai_sdk_chat_completions',
     );
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
+});
+
+test('xAI code-completion profile omits reasoning options', async () => {
+  let capturedBody: Record<string, unknown> | undefined;
+  setLlmFetchTransportOverrideForTests(async (_input, init) => {
+    capturedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return new Response(JSON.stringify({
+      id: 'chatcmpl-xai-cc',
+      object: 'chat.completion',
+      created: 0,
+      model: 'grok-4.3',
+      choices: [{
+        index: 0,
+        finish_reason: 'stop',
+        message: { role: 'assistant', content: 'XAI_CC_OK' },
+      }],
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+
+  const transport = new AiSdkOpenAiCompatibleTransport();
+  try {
+    const config = applyCodeCompletionTransportProfile({
+      apiKey: 'test-key',
+      model: 'grok-4.3',
+      baseUrl: 'https://api.x.ai/v1',
+      llmVendor: 'xai',
+      reasoningEffort: 'high',
+      workspaceRoot: process.cwd(),
+    }) as import('./openai-compat.js').OpenAiTransportConfig;
+
+    const result = await transport.startToolAgentRound(
+      config,
+      { messages: [{ role: 'user', content: 'hello' }], steps: 0 },
+      [],
+    );
+
+    assert.equal(result.kind, 'success');
+    assert.equal(capturedBody?.reasoning_effort, undefined);
   } finally {
     setLlmFetchTransportOverrideForTests(undefined);
   }

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -92,6 +92,7 @@ import {
 } from './gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openrouter-anthropic-reasoning.js';
 import { generateSiliconFlowImage } from '../image-generation/siliconflow-backend.js';
+import { isCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
 import { generateVideoWithRouter } from '../video-generation/router.js';
 import { getLlmFetch } from '../llm-fetch.js';
 import { createAlibabaChatCompletionsAwareFetch } from '../open-responses/alibaba-chat-completions-fetch.js';
@@ -1005,6 +1006,25 @@ function buildAiSdkProviderOptions(
 
     return {
       vertex: vertexOptions as JsonObject,
+    };
+  }
+
+  if (isOpenAiOfficialAiSdkProvider(config)) {
+    const reasoningEffort = openAiReasoningEffort(config) as
+      | OpenAICompatibleLanguageModelChatOptions['reasoningEffort']
+      | undefined;
+    const openaiOptions: JsonObject = {};
+    if (reasoningEffort !== undefined) {
+      openaiOptions.reasoningEffort = reasoningEffort;
+    }
+    if (isCodeCompletionTransportProfile(config) && reasoningEffort === 'none') {
+      openaiOptions.reasoningSummary = 'off';
+    }
+    if (Object.keys(openaiOptions).length === 0) {
+      return {};
+    }
+    return {
+      openai: openaiOptions as JsonObject,
     };
   }
 

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -86,6 +86,10 @@ import {
   isGatewayAnthropicClaudeModel,
 } from './gateway-anthropic-thinking.js';
 import {
+  buildGatewayCodeCompletionProviderOptions,
+  shouldUseGatewayCodeCompletionProviderOptions,
+} from './gateway-code-completion-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   buildGoogleThinkingConfigForEffort,
   isGatewayGoogleGeminiModel,
@@ -906,6 +910,10 @@ function createAiSdkOpenAiProvider(config: OpenAiTransportConfig) {
 function buildAiSdkProviderOptions(
   config: OpenAiTransportConfig,
 ): Record<string, JsonObject> {
+  if (shouldUseGatewayCodeCompletionProviderOptions(config)) {
+    return buildGatewayCodeCompletionProviderOptions(config);
+  }
+
   if (isVercelAiGatewayProvider(config) && isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
     return buildGatewayAnthropicProviderOptions(config);
   }

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -102,6 +102,7 @@ import { getLlmFetch } from '../llm-fetch.js';
 import { createAlibabaChatCompletionsAwareFetch } from '../open-responses/alibaba-chat-completions-fetch.js';
 import {
   buildAlibabaChatCompletionsExtraBody,
+  shouldPatchAlibabaChatCompletionsExtraBody,
   shouldUseAlibabaChatCompletionsBuiltInTools,
 } from '../open-responses/alibaba-built-in-tools.js';
 import {
@@ -878,7 +879,7 @@ function createAiSdkDeepSeekProvider(config: OpenAiTransportConfig) {
 }
 
 function createAiSdkAlibabaProvider(config: OpenAiTransportConfig) {
-  const fetchWrapper = shouldUseAlibabaChatCompletionsBuiltInTools(config)
+  const fetchWrapper = shouldPatchAlibabaChatCompletionsExtraBody(config)
     ? createAlibabaChatCompletionsAwareFetch(config, getLlmFetch())
     : getLlmFetch();
 
@@ -927,6 +928,14 @@ function buildAiSdkProviderOptions(
   }
 
   if (isAlibabaOfficialAiSdkProvider(config)) {
+    if (isCodeCompletionTransportProfile(config)) {
+      return {
+        alibaba: {
+          enable_thinking: false,
+        } as JsonObject,
+      };
+    }
+
     const extraBody = shouldUseAlibabaChatCompletionsBuiltInTools(config)
       ? buildAlibabaChatCompletionsExtraBody({ streaming: true })
       : undefined;

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayCodeCompletionProviderOptions,
+  parseGatewayUpstreamSlug,
+  shouldUseGatewayCodeCompletionProviderOptions,
+} from './gateway-code-completion-thinking.js';
+
+const gatewayConfig = {
+  llmVendor: 'vercel-ai-gateway' as const,
+  transportRequestProfile: 'code-completion' as const,
+};
+
+test('parseGatewayUpstreamSlug extracts upstream slug', () => {
+  assert.equal(parseGatewayUpstreamSlug('deepseek/deepseek-v3'), 'deepseek');
+  assert.equal(parseGatewayUpstreamSlug('moonshotai/kimi-k2'), 'moonshotai');
+  assert.equal(parseGatewayUpstreamSlug('zai/glm-4.7'), 'zai');
+  assert.equal(parseGatewayUpstreamSlug('gpt-5'), undefined);
+});
+
+test('shouldUseGatewayCodeCompletionProviderOptions matches gateway code-completion only', () => {
+  assert.equal(
+    shouldUseGatewayCodeCompletionProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      transportRequestProfile: 'code-completion',
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseGatewayCodeCompletionProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      transportRequestProfile: 'agent',
+    }),
+    false,
+  );
+});
+
+test('buildGatewayCodeCompletionProviderOptions routes anthropic claude to disabled thinking', () => {
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'anthropic/claude-sonnet-4.6',
+    }),
+    {
+      anthropic: {
+        thinking: { type: 'disabled' },
+        toolStreaming: true,
+      },
+    },
+  );
+});
+
+test('buildGatewayCodeCompletionProviderOptions routes google gemini to thinkingBudget 0', () => {
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'google/gemini-2.5-flash',
+    }),
+    {
+      google: {
+        thinkingConfig: {
+          thinkingBudget: 0,
+        },
+      },
+    },
+  );
+});
+
+test('buildGatewayCodeCompletionProviderOptions routes openai to none/off', () => {
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'openai/gpt-5',
+    }),
+    {
+      openai: {
+        reasoningEffort: 'none',
+        reasoningSummary: 'off',
+      },
+    },
+  );
+});
+
+test('buildGatewayCodeCompletionProviderOptions routes deepseek and moonshotai to thinking disabled', () => {
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'deepseek/deepseek-v3',
+    }),
+    {
+      deepseek: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'moonshotai/kimi-k2',
+    }),
+    {
+      moonshotai: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+});
+
+test('buildGatewayCodeCompletionProviderOptions routes zai alibaba minimax xiaomi slugs', () => {
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'zai/glm-4.7',
+    }),
+    {
+      zai: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'alibaba/qwen3-max',
+    }),
+    {
+      alibaba: {
+        enable_thinking: false,
+      },
+    },
+  );
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'minimax/MiniMax-M2.5',
+    }),
+    {
+      minimax: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'xiaomi/mimo-v2',
+    }),
+    {
+      xiaomi: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+});
+
+test('buildGatewayCodeCompletionProviderOptions omits xai reasoning options', () => {
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'xai/grok-4',
+    }),
+    {},
+  );
+});
+
+test('buildGatewayCodeCompletionProviderOptions falls back to openai none for unknown slugs', () => {
+  assert.deepEqual(
+    buildGatewayCodeCompletionProviderOptions({
+      ...gatewayConfig,
+      model: 'fireworks/some-model',
+    }),
+    {
+      openai: {
+        reasoningEffort: 'none',
+        reasoningSummary: 'off',
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
@@ -1,0 +1,98 @@
+import type { JsonObject, JsonValue } from '../ports.js';
+import { isCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import {
+  buildGatewayGoogleProviderOptions,
+  isGatewayGoogleGeminiModel,
+} from './gateway-google-thinking.js';
+import { isGatewayAnthropicClaudeModel } from './gateway-anthropic-thinking.js';
+
+/** 解析 Gateway 模型 ID 的上游 slug，如 `deepseek/deepseek-v3` → `deepseek`。 */
+export function parseGatewayUpstreamSlug(model: string): string | undefined {
+  const normalized = model.trim();
+  const slashIndex = normalized.indexOf('/');
+  if (slashIndex <= 0) {
+    return undefined;
+  }
+  return normalized.slice(0, slashIndex).toLowerCase();
+}
+
+function openAiNoneReasoningOptions(): Record<string, JsonObject> {
+  return {
+    openai: {
+      reasoningEffort: 'none',
+      reasoningSummary: 'off',
+    },
+  };
+}
+
+function thinkingTypeDisabledOptions(providerKey: string): Record<string, JsonObject> {
+  return {
+    [providerKey]: {
+      thinking: {
+        type: 'disabled',
+      },
+    } as JsonObject,
+  };
+}
+
+/**
+ * Gateway 无统一关闭思考开关；按 model 上游 slug 注入与各直连厂商相同的 providerOptions。
+ * 仅用于 `transportRequestProfile: 'code-completion'`。
+ */
+export function buildGatewayCodeCompletionProviderOptions(
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'reasoningEffort' | 'transportRequestProfile'
+  >,
+): Record<string, JsonObject> {
+  const slug = parseGatewayUpstreamSlug(config.model);
+
+  if (slug === undefined) {
+    return openAiNoneReasoningOptions();
+  }
+
+  if (slug === 'anthropic' && isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
+    return {
+      anthropic: {
+        thinking: { type: 'disabled' } as JsonValue,
+        toolStreaming: true,
+      },
+    };
+  }
+
+  if (slug === 'google' && isGatewayGoogleGeminiModel(config.llmVendor, config.model)) {
+    return buildGatewayGoogleProviderOptions(config, 'none');
+  }
+
+  switch (slug) {
+    case 'openai':
+      return openAiNoneReasoningOptions();
+    case 'deepseek':
+      return thinkingTypeDisabledOptions('deepseek');
+    case 'moonshotai':
+      return thinkingTypeDisabledOptions('moonshotai');
+    case 'xai':
+      return {};
+    case 'zai':
+      return thinkingTypeDisabledOptions('zai');
+    case 'alibaba':
+      return {
+        alibaba: {
+          enable_thinking: false,
+        },
+      };
+    case 'minimax':
+      return thinkingTypeDisabledOptions('minimax');
+    case 'xiaomi':
+      return thinkingTypeDisabledOptions('xiaomi');
+    default:
+      return openAiNoneReasoningOptions();
+  }
+}
+
+export function shouldUseGatewayCodeCompletionProviderOptions(
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'transportRequestProfile'>,
+): boolean {
+  return config.llmVendor === 'vercel-ai-gateway' && isCodeCompletionTransportProfile(config);
+}

--- a/packages/agent-core/src/openai/openai-compat-siliconflow.test.ts
+++ b/packages/agent-core/src/openai/openai-compat-siliconflow.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
+import { openAiVendorChatCompletionBodyExtras } from './openai-compat.js';
+
+test('SiliconFlow code-completion profile always sends enable_thinking false', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'Qwen/Qwen3-8B',
+    llmVendor: 'siliconflow',
+  });
+
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(config as import('./openai-compat.js').OpenAiTransportConfig),
+    {
+      enable_thinking: false,
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
+++ b/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
+import { openAiVendorChatCompletionBodyExtras } from './openai-compat.js';
+
+test('DeepSeek code-completion profile disables thinking via vendorExtendedThinking', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'deepseek-v4-flash',
+    llmVendor: 'deepseek',
+  });
+
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(config as import('./openai-compat.js').OpenAiTransportConfig),
+    {
+      thinking: { type: 'disabled' },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
+++ b/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
@@ -65,3 +65,18 @@ test('MiniMax code-completion profile disables thinking via request body extras'
     },
   );
 });
+
+test('Xiaomi code-completion profile disables thinking via request body extras', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'mimo-v2',
+    llmVendor: 'xiaomi',
+  });
+
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(config as import('./openai-compat.js').OpenAiTransportConfig),
+    {
+      thinking: { type: 'disabled' },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
+++ b/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
@@ -18,3 +18,19 @@ test('DeepSeek code-completion profile disables thinking via vendorExtendedThink
     },
   );
 });
+
+test('Z.ai code-completion profile disables thinking via request body extras', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'glm-4.7',
+    llmVendor: 'z-ai',
+  });
+
+  assert.equal((config as import('./openai-compat.js').OpenAiTransportConfig).vendorExtendedThinking, false);
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(config as import('./openai-compat.js').OpenAiTransportConfig),
+    {
+      thinking: { type: 'disabled' },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
+++ b/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
@@ -50,3 +50,18 @@ test('Zhipu AI code-completion profile disables thinking via request body extras
     },
   );
 });
+
+test('MiniMax code-completion profile disables thinking via request body extras', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'MiniMax-M3',
+    llmVendor: 'minimax',
+  });
+
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(config as import('./openai-compat.js').OpenAiTransportConfig),
+    {
+      thinking: { type: 'disabled' },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
+++ b/packages/agent-core/src/openai/openai-compat-vendor-extras.test.ts
@@ -34,3 +34,19 @@ test('Z.ai code-completion profile disables thinking via request body extras', (
     },
   );
 });
+
+test('Zhipu AI code-completion profile disables thinking via request body extras', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'glm-4-plus',
+    llmVendor: 'zhipu-ai',
+  });
+
+  assert.equal((config as import('./openai-compat.js').OpenAiTransportConfig).vendorExtendedThinking, false);
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(config as import('./openai-compat.js').OpenAiTransportConfig),
+    {
+      thinking: { type: 'disabled' },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openai-compat-volcengine.test.ts
+++ b/packages/agent-core/src/openai/openai-compat-volcengine.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { applyCodeCompletionTransportProfile } from '../code-completion/transport-profile.js';
+import { openAiVendorChatCompletionBodyExtras } from './openai-compat.js';
+
+test('Volcengine code-completion profile disables thinking via thinking.type', () => {
+  const config = applyCodeCompletionTransportProfile({
+    apiKey: 'k',
+    model: 'doubao-seed-1-6',
+    llmVendor: 'volcengine',
+  });
+
+  assert.deepEqual(
+    openAiVendorChatCompletionBodyExtras(config as import('./openai-compat.js').OpenAiTransportConfig),
+    {
+      thinking: { type: 'disabled' },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -210,6 +210,7 @@ export function openAiVendorChatCompletionBodyExtras(
     || config.llmVendor === 'z-ai'
     || config.llmVendor === 'zhipu-ai'
     || config.llmVendor === 'minimax'
+    || config.llmVendor === 'xiaomi'
   ) {
     const enabled = config.vendorExtendedThinking !== false;
     extras.thinking = { type: enabled ? 'enabled' : 'disabled' };

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -211,6 +211,7 @@ export function openAiVendorChatCompletionBodyExtras(
     || config.llmVendor === 'zhipu-ai'
     || config.llmVendor === 'minimax'
     || config.llmVendor === 'xiaomi'
+    || config.llmVendor === 'volcengine'
   ) {
     const enabled = config.vendorExtendedThinking !== false;
     extras.thinking = { type: enabled ? 'enabled' : 'disabled' };

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -216,6 +216,10 @@ export function openAiVendorChatCompletionBodyExtras(
     extras.thinking = { type: enabled ? 'enabled' : 'disabled' };
   }
 
+  if (config.llmVendor === 'siliconflow' && config.transportRequestProfile === 'code-completion') {
+    extras.enable_thinking = false;
+  }
+
   const openRouterReasoning = buildOpenRouterClaudeReasoningBody(config);
   if (openRouterReasoning !== undefined) {
     extras.reasoning = openRouterReasoning;

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -205,7 +205,7 @@ export function openAiVendorChatCompletionBodyExtras(
   config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'>,
 ): Record<string, unknown> {
   const extras: Record<string, unknown> = {};
-  if (config.llmVendor === 'deepseek' || config.llmVendor === 'z-ai') {
+  if (config.llmVendor === 'deepseek' || config.llmVendor === 'z-ai' || config.llmVendor === 'zhipu-ai') {
     const enabled = config.vendorExtendedThinking !== false;
     extras.thinking = { type: enabled ? 'enabled' : 'disabled' };
   }

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -205,7 +205,7 @@ export function openAiVendorChatCompletionBodyExtras(
   config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'>,
 ): Record<string, unknown> {
   const extras: Record<string, unknown> = {};
-  if (config.llmVendor === 'deepseek') {
+  if (config.llmVendor === 'deepseek' || config.llmVendor === 'z-ai') {
     const enabled = config.vendorExtendedThinking !== false;
     extras.thinking = { type: enabled ? 'enabled' : 'disabled' };
   }

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -202,10 +202,15 @@ export function openAiReasoningEffort(
  * Moonshot 已改用 `@ai-sdk/moonshotai` 的 `providerOptions.moonshotai.thinking`。
  */
 export function openAiVendorChatCompletionBodyExtras(
-  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'>,
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking' | 'transportRequestProfile'>,
 ): Record<string, unknown> {
   const extras: Record<string, unknown> = {};
-  if (config.llmVendor === 'deepseek' || config.llmVendor === 'z-ai' || config.llmVendor === 'zhipu-ai') {
+  if (
+    config.llmVendor === 'deepseek'
+    || config.llmVendor === 'z-ai'
+    || config.llmVendor === 'zhipu-ai'
+    || config.llmVendor === 'minimax'
+  ) {
     const enabled = config.vendorExtendedThinking !== false;
     extras.thinking = { type: enabled ? 'enabled' : 'disabled' };
   }

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -1,5 +1,5 @@
 import type { JsonObject, JsonValue } from '../ports.js';
-import type { LlmModelCapabilities } from '../llm-provider-shared.js';
+import type { LlmModelCapabilities, TransportRequestProfile } from '../llm-provider-shared.js';
 import { resolveOpenAiTransportReasoningEffortForContext } from '../reasoning-effort.js';
 import { cloneJsonValue } from '../tool-agent.js';
 import {
@@ -110,6 +110,8 @@ export interface OpenAiTransportConfig {
   vertexClientEmail?: string;
   /** 服务账号 `private_key`（与 `vertexClientEmail` 成对）。 */
   vertexPrivateKey?: string;
+  /** 代码补全等非 Agent 轻量请求的策略画像；缺省为 agent 路径默认行为。 */
+  transportRequestProfile?: TransportRequestProfile;
   /**
    * 透传 `createVertex` 的 `googleAuthOptions`（如 ADC 自定义或测试用 `authClient`）。
    * 若已设置 `vertexClientEmail` / `vertexPrivateKey`，宿主构建的 credentials 优先于此字段。


### PR DESCRIPTION
## Summary

- 新增 \	ransportRequestProfile: 'code-completion'\ 统一策略层，\pplyCodeCompletionTransportProfile\ 按 transportKind / llmVendor 写入关闭思考所需字段
- 覆盖 pickerOrder 全部预设：OpenAI/xAI/OpenRouter/Azure（reasoningEffort none）、Anthropic（thinking disabled）、Google/Vertex（thinkingBudget 0）、DeepSeek/Moonshot/z-ai/zhipu/MiniMax/小米/火山（thinking.type disabled）、阿里/SiliconFlow（enable_thinking false）、Gateway 按 model slug 路由、Bedrock（reasoningEffort none）、custom fallback
- Desktop \uildCodeCompletionTransportConfig\ 委托 agent-core，删除本地 provider 白名单；各 Phase 独立 commit 便于 review

## Test plan

- [x] \packages/agent-core\ build 与 transport-profile / vendor extras / gateway 单测
- [x] \packages/agent-core\ Google / xAI / Moonshot / Vertex / SiliconFlow / 阿里 fetch 集成单测
- [x] \pps/desktop/test/host/code-completion.test.mjs\ 断言 transportRequestProfile 与各 vendor 策略
- [x] 未改模型可见 system/tool 大段文案，无需 eval:compare