### PR TITLE
feat(desktop, agent-core): 模型 Inspector Thinking 开关与多厂商传输注入

### DIFF
--- a/apps/desktop/scripts/check-renderer-agent-core-imports.mjs
+++ b/apps/desktop/scripts/check-renderer-agent-core-imports.mjs
@@ -17,6 +17,7 @@ const RENDERER_SAFE_AGENT_CORE_SUBPATHS = new Set([
   'shell-tool-result',
   'code-completion-to-monaco',
   'code-completion-delete-diff',
+  'model-thinking-controls',
 ]);
 
 const RENDERER_SCAN_ROOTS = ['components', 'hooks', 'lib', 'App.tsx'];

--- a/apps/desktop/src/components/composer/composer-surface.tsx
+++ b/apps/desktop/src/components/composer/composer-surface.tsx
@@ -67,6 +67,7 @@ export type ComposerSurfaceProps = {
   onAbort?(): void;
   onModelSelect(name: string): void;
   onModelReasoningEffortSelect(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
+  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void;
   onAgentModeChange(mode: DesktopAgentMode): void;
   onLoopEnabledChange?(enabled: boolean): void;
   richInputRef?: RefObject<ComposerRichInputHandle | null>;
@@ -108,6 +109,7 @@ export function ComposerSurface({
   onAbort,
   onModelSelect,
   onModelReasoningEffortSelect,
+  onModelThinkingEnabledSelect,
   onAgentModeChange,
   onLoopEnabledChange,
   richInputRef,
@@ -250,6 +252,7 @@ export function ComposerSurface({
               disabled={readOnly}
               onModelSelect={onModelSelect}
               onModelReasoningEffortSelect={onModelReasoningEffortSelect}
+              onModelThinkingEnabledSelect={onModelThinkingEnabledSelect}
               triggerClassName="max-w-[min(12rem,100%)] pr-0.5 pl-1"
               menuContentClassName="z-[100]"
             />

--- a/apps/desktop/src/components/composer/composer-surface.tsx
+++ b/apps/desktop/src/components/composer/composer-surface.tsx
@@ -67,7 +67,7 @@ export type ComposerSurfaceProps = {
   onAbort?(): void;
   onModelSelect(name: string): void;
   onModelReasoningEffortSelect(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
-  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void;
+  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void | Promise<boolean>;
   onAgentModeChange(mode: DesktopAgentMode): void;
   onLoopEnabledChange?(enabled: boolean): void;
   richInputRef?: RefObject<ComposerRichInputHandle | null>;

--- a/apps/desktop/src/components/conversation/composer-dock.tsx
+++ b/apps/desktop/src/components/conversation/composer-dock.tsx
@@ -345,6 +345,7 @@ export const ComposerDock = forwardRef<HTMLDivElement, ComposerDockProps>(functi
                 loopEnabled={snapshot?.conversation.loopEnabled === true}
                 onModelSelect={runtime.setActiveModel}
                 onModelReasoningEffortSelect={runtime.setModelReasoningEffort}
+                onModelThinkingEnabledSelect={runtime.setModelThinkingEnabled}
                 onAgentModeChange={onComposerAgentModeChange}
                 onLoopEnabledChange={(enabled) => {
                   void runtime.setLoopEnabled(enabled);

--- a/apps/desktop/src/components/conversation/conversation-list.tsx
+++ b/apps/desktop/src/components/conversation/conversation-list.tsx
@@ -390,6 +390,7 @@ export function ConversationList({
                 onRewindDrop={onRewindDrop}
                 onModelSelect={runtime.setActiveModel}
                 onModelReasoningEffortSelect={runtime.setModelReasoningEffort}
+                onModelThinkingEnabledSelect={runtime.setModelThinkingEnabled}
                 onAgentModeChange={onComposerAgentModeChange}
                 readManagedImagePreviewDataUrl={runtime.readManagedImagePreviewDataUrl}
                 readManagedVideoPreviewUrl={runtime.readManagedVideoPreviewUrl}

--- a/apps/desktop/src/components/conversation/message-card.tsx
+++ b/apps/desktop/src/components/conversation/message-card.tsx
@@ -85,6 +85,7 @@ export function MessageCard({
   onRewindDrop,
   onModelSelect,
   onModelReasoningEffortSelect,
+  onModelThinkingEnabledSelect,
   onAgentModeChange,
   pendingAuxState,
   readManagedImagePreviewDataUrl,
@@ -148,6 +149,7 @@ export function MessageCard({
   onRewindDrop(event: ReactDragEvent<HTMLElement>): void;
   onModelSelect(name: string): void;
   onModelReasoningEffortSelect(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
+  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void;
   onAgentModeChange(mode: DesktopAgentMode): void;
   readManagedImagePreviewDataUrl: ReadManagedImagePreview;
   readManagedVideoPreviewUrl: ReadManagedVideoPreview;
@@ -285,6 +287,7 @@ export function MessageCard({
             loopEnabled={false}
             onModelSelect={onModelSelect}
             onModelReasoningEffortSelect={onModelReasoningEffortSelect}
+            onModelThinkingEnabledSelect={onModelThinkingEnabledSelect}
             onAgentModeChange={onAgentModeChange}
             onLoopEnabledChange={() => {}}
             canSend={rewindCanSubmit}

--- a/apps/desktop/src/components/conversation/message-card.tsx
+++ b/apps/desktop/src/components/conversation/message-card.tsx
@@ -149,7 +149,7 @@ export function MessageCard({
   onRewindDrop(event: ReactDragEvent<HTMLElement>): void;
   onModelSelect(name: string): void;
   onModelReasoningEffortSelect(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
-  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void;
+  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void | Promise<boolean>;
   onAgentModeChange(mode: DesktopAgentMode): void;
   readManagedImagePreviewDataUrl: ReadManagedImagePreview;
   readManagedVideoPreviewUrl: ReadManagedVideoPreview;

--- a/apps/desktop/src/components/model-catalog-detail-panel.tsx
+++ b/apps/desktop/src/components/model-catalog-detail-panel.tsx
@@ -67,6 +67,13 @@ export function ModelCatalogDetailPanel({
       }),
     [catalogEntry?.pricing, contextLength, t],
   );
+  const hasDetailFields = detailFields.length > 0;
+  const hasFollowingSection = Boolean(children || hasDetailFields);
+  const controlsIsLast = !hasDetailFields;
+  const sectionPadding = isList ? 'px-2 py-1.5' : 'px-3 py-2.5';
+  const sectionPaddingLast = isList ? 'px-2 pt-1.5' : 'px-3 pt-2.5';
+  const sectionDivider = 'border-b border-border/40';
+
   return (
     <div className={cn(isList ? 'flex flex-col' : '-mx-3 flex flex-col')}>
       <div
@@ -102,17 +109,28 @@ export function ModelCatalogDetailPanel({
         ) : null}
       </div>
       {description ? (
-        <div className={cn(isList ? 'px-2 py-1.5 text-xs' : 'px-3 pt-3 text-xs')}>
+        <div
+          className={cn(
+            hasFollowingSection ? sectionPadding : sectionPaddingLast,
+            hasFollowingSection && sectionDivider,
+            'text-xs',
+          )}
+        >
           <p className="whitespace-pre-wrap leading-5 text-foreground/90">{description}</p>
         </div>
       ) : null}
       {children ? (
-        <div className={cn(description ? 'border-y' : 'border-b', 'border-border/40', isList ? 'px-2 py-1.5' : 'px-3 py-2.5')}>
+        <div
+          className={cn(
+            controlsIsLast ? sectionPaddingLast : sectionPadding,
+            !controlsIsLast && sectionDivider,
+          )}
+        >
           {children}
         </div>
       ) : null}
-      {detailFields.length > 0 ? (
-        <div className={cn(isList ? 'space-y-2 px-2 py-1.5 text-xs' : 'space-y-2 px-3 pt-3 text-xs')}>
+      {hasDetailFields ? (
+        <div className={cn(sectionPaddingLast, 'space-y-2 text-xs')}>
           {detailFields.map((field) => (
             <ModelCatalogDetailFieldSection
               key={field.id}

--- a/apps/desktop/src/components/model-picker-inspector-panel.tsx
+++ b/apps/desktop/src/components/model-picker-inspector-panel.tsx
@@ -1,9 +1,15 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
   modelReasoningEffortLabel,
   modelReasoningEffortOptions,
 } from '@spirit-agent/core/reasoning-effort';
+import {
+  modelShowsReasoningEffortControl,
+  modelSupportsThinkingSwitch,
+  resolveModelThinkingEnabled,
+} from '@spirit-agent/core/model-thinking-controls';
 
 import { ModelCatalogDetailPanel } from '@/components/model-catalog-detail-panel';
 import { Label } from '@/components/ui/label';
@@ -14,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
 import {
   DESKTOP_OVERLAY_LIST_DETAIL_LABEL,
 } from '@/lib/desktop-chrome';
@@ -29,6 +36,7 @@ type ModelPickerInspectorPanelProps = {
   providerLabel: string;
   density?: 'default' | 'list';
   onReasoningEffortChange: (modelName: string, effort: DesktopModelReasoningEffort) => void;
+  onThinkingEnabledChange?: (modelName: string, enabled: boolean) => void;
 };
 
 export function ModelPickerInspectorPanel({
@@ -37,48 +45,76 @@ export function ModelPickerInspectorPanel({
   providerLabel,
   density = 'default',
   onReasoningEffortChange,
+  onThinkingEnabledChange,
 }: ModelPickerInspectorPanelProps) {
   const { t } = useTranslation();
   const isList = density === 'list';
-  const effortOptions = modelReasoningEffortOptions({
-    provider: model.provider,
+  const modelContext = {
+    ...(model.provider ? { provider: model.provider } : {}),
     model: model.name,
     ...(model.supportedReasoningEfforts !== undefined
       ? { supportedEfforts: model.supportedReasoningEfforts }
       : {}),
-    transportKind: model.transportKind,
-  });
+    ...(model.transportKind ? { transportKind: model.transportKind } : {}),
+  };
+  const supportsThinkingSwitch = modelSupportsThinkingSwitch(modelContext);
+  const [pendingThinkingEnabled, setPendingThinkingEnabled] = useState<boolean | null>(null);
+  useEffect(() => {
+    setPendingThinkingEnabled(null);
+  }, [model.name, model.thinkingEnabled]);
+  const thinkingEnabled =
+    pendingThinkingEnabled ?? resolveModelThinkingEnabled(model.thinkingEnabled);
+  const showReasoningEffort = modelShowsReasoningEffortControl(modelContext, thinkingEnabled);
+  const effortOptions = showReasoningEffort ? modelReasoningEffortOptions(modelContext) : [];
+  const labelClass = isList ? DESKTOP_OVERLAY_LIST_DETAIL_LABEL : 'text-xs text-muted-foreground';
+  const selectTriggerClass = isList
+    ? 'h-7 w-auto border-0 bg-transparent px-0 text-xs shadow-none [&_span]:justify-end'
+    : 'h-8 w-auto border-0 bg-transparent px-0 text-xs shadow-none [&_span]:justify-end';
 
-  const reasoningEffortControl = effortOptions.length > 1 ? (
-    <div className="flex items-center justify-between gap-2">
-      <Label className={isList ? DESKTOP_OVERLAY_LIST_DETAIL_LABEL : 'text-xs text-muted-foreground'}>
-        {t('app.modelPickerReasoningEffort')}
-      </Label>
-      <Select
-        value={model.reasoningEffort}
-        onValueChange={(value) => {
-          onReasoningEffortChange(model.name, value as DesktopModelReasoningEffort);
-        }}
-      >
-        <SelectTrigger
-          className={
-            isList
-              ? 'h-7 w-auto border-0 bg-transparent px-0 text-xs shadow-none [&_span]:justify-end'
-              : 'h-8 w-auto border-0 bg-transparent px-0 text-xs shadow-none [&_span]:justify-end'
-          }
-        >
-          <SelectValue>{modelReasoningEffortLabel(model.reasoningEffort)}</SelectValue>
-        </SelectTrigger>
-        <SelectContent className="z-[110]">
-          {effortOptions.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  ) : null;
+  const modelControls =
+    supportsThinkingSwitch || effortOptions.length > 1 ? (
+      <div className="space-y-2">
+        {supportsThinkingSwitch ? (
+          <div className="flex items-center justify-between gap-2">
+            <Label className={labelClass} htmlFor={`model-thinking-${model.name}`}>
+              {t('app.modelPickerThinking')}
+            </Label>
+            <Switch
+              id={`model-thinking-${model.name}`}
+              checked={thinkingEnabled}
+              onCheckedChange={(checked) => {
+                setPendingThinkingEnabled(checked);
+                onThinkingEnabledChange?.(model.name, checked);
+              }}
+            />
+          </div>
+        ) : null}
+        {effortOptions.length > 1 ? (
+          <div className="flex items-center justify-between gap-2">
+            <Label className={labelClass}>{t('app.modelPickerReasoningEffort')}</Label>
+            <Select
+              value={model.reasoningEffort}
+              onValueChange={(value) => {
+                onReasoningEffortChange(model.name, value as DesktopModelReasoningEffort);
+              }}
+            >
+              <SelectTrigger className={selectTriggerClass}>
+                <SelectValue>
+                  {modelReasoningEffortLabel(model.reasoningEffort)}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent className="z-[110]">
+                {effortOptions.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : null}
+      </div>
+    ) : null;
 
   return (
     <div className={isList ? 'flex flex-col' : 'space-y-4'}>
@@ -88,7 +124,7 @@ export function ModelPickerInspectorPanel({
         providerLabel={providerLabel}
         density={density}
       >
-        {reasoningEffortControl}
+        {modelControls}
       </ModelCatalogDetailPanel>
     </div>
   );

--- a/apps/desktop/src/components/model-picker-inspector-panel.tsx
+++ b/apps/desktop/src/components/model-picker-inspector-panel.tsx
@@ -6,6 +6,7 @@ import {
   modelReasoningEffortOptions,
 } from '@spirit-agent/core/reasoning-effort';
 import {
+  modelEffortControlLabelKind,
   modelShowsReasoningEffortControl,
   modelSupportsThinkingSwitch,
   resolveModelThinkingEnabled,
@@ -66,6 +67,10 @@ export function ModelPickerInspectorPanel({
     pendingThinkingEnabled ?? resolveModelThinkingEnabled(model.thinkingEnabled);
   const showReasoningEffort = modelShowsReasoningEffortControl(modelContext, thinkingEnabled);
   const effortOptions = showReasoningEffort ? modelReasoningEffortOptions(modelContext) : [];
+  const effortLabelKey =
+    modelEffortControlLabelKind(modelContext) === 'effort'
+      ? 'app.modelPickerEffort'
+      : 'app.modelPickerReasoningEffort';
   const labelClass = isList ? DESKTOP_OVERLAY_LIST_DETAIL_LABEL : 'text-xs text-muted-foreground';
   const selectTriggerClass = isList
     ? 'h-7 w-auto border-0 bg-transparent px-0 text-xs shadow-none [&_span]:justify-end'
@@ -91,7 +96,7 @@ export function ModelPickerInspectorPanel({
         ) : null}
         {effortOptions.length > 1 ? (
           <div className="flex items-center justify-between gap-2">
-            <Label className={labelClass}>{t('app.modelPickerReasoningEffort')}</Label>
+            <Label className={labelClass}>{t(effortLabelKey)}</Label>
             <Select
               value={model.reasoningEffort}
               onValueChange={(value) => {

--- a/apps/desktop/src/components/model-picker-inspector-panel.tsx
+++ b/apps/desktop/src/components/model-picker-inspector-panel.tsx
@@ -37,7 +37,7 @@ type ModelPickerInspectorPanelProps = {
   providerLabel: string;
   density?: 'default' | 'list';
   onReasoningEffortChange: (modelName: string, effort: DesktopModelReasoningEffort) => void;
-  onThinkingEnabledChange?: (modelName: string, enabled: boolean) => void;
+  onThinkingEnabledChange?: (modelName: string, enabled: boolean) => void | Promise<boolean>;
 };
 
 export function ModelPickerInspectorPanel({
@@ -89,7 +89,13 @@ export function ModelPickerInspectorPanel({
               checked={thinkingEnabled}
               onCheckedChange={(checked) => {
                 setPendingThinkingEnabled(checked);
-                onThinkingEnabledChange?.(model.name, checked);
+                void Promise.resolve(onThinkingEnabledChange?.(model.name, checked)).then(
+                  (ok) => {
+                    if (ok === false) {
+                      setPendingThinkingEnabled(null);
+                    }
+                  },
+                );
               }}
             />
           </div>

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -98,6 +98,7 @@ export type ModelPickerMenuProps = {
   onOpenChange?(open: boolean): void;
   onModelSelect(name: string): void;
   onModelReasoningEffortSelect?(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
+  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void;
   triggerClassName?: string;
   menuContentClassName?: string;
 };
@@ -112,6 +113,7 @@ export function ModelPickerMenu({
   onOpenChange,
   onModelSelect,
   onModelReasoningEffortSelect,
+  onModelThinkingEnabledSelect,
   triggerClassName,
   menuContentClassName,
 }: ModelPickerMenuProps) {
@@ -316,10 +318,11 @@ export function ModelPickerMenu({
             )}
           >
             {(activeItem) => {
-              const model = activeItem as ModelPickerItem | null;
-              if (!model) {
+              const hoveredModel = activeItem as ModelPickerItem | null;
+              if (!hoveredModel) {
                 return null;
               }
+              const model = models.find((entry) => entry.name === hoveredModel.name) ?? hoveredModel;
               const group = filteredModelGroups.find((entry) =>
                 entry.items.some((item) => item.name === model.name),
               );
@@ -338,6 +341,9 @@ export function ModelPickerMenu({
                     onModelSelect(modelName);
                     setModelFilter("");
                     setModelMenuOpen(false);
+                  }}
+                  onThinkingEnabledChange={(modelName, enabled) => {
+                    onModelThinkingEnabledSelect?.(modelName, enabled);
                   }}
                 />
               );

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -378,17 +378,18 @@ function ModelPickerTriggerLabel({
       : {}),
     ...(model.transportKind ? { transportKind: model.transportKind } : {}),
   };
-  const showThinkingBadge =
-    modelSupportsThinkingSwitch(modelContext)
-    && resolveModelThinkingEnabled(model.thinkingEnabled);
+  const supportsThinkingSwitch = modelSupportsThinkingSwitch(modelContext);
+  const thinkingEnabled = resolveModelThinkingEnabled(model.thinkingEnabled);
+  const secondaryLabel =
+    supportsThinkingSwitch && !thinkingEnabled
+      ? t("app.modelPickerNotThinking")
+      : modelReasoningEffortLabel(reasoningEffort);
 
   return (
     <span className="inline-flex min-w-0 max-w-full items-baseline gap-1.5">
       <span className="min-w-0 truncate">{name}</span>
       <span className={cn("shrink-0", toolCardSecondaryTextClass)}>
-        {showThinkingBadge
-          ? t("app.modelPickerThinking")
-          : modelReasoningEffortLabel(reasoningEffort)}
+        {secondaryLabel}
       </span>
     </span>
   );

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -102,7 +102,7 @@ export type ModelPickerMenuProps = {
   onOpenChange?(open: boolean): void;
   onModelSelect(name: string): void;
   onModelReasoningEffortSelect?(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
-  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void;
+  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void | Promise<boolean>;
   triggerClassName?: string;
   menuContentClassName?: string;
 };

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -35,8 +35,12 @@ import {
 } from "@/lib/model-catalog-detail";
 import { toolCardSecondaryTextClass } from "@/lib/file-tool-lsp-diagnostics-display";
 import { modelReasoningEffortLabel } from "@spirit-agent/core/reasoning-effort";
+import {
+  modelSupportsThinkingSwitch,
+  resolveModelThinkingEnabled,
+} from "@spirit-agent/core/model-thinking-controls";
 import { groupModelsForPicker } from "@/lib/model-picker-groups";
-import type { DesktopModelReasoningEffort, DesktopSnapshot } from "@/types";
+import type { DesktopModelReasoningEffort, DesktopSnapshot, ModelProfileSnapshot } from "@/types";
 import { cn } from "@/lib/utils";
 
 type ModelPickerItem = DesktopSnapshot["config"]["models"][number];
@@ -265,6 +269,7 @@ export function ModelPickerMenu({
                       reasoningEffort={
                         activeReasoningEffort ?? activeModelProfile.reasoningEffort
                       }
+                      model={activeModelProfile}
                     />
                   ) : (
                     <span className="min-w-0 truncate">{activeModelName}</span>
@@ -358,15 +363,32 @@ export function ModelPickerMenu({
 function ModelPickerTriggerLabel({
   name,
   reasoningEffort,
+  model,
 }: {
   name: string;
   reasoningEffort: DesktopModelReasoningEffort;
+  model: ModelProfileSnapshot;
 }) {
+  const { t } = useTranslation();
+  const modelContext = {
+    ...(model.provider ? { provider: model.provider } : {}),
+    model: model.name,
+    ...(model.supportedReasoningEfforts !== undefined
+      ? { supportedEfforts: model.supportedReasoningEfforts }
+      : {}),
+    ...(model.transportKind ? { transportKind: model.transportKind } : {}),
+  };
+  const showThinkingBadge =
+    modelSupportsThinkingSwitch(modelContext)
+    && resolveModelThinkingEnabled(model.thinkingEnabled);
+
   return (
     <span className="inline-flex min-w-0 max-w-full items-baseline gap-1.5">
       <span className="min-w-0 truncate">{name}</span>
       <span className={cn("shrink-0", toolCardSecondaryTextClass)}>
-        {modelReasoningEffortLabel(reasoningEffort)}
+        {showThinkingBadge
+          ? t("app.modelPickerThinking")
+          : modelReasoningEffortLabel(reasoningEffort)}
       </span>
     </span>
   );

--- a/apps/desktop/src/components/ui/switch.tsx
+++ b/apps/desktop/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1898,6 +1898,25 @@ export function useDesktopRuntime() {
       settingsRef.current = next;
       setSettings(next);
 
+      const optimisticModels = snapshot.config.models.map((item) => {
+        if (item.name !== name) {
+          return item;
+        }
+        if (enabled) {
+          const { thinkingEnabled: _removed, ...rest } = item;
+          return rest;
+        }
+        return { ...item, thinkingEnabled: false as const };
+      });
+      applySnapshot({
+        ...snapshot,
+        config: {
+          ...snapshot.config,
+          activeModel: model.name,
+          models: optimisticModels,
+        },
+      });
+
       try {
         const res = await api.updateConfig({
           ...updateConfigFromSettingsForm(next, {
@@ -1911,6 +1930,7 @@ export function useDesktopRuntime() {
         setRuntimeError("");
         setSettings((current) => ({ ...current, apiKey: "" }));
       } catch (error) {
+        applySnapshot(snapshot);
         setRuntimeError(describeError(error));
       }
     },

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1879,6 +1879,44 @@ export function useDesktopRuntime() {
     [api, applySnapshot, snapshot],
   );
 
+  const setModelThinkingEnabled = useCallback(
+    async (name: string, enabled: boolean) => {
+      if (!api || !snapshot) {
+        return;
+      }
+
+      const model = snapshot.config.models.find((item) => item.name === name);
+      if (!model) {
+        return;
+      }
+
+      const next = {
+        ...settingsRef.current,
+        activeModel: model.name,
+        apiBase: model.apiBase,
+      };
+      settingsRef.current = next;
+      setSettings(next);
+
+      try {
+        const res = await api.updateConfig({
+          ...updateConfigFromSettingsForm(next, {
+            enabled: next.webHostEnabled,
+            host: next.webHostHost,
+            port: next.webHostPort,
+          }),
+          thinkingEnabled: enabled,
+        });
+        applySnapshot(res);
+        setRuntimeError("");
+        setSettings((current) => ({ ...current, apiKey: "" }));
+      } catch (error) {
+        setRuntimeError(describeError(error));
+      }
+    },
+    [api, applySnapshot, snapshot],
+  );
+
   const resetWebHostPairing = useCallback(async () => {
     if (!api) {
       return;
@@ -3031,6 +3069,7 @@ export function useDesktopRuntime() {
     approvalGuidance,
     setActiveModel,
     setModelReasoningEffort,
+    setModelThinkingEnabled,
     setApprovalGuidance,
     setAgentModeChipDismissed,
     setComposer,

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1880,42 +1880,24 @@ export function useDesktopRuntime() {
   );
 
   const setModelThinkingEnabled = useCallback(
-    async (name: string, enabled: boolean) => {
+    async (name: string, enabled: boolean): Promise<boolean> => {
       if (!api || !snapshot) {
-        return;
+        return false;
       }
 
       const model = snapshot.config.models.find((item) => item.name === name);
       if (!model) {
-        return;
+        return false;
       }
 
+      const previousSettings = settingsRef.current;
       const next = {
-        ...settingsRef.current,
+        ...previousSettings,
         activeModel: model.name,
         apiBase: model.apiBase,
       };
       settingsRef.current = next;
       setSettings(next);
-
-      const optimisticModels = snapshot.config.models.map((item) => {
-        if (item.name !== name) {
-          return item;
-        }
-        if (enabled) {
-          const { thinkingEnabled: _removed, ...rest } = item;
-          return rest;
-        }
-        return { ...item, thinkingEnabled: false as const };
-      });
-      applySnapshot({
-        ...snapshot,
-        config: {
-          ...snapshot.config,
-          activeModel: model.name,
-          models: optimisticModels,
-        },
-      });
 
       try {
         const res = await api.updateConfig({
@@ -1929,9 +1911,12 @@ export function useDesktopRuntime() {
         applySnapshot(res);
         setRuntimeError("");
         setSettings((current) => ({ ...current, apiKey: "" }));
+        return true;
       } catch (error) {
-        applySnapshot(snapshot);
+        settingsRef.current = previousSettings;
+        setSettings(previousSettings);
         setRuntimeError(describeError(error));
+        return false;
       }
     },
     [api, applySnapshot, snapshot],

--- a/apps/desktop/src/host/host-model-commands.ts
+++ b/apps/desktop/src/host/host-model-commands.ts
@@ -8,6 +8,7 @@ import {
   resolveModelReasoningEffortForContext,
   type ModelReasoningEffort,
 } from '@spirit-agent/core/reasoning-effort';
+import { shouldPinReasoningEffortToDefault } from '@spirit-agent/core/model-thinking-controls';
 
 import { resolveDesktopAgentMode } from '../lib/agent-mode.js';
 import { parseModelContextLength } from '../lib/context-usage.js';
@@ -130,6 +131,7 @@ export async function updateConfigCommand(
     const activeModel = request.activeModel.trim();
     const apiBase = request.apiBase.trim();
     const reasoningEffort = request.reasoningEffort;
+    const thinkingEnabled = request.thinkingEnabled;
     let existing = activeModel
       ? state.config.models.find((model) => model.name === activeModel)
       : undefined;
@@ -152,6 +154,24 @@ export async function updateConfigCommand(
               ? { supportedEfforts: existing.supportedReasoningEfforts }
               : {}),
           });
+        }
+        if (thinkingEnabled !== undefined) {
+          const modelContext = {
+            ...(existing.provider ? { provider: existing.provider } : {}),
+            model: existing.name,
+            ...(existing.transportKind ? { transportKind: existing.transportKind } : {}),
+            ...(existing.supportedReasoningEfforts !== undefined
+              ? { supportedEfforts: existing.supportedReasoningEfforts }
+              : {}),
+          };
+          if (thinkingEnabled) {
+            delete existing.thinkingEnabled;
+          } else {
+            existing.thinkingEnabled = false;
+          }
+          if (shouldPinReasoningEffortToDefault(thinkingEnabled, modelContext)) {
+            existing.reasoningEffort = resolveModelReasoningEffortForContext('default', modelContext);
+          }
         }
       } else {
         state.config.models.push({

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -9,7 +9,13 @@ import {
 import {
   resolveAnthropicTransportReasoningEffortForContext,
   resolveOpenAiTransportReasoningEffortForContext,
+  type ModelReasoningEffortContext,
 } from '@spirit-agent/core/reasoning-effort';
+import {
+  modelSupportsThinkingSwitch,
+  resolveVendorExtendedThinking,
+  shouldPinReasoningEffortToDefault,
+} from '@spirit-agent/core/model-thinking-controls';
 import {
   listProviderModels,
   resolveProviderConnectApiBase,
@@ -173,6 +179,73 @@ export function openAiCompatibleVendorFromProvider(
     : undefined;
 }
 
+type AgentModelProfileFields = Pick<
+  ModelProfileSnapshot,
+  | 'provider'
+  | 'transportKind'
+  | 'reasoningEffort'
+  | 'supportedReasoningEfforts'
+  | 'thinkingEnabled'
+>;
+
+function buildAgentModelReasoningContext(
+  profile: AgentModelProfileFields | undefined,
+  model: string,
+): ModelReasoningEffortContext {
+  return {
+    ...(profile?.provider ? { provider: profile.provider } : {}),
+    ...(profile?.transportKind ? { transportKind: profile.transportKind } : {}),
+    ...(profile?.supportedReasoningEfforts !== undefined
+      ? { supportedEfforts: profile.supportedReasoningEfforts }
+      : {}),
+    model,
+  };
+}
+
+function resolveAgentOpenAiReasoningEffort(
+  profile: AgentModelProfileFields | undefined,
+  model: string,
+  transportKind: NonNullable<ModelReasoningEffortContext['transportKind']>,
+) {
+  const context = {
+    ...buildAgentModelReasoningContext(profile, model),
+    transportKind,
+  };
+  const thinkingEnabled = profile?.thinkingEnabled !== false;
+  if (
+    modelSupportsThinkingSwitch(context)
+    && shouldPinReasoningEffortToDefault(thinkingEnabled, context)
+  ) {
+    return undefined;
+  }
+  return resolveOpenAiTransportReasoningEffortForContext(profile?.reasoningEffort, context);
+}
+
+function resolveAgentVendorExtendedThinking(
+  profile: AgentModelProfileFields | undefined,
+  model: string,
+): boolean | undefined {
+  const context = buildAgentModelReasoningContext(profile, model);
+  if (!modelSupportsThinkingSwitch(context)) {
+    return undefined;
+  }
+  return resolveVendorExtendedThinking(profile?.thinkingEnabled);
+}
+
+function resolveAgentAnthropicExplicitThinking(
+  profile: AgentModelProfileFields | undefined,
+  model: string,
+): AnthropicTransportConfig['thinking'] | undefined {
+  if (profile?.thinkingEnabled !== false) {
+    return undefined;
+  }
+  const context = buildAgentModelReasoningContext(profile, model);
+  if (!modelSupportsThinkingSwitch(context)) {
+    return undefined;
+  }
+  return { type: 'disabled' };
+}
+
 export function buildPrimaryTransportConfig(input: {
   apiKey: string;
   model: string;
@@ -188,6 +261,7 @@ export function buildPrimaryTransportConfig(input: {
     | 'capabilities'
     | 'reasoningEffort'
     | 'supportedReasoningEfforts'
+    | 'thinkingEnabled'
     | 'awsRegion'
     | 'vertexProject'
     | 'vertexLocation'
@@ -261,16 +335,10 @@ export function buildPrimaryTransportConfig(input: {
 
   if (transportKind === 'open-responses') {
     const llmVendor = openAiCompatibleVendorFromProvider(input.profile?.provider);
-    const normalizedReasoningEffort = resolveOpenAiTransportReasoningEffortForContext(
-      input.profile?.reasoningEffort,
-      {
-        ...(input.profile?.provider ? { provider: input.profile.provider } : {}),
-        transportKind: 'open-responses',
-        ...(input.profile?.supportedReasoningEfforts !== undefined
-          ? { supportedEfforts: input.profile.supportedReasoningEfforts }
-          : {}),
-        model: input.model,
-      },
+    const normalizedReasoningEffort = resolveAgentOpenAiReasoningEffort(
+      input.profile,
+      input.model,
+      'open-responses',
     );
     const responsesProvider: OpenResponsesSdkProvider | undefined =
       input.profile?.provider === 'openai'
@@ -320,6 +388,7 @@ export function buildPrimaryTransportConfig(input: {
         model: input.model,
       },
     );
+    const explicitThinking = resolveAgentAnthropicExplicitThinking(input.profile, input.model);
     return {
       transportKind: 'anthropic',
       apiKey: input.apiKey,
@@ -333,6 +402,7 @@ export function buildPrimaryTransportConfig(input: {
         ? { supportedEfforts: supportedAnthropicEfforts }
         : {}),
       ...(anthropicEffort ? { effort: anthropicEffort } : {}),
+      ...(explicitThinking ? { thinking: explicitThinking } : {}),
     };
   }
 
@@ -372,17 +442,12 @@ export function buildPrimaryTransportConfig(input: {
   }
 
   const llmVendor = openAiCompatibleVendorFromProvider(input.profile?.provider);
-  const normalizedReasoningEffort = resolveOpenAiTransportReasoningEffortForContext(
-    input.profile?.reasoningEffort,
-    {
-      ...(input.profile?.provider ? { provider: input.profile.provider } : {}),
-      ...(input.profile?.transportKind ? { transportKind: input.profile.transportKind } : {}),
-      ...(input.profile?.supportedReasoningEfforts !== undefined
-        ? { supportedEfforts: input.profile.supportedReasoningEfforts }
-        : {}),
-      model: input.model,
-    },
+  const normalizedReasoningEffort = resolveAgentOpenAiReasoningEffort(
+    input.profile,
+    input.model,
+    'openai-compatible',
   );
+  const vendorExtendedThinking = resolveAgentVendorExtendedThinking(input.profile, input.model);
   const vertexCredentials = input.googleVertexCredentials;
   const vertexProject = input.profile?.vertexProject?.trim();
   const vertexLocation = input.profile?.vertexLocation?.trim();
@@ -402,6 +467,7 @@ export function buildPrimaryTransportConfig(input: {
       ? { modelCapabilities: modelCapabilitiesFromConfig(input.profile.capabilities) }
       : {}),
     ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
+    ...(vendorExtendedThinking === false ? { vendorExtendedThinking: false as const } : {}),
   };
 }
 

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -13,6 +13,7 @@ import {
 } from '@spirit-agent/core/reasoning-effort';
 import {
   modelSupportsThinkingSwitch,
+  resolveAnthropicExplicitThinkingConfig,
   resolveVendorExtendedThinking,
   shouldPinReasoningEffortToDefault,
 } from '@spirit-agent/core/model-thinking-controls';
@@ -236,14 +237,8 @@ function resolveAgentAnthropicExplicitThinking(
   profile: AgentModelProfileFields | undefined,
   model: string,
 ): AnthropicTransportConfig['thinking'] | undefined {
-  if (profile?.thinkingEnabled !== false) {
-    return undefined;
-  }
   const context = buildAgentModelReasoningContext(profile, model);
-  if (!modelSupportsThinkingSwitch(context)) {
-    return undefined;
-  }
-  return { type: 'disabled' };
+  return resolveAnthropicExplicitThinkingConfig(profile?.thinkingEnabled, context);
 }
 
 export function buildPrimaryTransportConfig(input: {
@@ -354,6 +349,7 @@ export function buildPrimaryTransportConfig(input: {
       model: input.model,
       ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
     });
+    const vendorExtendedThinking = resolveAgentVendorExtendedThinking(input.profile, input.model);
 
     return {
       transportKind: 'open-responses',
@@ -370,6 +366,7 @@ export function buildPrimaryTransportConfig(input: {
         : {}),
       ...(normalizedReasoningEffort ? { reasoningEffort: normalizedReasoningEffort } : {}),
       ...(reasoningSummary ? { reasoningSummary } : {}),
+      ...(vendorExtendedThinking === false ? { vendorExtendedThinking: false as const } : {}),
     };
   }
 

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -77,6 +77,7 @@ export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopS
         name: model.name,
         apiBase: model.apiBase,
         reasoningEffort: model.reasoningEffort,
+        ...(model.thinkingEnabled === false ? { thinkingEnabled: false } : {}),
         ...(model.supportedReasoningEfforts !== undefined
           ? { supportedReasoningEfforts: [...model.supportedReasoningEfforts] }
           : {}),

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -899,6 +899,7 @@ function normalizeConfig(raw: Partial<DesktopConfigFile>): DesktopConfigFile {
             ...(vertexLocation ? { vertexLocation } : {}),
             ...(azureResourceName ? { azureResourceName } : {}),
             ...(contextLength !== undefined ? { contextLength } : {}),
+            ...(model.thinkingEnabled === false ? { thinkingEnabled: false } : {}),
           };
         })
         .filter((model): model is ModelProfileSnapshot => model !== null)

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -615,6 +615,7 @@
     "filterModels": "Filter models",
     "modelPickerContextTokens": "Context: {{value}} tokens",
     "modelPickerReasoningEffort": "Reasoning Effort",
+    "modelPickerThinking": "Thinking",
     "noModelsAvailable": "No models available",
     "abort": "Abort",
     "send": "Send",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -617,6 +617,7 @@
     "modelPickerReasoningEffort": "Reasoning Effort",
     "modelPickerEffort": "Effort",
     "modelPickerThinking": "Thinking",
+    "modelPickerNotThinking": "No Thinking",
     "noModelsAvailable": "No models available",
     "abort": "Abort",
     "send": "Send",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -615,6 +615,7 @@
     "filterModels": "Filter models",
     "modelPickerContextTokens": "Context: {{value}} tokens",
     "modelPickerReasoningEffort": "Reasoning Effort",
+    "modelPickerEffort": "Effort",
     "modelPickerThinking": "Thinking",
     "noModelsAvailable": "No models available",
     "abort": "Abort",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -612,6 +612,7 @@
     "filterModels": "筛选模型",
     "modelPickerContextTokens": "上下文：{{value}} tokens",
     "modelPickerReasoningEffort": "推理强度",
+    "modelPickerThinking": "思考",
     "noModelsAvailable": "无可用模型",
     "abort": "中止",
     "send": "发送",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -614,6 +614,7 @@
     "modelPickerReasoningEffort": "推理强度",
     "modelPickerEffort": "强度",
     "modelPickerThinking": "思考",
+    "modelPickerNotThinking": "不思考",
     "noModelsAvailable": "无可用模型",
     "abort": "中止",
     "send": "发送",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -612,6 +612,7 @@
     "filterModels": "筛选模型",
     "modelPickerContextTokens": "上下文：{{value}} tokens",
     "modelPickerReasoningEffort": "推理强度",
+    "modelPickerEffort": "强度",
     "modelPickerThinking": "思考",
     "noModelsAvailable": "无可用模型",
     "abort": "中止",

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -44,6 +44,8 @@ export interface UpdateConfigRequest {
   lightweightChatModel?: string;
   apiBase: string;
   reasoningEffort?: DesktopModelReasoningEffort;
+  /** 厂商 extended thinking；false 关闭。缺省不修改。 */
+  thinkingEnabled?: boolean;
   uiLocale?: string;
   apiKey?: string;
   /** 与 Rust `UpdateConfigRequest.windows_mica` 一致；缺省不修改已保存的 Mica 开关。 */
@@ -1152,6 +1154,8 @@ export interface ModelProfileSnapshot {
   name: string;
   apiBase: string;
   reasoningEffort: DesktopModelReasoningEffort;
+  /** 厂商 extended thinking；缺省 true。仅 thinking 型模型持久化 false。 */
+  thinkingEnabled?: boolean;
   supportedReasoningEfforts?: DesktopModelReasoningEffort[];
   capabilities?: DesktopModelCapability[];
   /** 持久化来源；缺省表示历史自定义配置。 */

--- a/apps/desktop/test/host/model-config-thinking.test.mjs
+++ b/apps/desktop/test/host/model-config-thinking.test.mjs
@@ -38,7 +38,7 @@ test('buildPrimaryTransportConfig disables DeepSeek V4 thinking and strips effor
   assert.equal(config.reasoningEffort, undefined);
 });
 
-test('buildPrimaryTransportConfig pins Z.ai effort when thinking enabled', () => {
+test('buildPrimaryTransportConfig wires Z.ai effort when thinking enabled', () => {
   const config = buildPrimaryTransportConfig({
     apiKey: 'test-key',
     model: 'glm-4.7',
@@ -52,7 +52,7 @@ test('buildPrimaryTransportConfig pins Z.ai effort when thinking enabled', () =>
     },
   });
   assert.equal(config.vendorExtendedThinking, undefined);
-  assert.equal(config.reasoningEffort, undefined);
+  assert.equal(config.reasoningEffort, 'medium');
 });
 
 test('buildPrimaryTransportConfig disables Alibaba thinking when thinkingEnabled false', () => {

--- a/apps/desktop/test/host/model-config-thinking.test.mjs
+++ b/apps/desktop/test/host/model-config-thinking.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { buildPrimaryTransportConfig } from '../../dist-electron/src/host/model-config.js';
+
+test('buildPrimaryTransportConfig wires DeepSeek V4 thinking on with high effort', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'deepseek-v4-pro',
+    baseUrl: 'https://api.deepseek.com/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'deepseek',
+      transportKind: 'openai-compatible',
+      reasoningEffort: 'high',
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, 'high');
+});
+
+test('buildPrimaryTransportConfig disables DeepSeek V4 thinking and strips effort', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'deepseek-v4-pro',
+    baseUrl: 'https://api.deepseek.com/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'deepseek',
+      transportKind: 'openai-compatible',
+      reasoningEffort: 'high',
+      thinkingEnabled: false,
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.vendorExtendedThinking, false);
+  assert.equal(config.reasoningEffort, undefined);
+});
+
+test('buildPrimaryTransportConfig pins Z.ai effort when thinking enabled', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'glm-4.7',
+    baseUrl: 'https://api.z.ai/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'z-ai',
+      transportKind: 'openai-compatible',
+      reasoningEffort: 'medium',
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, undefined);
+});
+
+test('buildPrimaryTransportConfig disables Alibaba thinking when thinkingEnabled false', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'qwen-plus',
+    baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'alibaba',
+      transportKind: 'openai-compatible',
+      reasoningEffort: 'default',
+      thinkingEnabled: false,
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.vendorExtendedThinking, false);
+});

--- a/apps/desktop/test/host/model-config-thinking.test.mjs
+++ b/apps/desktop/test/host/model-config-thinking.test.mjs
@@ -72,6 +72,25 @@ test('buildPrimaryTransportConfig disables Alibaba thinking when thinkingEnabled
   assert.equal(config.vendorExtendedThinking, false);
 });
 
+test('buildPrimaryTransportConfig wires Gateway Claude budget thinking off via vendorExtendedThinking', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'anthropic/claude-opus-4-5',
+    baseUrl: 'https://gateway.ai.vercel.com/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'vercel-ai-gateway',
+      transportKind: 'open-responses',
+      reasoningEffort: 'medium',
+      thinkingEnabled: false,
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.transportKind, 'open-responses');
+  assert.equal(config.vendorExtendedThinking, false);
+  assert.equal(config.reasoningEffort, 'medium');
+});
+
 test('buildPrimaryTransportConfig wires Gateway Claude adaptive thinking off via vendorExtendedThinking', () => {
   const config = buildPrimaryTransportConfig({
     apiKey: 'test-key',

--- a/apps/desktop/test/host/model-config-thinking.test.mjs
+++ b/apps/desktop/test/host/model-config-thinking.test.mjs
@@ -71,3 +71,40 @@ test('buildPrimaryTransportConfig disables Alibaba thinking when thinkingEnabled
   });
   assert.equal(config.vendorExtendedThinking, false);
 });
+
+test('buildPrimaryTransportConfig wires Gateway Claude adaptive thinking off via vendorExtendedThinking', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'anthropic/claude-opus-4-8',
+    baseUrl: 'https://gateway.ai.vercel.com/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'vercel-ai-gateway',
+      transportKind: 'open-responses',
+      reasoningEffort: 'high',
+      thinkingEnabled: false,
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.transportKind, 'open-responses');
+  assert.equal(config.vendorExtendedThinking, false);
+  assert.equal(config.reasoningEffort, 'high');
+});
+
+test('buildPrimaryTransportConfig wires Gateway Claude adaptive thinking on with effort', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'anthropic/claude-opus-4-8',
+    baseUrl: 'https://gateway.ai.vercel.com/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'vercel-ai-gateway',
+      transportKind: 'open-responses',
+      reasoningEffort: 'high',
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.transportKind, 'open-responses');
+  assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, 'high');
+});

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/reasoning-effort.d.ts",
       "default": "./dist/reasoning-effort.js"
     },
+    "./model-thinking-controls": {
+      "types": "./dist/model-thinking-controls.d.ts",
+      "default": "./dist/model-thinking-controls.js"
+    },
     "./model-display-name": {
       "types": "./dist/model-display-name.d.ts",
       "default": "./dist/model-display-name.js"

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   isDeepSeekReasoningOnlyModel,
+  modelShowsReasoningEffortControl,
   modelSupportsReasoningEffortWhileThinking,
   modelSupportsThinkingSwitch,
   modelUsesReasoningEffortPrimaryControl,
@@ -20,6 +21,33 @@ test('DeepSeek V4 supports thinking switch and effort while thinking', () => {
   assert.equal(modelSupportsThinkingSwitch(context), true);
   assert.equal(modelSupportsReasoningEffortWhileThinking(context), true);
   assert.equal(shouldPinReasoningEffortToDefault(true, context), false);
+  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
+});
+
+test('DeepSeek non-V4 thinking switch has no reasoning effort options', () => {
+  const context = {
+    provider: 'deepseek' as const,
+    model: 'deepseek-chat',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelSupportsReasoningEffortWhileThinking(context), false);
+  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
+});
+
+test('Z.ai shows reasoning effort when thinking enabled', () => {
+  const context = {
+    provider: 'z-ai' as const,
+    model: 'glm-4.7',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
+  assert.equal(shouldPinReasoningEffortToDefault(true, context), false);
+  assert.equal(shouldPinReasoningEffortToDefault(false, context), true);
 });
 
 test('DeepSeek R1 has no thinking switch', () => {
@@ -52,15 +80,15 @@ test('OpenAI uses reasoning effort primary control only', () => {
   assert.equal(modelSupportsThinkingSwitch(context), false);
 });
 
-test('Z.ai supports thinking switch with pinned effort when thinking on', () => {
+test('Gateway OpenAI slug uses reasoning effort primary control', () => {
   const context = {
-    provider: 'z-ai' as const,
-    model: 'glm-4.7',
-    transportKind: 'openai-compatible' as const,
+    provider: 'vercel-ai-gateway' as const,
+    model: 'openai/gpt-5.5',
+    transportKind: 'open-responses' as const,
   };
-  assert.equal(modelSupportsThinkingSwitch(context), true);
-  assert.equal(modelSupportsReasoningEffortWhileThinking(context), false);
-  assert.equal(shouldPinReasoningEffortToDefault(true, context), true);
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+  assert.equal(modelShowsReasoningEffortControl(context, false), true);
 });
 
 test('Gateway Claude slug uses reasoning effort primary control', () => {
@@ -80,6 +108,18 @@ test('Gateway DeepSeek slug supports thinking switch', () => {
     transportKind: 'openai-compatible' as const,
   };
   assert.equal(modelSupportsThinkingSwitch(context), true);
+});
+
+test('Gateway DeepSeek V4 shows reasoning effort when thinking enabled', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'deepseek/deepseek-v4-pro',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelSupportsReasoningEffortWhileThinking(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
 });
 
 test('resolveVendorExtendedThinking maps enabled default to undefined wire omission', () => {

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -29,15 +29,15 @@ test('DeepSeek V4 supports thinking switch and effort while thinking', () => {
   assert.equal(modelShowsReasoningEffortControl(context, false), false);
 });
 
-test('DeepSeek non-V4 thinking switch has no reasoning effort options', () => {
+test('DeepSeek non-V4 has no thinking switch or reasoning effort control', () => {
   const context = {
     provider: 'deepseek' as const,
     model: 'deepseek-chat',
     transportKind: 'openai-compatible' as const,
   };
-  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
   assert.equal(modelSupportsReasoningEffortWhileThinking(context), false);
-  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, true), false);
   assert.equal(modelShowsReasoningEffortControl(context, false), false);
 });
 
@@ -136,13 +136,23 @@ test('Gateway Claude without extended thinking stays hidden', () => {
   assert.equal(modelSupportsThinkingSwitch(context), false);
 });
 
-test('Gateway DeepSeek slug supports thinking switch', () => {
+test('Gateway DeepSeek non-V4 has no thinking switch', () => {
   const context = {
     provider: 'vercel-ai-gateway' as const,
     model: 'deepseek/deepseek-v3',
     transportKind: 'openai-compatible' as const,
   };
-  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+  assert.equal(modelShowsReasoningEffortControl(context, true), false);
+});
+
+test('Gateway DeepSeek V3.2 has no thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'deepseek/deepseek-v3.2',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), false);
 });
 
 test('Gateway DeepSeek V4 shows reasoning effort when thinking enabled', () => {

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  isDeepSeekReasoningOnlyModel,
+  modelSupportsReasoningEffortWhileThinking,
+  modelSupportsThinkingSwitch,
+  modelUsesReasoningEffortPrimaryControl,
+  resolveVendorExtendedThinking,
+  shouldPinReasoningEffortToDefault,
+} from './model-thinking-controls.js';
+
+test('DeepSeek V4 supports thinking switch and effort while thinking', () => {
+  const context = {
+    provider: 'deepseek' as const,
+    model: 'deepseek-v4-pro',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), false);
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelSupportsReasoningEffortWhileThinking(context), true);
+  assert.equal(shouldPinReasoningEffortToDefault(true, context), false);
+});
+
+test('DeepSeek R1 has no thinking switch', () => {
+  const context = {
+    provider: 'deepseek' as const,
+    model: 'deepseek-r1',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(isDeepSeekReasoningOnlyModel(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
+test('Moonshot uses reasoning effort primary control only', () => {
+  const context = {
+    provider: 'moonshot-ai' as const,
+    model: 'kimi-k2.5',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
+test('OpenAI uses reasoning effort primary control only', () => {
+  const context = {
+    provider: 'openai' as const,
+    model: 'gpt-5',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
+test('Z.ai supports thinking switch with pinned effort when thinking on', () => {
+  const context = {
+    provider: 'z-ai' as const,
+    model: 'glm-4.7',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelSupportsReasoningEffortWhileThinking(context), false);
+  assert.equal(shouldPinReasoningEffortToDefault(true, context), true);
+});
+
+test('Gateway Claude slug uses reasoning effort primary control', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'anthropic/claude-sonnet-4-6',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
+test('Gateway DeepSeek slug supports thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'deepseek/deepseek-v3',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+});
+
+test('resolveVendorExtendedThinking maps enabled default to undefined wire omission', () => {
+  assert.equal(resolveVendorExtendedThinking(undefined), undefined);
+  assert.equal(resolveVendorExtendedThinking(true), undefined);
+  assert.equal(resolveVendorExtendedThinking(false), false);
+});

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -64,11 +64,67 @@ test('DeepSeek R1 has no thinking switch', () => {
   assert.equal(modelSupportsThinkingSwitch(context), false);
 });
 
-test('Moonshot uses reasoning effort primary control only', () => {
+test('Moonshot kimi-k2 uses reasoning effort primary control only', () => {
+  const context = {
+    provider: 'moonshot-ai' as const,
+    model: 'kimi-k2',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
+test('Moonshot kimi-k2.5 supports thinking switch and effort when thinking enabled', () => {
   const context = {
     provider: 'moonshot-ai' as const,
     model: 'kimi-k2.5',
     transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), false);
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
+  assert.equal(shouldPinReasoningEffortToDefault(false, context), true);
+});
+
+test('Moonshot kimi-k2.7-code uses reasoning effort primary control only', () => {
+  const context = {
+    provider: 'moonshot-ai' as const,
+    model: 'kimi-k2.7-code',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+  assert.equal(modelShowsReasoningEffortControl(context, false), true);
+});
+
+test('Moonshot moonshot-v1 uses reasoning effort primary control only', () => {
+  const context = {
+    provider: 'moonshot-ai' as const,
+    model: 'moonshot-v1-8k',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
+test('Gateway Moonshot kimi-k2.5 supports thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'moonshotai/kimi-k2.5',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), false);
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
+});
+
+test('Gateway Moonshot kimi-k2.7-code uses reasoning effort primary control', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'moonshotai/kimi-k2.7-code',
+    transportKind: 'open-responses' as const,
   };
   assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
   assert.equal(modelSupportsThinkingSwitch(context), false);

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -140,6 +140,25 @@ test('Gateway Xiaomi mimo-v2-flash has no thinking switch', () => {
   assert.equal(modelSupportsThinkingSwitch(context), false);
 });
 
+test('Gateway Z.ai glm-4.7 supports thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'zai/glm-4.7',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
+});
+
+test('Gateway Z.ai glm-4 has no thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'zai/glm-4',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
 test('OpenAI uses reasoning effort primary control only', () => {
   const context = {
     provider: 'openai' as const,

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -159,6 +159,42 @@ test('Gateway Z.ai glm-4 has no thinking switch', () => {
   assert.equal(modelSupportsThinkingSwitch(context), false);
 });
 
+test('direct MiniMax M3 supports thinking switch', () => {
+  const context = {
+    provider: 'minimax' as const,
+    model: 'MiniMax-M3',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+});
+
+test('direct MiniMax M2.5 has no thinking switch', () => {
+  const context = {
+    provider: 'minimax' as const,
+    model: 'MiniMax-M2.5',
+    transportKind: 'openai-compatible' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
+test('Gateway MiniMax M3 supports thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'minimax/minimax-m3',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+});
+
+test('Gateway MiniMax M2.5 has no thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'minimax/MiniMax-M2.5',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+});
+
 test('OpenAI uses reasoning effort primary control only', () => {
   const context = {
     provider: 'openai' as const,

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -2,11 +2,14 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  isAnthropicClaudeAdaptiveThinkingModel,
   isDeepSeekReasoningOnlyModel,
+  modelEffortControlLabelKind,
   modelShowsReasoningEffortControl,
   modelSupportsReasoningEffortWhileThinking,
   modelSupportsThinkingSwitch,
   modelUsesReasoningEffortPrimaryControl,
+  resolveAnthropicExplicitThinkingConfig,
   resolveVendorExtendedThinking,
   shouldPinReasoningEffortToDefault,
 } from './model-thinking-controls.js';
@@ -89,16 +92,34 @@ test('Gateway OpenAI slug uses reasoning effort primary control', () => {
   assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
   assert.equal(modelSupportsThinkingSwitch(context), false);
   assert.equal(modelShowsReasoningEffortControl(context, false), true);
+  assert.equal(modelEffortControlLabelKind(context), 'reasoningEffort');
 });
 
-test('Gateway Claude slug uses reasoning effort primary control', () => {
+test('Gateway Claude adaptive supports thinking switch and effort label', () => {
   const context = {
     provider: 'vercel-ai-gateway' as const,
-    model: 'anthropic/claude-sonnet-4-6',
+    model: 'anthropic/claude-opus-4-8',
     transportKind: 'open-responses' as const,
   };
+  assert.equal(isAnthropicClaudeAdaptiveThinkingModel(context), true);
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), false);
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, true), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), true);
+  assert.equal(shouldPinReasoningEffortToDefault(false, context), false);
+  assert.equal(modelEffortControlLabelKind(context), 'effort');
+});
+
+test('Gateway Claude legacy budget uses effort primary control without thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'anthropic/claude-sonnet-4-5',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(isAnthropicClaudeAdaptiveThinkingModel(context), false);
   assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
   assert.equal(modelSupportsThinkingSwitch(context), false);
+  assert.equal(modelEffortControlLabelKind(context), 'effort');
 });
 
 test('Gateway DeepSeek slug supports thinking switch', () => {
@@ -120,6 +141,25 @@ test('Gateway DeepSeek V4 shows reasoning effort when thinking enabled', () => {
   assert.equal(modelSupportsReasoningEffortWhileThinking(context), true);
   assert.equal(modelShowsReasoningEffortControl(context, true), true);
   assert.equal(modelShowsReasoningEffortControl(context, false), false);
+});
+
+test('resolveAnthropicExplicitThinkingConfig maps adaptive and disabled', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'anthropic/claude-opus-4-8',
+    transportKind: 'open-responses' as const,
+  };
+  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(undefined, context), {
+    type: 'adaptive',
+    display: 'summarized',
+  });
+  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(true, context), {
+    type: 'adaptive',
+    display: 'summarized',
+  });
+  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(false, context), {
+    type: 'disabled',
+  });
 });
 
 test('resolveVendorExtendedThinking maps enabled default to undefined wire omission', () => {

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   isAnthropicClaudeAdaptiveThinkingModel,
+  isAnthropicClaudeBudgetThinkingModel,
   isDeepSeekReasoningOnlyModel,
   modelEffortControlLabelKind,
   modelShowsReasoningEffortControl,
@@ -110,16 +111,29 @@ test('Gateway Claude adaptive supports thinking switch and effort label', () => 
   assert.equal(modelEffortControlLabelKind(context), 'effort');
 });
 
-test('Gateway Claude legacy budget uses effort primary control without thinking switch', () => {
+test('Gateway Claude legacy budget supports thinking switch without effort control', () => {
   const context = {
     provider: 'vercel-ai-gateway' as const,
-    model: 'anthropic/claude-sonnet-4-5',
+    model: 'anthropic/claude-opus-4-5',
     transportKind: 'open-responses' as const,
   };
   assert.equal(isAnthropicClaudeAdaptiveThinkingModel(context), false);
-  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(isAnthropicClaudeBudgetThinkingModel(context), true);
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), false);
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, true), false);
+  assert.equal(modelEffortControlLabelKind(context), 'reasoningEffort');
+});
+
+test('Gateway Claude without extended thinking stays hidden', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'anthropic/claude-3-5-sonnet',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(isAnthropicClaudeBudgetThinkingModel(context), false);
+  assert.equal(isAnthropicClaudeAdaptiveThinkingModel(context), false);
   assert.equal(modelSupportsThinkingSwitch(context), false);
-  assert.equal(modelEffortControlLabelKind(context), 'effort');
 });
 
 test('Gateway DeepSeek slug supports thinking switch', () => {
@@ -144,19 +158,32 @@ test('Gateway DeepSeek V4 shows reasoning effort when thinking enabled', () => {
 });
 
 test('resolveAnthropicExplicitThinkingConfig maps adaptive and disabled', () => {
-  const context = {
+  const adaptiveContext = {
     provider: 'vercel-ai-gateway' as const,
     model: 'anthropic/claude-opus-4-8',
     transportKind: 'open-responses' as const,
   };
-  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(undefined, context), {
+  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(undefined, adaptiveContext), {
     type: 'adaptive',
     display: 'summarized',
   });
-  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(true, context), {
+  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(true, adaptiveContext), {
     type: 'adaptive',
     display: 'summarized',
   });
+  assert.deepEqual(resolveAnthropicExplicitThinkingConfig(false, adaptiveContext), {
+    type: 'disabled',
+  });
+});
+
+test('resolveAnthropicExplicitThinkingConfig maps budget disabled only', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'anthropic/claude-opus-4-5',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(resolveAnthropicExplicitThinkingConfig(undefined, context), undefined);
+  assert.equal(resolveAnthropicExplicitThinkingConfig(true, context), undefined);
   assert.deepEqual(resolveAnthropicExplicitThinkingConfig(false, context), {
     type: 'disabled',
   });

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -120,13 +120,23 @@ test('Gateway Moonshot kimi-k2.5 supports thinking switch', () => {
   assert.equal(modelShowsReasoningEffortControl(context, false), false);
 });
 
-test('Gateway Moonshot kimi-k2.7-code uses reasoning effort primary control', () => {
+test('Gateway Xiaomi mimo-v2.5 supports thinking switch', () => {
   const context = {
     provider: 'vercel-ai-gateway' as const,
-    model: 'moonshotai/kimi-k2.7-code',
-    transportKind: 'open-responses' as const,
+    model: 'xiaomi/mimo-v2.5',
+    transportKind: 'openai-compatible' as const,
   };
-  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), true);
+  assert.equal(modelShowsReasoningEffortControl(context, false), false);
+  assert.equal(shouldPinReasoningEffortToDefault(false, context), true);
+});
+
+test('Gateway Xiaomi mimo-v2-flash has no thinking switch', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'xiaomi/mimo-v2-flash',
+    transportKind: 'openai-compatible' as const,
+  };
   assert.equal(modelSupportsThinkingSwitch(context), false);
 });
 

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -10,6 +10,7 @@ import {
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
 import { isMoonshotThinkingSwitchModel } from './openai/moonshot-thinking-switch.js';
 import { isXiaomiThinkingSwitchEligibleModel } from './openai/gateway-xiaomi-thinking.js';
+import { isZaiThinkingSwitchEligibleModel } from './openai/gateway-zai-thinking.js';
 import {
   isRoutedAnthropicClaudeModel,
   resolveRoutedAnthropicClaudeCapabilities,
@@ -137,6 +138,9 @@ function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): bo
   }
   if (slug === 'xiaomi') {
     return isXiaomiThinkingSwitchEligibleModel(context.model ?? '');
+  }
+  if (slug === 'zai') {
+    return isZaiThinkingSwitchEligibleModel(context.model ?? '');
   }
   return true;
 }

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -8,6 +8,7 @@ import {
   isXaiReasoningEffortModel,
 } from './reasoning-effort.js';
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
+import { isMoonshotThinkingSwitchModel } from './openai/moonshot-thinking-switch.js';
 import {
   isRoutedAnthropicClaudeModel,
   resolveRoutedAnthropicClaudeCapabilities,
@@ -28,7 +29,6 @@ const GATEWAY_REASONING_EFFORT_SLUGS = new Set([
   'openai',
   'google',
   'anthropic',
-  'moonshotai',
   'xai',
 ]);
 
@@ -131,6 +131,9 @@ function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): bo
   if (slug === 'deepseek') {
     return isDeepSeekV4ReasoningEffortModel(context);
   }
+  if (slug === 'moonshotai') {
+    return isMoonshotThinkingSwitchModel(context);
+  }
   return true;
 }
 
@@ -141,7 +144,13 @@ function isGatewayReasoningEffortPrimaryControlModel(
     return false;
   }
   const slug = parseGatewayUpstreamSlug(context.model ?? '');
-  return slug !== undefined && GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
+  if (slug === undefined) {
+    return false;
+  }
+  if (slug === 'moonshotai') {
+    return !isMoonshotThinkingSwitchModel(context);
+  }
+  return GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
 }
 
 /** OpenAI / Reasoning Effort 主控厂商：不显示 Thinking 开关（不含 DeepSeek V4 hybrid 与 Claude switchable）。 */
@@ -162,7 +171,10 @@ export function modelUsesReasoningEffortPrimaryControl(
   if (provider === 'anthropic') {
     return true;
   }
-  if (isXaiReasoningEffortModel(context) || isMoonshotReasoningEffortModel(context)) {
+  if (isXaiReasoningEffortModel(context)) {
+    return true;
+  }
+  if (isMoonshotReasoningEffortModel(context) && !isMoonshotThinkingSwitchModel(context)) {
     return true;
   }
   if (isGoogleReasoningEffortModel(context)) {
@@ -194,6 +206,9 @@ export function modelSupportsThinkingSwitch(context?: ModelReasoningEffortContex
     return true;
   }
   if (isDeepSeekThinkingSwitchModel(context)) {
+    return true;
+  }
+  if (isMoonshotThinkingSwitchModel(context)) {
     return true;
   }
   if (isGatewayThinkingSwitchModel(context)) {

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -1,0 +1,150 @@
+import type { ModelReasoningEffortContext } from './reasoning-effort.js';
+import {
+  isDeepSeekV4ReasoningEffortModel,
+  isGatewayAnthropicClaudeReasoningModel,
+  isGoogleReasoningEffortModel,
+  isMoonshotReasoningEffortModel,
+  isOpenRouterAnthropicClaudeReasoningModel,
+  isXaiReasoningEffortModel,
+} from './reasoning-effort.js';
+import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
+
+const DIRECT_THINKING_SWITCH_PROVIDERS = new Set([
+  'z-ai',
+  'zhipu-ai',
+  'minimax',
+  'xiaomi',
+  'volcengine',
+  'alibaba',
+  'siliconflow',
+]);
+
+const GATEWAY_REASONING_EFFORT_SLUGS = new Set([
+  'openai',
+  'google',
+  'anthropic',
+  'moonshotai',
+  'xai',
+]);
+
+function normalizeModelId(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+/** DeepSeek R1 / reasoner：始终思考，无 thinking toggle。 */
+export function isDeepSeekReasoningOnlyModel(context?: ModelReasoningEffortContext): boolean {
+  if (context?.provider !== 'deepseek') {
+    return false;
+  }
+  const model = normalizeModelId(context.model);
+  return model.includes('deepseek-reasoner')
+    || model.includes('deepseek-r1')
+    || model === 'deepseek-r1';
+}
+
+function isDeepSeekThinkingSwitchModel(context?: ModelReasoningEffortContext): boolean {
+  if (context?.provider !== 'deepseek') {
+    return false;
+  }
+  if (isDeepSeekReasoningOnlyModel(context)) {
+    return false;
+  }
+  return true;
+}
+
+function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): boolean {
+  if (context?.provider !== 'vercel-ai-gateway') {
+    return false;
+  }
+  const slug = parseGatewayUpstreamSlug(context.model ?? '');
+  if (slug === undefined) {
+    return false;
+  }
+  return !GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
+}
+
+/** OpenAI / Reasoning Effort 主控厂商：不显示 Thinking 开关（不含 DeepSeek V4 hybrid）。 */
+export function modelUsesReasoningEffortPrimaryControl(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  if (isDeepSeekV4ReasoningEffortModel(context)) {
+    return false;
+  }
+
+  const provider = context?.provider;
+  if (provider === 'openai' || provider === 'azure' || provider === 'amazon-bedrock') {
+    return true;
+  }
+  if (provider === 'anthropic') {
+    return true;
+  }
+  if (isXaiReasoningEffortModel(context) || isMoonshotReasoningEffortModel(context)) {
+    return true;
+  }
+  if (isGoogleReasoningEffortModel(context)) {
+    return true;
+  }
+  if (isGatewayAnthropicClaudeReasoningModel(context) || isOpenRouterAnthropicClaudeReasoningModel(context)) {
+    return true;
+  }
+
+  return false;
+}
+
+export function modelSupportsThinkingSwitch(context?: ModelReasoningEffortContext): boolean {
+  if (modelUsesReasoningEffortPrimaryControl(context)) {
+    return false;
+  }
+  if (isDeepSeekReasoningOnlyModel(context)) {
+    return false;
+  }
+
+  const provider = context?.provider;
+  if (provider !== undefined && DIRECT_THINKING_SWITCH_PROVIDERS.has(provider)) {
+    return true;
+  }
+  if (isDeepSeekThinkingSwitchModel(context)) {
+    return true;
+  }
+  if (isGatewayThinkingSwitchModel(context)) {
+    return true;
+  }
+
+  return false;
+}
+
+/** DeepSeek V4 等 hybrid：thinking 开启时 Reasoning Effort 仍可调。 */
+export function modelSupportsReasoningEffortWhileThinking(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  return isDeepSeekV4ReasoningEffortModel(context);
+}
+
+export function resolveVendorExtendedThinking(thinkingEnabled?: boolean): boolean | undefined {
+  if (thinkingEnabled === false) {
+    return false;
+  }
+  return undefined;
+}
+
+export function shouldPinReasoningEffortToDefault(
+  thinkingEnabled: boolean | undefined,
+  context?: ModelReasoningEffortContext,
+): boolean {
+  if (thinkingEnabled === false) {
+    return true;
+  }
+  if (thinkingEnabled === undefined || thinkingEnabled === true) {
+    if (modelSupportsReasoningEffortWhileThinking(context)) {
+      return false;
+    }
+    if (modelSupportsThinkingSwitch(context)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolveModelThinkingEnabled(thinkingEnabled?: boolean): boolean {
+  return thinkingEnabled !== false;
+}

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -8,6 +8,7 @@ import {
   isXaiReasoningEffortModel,
 } from './reasoning-effort.js';
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
+import { isMinimaxM3ThinkingSwitchModel } from './openai/gateway-minimax-thinking.js';
 import { isMoonshotThinkingSwitchModel } from './openai/moonshot-thinking-switch.js';
 import { isXiaomiThinkingSwitchEligibleModel } from './openai/gateway-xiaomi-thinking.js';
 import { isZaiThinkingSwitchEligibleModel } from './openai/gateway-zai-thinking.js';
@@ -20,7 +21,6 @@ import {
 const DIRECT_THINKING_SWITCH_PROVIDERS = new Set([
   'z-ai',
   'zhipu-ai',
-  'minimax',
   'xiaomi',
   'volcengine',
   'alibaba',
@@ -142,6 +142,9 @@ function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): bo
   if (slug === 'zai') {
     return isZaiThinkingSwitchEligibleModel(context.model ?? '');
   }
+  if (slug === 'minimax') {
+    return isMinimaxM3ThinkingSwitchModel(context.model ?? '');
+  }
   return true;
 }
 
@@ -210,6 +213,9 @@ export function modelSupportsThinkingSwitch(context?: ModelReasoningEffortContex
   }
 
   const provider = context?.provider;
+  if (provider === 'minimax') {
+    return isMinimaxM3ThinkingSwitchModel(context?.model ?? '');
+  }
   if (provider !== undefined && DIRECT_THINKING_SWITCH_PROVIDERS.has(provider)) {
     return true;
   }

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -63,6 +63,16 @@ function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): bo
   return !GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
 }
 
+function isGatewayReasoningEffortPrimaryControlModel(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  if (context?.provider !== 'vercel-ai-gateway') {
+    return false;
+  }
+  const slug = parseGatewayUpstreamSlug(context.model ?? '');
+  return slug !== undefined && GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
+}
+
 /** OpenAI / Reasoning Effort 主控厂商：不显示 Thinking 开关（不含 DeepSeek V4 hybrid）。 */
 export function modelUsesReasoningEffortPrimaryControl(
   context?: ModelReasoningEffortContext,
@@ -82,6 +92,9 @@ export function modelUsesReasoningEffortPrimaryControl(
     return true;
   }
   if (isGoogleReasoningEffortModel(context)) {
+    return true;
+  }
+  if (isGatewayReasoningEffortPrimaryControlModel(context)) {
     return true;
   }
   if (isGatewayAnthropicClaudeReasoningModel(context) || isOpenRouterAnthropicClaudeReasoningModel(context)) {
@@ -113,11 +126,28 @@ export function modelSupportsThinkingSwitch(context?: ModelReasoningEffortContex
   return false;
 }
 
-/** DeepSeek V4 等 hybrid：thinking 开启时 Reasoning Effort 仍可调。 */
+/** DeepSeek V4：仅 thinking 开启时 API 接受 reasoning_effort（high/max）。 */
 export function modelSupportsReasoningEffortWhileThinking(
   context?: ModelReasoningEffortContext,
 ): boolean {
   return isDeepSeekV4ReasoningEffortModel(context);
+}
+
+/**
+ * Inspector：是否允许展示 Reasoning Effort 控件。
+ * Reasoning Effort 主控模型始终展示；thinking 型模型仅在 thinking 开启时展示（具体档位由 modelReasoningEffortOptions 决定）。
+ */
+export function modelShowsReasoningEffortControl(
+  context?: ModelReasoningEffortContext,
+  thinkingEnabled?: boolean,
+): boolean {
+  if (modelUsesReasoningEffortPrimaryControl(context)) {
+    return true;
+  }
+  if (!modelSupportsThinkingSwitch(context)) {
+    return false;
+  }
+  return thinkingEnabled !== false;
 }
 
 export function resolveVendorExtendedThinking(thinkingEnabled?: boolean): boolean | undefined {
@@ -127,22 +157,15 @@ export function resolveVendorExtendedThinking(thinkingEnabled?: boolean): boolea
   return undefined;
 }
 
+/** thinking 关闭时剥离 reasoning effort；开启时保留用户所选档位（含 Z.ai / DeepSeek V4）。 */
 export function shouldPinReasoningEffortToDefault(
   thinkingEnabled: boolean | undefined,
   context?: ModelReasoningEffortContext,
 ): boolean {
-  if (thinkingEnabled === false) {
-    return true;
+  if (modelUsesReasoningEffortPrimaryControl(context)) {
+    return false;
   }
-  if (thinkingEnabled === undefined || thinkingEnabled === true) {
-    if (modelSupportsReasoningEffortWhileThinking(context)) {
-      return false;
-    }
-    if (modelSupportsThinkingSwitch(context)) {
-      return true;
-    }
-  }
-  return false;
+  return thinkingEnabled === false;
 }
 
 export function resolveModelThinkingEnabled(thinkingEnabled?: boolean): boolean {

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -113,7 +113,7 @@ function isDeepSeekThinkingSwitchModel(context?: ModelReasoningEffortContext): b
   if (isDeepSeekReasoningOnlyModel(context)) {
     return false;
   }
-  return true;
+  return isDeepSeekV4ReasoningEffortModel(context);
 }
 
 function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): boolean {
@@ -124,7 +124,14 @@ function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): bo
   if (slug === undefined) {
     return false;
   }
-  return !GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
+  if (GATEWAY_REASONING_EFFORT_SLUGS.has(slug)) {
+    return false;
+  }
+  // DeepSeek V3 及以下靠模型名区分 thinking 变体，无 extended thinking 开关。
+  if (slug === 'deepseek') {
+    return isDeepSeekV4ReasoningEffortModel(context);
+  }
+  return true;
 }
 
 function isGatewayReasoningEffortPrimaryControlModel(

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -9,6 +9,7 @@ import {
 } from './reasoning-effort.js';
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
 import { isMoonshotThinkingSwitchModel } from './openai/moonshot-thinking-switch.js';
+import { isXiaomiThinkingSwitchEligibleModel } from './openai/gateway-xiaomi-thinking.js';
 import {
   isRoutedAnthropicClaudeModel,
   resolveRoutedAnthropicClaudeCapabilities,
@@ -133,6 +134,9 @@ function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): bo
   }
   if (slug === 'moonshotai') {
     return isMoonshotThinkingSwitchModel(context);
+  }
+  if (slug === 'xiaomi') {
+    return isXiaomiThinkingSwitchEligibleModel(context.model ?? '');
   }
   return true;
 }

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -2,12 +2,10 @@ import type { AnthropicThinkingConfig } from './anthropic/anthropic-compat.js';
 import type { ModelReasoningEffortContext } from './reasoning-effort.js';
 import {
   isDeepSeekV4ReasoningEffortModel,
-  isGatewayAnthropicClaudeReasoningModel,
   isGoogleReasoningEffortModel,
   isMoonshotReasoningEffortModel,
   isOpenRouterAnthropicClaudeReasoningModel,
   isXaiReasoningEffortModel,
-  isAnthropicReasoningEffortModel,
 } from './reasoning-effort.js';
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
 import {
@@ -62,19 +60,33 @@ function resolveAnthropicClaudeCapabilitiesForContext(
   return resolveRoutedAnthropicClaudeCapabilities(modelId);
 }
 
-/** Anthropic Claude（直连 / Gateway / OpenRouter）：UI 与 wire 语义为 Effort，非 Reasoning Effort。 */
+/** Claude adaptive thinking（4.6+）：UI Effort 控件与 output_config.effort 语义。 */
 export function isAnthropicClaudeEffortModel(context?: ModelReasoningEffortContext): boolean {
-  return isAnthropicReasoningEffortModel(context)
-    || isGatewayAnthropicClaudeReasoningModel(context)
-    || isOpenRouterAnthropicClaudeReasoningModel(context);
+  return isAnthropicClaudeAdaptiveThinkingModel(context);
 }
 
-/** Claude adaptive thinking：可开关 thinking.type=adaptive，并与 Effort 共存。 */
+/** Claude adaptive thinking（4.6+）：开启时 thinking.type=adaptive。 */
 export function isAnthropicClaudeAdaptiveThinkingModel(
   context?: ModelReasoningEffortContext,
 ): boolean {
   const capabilities = resolveAnthropicClaudeCapabilitiesForContext(context);
   return capabilities?.thinkingMode === 'adaptive';
+}
+
+/** Claude budget thinking（4.5 及更早支持 extended thinking 的型号）：开启时 thinking.type=enabled。 */
+export function isAnthropicClaudeBudgetThinkingModel(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  const capabilities = resolveAnthropicClaudeCapabilitiesForContext(context);
+  return capabilities?.thinkingMode === 'budget';
+}
+
+/** Claude 可开关 thinking（adaptive 或 budget）；thinkingMode=none 的型号不在此列。 */
+export function isAnthropicClaudeSwitchableThinkingModel(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  return isAnthropicClaudeAdaptiveThinkingModel(context)
+    || isAnthropicClaudeBudgetThinkingModel(context);
 }
 
 export function modelEffortControlLabelKind(
@@ -125,11 +137,11 @@ function isGatewayReasoningEffortPrimaryControlModel(
   return slug !== undefined && GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
 }
 
-/** OpenAI / Reasoning Effort 主控厂商：不显示 Thinking 开关（不含 DeepSeek V4 hybrid 与 Claude adaptive）。 */
+/** OpenAI / Reasoning Effort 主控厂商：不显示 Thinking 开关（不含 DeepSeek V4 hybrid 与 Claude switchable）。 */
 export function modelUsesReasoningEffortPrimaryControl(
   context?: ModelReasoningEffortContext,
 ): boolean {
-  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
+  if (isAnthropicClaudeSwitchableThinkingModel(context)) {
     return false;
   }
   if (isDeepSeekV4ReasoningEffortModel(context)) {
@@ -160,7 +172,7 @@ export function modelUsesReasoningEffortPrimaryControl(
 }
 
 export function modelSupportsThinkingSwitch(context?: ModelReasoningEffortContext): boolean {
-  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
+  if (isAnthropicClaudeSwitchableThinkingModel(context)) {
     return true;
   }
   if (modelUsesReasoningEffortPrimaryControl(context)) {
@@ -193,15 +205,18 @@ export function modelSupportsReasoningEffortWhileThinking(
 
 /**
  * Inspector：是否展示 Effort / Reasoning Effort 控件。
- * Claude Effort 模型始终展示；Reasoning Effort 主控模型始终展示；
- * 其余 thinking 型模型仅在 thinking 开启时展示。
+ * Claude adaptive（4.6+）始终展示 Effort；budget 型 Claude 仅 Thinking 开关；
+ * Reasoning Effort 主控模型始终展示；其余 thinking 型模型仅在 thinking 开启时展示。
  */
 export function modelShowsReasoningEffortControl(
   context?: ModelReasoningEffortContext,
   thinkingEnabled?: boolean,
 ): boolean {
-  if (isAnthropicClaudeEffortModel(context)) {
+  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
     return true;
+  }
+  if (isAnthropicClaudeBudgetThinkingModel(context)) {
+    return false;
   }
   if (modelUsesReasoningEffortPrimaryControl(context)) {
     return true;
@@ -219,12 +234,12 @@ export function resolveVendorExtendedThinking(thinkingEnabled?: boolean): boolea
   return undefined;
 }
 
-/** thinking 关闭时剥离 reasoning effort；Claude Effort 与 Reasoning Effort 主控模型保留用户档位。 */
+/** thinking 关闭时剥离 reasoning effort；Claude adaptive Effort 与 Reasoning Effort 主控模型保留用户档位。 */
 export function shouldPinReasoningEffortToDefault(
   thinkingEnabled: boolean | undefined,
   context?: ModelReasoningEffortContext,
 ): boolean {
-  if (isAnthropicClaudeEffortModel(context)) {
+  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
     return false;
   }
   if (modelUsesReasoningEffortPrimaryControl(context)) {
@@ -237,22 +252,28 @@ export function resolveModelThinkingEnabled(thinkingEnabled?: boolean): boolean 
   return thinkingEnabled !== false;
 }
 
-/** Anthropic 直连 transport：显式 thinking 配置（adaptive / disabled）。 */
+/** Anthropic 直连 transport：显式 thinking 配置（adaptive / enabled / disabled）。 */
 export function resolveAnthropicExplicitThinkingConfig(
   thinkingEnabled: boolean | undefined,
   context?: ModelReasoningEffortContext,
 ): AnthropicThinkingConfig | undefined {
-  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
+  const capabilities = resolveAnthropicClaudeCapabilitiesForContext(context);
+
+  if (capabilities?.thinkingMode === 'adaptive') {
     if (thinkingEnabled === false) {
       return { type: 'disabled' };
     }
-    const capabilities = resolveAnthropicClaudeCapabilitiesForContext(context);
-    if (capabilities?.thinkingMode === 'adaptive') {
-      return {
-        type: 'adaptive',
-        ...(capabilities.adaptiveDisplay ? { display: capabilities.adaptiveDisplay } : {}),
-      };
+    return {
+      type: 'adaptive',
+      ...(capabilities.adaptiveDisplay ? { display: capabilities.adaptiveDisplay } : {}),
+    };
+  }
+
+  if (capabilities?.thinkingMode === 'budget') {
+    if (thinkingEnabled === false) {
+      return { type: 'disabled' };
     }
+    return undefined;
   }
 
   if (thinkingEnabled === false && modelSupportsThinkingSwitch(context)) {

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -1,3 +1,4 @@
+import type { AnthropicThinkingConfig } from './anthropic/anthropic-compat.js';
 import type { ModelReasoningEffortContext } from './reasoning-effort.js';
 import {
   isDeepSeekV4ReasoningEffortModel,
@@ -6,8 +7,14 @@ import {
   isMoonshotReasoningEffortModel,
   isOpenRouterAnthropicClaudeReasoningModel,
   isXaiReasoningEffortModel,
+  isAnthropicReasoningEffortModel,
 } from './reasoning-effort.js';
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
+import {
+  isRoutedAnthropicClaudeModel,
+  resolveRoutedAnthropicClaudeCapabilities,
+  type RoutedAnthropicClaudeCapabilities,
+} from './openai/routed-anthropic-claude-capabilities.js';
 
 const DIRECT_THINKING_SWITCH_PROVIDERS = new Set([
   'z-ai',
@@ -27,8 +34,53 @@ const GATEWAY_REASONING_EFFORT_SLUGS = new Set([
   'xai',
 ]);
 
+export type ModelEffortControlLabelKind = 'effort' | 'reasoningEffort';
+
 function normalizeModelId(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function routedAnthropicModelId(context?: ModelReasoningEffortContext): string | undefined {
+  const model = context?.model?.trim();
+  if (!model) {
+    return undefined;
+  }
+  if (isRoutedAnthropicClaudeModel(model)) {
+    return model;
+  }
+  const prefixed = `anthropic/${model}`;
+  return isRoutedAnthropicClaudeModel(prefixed) ? prefixed : undefined;
+}
+
+function resolveAnthropicClaudeCapabilitiesForContext(
+  context?: ModelReasoningEffortContext,
+): RoutedAnthropicClaudeCapabilities | undefined {
+  const modelId = routedAnthropicModelId(context);
+  if (modelId === undefined) {
+    return undefined;
+  }
+  return resolveRoutedAnthropicClaudeCapabilities(modelId);
+}
+
+/** Anthropic Claude（直连 / Gateway / OpenRouter）：UI 与 wire 语义为 Effort，非 Reasoning Effort。 */
+export function isAnthropicClaudeEffortModel(context?: ModelReasoningEffortContext): boolean {
+  return isAnthropicReasoningEffortModel(context)
+    || isGatewayAnthropicClaudeReasoningModel(context)
+    || isOpenRouterAnthropicClaudeReasoningModel(context);
+}
+
+/** Claude adaptive thinking：可开关 thinking.type=adaptive，并与 Effort 共存。 */
+export function isAnthropicClaudeAdaptiveThinkingModel(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  const capabilities = resolveAnthropicClaudeCapabilitiesForContext(context);
+  return capabilities?.thinkingMode === 'adaptive';
+}
+
+export function modelEffortControlLabelKind(
+  context?: ModelReasoningEffortContext,
+): ModelEffortControlLabelKind {
+  return isAnthropicClaudeEffortModel(context) ? 'effort' : 'reasoningEffort';
 }
 
 /** DeepSeek R1 / reasoner：始终思考，无 thinking toggle。 */
@@ -73,10 +125,13 @@ function isGatewayReasoningEffortPrimaryControlModel(
   return slug !== undefined && GATEWAY_REASONING_EFFORT_SLUGS.has(slug);
 }
 
-/** OpenAI / Reasoning Effort 主控厂商：不显示 Thinking 开关（不含 DeepSeek V4 hybrid）。 */
+/** OpenAI / Reasoning Effort 主控厂商：不显示 Thinking 开关（不含 DeepSeek V4 hybrid 与 Claude adaptive）。 */
 export function modelUsesReasoningEffortPrimaryControl(
   context?: ModelReasoningEffortContext,
 ): boolean {
+  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
+    return false;
+  }
   if (isDeepSeekV4ReasoningEffortModel(context)) {
     return false;
   }
@@ -97,7 +152,7 @@ export function modelUsesReasoningEffortPrimaryControl(
   if (isGatewayReasoningEffortPrimaryControlModel(context)) {
     return true;
   }
-  if (isGatewayAnthropicClaudeReasoningModel(context) || isOpenRouterAnthropicClaudeReasoningModel(context)) {
+  if (isOpenRouterAnthropicClaudeReasoningModel(context)) {
     return true;
   }
 
@@ -105,6 +160,9 @@ export function modelUsesReasoningEffortPrimaryControl(
 }
 
 export function modelSupportsThinkingSwitch(context?: ModelReasoningEffortContext): boolean {
+  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
+    return true;
+  }
   if (modelUsesReasoningEffortPrimaryControl(context)) {
     return false;
   }
@@ -134,13 +192,17 @@ export function modelSupportsReasoningEffortWhileThinking(
 }
 
 /**
- * Inspector：是否允许展示 Reasoning Effort 控件。
- * Reasoning Effort 主控模型始终展示；thinking 型模型仅在 thinking 开启时展示（具体档位由 modelReasoningEffortOptions 决定）。
+ * Inspector：是否展示 Effort / Reasoning Effort 控件。
+ * Claude Effort 模型始终展示；Reasoning Effort 主控模型始终展示；
+ * 其余 thinking 型模型仅在 thinking 开启时展示。
  */
 export function modelShowsReasoningEffortControl(
   context?: ModelReasoningEffortContext,
   thinkingEnabled?: boolean,
 ): boolean {
+  if (isAnthropicClaudeEffortModel(context)) {
+    return true;
+  }
   if (modelUsesReasoningEffortPrimaryControl(context)) {
     return true;
   }
@@ -157,11 +219,14 @@ export function resolveVendorExtendedThinking(thinkingEnabled?: boolean): boolea
   return undefined;
 }
 
-/** thinking 关闭时剥离 reasoning effort；开启时保留用户所选档位（含 Z.ai / DeepSeek V4）。 */
+/** thinking 关闭时剥离 reasoning effort；Claude Effort 与 Reasoning Effort 主控模型保留用户档位。 */
 export function shouldPinReasoningEffortToDefault(
   thinkingEnabled: boolean | undefined,
   context?: ModelReasoningEffortContext,
 ): boolean {
+  if (isAnthropicClaudeEffortModel(context)) {
+    return false;
+  }
   if (modelUsesReasoningEffortPrimaryControl(context)) {
     return false;
   }
@@ -170,4 +235,29 @@ export function shouldPinReasoningEffortToDefault(
 
 export function resolveModelThinkingEnabled(thinkingEnabled?: boolean): boolean {
   return thinkingEnabled !== false;
+}
+
+/** Anthropic 直连 transport：显式 thinking 配置（adaptive / disabled）。 */
+export function resolveAnthropicExplicitThinkingConfig(
+  thinkingEnabled: boolean | undefined,
+  context?: ModelReasoningEffortContext,
+): AnthropicThinkingConfig | undefined {
+  if (isAnthropicClaudeAdaptiveThinkingModel(context)) {
+    if (thinkingEnabled === false) {
+      return { type: 'disabled' };
+    }
+    const capabilities = resolveAnthropicClaudeCapabilitiesForContext(context);
+    if (capabilities?.thinkingMode === 'adaptive') {
+      return {
+        type: 'adaptive',
+        ...(capabilities.adaptiveDisplay ? { display: capabilities.adaptiveDisplay } : {}),
+      };
+    }
+  }
+
+  if (thinkingEnabled === false && modelSupportsThinkingSwitch(context)) {
+    return { type: 'disabled' };
+  }
+
+  return undefined;
 }

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -125,6 +125,23 @@ test('buildResponsesProviderOptions maps gateway openai reasoning options', () =
   });
 });
 
+test('buildResponsesProviderOptions maps gateway xai reasoning via xai namespace', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'xai/grok-4.3',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'none',
+    }),
+    {
+      xai: {
+        reasoningEffort: 'none',
+      },
+    },
+  );
+});
+
 test('buildResponsesProviderOptions maps gateway anthropic claude to adaptive thinking', () => {
   assert.deepEqual(
     buildResponsesProviderOptions({

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -281,3 +281,22 @@ test('buildResponsesProviderOptions routes gateway code-completion by upstream s
     },
   );
 });
+
+test('buildResponsesProviderOptions disables Gateway DeepSeek V4 thinking via deepseek namespace', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'deepseek/deepseek-v4-pro',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'default',
+      reasoningSummary: 'auto',
+      vendorExtendedThinking: false,
+    }),
+    {
+      deepseek: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -159,6 +159,37 @@ test('buildResponsesProviderOptions maps gateway alibaba qwen to enable_thinking
   );
 });
 
+test('buildResponsesProviderOptions maps gateway minimax m3 to adaptive thinking', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'minimax/minimax-m3',
+      llmVendor: 'vercel-ai-gateway',
+    }),
+    {
+      minimax: {
+        thinking: { type: 'adaptive' },
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'minimax/minimax-m3',
+      llmVendor: 'vercel-ai-gateway',
+      vendorExtendedThinking: false,
+    }),
+    {
+      minimax: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+});
+
 test('buildResponsesProviderOptions maps gateway anthropic claude to adaptive thinking', () => {
   assert.deepEqual(
     buildResponsesProviderOptions({

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -142,6 +142,23 @@ test('buildResponsesProviderOptions maps gateway xai reasoning via xai namespace
   );
 });
 
+test('buildResponsesProviderOptions maps gateway alibaba qwen to enable_thinking false', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'alibaba/qwen3-max',
+      llmVendor: 'vercel-ai-gateway',
+      vendorExtendedThinking: false,
+    }),
+    {
+      alibaba: {
+        enableThinking: false,
+      },
+    },
+  );
+});
+
 test('buildResponsesProviderOptions maps gateway anthropic claude to adaptive thinking', () => {
   assert.deepEqual(
     buildResponsesProviderOptions({

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -29,6 +29,10 @@ import {
   shouldUseOpenAiSdkApplyPatchTool,
 } from './apply-patch-eligibility.js';
 import {
+  buildGatewayMinimaxProviderOptions,
+  isGatewayMinimaxModel,
+} from '../openai/gateway-minimax-thinking.js';
+import {
   buildGatewayAlibabaProviderOptions,
   isGatewayAlibabaModel,
 } from '../openai/gateway-alibaba-thinking.js';
@@ -282,6 +286,14 @@ export function buildResponsesProviderOptions(
       const alibabaOptions = buildGatewayAlibabaProviderOptions(config);
       if (Object.keys(alibabaOptions).length > 0) {
         return alibabaOptions;
+      }
+    }
+
+    if (isGatewayMinimaxModel(config.llmVendor, config.model)) {
+      const minimaxOptions = buildGatewayMinimaxProviderOptions(config);
+      if (Object.keys(minimaxOptions).length > 0) {
+        // Gateway MiniMax M3 经 open-responses 当前不产出 reasoning-delta，Thought UI 仍可能为空。
+        return minimaxOptions;
       }
     }
 

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -49,6 +49,10 @@ import {
   isGatewayXiaomiModel,
 } from '../openai/gateway-xiaomi-thinking.js';
 import {
+  buildGatewayZaiProviderOptions,
+  isGatewayZaiModel,
+} from '../openai/gateway-zai-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   isGatewayGoogleGeminiModel,
 } from '../openai/gateway-google-thinking.js';
@@ -254,6 +258,13 @@ export function buildResponsesProviderOptions(
       const xiaomiOptions = buildGatewayXiaomiProviderOptions(config);
       if (Object.keys(xiaomiOptions).length > 0) {
         return xiaomiOptions;
+      }
+    }
+
+    if (isGatewayZaiModel(config.llmVendor, config.model)) {
+      const zaiOptions = buildGatewayZaiProviderOptions(config);
+      if (Object.keys(zaiOptions).length > 0) {
+        return zaiOptions;
       }
     }
 

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -41,6 +41,10 @@ import {
   isGatewayDeepSeekModel,
 } from '../openai/gateway-deepseek-thinking.js';
 import {
+  buildGatewayMoonshotProviderOptions,
+  isGatewayMoonshotModel,
+} from '../openai/moonshot-thinking-switch.js';
+import {
   buildGatewayGoogleProviderOptions,
   isGatewayGoogleGeminiModel,
 } from '../openai/gateway-google-thinking.js';
@@ -233,6 +237,13 @@ export function buildResponsesProviderOptions(
 
     if (isGatewayDeepSeekModel(config.llmVendor, config.model)) {
       return buildGatewayDeepSeekProviderOptions(config);
+    }
+
+    if (isGatewayMoonshotModel(config.llmVendor, config.model)) {
+      const moonshotOptions = buildGatewayMoonshotProviderOptions(config);
+      if (Object.keys(moonshotOptions).length > 0) {
+        return moonshotOptions;
+      }
     }
 
     // Gateway v3 language-model 原样转发 providerOptions；OpenAI 路由模型须用 openai 命名空间（见 Vercel AI Gateway reasoning 文档）。

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -37,6 +37,10 @@ import {
   shouldUseGatewayCodeCompletionProviderOptions,
 } from '../openai/gateway-code-completion-thinking.js';
 import {
+  buildGatewayDeepSeekProviderOptions,
+  isGatewayDeepSeekModel,
+} from '../openai/gateway-deepseek-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   isGatewayGoogleGeminiModel,
 } from '../openai/gateway-google-thinking.js';
@@ -225,6 +229,10 @@ export function buildResponsesProviderOptions(
 
     if (isGatewayGoogleGeminiModel(config.llmVendor, config.model)) {
       return buildGatewayGoogleProviderOptions(config, reasoningEffort);
+    }
+
+    if (isGatewayDeepSeekModel(config.llmVendor, config.model)) {
+      return buildGatewayDeepSeekProviderOptions(config);
     }
 
     // Gateway v3 language-model 原样转发 providerOptions；OpenAI 路由模型须用 openai 命名空间（见 Vercel AI Gateway reasoning 文档）。

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -53,6 +53,11 @@ import {
   isGatewayZaiModel,
 } from '../openai/gateway-zai-thinking.js';
 import {
+  buildGatewayXaiProviderOptions,
+  isGatewayXaiModel,
+  resolveXaiProviderReasoningEffort,
+} from '../openai/gateway-xai-reasoning.js';
+import {
   buildGatewayGoogleProviderOptions,
   isGatewayGoogleGeminiModel,
 } from '../openai/gateway-google-thinking.js';
@@ -269,6 +274,17 @@ export function buildResponsesProviderOptions(
       }
     }
 
+    if (isGatewayXaiModel(config.llmVendor, config.model)) {
+      const xaiOptions = buildGatewayXaiProviderOptions(
+        config.llmVendor,
+        config.model,
+        openResponsesReasoningEffort(config),
+      );
+      if (Object.keys(xaiOptions).length > 0) {
+        return xaiOptions;
+      }
+    }
+
     // Gateway v3 language-model 原样转发 providerOptions；OpenAI 路由模型须用 openai 命名空间（见 Vercel AI Gateway reasoning 文档）。
     const openaiOptions: JsonObject = {
       ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
@@ -280,13 +296,16 @@ export function buildResponsesProviderOptions(
 
   const provider = resolveOpenResponsesSdkProvider(config);
   if (provider === 'xai') {
-    const xaiOptions = {
-      ...(xaiResponsesReasoningEffort(reasoningEffort) !== undefined
-        ? { reasoningEffort: xaiResponsesReasoningEffort(reasoningEffort) }
-        : {}),
-    } satisfies XaiLanguageModelResponsesOptions;
+    const xaiReasoningEffort = resolveXaiProviderReasoningEffort(reasoningEffort);
+    if (xaiReasoningEffort === undefined) {
+      return {};
+    }
 
-    return Object.keys(xaiOptions).length > 0 ? { xai: xaiOptions as JsonObject } : {};
+    return {
+      xai: {
+        reasoningEffort: xaiReasoningEffort,
+      } as JsonObject,
+    };
   }
 
   if (provider === 'azure') {
@@ -351,12 +370,6 @@ export function buildResponsesProviderOptions(
   }
 
   return { openai: openaiOptions };
-}
-
-function xaiResponsesReasoningEffort(
-  effort: string | undefined,
-): XaiLanguageModelResponsesOptions['reasoningEffort'] | undefined {
-  return effort === 'low' || effort === 'medium' || effort === 'high' ? effort : undefined;
 }
 
 function shouldAttachPreviousResponseId(config: OpenResponsesTransportConfig): boolean {

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -264,6 +264,7 @@ export function buildResponsesProviderOptions(
     if (isGatewayZaiModel(config.llmVendor, config.model)) {
       const zaiOptions = buildGatewayZaiProviderOptions(config);
       if (Object.keys(zaiOptions).length > 0) {
+        // Gateway Z.ai 在 open-responses transport 下上游不返回可展示思考流；见 #169。
         return zaiOptions;
       }
     }

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -292,7 +292,7 @@ export function buildResponsesProviderOptions(
     if (isGatewayMinimaxModel(config.llmVendor, config.model)) {
       const minimaxOptions = buildGatewayMinimaxProviderOptions(config);
       if (Object.keys(minimaxOptions).length > 0) {
-        // Gateway MiniMax M3 经 open-responses 当前不产出 reasoning-delta，Thought UI 仍可能为空。
+        // Gateway MiniMax M3 在 open-responses 下不返回可展示思考流；见 #170。
         return minimaxOptions;
       }
     }

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -45,6 +45,10 @@ import {
   isGatewayMoonshotModel,
 } from '../openai/moonshot-thinking-switch.js';
 import {
+  buildGatewayXiaomiProviderOptions,
+  isGatewayXiaomiModel,
+} from '../openai/gateway-xiaomi-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   isGatewayGoogleGeminiModel,
 } from '../openai/gateway-google-thinking.js';
@@ -243,6 +247,13 @@ export function buildResponsesProviderOptions(
       const moonshotOptions = buildGatewayMoonshotProviderOptions(config);
       if (Object.keys(moonshotOptions).length > 0) {
         return moonshotOptions;
+      }
+    }
+
+    if (isGatewayXiaomiModel(config.llmVendor, config.model)) {
+      const xiaomiOptions = buildGatewayXiaomiProviderOptions(config);
+      if (Object.keys(xiaomiOptions).length > 0) {
+        return xiaomiOptions;
       }
     }
 

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -29,6 +29,10 @@ import {
   shouldUseOpenAiSdkApplyPatchTool,
 } from './apply-patch-eligibility.js';
 import {
+  buildGatewayAlibabaProviderOptions,
+  isGatewayAlibabaModel,
+} from '../openai/gateway-alibaba-thinking.js';
+import {
   buildGatewayAnthropicProviderOptions,
   isGatewayAnthropicClaudeModel,
 } from '../openai/gateway-anthropic-thinking.js';
@@ -271,6 +275,13 @@ export function buildResponsesProviderOptions(
       if (Object.keys(zaiOptions).length > 0) {
         // Gateway Z.ai 在 open-responses transport 下上游不返回可展示思考流；见 #169。
         return zaiOptions;
+      }
+    }
+
+    if (isGatewayAlibabaModel(config.llmVendor, config.model)) {
+      const alibabaOptions = buildGatewayAlibabaProviderOptions(config);
+      if (Object.keys(alibabaOptions).length > 0) {
+        return alibabaOptions;
       }
     }
 

--- a/packages/agent-core/src/open-responses/responses-compat.ts
+++ b/packages/agent-core/src/open-responses/responses-compat.ts
@@ -66,6 +66,8 @@ export interface OpenResponsesTransportConfig {
   azureResourceName?: string;
   /** 代码补全等非 Agent 轻量请求的策略画像；缺省为 agent 路径默认行为。 */
   transportRequestProfile?: TransportRequestProfile;
+  /** 厂商 extended thinking；false 关闭 Claude / DeepSeek 等 thinking 开关。 */
+  vendorExtendedThinking?: boolean;
 }
 
 export type OpenResponsesRequestTraceKind =

--- a/packages/agent-core/src/open-responses/xai-responses.test.ts
+++ b/packages/agent-core/src/open-responses/xai-responses.test.ts
@@ -28,6 +28,12 @@ test('xAI responses provider resolves official SDK, options, and trace kind', ()
   assert.deepEqual(buildResponsesProviderOptions(xaiConfig), {
     xai: { reasoningEffort: 'medium' },
   });
+  assert.deepEqual(
+    buildResponsesProviderOptions({ ...xaiConfig, reasoningEffort: 'none' }),
+    {
+      xai: { reasoningEffort: 'none' },
+    },
+  );
 
   const trace = buildOpenResponsesRequestTrace(
     xaiConfig,

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -94,6 +94,11 @@ import {
   isGatewayDeepSeekModel,
 } from './gateway-deepseek-thinking.js';
 import {
+  buildGatewayMoonshotProviderOptions,
+  isGatewayMoonshotModel,
+  isMoonshotThinkingSwitchModel,
+} from './moonshot-thinking-switch.js';
+import {
   buildGatewayGoogleProviderOptions,
   buildGoogleThinkingConfigForEffort,
   isGatewayGoogleGeminiModel,
@@ -931,6 +936,13 @@ function buildAiSdkProviderOptions(
     return buildGatewayDeepSeekProviderOptions(config);
   }
 
+  if (isVercelAiGatewayProvider(config) && isGatewayMoonshotModel(config.llmVendor, config.model)) {
+    const moonshotOptions = buildGatewayMoonshotProviderOptions(config);
+    if (Object.keys(moonshotOptions).length > 0) {
+      return moonshotOptions;
+    }
+  }
+
   if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {
     return {};
   }
@@ -979,6 +991,15 @@ function buildAiSdkProviderOptions(
   }
 
   if (isMoonshotOfficialAiSdkProvider(config)) {
+    const moonshotContext = {
+      provider: 'moonshot-ai' as const,
+      model: config.model,
+      transportKind: 'openai-compatible' as const,
+    };
+    if (!isMoonshotThinkingSwitchModel(moonshotContext)) {
+      return {};
+    }
+
     const moonshotaiOptions = {
       thinking: {
         type: config.vendorExtendedThinking === false ? 'disabled' : 'enabled',

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -18,7 +18,6 @@ import {
 } from '@ai-sdk/moonshotai';
 import {
   createXai,
-  type XaiLanguageModelChatOptions,
 } from '@ai-sdk/xai';
 import { createGateway } from '@ai-sdk/gateway';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -106,6 +105,11 @@ import {
   buildGatewayZaiProviderOptions,
   isGatewayZaiModel,
 } from './gateway-zai-thinking.js';
+import {
+  buildGatewayXaiProviderOptions,
+  isGatewayXaiModel,
+  resolveXaiProviderReasoningEffort,
+} from './gateway-xai-reasoning.js';
 import {
   buildGatewayGoogleProviderOptions,
   buildGoogleThinkingConfigForEffort,
@@ -965,6 +969,17 @@ function buildAiSdkProviderOptions(
     }
   }
 
+  if (isVercelAiGatewayProvider(config) && isGatewayXaiModel(config.llmVendor, config.model)) {
+    const xaiOptions = buildGatewayXaiProviderOptions(
+      config.llmVendor,
+      config.model,
+      openAiReasoningEffort(config),
+    );
+    if (Object.keys(xaiOptions).length > 0) {
+      return xaiOptions;
+    }
+  }
+
   if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {
     return {};
   }
@@ -1034,17 +1049,15 @@ function buildAiSdkProviderOptions(
   }
 
   if (isXaiOfficialAiSdkProvider(config)) {
-    const reasoningEffort = xaiChatReasoningEffort(openAiReasoningEffort(config));
+    const reasoningEffort = resolveXaiProviderReasoningEffort(openAiReasoningEffort(config));
     if (reasoningEffort === undefined) {
       return {};
     }
 
-    const xaiOptions = {
-      reasoningEffort,
-    } satisfies XaiLanguageModelChatOptions;
-
     return {
-      xai: xaiOptions as JsonObject,
+      xai: {
+        reasoningEffort,
+      } as JsonObject,
     };
   }
 
@@ -1856,16 +1869,6 @@ function isGoogleOfficialAiSdkProvider(config: OpenAiTransportConfig): boolean {
 
 function isGoogleVertexOfficialAiSdkProvider(config: OpenAiTransportConfig): boolean {
   return config.llmVendor === 'google-vertex-ai';
-}
-
-function xaiChatReasoningEffort(
-  effort: string | undefined,
-): XaiLanguageModelChatOptions['reasoningEffort'] | undefined {
-  if (effort === 'low' || effort === 'high') {
-    return effort;
-  }
-
-  return effort === 'medium' ? 'high' : undefined;
 }
 
 function buildAiSdkImageGenerationUrl(config: OpenAiImageGenerationConfig): string {

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -103,6 +103,10 @@ import {
   isGatewayXiaomiModel,
 } from './gateway-xiaomi-thinking.js';
 import {
+  buildGatewayZaiProviderOptions,
+  isGatewayZaiModel,
+} from './gateway-zai-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   buildGoogleThinkingConfigForEffort,
   isGatewayGoogleGeminiModel,
@@ -951,6 +955,13 @@ function buildAiSdkProviderOptions(
     const xiaomiOptions = buildGatewayXiaomiProviderOptions(config);
     if (Object.keys(xiaomiOptions).length > 0) {
       return xiaomiOptions;
+    }
+  }
+
+  if (isVercelAiGatewayProvider(config) && isGatewayZaiModel(config.llmVendor, config.model)) {
+    const zaiOptions = buildGatewayZaiProviderOptions(config);
+    if (Object.keys(zaiOptions).length > 0) {
+      return zaiOptions;
     }
   }
 

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -81,6 +81,10 @@ import {
   type OpenAiVideoGenerationConfig,
 } from './openai-compat.js';
 import {
+  buildGatewayMinimaxProviderOptions,
+  isGatewayMinimaxModel,
+} from './gateway-minimax-thinking.js';
+import {
   buildGatewayAlibabaProviderOptions,
   isGatewayAlibabaModel,
 } from './gateway-alibaba-thinking.js';
@@ -977,6 +981,13 @@ function buildAiSdkProviderOptions(
     const alibabaOptions = buildGatewayAlibabaProviderOptions(config);
     if (Object.keys(alibabaOptions).length > 0) {
       return alibabaOptions;
+    }
+  }
+
+  if (isVercelAiGatewayProvider(config) && isGatewayMinimaxModel(config.llmVendor, config.model)) {
+    const minimaxOptions = buildGatewayMinimaxProviderOptions(config);
+    if (Object.keys(minimaxOptions).length > 0) {
+      return minimaxOptions;
     }
   }
 

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -90,6 +90,10 @@ import {
   shouldUseGatewayCodeCompletionProviderOptions,
 } from './gateway-code-completion-thinking.js';
 import {
+  buildGatewayDeepSeekProviderOptions,
+  isGatewayDeepSeekModel,
+} from './gateway-deepseek-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   buildGoogleThinkingConfigForEffort,
   isGatewayGoogleGeminiModel,
@@ -921,6 +925,10 @@ function buildAiSdkProviderOptions(
 
   if (isVercelAiGatewayProvider(config) && isGatewayGoogleGeminiModel(config.llmVendor, config.model)) {
     return buildGatewayGoogleProviderOptions(config, openAiReasoningEffort(config));
+  }
+
+  if (isVercelAiGatewayProvider(config) && isGatewayDeepSeekModel(config.llmVendor, config.model)) {
+    return buildGatewayDeepSeekProviderOptions(config);
   }
 
   if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -936,18 +936,25 @@ function buildAiSdkProviderOptions(
       };
     }
 
+    const alibabaOptions: JsonObject = {};
+    if (config.vendorExtendedThinking === false) {
+      alibabaOptions.enable_thinking = false;
+    }
+
     const extraBody = shouldUseAlibabaChatCompletionsBuiltInTools(config)
       ? buildAlibabaChatCompletionsExtraBody({ streaming: true })
       : undefined;
 
-    if (extraBody === undefined) {
+    if (extraBody !== undefined) {
+      alibabaOptions.extraBody = extraBody;
+    }
+
+    if (Object.keys(alibabaOptions).length === 0) {
       return {};
     }
 
     return {
-      alibaba: {
-        extraBody,
-      } as JsonObject,
+      alibaba: alibabaOptions,
     };
   }
 

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -99,6 +99,10 @@ import {
   isMoonshotThinkingSwitchModel,
 } from './moonshot-thinking-switch.js';
 import {
+  buildGatewayXiaomiProviderOptions,
+  isGatewayXiaomiModel,
+} from './gateway-xiaomi-thinking.js';
+import {
   buildGatewayGoogleProviderOptions,
   buildGoogleThinkingConfigForEffort,
   isGatewayGoogleGeminiModel,
@@ -940,6 +944,13 @@ function buildAiSdkProviderOptions(
     const moonshotOptions = buildGatewayMoonshotProviderOptions(config);
     if (Object.keys(moonshotOptions).length > 0) {
       return moonshotOptions;
+    }
+  }
+
+  if (isVercelAiGatewayProvider(config) && isGatewayXiaomiModel(config.llmVendor, config.model)) {
+    const xiaomiOptions = buildGatewayXiaomiProviderOptions(config);
+    if (Object.keys(xiaomiOptions).length > 0) {
+      return xiaomiOptions;
     }
   }
 

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -81,6 +81,10 @@ import {
   type OpenAiVideoGenerationConfig,
 } from './openai-compat.js';
 import {
+  buildGatewayAlibabaProviderOptions,
+  isGatewayAlibabaModel,
+} from './gateway-alibaba-thinking.js';
+import {
   buildGatewayAnthropicProviderOptions,
   isGatewayAnthropicClaudeModel,
 } from './gateway-anthropic-thinking.js';
@@ -969,6 +973,13 @@ function buildAiSdkProviderOptions(
     }
   }
 
+  if (isVercelAiGatewayProvider(config) && isGatewayAlibabaModel(config.llmVendor, config.model)) {
+    const alibabaOptions = buildGatewayAlibabaProviderOptions(config);
+    if (Object.keys(alibabaOptions).length > 0) {
+      return alibabaOptions;
+    }
+  }
+
   if (isVercelAiGatewayProvider(config) && isGatewayXaiModel(config.llmVendor, config.model)) {
     const xaiOptions = buildGatewayXaiProviderOptions(
       config.llmVendor,
@@ -988,14 +999,14 @@ function buildAiSdkProviderOptions(
     if (isCodeCompletionTransportProfile(config)) {
       return {
         alibaba: {
-          enable_thinking: false,
+          enableThinking: false,
         } as JsonObject,
       };
     }
 
     const alibabaOptions: JsonObject = {};
     if (config.vendorExtendedThinking === false) {
-      alibabaOptions.enable_thinking = false;
+      alibabaOptions.enableThinking = false;
     }
 
     const extraBody = shouldUseAlibabaChatCompletionsBuiltInTools(config)

--- a/packages/agent-core/src/openai/gateway-alibaba-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-alibaba-thinking.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayAlibabaProviderOptions,
+  isGatewayAlibabaModel,
+} from './gateway-alibaba-thinking.js';
+
+test('isGatewayAlibabaModel matches vercel-ai-gateway alibaba routes only', () => {
+  assert.equal(isGatewayAlibabaModel('vercel-ai-gateway', 'alibaba/qwen3-max'), true);
+  assert.equal(isGatewayAlibabaModel('vercel-ai-gateway', 'openai/gpt-5'), false);
+  assert.equal(isGatewayAlibabaModel('alibaba', 'qwen3-max'), false);
+});
+
+test('buildGatewayAlibabaProviderOptions disables thinking via alibaba namespace', () => {
+  assert.deepEqual(
+    buildGatewayAlibabaProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'alibaba/qwen3-max',
+      vendorExtendedThinking: false,
+    }),
+    {
+      alibaba: {
+        enableThinking: false,
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayAlibabaProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'alibaba/qwen3-max',
+    }),
+    {},
+  );
+});

--- a/packages/agent-core/src/openai/gateway-alibaba-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-alibaba-thinking.ts
@@ -1,0 +1,31 @@
+import type { JsonObject } from '../ports.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
+
+export function isGatewayAlibabaModel(
+  llmVendor: string | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'alibaba';
+}
+
+/** Gateway Alibaba/Qwen：经 alibaba 命名空间注入 enableThinking（AI SDK camelCase；非 HTTP enable_thinking）。 */
+export function buildGatewayAlibabaProviderOptions(
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'vendorExtendedThinking'
+  >,
+): Record<string, JsonObject> {
+  if (!isGatewayAlibabaModel(config.llmVendor, config.model)) {
+    return {};
+  }
+  if (config.vendorExtendedThinking !== false) {
+    return {};
+  }
+
+  return {
+    alibaba: {
+      enableThinking: false,
+    } as JsonObject,
+  };
+}

--- a/packages/agent-core/src/openai/gateway-anthropic-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-anthropic-thinking.test.ts
@@ -54,7 +54,7 @@ test('resolveGatewayAnthropicClaudeCapabilities maps adaptive models and effort 
 test('resolveGatewayAnthropicClaudeCapabilities maps legacy claude models to budget thinking', () => {
   assert.deepEqual(resolveGatewayAnthropicClaudeCapabilities('anthropic/claude-sonnet-4-5'), {
     thinkingMode: 'budget',
-    supportedEfforts: ['low', 'medium', 'high'],
+    supportedEfforts: [],
   });
 });
 
@@ -99,7 +99,7 @@ test('buildGatewayAnthropicProviderOptions maps effort and summarized display fo
   );
 });
 
-test('buildGatewayAnthropicProviderOptions uses budget thinking for legacy claude when effort selected', () => {
+test('buildGatewayAnthropicProviderOptions uses fixed budget thinking for legacy claude', () => {
   assert.deepEqual(
     buildGatewayAnthropicProviderOptions({
       llmVendor: 'vercel-ai-gateway',
@@ -109,14 +109,13 @@ test('buildGatewayAnthropicProviderOptions uses budget thinking for legacy claud
     {
       anthropic: {
         toolStreaming: true,
-        thinking: { type: 'enabled', budgetTokens: 8_000 },
-        effort: 'medium',
+        thinking: { type: 'enabled', budgetTokens: 12_000 },
       },
     },
   );
 });
 
-test('buildGatewayAnthropicProviderOptions omits budget thinking for legacy claude at default effort', () => {
+test('buildGatewayAnthropicProviderOptions enables budget thinking for legacy claude at default effort', () => {
   assert.deepEqual(
     buildGatewayAnthropicProviderOptions({
       llmVendor: 'vercel-ai-gateway',
@@ -126,6 +125,24 @@ test('buildGatewayAnthropicProviderOptions omits budget thinking for legacy clau
     {
       anthropic: {
         toolStreaming: true,
+        thinking: { type: 'enabled', budgetTokens: 12_000 },
+      },
+    },
+  );
+});
+
+test('buildGatewayAnthropicProviderOptions disables budget thinking when vendorExtendedThinking false', () => {
+  assert.deepEqual(
+    buildGatewayAnthropicProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'anthropic/claude-opus-4-5',
+      reasoningEffort: 'medium',
+      vendorExtendedThinking: false,
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+        thinking: { type: 'disabled' },
       },
     },
   );

--- a/packages/agent-core/src/openai/gateway-anthropic-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-anthropic-thinking.test.ts
@@ -130,3 +130,20 @@ test('buildGatewayAnthropicProviderOptions omits budget thinking for legacy clau
     },
   );
 });
+
+test('buildGatewayAnthropicProviderOptions disables adaptive thinking when vendorExtendedThinking false', () => {
+  assert.deepEqual(
+    buildGatewayAnthropicProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'anthropic/claude-opus-4-8',
+      reasoningEffort: 'high',
+      vendorExtendedThinking: false,
+    }),
+    {
+      anthropic: {
+        toolStreaming: true,
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
@@ -53,14 +53,6 @@ function buildAdaptiveThinkingConfig(
   };
 }
 
-function buildBudgetThinkingConfig(effort: AnthropicEffort): AnthropicThinkingConfig {
-  const budgetKey = effort === 'low' || effort === 'medium' || effort === 'high' ? effort : 'high';
-  return {
-    type: 'enabled',
-    budgetTokens: ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT[budgetKey],
-  };
-}
-
 export function buildGatewayAnthropicProviderOptions(
   config: Pick<
     OpenAiTransportConfig,
@@ -93,9 +85,15 @@ export function buildGatewayAnthropicProviderOptions(
     return { anthropic };
   }
 
-  if (capabilities.thinkingMode === 'budget' && effort !== undefined) {
-    anthropic.thinking = buildBudgetThinkingConfig(effort) as unknown as JsonValue;
-    anthropic.effort = effort;
+  if (capabilities.thinkingMode === 'budget') {
+    if (config.vendorExtendedThinking === false) {
+      anthropic.thinking = { type: 'disabled' } as unknown as JsonValue;
+      return { anthropic };
+    }
+    anthropic.thinking = {
+      type: 'enabled',
+      budgetTokens: ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT.high,
+    } as unknown as JsonValue;
     return { anthropic };
   }
 

--- a/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-anthropic-thinking.ts
@@ -62,7 +62,10 @@ function buildBudgetThinkingConfig(effort: AnthropicEffort): AnthropicThinkingCo
 }
 
 export function buildGatewayAnthropicProviderOptions(
-  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model' | 'reasoningEffort'>,
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'
+  >,
 ): Record<string, JsonObject> {
   if (!isGatewayAnthropicClaudeModel(config.llmVendor, config.model)) {
     return {};
@@ -79,6 +82,10 @@ export function buildGatewayAnthropicProviderOptions(
   };
 
   if (capabilities.thinkingMode === 'adaptive') {
+    if (config.vendorExtendedThinking === false) {
+      anthropic.thinking = { type: 'disabled' } as unknown as JsonValue;
+      return { anthropic };
+    }
     anthropic.thinking = buildAdaptiveThinkingConfig(capabilities) as unknown as JsonValue;
     if (effort !== undefined) {
       anthropic.effort = effort;

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
@@ -154,13 +154,17 @@ test('buildGatewayCodeCompletionProviderOptions routes zai alibaba minimax xiaom
   );
 });
 
-test('buildGatewayCodeCompletionProviderOptions omits xai reasoning options', () => {
+test('buildGatewayCodeCompletionProviderOptions disables xai reasoning via xai namespace', () => {
   assert.deepEqual(
     buildGatewayCodeCompletionProviderOptions({
       ...gatewayConfig,
-      model: 'xai/grok-4',
+      model: 'xai/grok-4.3',
     }),
-    {},
+    {
+      xai: {
+        reasoningEffort: 'none',
+      },
+    },
   );
 });
 

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
@@ -126,7 +126,7 @@ test('buildGatewayCodeCompletionProviderOptions routes zai alibaba minimax xiaom
     }),
     {
       alibaba: {
-        enable_thinking: false,
+        enableThinking: false,
       },
     },
   );

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
@@ -6,6 +6,7 @@ import {
   isGatewayGoogleGeminiModel,
 } from './gateway-google-thinking.js';
 import { buildGatewayAlibabaProviderOptions } from './gateway-alibaba-thinking.js';
+import { buildGatewayMinimaxProviderOptions } from './gateway-minimax-thinking.js';
 import { isGatewayAnthropicClaudeModel } from './gateway-anthropic-thinking.js';
 
 /** 解析 Gateway 模型 ID 的上游 slug，如 `deepseek/deepseek-v3` → `deepseek`。 */
@@ -87,7 +88,10 @@ export function buildGatewayCodeCompletionProviderOptions(
         vendorExtendedThinking: false,
       });
     case 'minimax':
-      return thinkingTypeDisabledOptions('minimax');
+      return buildGatewayMinimaxProviderOptions({
+        ...config,
+        vendorExtendedThinking: false,
+      });
     case 'xiaomi':
       return thinkingTypeDisabledOptions('xiaomi');
     default:

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
@@ -73,7 +73,11 @@ export function buildGatewayCodeCompletionProviderOptions(
     case 'moonshotai':
       return thinkingTypeDisabledOptions('moonshotai');
     case 'xai':
-      return {};
+      return {
+        xai: {
+          reasoningEffort: 'none',
+        } as JsonObject,
+      };
     case 'zai':
       return thinkingTypeDisabledOptions('zai');
     case 'alibaba':

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
@@ -5,6 +5,7 @@ import {
   buildGatewayGoogleProviderOptions,
   isGatewayGoogleGeminiModel,
 } from './gateway-google-thinking.js';
+import { buildGatewayAlibabaProviderOptions } from './gateway-alibaba-thinking.js';
 import { isGatewayAnthropicClaudeModel } from './gateway-anthropic-thinking.js';
 
 /** 解析 Gateway 模型 ID 的上游 slug，如 `deepseek/deepseek-v3` → `deepseek`。 */
@@ -81,11 +82,10 @@ export function buildGatewayCodeCompletionProviderOptions(
     case 'zai':
       return thinkingTypeDisabledOptions('zai');
     case 'alibaba':
-      return {
-        alibaba: {
-          enable_thinking: false,
-        },
-      };
+      return buildGatewayAlibabaProviderOptions({
+        ...config,
+        vendorExtendedThinking: false,
+      });
     case 'minimax':
       return thinkingTypeDisabledOptions('minimax');
     case 'xiaomi':

--- a/packages/agent-core/src/openai/gateway-deepseek-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-deepseek-thinking.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayDeepSeekProviderOptions,
+  isGatewayDeepSeekModel,
+} from './gateway-deepseek-thinking.js';
+
+test('isGatewayDeepSeekModel matches vercel-ai-gateway deepseek routes only', () => {
+  assert.equal(isGatewayDeepSeekModel('vercel-ai-gateway', 'deepseek/deepseek-v4-pro'), true);
+  assert.equal(isGatewayDeepSeekModel('vercel-ai-gateway', 'openai/gpt-5'), false);
+  assert.equal(isGatewayDeepSeekModel('deepseek', 'deepseek-v4-pro'), false);
+});
+
+test('buildGatewayDeepSeekProviderOptions disables thinking for Gateway DeepSeek V4', () => {
+  assert.deepEqual(
+    buildGatewayDeepSeekProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'deepseek/deepseek-v4-pro',
+      reasoningEffort: 'default',
+      vendorExtendedThinking: false,
+    }),
+    {
+      deepseek: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+});
+
+test('buildGatewayDeepSeekProviderOptions enables thinking with effort for Gateway DeepSeek V4', () => {
+  assert.deepEqual(
+    buildGatewayDeepSeekProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'deepseek/deepseek-v4-pro',
+      reasoningEffort: 'high',
+    }),
+    {
+      deepseek: {
+        thinking: { type: 'enabled' },
+        reasoningEffort: 'high',
+      },
+    },
+  );
+});
+
+test('buildGatewayDeepSeekProviderOptions disables thinking for Gateway DeepSeek V3 slug', () => {
+  assert.deepEqual(
+    buildGatewayDeepSeekProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'deepseek/deepseek-v3.2',
+      reasoningEffort: 'default',
+      vendorExtendedThinking: false,
+    }),
+    {
+      deepseek: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/gateway-deepseek-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-deepseek-thinking.ts
@@ -1,0 +1,52 @@
+import type { JsonObject } from '../ports.js';
+import { isDeepSeekV4ReasoningEffortModel } from '../reasoning-effort.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { openAiReasoningEffort } from './openai-compat.js';
+import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
+
+export function isGatewayDeepSeekModel(
+  llmVendor: string | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'deepseek';
+}
+
+/** Gateway DeepSeek：经 deepseek providerOptions 控制 thinking（非 openai 命名空间）。 */
+export function buildGatewayDeepSeekProviderOptions(
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'
+  >,
+): Record<string, JsonObject> {
+  if (!isGatewayDeepSeekModel(config.llmVendor, config.model)) {
+    return {};
+  }
+
+  if (config.vendorExtendedThinking === false) {
+    return {
+      deepseek: {
+        thinking: { type: 'disabled' },
+      } as JsonObject,
+    };
+  }
+
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: config.model,
+    transportKind: 'openai-compatible' as const,
+  };
+
+  if (!isDeepSeekV4ReasoningEffortModel(context)) {
+    return {};
+  }
+
+  const deepseek: JsonObject = {
+    thinking: { type: 'enabled' },
+  };
+  const effort = openAiReasoningEffort(config);
+  if (effort !== undefined && effort !== 'default' && effort !== 'none') {
+    deepseek.reasoningEffort = effort;
+  }
+
+  return { deepseek };
+}

--- a/packages/agent-core/src/openai/gateway-google-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-google-thinking.test.ts
@@ -6,6 +6,7 @@ import {
   buildGoogleThinkingConfigForEffort,
   gatewayGoogleGeminiSupportedEfforts,
   isGatewayGoogleGeminiModel,
+  isGoogleGeminiMinimalThinkingLevelModel,
 } from './gateway-google-thinking.js';
 
 test('isGatewayGoogleGeminiModel matches vercel-ai-gateway google gemini routes only', () => {
@@ -31,6 +32,17 @@ test('isGatewayGoogleGeminiModel matches vercel-ai-gateway google gemini routes 
   );
 });
 
+test('isGoogleGeminiMinimalThinkingLevelModel matches flash routes only', () => {
+  assert.equal(
+    isGoogleGeminiMinimalThinkingLevelModel('google/gemini-3-flash-preview'),
+    true,
+  );
+  assert.equal(
+    isGoogleGeminiMinimalThinkingLevelModel('google/gemini-3.1-pro-preview'),
+    false,
+  );
+});
+
 test('buildGoogleThinkingConfigForEffort maps Gemini 3 and 2.5 effort levels', () => {
   assert.deepEqual(
     buildGoogleThinkingConfigForEffort('google/gemini-3.1-pro-preview', 'high'),
@@ -47,7 +59,17 @@ test('buildGoogleThinkingConfigForEffort maps Gemini 3 and 2.5 effort levels', (
     },
   );
   assert.deepEqual(
+    buildGoogleThinkingConfigForEffort('google/gemini-3-flash-preview', 'minimal'),
+    {
+      thinkingLevel: 'minimal',
+    },
+  );
+  assert.equal(
     buildGoogleThinkingConfigForEffort('google/gemini-3.1-pro-preview', 'none'),
+    undefined,
+  );
+  assert.deepEqual(
+    buildGoogleThinkingConfigForEffort('google/gemini-3-flash-preview', 'none'),
     {
       thinkingLevel: 'minimal',
     },
@@ -79,6 +101,14 @@ test('gatewayGoogleGeminiSupportedEfforts exports effort vocabulary for catalog 
   assert.deepEqual(
     gatewayGoogleGeminiSupportedEfforts('google/gemini-3.1-pro-preview'),
     ['low', 'medium', 'high'],
+  );
+  assert.deepEqual(
+    gatewayGoogleGeminiSupportedEfforts('google/gemini-3-flash-preview'),
+    ['minimal', 'low', 'medium', 'high'],
+  );
+  assert.deepEqual(
+    gatewayGoogleGeminiSupportedEfforts('google/gemini-2.5-flash'),
+    ['none', 'low', 'medium', 'high'],
   );
   assert.equal(gatewayGoogleGeminiSupportedEfforts('openai/gpt-5'), undefined);
 });

--- a/packages/agent-core/src/openai/gateway-google-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-google-thinking.ts
@@ -14,9 +14,30 @@ export function isGatewayGoogleGeminiModel(
   return model.trim().toLowerCase().startsWith('google/gemini-');
 }
 
-export function isGoogleGemini3Model(model: string): boolean {
+function normalizeGoogleGeminiModelId(model: string): string {
   const normalized = model.trim().toLowerCase();
+  const slashIndex = normalized.lastIndexOf('/');
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+export function isGoogleGemini3Model(model: string): boolean {
+  return normalizeGoogleGeminiModelId(model).includes('gemini-3');
+}
+
+/** Gemini 3+ 走 thinkingLevel；2.5 及更早走 thinkingBudget。 */
+export function isGoogleGeminiThinkingLevelModel(model: string): boolean {
+  const normalized = normalizeGoogleGeminiModelId(model);
   return normalized.includes('gemini-3');
+}
+
+/** Flash / Flash-Lite 系 Gemini 3+ 支持 API thinkingLevel=minimal（Pro 不支持）。 */
+export function isGoogleGeminiMinimalThinkingLevelModel(model: string): boolean {
+  if (!isGoogleGeminiThinkingLevelModel(model)) {
+    return false;
+  }
+
+  const normalized = normalizeGoogleGeminiModelId(model);
+  return normalized.includes('flash');
 }
 
 function googleGemini25ThinkingBudgetForEffort(
@@ -42,15 +63,28 @@ export function buildGoogleThinkingConfigForEffort(
     return undefined;
   }
 
-  if (effort === 'none') {
-    if (isGoogleGemini3Model(model)) {
+  if (effort === 'minimal') {
+    if (isGoogleGeminiMinimalThinkingLevelModel(model)) {
       return { thinkingLevel: 'minimal' };
+    }
+
+    return undefined;
+  }
+
+  if (effort === 'none') {
+    if (isGoogleGeminiThinkingLevelModel(model)) {
+      // 代码补全等内部路径仍写 none；Flash 系映射为 API minimal。
+      if (isGoogleGeminiMinimalThinkingLevelModel(model)) {
+        return { thinkingLevel: 'minimal' };
+      }
+
+      return undefined;
     }
 
     return { thinkingBudget: 0 };
   }
 
-  if (isGoogleGemini3Model(model)) {
+  if (isGoogleGeminiThinkingLevelModel(model)) {
     if (effort === 'low' || effort === 'medium' || effort === 'high') {
       return {
         thinkingLevel: effort,
@@ -80,7 +114,15 @@ export function gatewayGoogleGeminiSupportedEfforts(
     return undefined;
   }
 
-  return ['low', 'medium', 'high'];
+  if (isGoogleGeminiMinimalThinkingLevelModel(model)) {
+    return ['minimal', 'low', 'medium', 'high'];
+  }
+
+  if (isGoogleGeminiThinkingLevelModel(model)) {
+    return ['low', 'medium', 'high'];
+  }
+
+  return ['none', 'low', 'medium', 'high'];
 }
 
 export function buildGatewayGoogleProviderOptions(

--- a/packages/agent-core/src/openai/gateway-minimax-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-minimax-thinking.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayMinimaxProviderOptions,
+  isGatewayMinimaxModel,
+  isMinimaxM3ThinkingSwitchModel,
+} from './gateway-minimax-thinking.js';
+
+test('isMinimaxM3ThinkingSwitchModel matches MiniMax M3 routes only', () => {
+  assert.equal(isMinimaxM3ThinkingSwitchModel('minimax/minimax-m3'), true);
+  assert.equal(isMinimaxM3ThinkingSwitchModel('minimax/MiniMax-M3'), true);
+  assert.equal(isMinimaxM3ThinkingSwitchModel('minimax/MiniMax-M2.5'), false);
+});
+
+test('isGatewayMinimaxModel matches vercel-ai-gateway minimax routes only', () => {
+  assert.equal(isGatewayMinimaxModel('vercel-ai-gateway', 'minimax/minimax-m3'), true);
+  assert.equal(isGatewayMinimaxModel('vercel-ai-gateway', 'openai/gpt-5'), false);
+  assert.equal(isGatewayMinimaxModel('minimax', 'MiniMax-M3'), false);
+});
+
+test('buildGatewayMinimaxProviderOptions toggles thinking via minimax namespace', () => {
+  assert.deepEqual(
+    buildGatewayMinimaxProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'minimax/minimax-m3',
+      vendorExtendedThinking: false,
+    }),
+    {
+      minimax: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayMinimaxProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'minimax/minimax-m3',
+    }),
+    {
+      minimax: {
+        thinking: { type: 'adaptive' },
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayMinimaxProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'minimax/MiniMax-M2.5',
+    }),
+    {
+      minimax: {
+        thinking: { type: 'adaptive' },
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/openai/gateway-minimax-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-minimax-thinking.ts
@@ -24,7 +24,7 @@ export function isMinimaxM3ThinkingSwitchModel(model: string): boolean {
 
 /**
  * Gateway MiniMax：经 minimax 命名空间注入 thinking.type。
- * M3 经 Gateway open-responses 当前不产出 reasoning-delta，Thought UI 仍可能为空。
+ * M3 在 open-responses 下不返回可展示思考流；见 #170。
  */
 export function buildGatewayMinimaxProviderOptions(
   config: Pick<

--- a/packages/agent-core/src/openai/gateway-minimax-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-minimax-thinking.ts
@@ -1,0 +1,46 @@
+import type { JsonObject } from '../ports.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
+
+/** 文档：https://platform.minimax.io/docs/api-reference/text-openai-api — M3 用 adaptive/disabled。 */
+function normalizeMinimaxModelId(model: string): string {
+  const normalized = model.trim().toLowerCase();
+  const slashIndex = normalized.lastIndexOf('/');
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+export function isGatewayMinimaxModel(
+  llmVendor: string | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'minimax';
+}
+
+/** M2.x 无法关闭 thinking；M3 支持 disabled。 */
+export function isMinimaxM3ThinkingSwitchModel(model: string): boolean {
+  const id = normalizeMinimaxModelId(model);
+  return id.includes('m3') || id.includes('minimax-m3');
+}
+
+/**
+ * Gateway MiniMax：经 minimax 命名空间注入 thinking.type。
+ * M3 经 Gateway open-responses 当前不产出 reasoning-delta，Thought UI 仍可能为空。
+ */
+export function buildGatewayMinimaxProviderOptions(
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'vendorExtendedThinking'
+  >,
+): Record<string, JsonObject> {
+  if (!isGatewayMinimaxModel(config.llmVendor, config.model)) {
+    return {};
+  }
+
+  return {
+    minimax: {
+      thinking: {
+        type: config.vendorExtendedThinking === false ? 'disabled' : 'adaptive',
+      },
+    } as JsonObject,
+  };
+}

--- a/packages/agent-core/src/openai/gateway-xai-reasoning.test.ts
+++ b/packages/agent-core/src/openai/gateway-xai-reasoning.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayXaiProviderOptions,
+  isGatewayXaiModel,
+  resolveXaiProviderReasoningEffort,
+} from './gateway-xai-reasoning.js';
+
+test('resolveXaiProviderReasoningEffort accepts none and medium', () => {
+  assert.equal(resolveXaiProviderReasoningEffort('none'), 'none');
+  assert.equal(resolveXaiProviderReasoningEffort('medium'), 'medium');
+  assert.equal(resolveXaiProviderReasoningEffort('default'), undefined);
+});
+
+test('isGatewayXaiModel matches vercel-ai-gateway xai routes only', () => {
+  assert.equal(isGatewayXaiModel('vercel-ai-gateway', 'xai/grok-4.3'), true);
+  assert.equal(isGatewayXaiModel('vercel-ai-gateway', 'openai/gpt-5'), false);
+  assert.equal(isGatewayXaiModel('xai', 'grok-4.3'), false);
+});
+
+test('buildGatewayXaiProviderOptions uses xai namespace for reasoningEffort none', () => {
+  assert.deepEqual(
+    buildGatewayXaiProviderOptions('vercel-ai-gateway', 'xai/grok-4.3', 'none'),
+    {
+      xai: {
+        reasoningEffort: 'none',
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayXaiProviderOptions('vercel-ai-gateway', 'xai/grok-build-0.1', 'high'),
+    {
+      xai: {
+        reasoningEffort: 'high',
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayXaiProviderOptions('vercel-ai-gateway', 'xai/grok-4.3', 'default'),
+    {},
+  );
+});

--- a/packages/agent-core/src/openai/gateway-xai-reasoning.ts
+++ b/packages/agent-core/src/openai/gateway-xai-reasoning.ts
@@ -1,0 +1,42 @@
+import type { JsonObject } from '../ports.js';
+import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
+
+export type XaiProviderReasoningEffort = 'none' | 'low' | 'medium' | 'high';
+
+/** xAI Grok：经 xai 命名空间传 reasoningEffort（含 none 关闭思考）；见 https://docs.x.ai/developers/model-capabilities/text/reasoning */
+export function resolveXaiProviderReasoningEffort(
+  effort: string | undefined,
+): XaiProviderReasoningEffort | undefined {
+  if (effort === 'none' || effort === 'low' || effort === 'medium' || effort === 'high') {
+    return effort;
+  }
+  return undefined;
+}
+
+export function isGatewayXaiModel(
+  llmVendor: string | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'xai';
+}
+
+export function buildGatewayXaiProviderOptions(
+  llmVendor: string | undefined,
+  model: string,
+  reasoningEffort?: string,
+): Record<string, JsonObject> {
+  if (!isGatewayXaiModel(llmVendor, model)) {
+    return {};
+  }
+
+  const resolvedReasoningEffort = resolveXaiProviderReasoningEffort(reasoningEffort);
+  if (resolvedReasoningEffort === undefined) {
+    return {};
+  }
+
+  return {
+    xai: {
+      reasoningEffort: resolvedReasoningEffort,
+    } as JsonObject,
+  };
+}

--- a/packages/agent-core/src/openai/gateway-xiaomi-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-xiaomi-thinking.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayXiaomiProviderOptions,
+  isGatewayXiaomiModel,
+  isXiaomiThinkingSwitchEligibleModel,
+} from './gateway-xiaomi-thinking.js';
+
+test('isXiaomiThinkingSwitchEligibleModel covers MiMo thinking models only', () => {
+  assert.equal(isXiaomiThinkingSwitchEligibleModel('mimo-v2.5'), true);
+  assert.equal(isXiaomiThinkingSwitchEligibleModel('mimo-v2.5-pro'), true);
+  assert.equal(isXiaomiThinkingSwitchEligibleModel('xiaomi/mimo-v2.5'), true);
+  assert.equal(isXiaomiThinkingSwitchEligibleModel('mimo-v2-flash'), false);
+});
+
+test('isGatewayXiaomiModel matches vercel-ai-gateway xiaomi routes only', () => {
+  assert.equal(isGatewayXiaomiModel('vercel-ai-gateway', 'xiaomi/mimo-v2.5'), true);
+  assert.equal(isGatewayXiaomiModel('vercel-ai-gateway', 'openai/gpt-5'), false);
+  assert.equal(isGatewayXiaomiModel('xiaomi', 'mimo-v2.5'), false);
+});
+
+test('buildGatewayXiaomiProviderOptions toggles thinking for MiMo on Gateway', () => {
+  assert.deepEqual(
+    buildGatewayXiaomiProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'xiaomi/mimo-v2.5',
+      vendorExtendedThinking: false,
+    }),
+    {
+      xiaomi: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayXiaomiProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'xiaomi/mimo-v2.5',
+    }),
+    {
+      xiaomi: {
+        thinking: { type: 'enabled' },
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayXiaomiProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'xiaomi/mimo-v2-flash',
+      vendorExtendedThinking: false,
+    }),
+    {},
+  );
+});

--- a/packages/agent-core/src/openai/gateway-xiaomi-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-xiaomi-thinking.ts
@@ -1,0 +1,49 @@
+import type { JsonObject } from '../ports.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
+
+/** 文档：https://mimo.mi.com/docs/en-US/quick-start/usage-guide/other/deep-thinking */
+function normalizeXiaomiModelId(model: string): string {
+  const normalized = model.trim().toLowerCase();
+  const slashIndex = normalized.lastIndexOf('/');
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+/** mimo-v2-flash 无 deep thinking 模式；其余 mimo-v* 向前兼容。 */
+export function isXiaomiThinkingSwitchEligibleModel(model: string): boolean {
+  const id = normalizeXiaomiModelId(model);
+  if (id === 'mimo-v2-flash' || id.startsWith('mimo-v2-flash-')) {
+    return false;
+  }
+  return id.startsWith('mimo-v');
+}
+
+export function isGatewayXiaomiModel(
+  llmVendor: string | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'xiaomi';
+}
+
+/** Gateway Xiaomi MiMo：经 xiaomi 命名空间注入 thinking.type（非 openai 命名空间）。 */
+export function buildGatewayXiaomiProviderOptions(
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'vendorExtendedThinking'
+  >,
+): Record<string, JsonObject> {
+  if (!isGatewayXiaomiModel(config.llmVendor, config.model)) {
+    return {};
+  }
+  if (!isXiaomiThinkingSwitchEligibleModel(config.model)) {
+    return {};
+  }
+
+  return {
+    xiaomi: {
+      thinking: {
+        type: config.vendorExtendedThinking === false ? 'disabled' : 'enabled',
+      },
+    } as JsonObject,
+  };
+}

--- a/packages/agent-core/src/openai/gateway-zai-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-zai-thinking.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayZaiProviderOptions,
+  isGatewayZaiModel,
+  isZaiThinkingSwitchEligibleModel,
+} from './gateway-zai-thinking.js';
+
+test('isZaiThinkingSwitchEligibleModel covers GLM-4.5+ only', () => {
+  assert.equal(isZaiThinkingSwitchEligibleModel('glm-4.5'), true);
+  assert.equal(isZaiThinkingSwitchEligibleModel('glm-4.7'), true);
+  assert.equal(isZaiThinkingSwitchEligibleModel('glm-5.2'), true);
+  assert.equal(isZaiThinkingSwitchEligibleModel('zai/glm-4.7'), true);
+  assert.equal(isZaiThinkingSwitchEligibleModel('glm-4'), false);
+});
+
+test('isGatewayZaiModel matches vercel-ai-gateway zai routes only', () => {
+  assert.equal(isGatewayZaiModel('vercel-ai-gateway', 'zai/glm-4.7'), true);
+  assert.equal(isGatewayZaiModel('vercel-ai-gateway', 'openai/gpt-5'), false);
+  assert.equal(isGatewayZaiModel('z-ai', 'glm-4.7'), false);
+});
+
+test('buildGatewayZaiProviderOptions toggles thinking for Gateway Z.ai', () => {
+  assert.deepEqual(
+    buildGatewayZaiProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'zai/glm-4.7',
+      reasoningEffort: 'default',
+      vendorExtendedThinking: false,
+    }),
+    {
+      zai: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayZaiProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'zai/glm-4.7',
+      reasoningEffort: 'high',
+    }),
+    {
+      zai: {
+        thinking: { type: 'enabled' },
+      },
+      openai: {
+        reasoningEffort: 'high',
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayZaiProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'zai/glm-4',
+      reasoningEffort: 'high',
+    }),
+    {},
+  );
+});

--- a/packages/agent-core/src/openai/gateway-zai-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-zai-thinking.ts
@@ -1,0 +1,83 @@
+import type { JsonObject } from '../ports.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { openAiReasoningEffort } from './openai-compat.js';
+import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
+
+/** 文档：https://docs.z.ai/guides/capabilities/thinking — GLM-4.5+ 支持 thinking.type。 */
+function normalizeZaiModelId(model: string): string {
+  const normalized = model.trim().toLowerCase();
+  const slashIndex = normalized.lastIndexOf('/');
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+function parseGlmModelVersion(model: string): { major: number; minor: number } | undefined {
+  const match = normalizeZaiModelId(model).match(/^glm-(\d+)(?:\.(\d+))?/);
+  if (!match) {
+    return undefined;
+  }
+  const majorText = match[1];
+  if (majorText === undefined) {
+    return undefined;
+  }
+  const major = Number.parseInt(majorText, 10);
+  const minor = match[2] !== undefined ? Number.parseInt(match[2], 10) : 0;
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) {
+    return undefined;
+  }
+  return { major, minor };
+}
+
+/** GLM-4.5 及以上（含未来 glm-5+）支持 thinking.type 开关。 */
+export function isZaiThinkingSwitchEligibleModel(model: string): boolean {
+  const version = parseGlmModelVersion(model);
+  if (version === undefined) {
+    return false;
+  }
+  if (version.major > 4) {
+    return true;
+  }
+  return version.major === 4 && version.minor >= 5;
+}
+
+export function isGatewayZaiModel(
+  llmVendor: string | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'zai';
+}
+
+/** Gateway Z.ai：经 zai 命名空间注入 thinking.type；reasoning_effort 仍走 openai 命名空间。 */
+export function buildGatewayZaiProviderOptions(
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'
+  >,
+): Record<string, JsonObject> {
+  if (!isGatewayZaiModel(config.llmVendor, config.model)) {
+    return {};
+  }
+  if (!isZaiThinkingSwitchEligibleModel(config.model)) {
+    return {};
+  }
+
+  if (config.vendorExtendedThinking === false) {
+    return {
+      zai: {
+        thinking: { type: 'disabled' },
+      } as JsonObject,
+    };
+  }
+
+  const result: Record<string, JsonObject> = {
+    zai: {
+      thinking: { type: 'enabled' },
+    } as JsonObject,
+  };
+  const effort = openAiReasoningEffort(config);
+  if (effort !== undefined && effort !== 'default' && effort !== 'none') {
+    result.openai = {
+      reasoningEffort: effort,
+    } as JsonObject;
+  }
+  return result;
+}

--- a/packages/agent-core/src/openai/moonshot-thinking-switch.test.ts
+++ b/packages/agent-core/src/openai/moonshot-thinking-switch.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildGatewayMoonshotProviderOptions,
+  isGatewayMoonshotModel,
+  isMoonshotThinkingSwitchEligibleModel,
+  isMoonshotThinkingSwitchExcludedModel,
+  isMoonshotThinkingSwitchModel,
+} from './moonshot-thinking-switch.js';
+
+test('isMoonshotThinkingSwitchEligibleModel covers kimi-k2.5+ only', () => {
+  assert.equal(isMoonshotThinkingSwitchEligibleModel('kimi-k2'), false);
+  assert.equal(isMoonshotThinkingSwitchEligibleModel('kimi-k2-thinking'), false);
+  assert.equal(isMoonshotThinkingSwitchEligibleModel('kimi-k2-turbo-preview'), false);
+  assert.equal(isMoonshotThinkingSwitchEligibleModel('kimi-k2.5'), true);
+  assert.equal(isMoonshotThinkingSwitchEligibleModel('kimi-k2.6'), true);
+  assert.equal(isMoonshotThinkingSwitchEligibleModel('kimi-k3'), true);
+  assert.equal(isMoonshotThinkingSwitchEligibleModel('moonshotai/kimi-k2.5'), true);
+});
+
+test('isMoonshotThinkingSwitchExcludedModel blocks v1 and k2.7-code variants', () => {
+  assert.equal(isMoonshotThinkingSwitchExcludedModel('moonshot-v1-8k'), true);
+  assert.equal(isMoonshotThinkingSwitchExcludedModel('moonshot-v1-auto'), true);
+  assert.equal(isMoonshotThinkingSwitchExcludedModel('kimi-k2.7-code'), true);
+  assert.equal(isMoonshotThinkingSwitchExcludedModel('kimi-k2.7-code-highspeed'), true);
+  assert.equal(isMoonshotThinkingSwitchExcludedModel('moonshotai/kimi-k2.7-code'), true);
+  assert.equal(isMoonshotThinkingSwitchExcludedModel('kimi-k2.5'), false);
+});
+
+test('isMoonshotThinkingSwitchModel resolves direct and gateway providers', () => {
+  const direct = {
+    provider: 'moonshot-ai' as const,
+    model: 'kimi-k2.5',
+    transportKind: 'openai-compatible' as const,
+  };
+  const gateway = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'moonshotai/kimi-k2.6',
+    transportKind: 'open-responses' as const,
+  };
+  const gatewayCode = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'moonshotai/kimi-k2.7-code',
+    transportKind: 'open-responses' as const,
+  };
+
+  assert.equal(isMoonshotThinkingSwitchModel(direct), true);
+  assert.equal(isMoonshotThinkingSwitchModel(gateway), true);
+  assert.equal(isMoonshotThinkingSwitchModel(gatewayCode), false);
+});
+
+test('isGatewayMoonshotModel matches vercel-ai-gateway moonshotai routes only', () => {
+  assert.equal(isGatewayMoonshotModel('vercel-ai-gateway', 'moonshotai/kimi-k2.5'), true);
+  assert.equal(isGatewayMoonshotModel('vercel-ai-gateway', 'openai/gpt-5'), false);
+  assert.equal(isGatewayMoonshotModel('moonshot-ai', 'kimi-k2.5'), false);
+});
+
+test('buildGatewayMoonshotProviderOptions toggles thinking for switchable models', () => {
+  assert.deepEqual(
+    buildGatewayMoonshotProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'moonshotai/kimi-k2.5',
+      reasoningEffort: 'default',
+      vendorExtendedThinking: false,
+    }),
+    {
+      moonshotai: {
+        thinking: { type: 'disabled' },
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayMoonshotProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'moonshotai/kimi-k2.5',
+      reasoningEffort: 'low',
+    }),
+    {
+      moonshotai: {
+        thinking: { type: 'enabled' },
+      },
+      openai: {
+        reasoningEffort: 'low',
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayMoonshotProviderOptions({
+      llmVendor: 'vercel-ai-gateway',
+      model: 'moonshotai/kimi-k2.7-code',
+      reasoningEffort: 'low',
+    }),
+    {},
+  );
+});

--- a/packages/agent-core/src/openai/moonshot-thinking-switch.ts
+++ b/packages/agent-core/src/openai/moonshot-thinking-switch.ts
@@ -1,0 +1,120 @@
+import type { JsonObject } from '../ports.js';
+import type { ModelReasoningEffortContext } from '../reasoning-effort.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { openAiReasoningEffort } from './openai-compat.js';
+import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
+
+/** 文档：https://platform.kimi.com/docs/api/chat — 仅 kimi-k2.5+ 支持 thinking.type 开关。 */
+function normalizeMoonshotModelId(model: string): string {
+  const normalized = model.trim().toLowerCase();
+  const slashIndex = normalized.lastIndexOf('/');
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+function parseKimiKModelVersion(model: string): { major: number; minor: number } | undefined {
+  const match = normalizeMoonshotModelId(model).match(/^kimi-k(\d+)(?:\.(\d+))?/);
+  if (!match) {
+    return undefined;
+  }
+  const majorText = match[1];
+  if (majorText === undefined) {
+    return undefined;
+  }
+  const major = Number.parseInt(majorText, 10);
+  const minor = match[2] !== undefined ? Number.parseInt(match[2], 10) : 0;
+  if (!Number.isFinite(major) || !Number.isFinite(minor)) {
+    return undefined;
+  }
+  return { major, minor };
+}
+
+/** moonshot-v1-* 与 kimi-k2.7-code-*（含 highspeed）不支持 thinking.type 开关。 */
+export function isMoonshotThinkingSwitchExcludedModel(model: string): boolean {
+  const id = normalizeMoonshotModelId(model);
+  if (id.startsWith('moonshot-v1-') || id === 'moonshot-v1') {
+    return true;
+  }
+  if (/^kimi-k2\.7-code(?:-|$)/.test(id)) {
+    return true;
+  }
+  return false;
+}
+
+/** kimi-k2.5 及以上（含未来 k2.x / k3+），排除不支持 thinking 的型号。 */
+export function isMoonshotThinkingSwitchEligibleModel(model: string): boolean {
+  if (isMoonshotThinkingSwitchExcludedModel(model)) {
+    return false;
+  }
+  const version = parseKimiKModelVersion(model);
+  if (version === undefined) {
+    return false;
+  }
+  if (version.major > 2) {
+    return true;
+  }
+  return version.major === 2 && version.minor >= 5;
+}
+
+export function isMoonshotThinkingSwitchModel(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  if (context?.provider === 'moonshot-ai') {
+    return isMoonshotThinkingSwitchEligibleModel(context.model ?? '');
+  }
+  if (
+    context?.provider === 'vercel-ai-gateway'
+    && parseGatewayUpstreamSlug(context.model ?? '') === 'moonshotai'
+  ) {
+    return isMoonshotThinkingSwitchEligibleModel(context.model ?? '');
+  }
+  return false;
+}
+
+export function isGatewayMoonshotModel(
+  llmVendor: string | undefined,
+  model: string,
+): boolean {
+  return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'moonshotai';
+}
+
+/** Gateway Moonshot：开关型型号经 moonshotai 命名空间控制 thinking；reasoning_effort 仍走 openai 命名空间。 */
+export function buildGatewayMoonshotProviderOptions(
+  config: Pick<
+    OpenAiTransportConfig,
+    'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'
+  >,
+): Record<string, JsonObject> {
+  if (!isGatewayMoonshotModel(config.llmVendor, config.model)) {
+    return {};
+  }
+
+  const context: ModelReasoningEffortContext = {
+    provider: 'vercel-ai-gateway',
+    model: config.model,
+    transportKind: 'openai-compatible',
+  };
+  if (!isMoonshotThinkingSwitchModel(context)) {
+    return {};
+  }
+
+  if (config.vendorExtendedThinking === false) {
+    return {
+      moonshotai: {
+        thinking: { type: 'disabled' },
+      } as JsonObject,
+    };
+  }
+
+  const result: Record<string, JsonObject> = {
+    moonshotai: {
+      thinking: { type: 'enabled' },
+    } as JsonObject,
+  };
+  const effort = openAiReasoningEffort(config);
+  if (effort !== undefined && effort !== 'default' && effort !== 'none') {
+    result.openai = {
+      reasoningEffort: effort,
+    } as JsonObject;
+  }
+  return result;
+}

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -219,6 +219,8 @@ export function openAiVendorChatCompletionBodyExtras(
 
   if (config.llmVendor === 'siliconflow' && config.transportRequestProfile === 'code-completion') {
     extras.enable_thinking = false;
+  } else if (config.llmVendor === 'siliconflow' && config.vendorExtendedThinking === false) {
+    extras.enable_thinking = false;
   }
 
   const openRouterReasoning = buildOpenRouterClaudeReasoningBody(config);

--- a/packages/agent-core/src/openai/openrouter-anthropic-reasoning.test.ts
+++ b/packages/agent-core/src/openai/openrouter-anthropic-reasoning.test.ts
@@ -79,6 +79,18 @@ test('buildOpenRouterClaudeReasoningBody maps none to effort none', () => {
   );
 });
 
+test('buildOpenRouterClaudeReasoningBody disables adaptive thinking when vendorExtendedThinking false', () => {
+  assert.deepEqual(
+    buildOpenRouterClaudeReasoningBody({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-opus-4-8',
+      reasoningEffort: 'high',
+      vendorExtendedThinking: false,
+    }),
+    { enabled: false },
+  );
+});
+
 test('shouldInjectOpenRouterClaudeReasoning follows buildOpenRouterClaudeReasoningBody', () => {
   assert.equal(
     shouldInjectOpenRouterClaudeReasoning({

--- a/packages/agent-core/src/openai/openrouter-anthropic-reasoning.test.ts
+++ b/packages/agent-core/src/openai/openrouter-anthropic-reasoning.test.ts
@@ -46,25 +46,37 @@ test('buildOpenRouterClaudeReasoningBody maps effort for opus 4.8', () => {
   );
 });
 
-test('buildOpenRouterClaudeReasoningBody uses budget max_tokens for legacy claude', () => {
+test('buildOpenRouterClaudeReasoningBody uses fixed budget max_tokens for legacy claude', () => {
   assert.deepEqual(
     buildOpenRouterClaudeReasoningBody({
       llmVendor: 'openrouter',
       model: 'anthropic/claude-sonnet-4-5',
       reasoningEffort: 'medium',
     }),
-    { enabled: true, max_tokens: 8_000 },
+    { enabled: true, max_tokens: 12_000 },
   );
 });
 
-test('buildOpenRouterClaudeReasoningBody omits thinking for legacy claude at default effort', () => {
-  assert.equal(
+test('buildOpenRouterClaudeReasoningBody enables budget thinking for legacy claude at default effort', () => {
+  assert.deepEqual(
     buildOpenRouterClaudeReasoningBody({
       llmVendor: 'openrouter',
       model: 'anthropic/claude-sonnet-4-5',
       reasoningEffort: 'default',
     }),
-    undefined,
+    { enabled: true, max_tokens: 12_000 },
+  );
+});
+
+test('buildOpenRouterClaudeReasoningBody disables budget thinking when vendorExtendedThinking false', () => {
+  assert.deepEqual(
+    buildOpenRouterClaudeReasoningBody({
+      llmVendor: 'openrouter',
+      model: 'anthropic/claude-opus-4-5',
+      reasoningEffort: 'medium',
+      vendorExtendedThinking: false,
+    }),
+    { enabled: false },
   );
 });
 

--- a/packages/agent-core/src/openai/openrouter-anthropic-reasoning.ts
+++ b/packages/agent-core/src/openai/openrouter-anthropic-reasoning.ts
@@ -11,7 +11,7 @@ import type { OpenResponsesTransportConfig } from '../open-responses/responses-c
 
 export type OpenRouterClaudeReasoningConfig = Pick<
   OpenAiTransportConfig,
-  'llmVendor' | 'model' | 'reasoningEffort'
+  'llmVendor' | 'model' | 'reasoningEffort' | 'vendorExtendedThinking'
 >;
 
 export function isOpenRouterAnthropicClaudeModel(
@@ -39,6 +39,9 @@ export function buildOpenRouterClaudeReasoningBody(
   );
 
   if (capabilities.thinkingMode === 'adaptive') {
+    if (config.vendorExtendedThinking === false) {
+      return { enabled: false };
+    }
     if (effort !== undefined) {
       return { enabled: true, effort };
     }

--- a/packages/agent-core/src/openai/openrouter-anthropic-reasoning.ts
+++ b/packages/agent-core/src/openai/openrouter-anthropic-reasoning.ts
@@ -48,11 +48,13 @@ export function buildOpenRouterClaudeReasoningBody(
     return { enabled: true };
   }
 
-  if (capabilities.thinkingMode === 'budget' && effort !== undefined) {
-    const budgetKey = effort === 'low' || effort === 'medium' || effort === 'high' ? effort : 'high';
+  if (capabilities.thinkingMode === 'budget') {
+    if (config.vendorExtendedThinking === false) {
+      return { enabled: false };
+    }
     return {
       enabled: true,
-      max_tokens: ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT[budgetKey],
+      max_tokens: ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT.high,
     };
   }
 

--- a/packages/agent-core/src/openai/routed-anthropic-claude-capabilities.ts
+++ b/packages/agent-core/src/openai/routed-anthropic-claude-capabilities.ts
@@ -9,8 +9,6 @@ export interface RoutedAnthropicClaudeCapabilities {
   adaptiveDisplay?: 'summarized';
 }
 
-const LEGACY_BUDGET_EFFORTS: readonly AnthropicEffort[] = ['low', 'medium', 'high'];
-
 export const ROUTED_ANTHROPIC_BUDGET_TOKENS_BY_EFFORT: Record<'low' | 'medium' | 'high', number> = {
   low: 4_000,
   medium: 8_000,
@@ -59,7 +57,7 @@ export function resolveRoutedAnthropicClaudeCapabilities(
   if (isLegacyRoutedAnthropicClaudeModel(modelId)) {
     return {
       thinkingMode: 'budget',
-      supportedEfforts: LEGACY_BUDGET_EFFORTS,
+      supportedEfforts: [],
     };
   }
 

--- a/packages/agent-core/src/reasoning-effort.test.ts
+++ b/packages/agent-core/src/reasoning-effort.test.ts
@@ -114,21 +114,40 @@ test('google models normalize reasoning efforts to supported values', () => {
   assert.equal(
     resolveModelReasoningEffortForContext('minimal', {
       provider: 'google',
+      model: 'gemini-3-flash-preview',
       transportKind: 'openai-compatible',
     }),
-    'low',
+    'minimal',
   );
   assert.equal(
-    resolveOpenAiTransportReasoningEffortForContext('none', {
+    resolveModelReasoningEffortForContext('minimal', {
       provider: 'google',
+      model: 'gemini-2.5-flash',
       transportKind: 'openai-compatible',
     }),
     'none',
   );
   assert.equal(
+    resolveOpenAiTransportReasoningEffortForContext('none', {
+      provider: 'google',
+      model: 'gemini-2.5-flash',
+      transportKind: 'openai-compatible',
+    }),
+    'none',
+  );
+  assert.equal(
+    resolveOpenAiTransportReasoningEffortForContext('none', {
+      provider: 'google',
+      model: 'gemini-3-flash-preview',
+      transportKind: 'openai-compatible',
+    }),
+    'minimal',
+  );
+  assert.equal(
     resolveOpenAiTransportReasoningEffortForContext('max', {
       provider: 'google',
       transportKind: 'openai-compatible',
+      model: 'gemini-2.5-flash',
     }),
     'high',
   );
@@ -154,23 +173,43 @@ test('anthropic supported efforts restrict unavailable levels', () => {
 });
 
 test('gateway gemini models use google effort options', () => {
-  const geminiOptions = modelReasoningEffortOptions({
+  const geminiProOptions = modelReasoningEffortOptions({
     provider: 'vercel-ai-gateway',
     model: 'google/gemini-3.1-pro-preview',
     transportKind: 'open-responses',
   });
   assert.deepEqual(
-    geminiOptions.map((option) => option.value),
+    geminiProOptions.map((option) => option.value),
+    ['default', 'low', 'medium', 'high'],
+  );
+
+  const geminiFlashOptions = modelReasoningEffortOptions({
+    provider: 'vercel-ai-gateway',
+    model: 'google/gemini-3-flash-preview',
+    transportKind: 'open-responses',
+  });
+  assert.deepEqual(
+    geminiFlashOptions.map((option) => option.value),
+    ['default', 'minimal', 'low', 'medium', 'high'],
+  );
+
+  const gemini25Options = modelReasoningEffortOptions({
+    provider: 'vercel-ai-gateway',
+    model: 'google/gemini-2.5-flash',
+    transportKind: 'openai-compatible',
+  });
+  assert.deepEqual(
+    gemini25Options.map((option) => option.value),
     ['default', 'none', 'low', 'medium', 'high'],
   );
 
   assert.equal(
-    resolveModelReasoningEffortForContext('minimal', {
+    resolveModelReasoningEffortForContext('none', {
       provider: 'vercel-ai-gateway',
-      model: 'google/gemini-3.1-pro-preview',
+      model: 'google/gemini-3-flash-preview',
       transportKind: 'open-responses',
     }),
-    'low',
+    'minimal',
   );
   assert.equal(
     resolveOpenAiTransportReasoningEffortForContext('medium', {

--- a/packages/agent-core/src/reasoning-effort.test.ts
+++ b/packages/agent-core/src/reasoning-effort.test.ts
@@ -34,6 +34,27 @@ test('deepseek v4 models normalize medium to high and preserve max', () => {
   );
 });
 
+test('deepseek non-v4 models do not expose openai-compatible reasoning effort options', () => {
+  const options = modelReasoningEffortOptions({
+    provider: 'deepseek',
+    model: 'deepseek-chat',
+    transportKind: 'openai-compatible',
+  });
+  assert.deepEqual(options, [{ value: 'default', label: 'Default' }]);
+});
+
+test('gateway deepseek v4 models use deepseek v4 reasoning effort options', () => {
+  const options = modelReasoningEffortOptions({
+    provider: 'vercel-ai-gateway',
+    model: 'deepseek/deepseek-v4-pro',
+    transportKind: 'openai-compatible',
+  });
+  assert.deepEqual(
+    options.map((option) => option.value),
+    ['default', 'high', 'max'],
+  );
+});
+
 test('anthropic models normalize max to high transport effort', () => {
   assert.equal(
     resolveAnthropicTransportReasoningEffortForContext('max', {

--- a/packages/agent-core/src/reasoning-effort.ts
+++ b/packages/agent-core/src/reasoning-effort.ts
@@ -5,7 +5,7 @@ import {
   resolveGatewayAnthropicClaudeCapabilities,
 } from './openai/gateway-anthropic-thinking.js';
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
-import { isGatewayGoogleGeminiModel } from './openai/gateway-google-thinking.js';
+import { isGatewayGoogleGeminiModel, isGoogleGeminiMinimalThinkingLevelModel, isGoogleGeminiThinkingLevelModel } from './openai/gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openai/openrouter-anthropic-reasoning.js';
 import {
   isRoutedAnthropicClaudeModel,
@@ -52,7 +52,7 @@ export type MoonshotReasoningEffort = 'default' | 'minimal' | 'low' | 'medium' |
 
 export type XaiReasoningEffort = 'default' | 'none' | 'low' | 'medium' | 'high';
 
-export type GoogleReasoningEffort = 'default' | 'none' | 'low' | 'medium' | 'high';
+export type GoogleReasoningEffort = 'default' | 'none' | 'minimal' | 'low' | 'medium' | 'high';
 
 export type AnthropicReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
@@ -109,7 +109,26 @@ export const XAI_REASONING_EFFORT_OPTIONS: ReadonlyArray<
   { value: 'high', label: 'High' },
 ];
 
-export const GOOGLE_REASONING_EFFORT_OPTIONS: ReadonlyArray<
+export const GOOGLE_GEMINI_MINIMAL_REASONING_EFFORT_OPTIONS: ReadonlyArray<
+  ModelReasoningEffortOption<GoogleReasoningEffort>
+> = [
+  { value: 'default', label: 'Default' },
+  { value: 'minimal', label: 'Minimal' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+export const GOOGLE_GEMINI_LEVEL_REASONING_EFFORT_OPTIONS: ReadonlyArray<
+  ModelReasoningEffortOption<GoogleReasoningEffort>
+> = [
+  { value: 'default', label: 'Default' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+
+export const GOOGLE_GEMINI_BUDGET_REASONING_EFFORT_OPTIONS: ReadonlyArray<
   ModelReasoningEffortOption<GoogleReasoningEffort>
 > = [
   { value: 'default', label: 'Default' },
@@ -118,6 +137,8 @@ export const GOOGLE_REASONING_EFFORT_OPTIONS: ReadonlyArray<
   { value: 'medium', label: 'Medium' },
   { value: 'high', label: 'High' },
 ];
+
+export const GOOGLE_REASONING_EFFORT_OPTIONS = GOOGLE_GEMINI_BUDGET_REASONING_EFFORT_OPTIONS;
 
 export const ANTHROPIC_REASONING_EFFORT_OPTIONS: ReadonlyArray<
   ModelReasoningEffortOption<AnthropicReasoningEffort>
@@ -137,7 +158,9 @@ const ALL_REASONING_EFFORT_OPTIONS = dedupeReasoningEffortOptions([
   ...DEEPSEEK_V4_REASONING_EFFORT_OPTIONS,
   ...MOONSHOT_REASONING_EFFORT_OPTIONS,
   ...XAI_REASONING_EFFORT_OPTIONS,
-  ...GOOGLE_REASONING_EFFORT_OPTIONS,
+  ...GOOGLE_GEMINI_MINIMAL_REASONING_EFFORT_OPTIONS,
+  ...GOOGLE_GEMINI_LEVEL_REASONING_EFFORT_OPTIONS,
+  ...GOOGLE_GEMINI_BUDGET_REASONING_EFFORT_OPTIONS,
   ...ANTHROPIC_REASONING_EFFORT_OPTIONS,
 ]);
 
@@ -159,10 +182,6 @@ const MOONSHOT_REASONING_EFFORT_VALUES = new Set<string>(
 
 const XAI_REASONING_EFFORT_VALUES = new Set<string>(
   XAI_REASONING_EFFORT_OPTIONS.map((option) => option.value),
-);
-
-const GOOGLE_REASONING_EFFORT_VALUES = new Set<string>(
-  GOOGLE_REASONING_EFFORT_OPTIONS.map((option) => option.value),
 );
 
 const ANTHROPIC_REASONING_EFFORT_VALUES = new Set<string>(
@@ -244,7 +263,7 @@ export function modelReasoningEffortOptions(
   }
 
   if (isGoogleReasoningEffortModel(context)) {
-    return GOOGLE_REASONING_EFFORT_OPTIONS;
+    return googleReasoningEffortOptionsForContext(context);
   }
 
   if (isAnthropicReasoningEffortModel(context)) {
@@ -363,6 +382,23 @@ export function isGoogleReasoningEffortModel(
     );
 }
 
+export function googleReasoningEffortOptionsForContext(
+  context?: ModelReasoningEffortContext,
+): ReadonlyArray<ModelReasoningEffortOption<ModelReasoningEffort>> {
+  const model = context?.model ?? '';
+  if (isGoogleGeminiMinimalThinkingLevelModel(model)) {
+    return GOOGLE_GEMINI_MINIMAL_REASONING_EFFORT_OPTIONS;
+  }
+  if (isGoogleGeminiThinkingLevelModel(model)) {
+    return GOOGLE_GEMINI_LEVEL_REASONING_EFFORT_OPTIONS;
+  }
+  return GOOGLE_GEMINI_BUDGET_REASONING_EFFORT_OPTIONS;
+}
+
+function googleReasoningEffortValuesForModel(model: string): Set<string> {
+  return new Set(googleReasoningEffortOptionsForContext({ model }).map((option) => option.value));
+}
+
 export function isAnthropicReasoningEffortModel(
   context?: ModelReasoningEffortContext,
 ): boolean {
@@ -458,14 +494,29 @@ function resolveCompatibleModelReasoningEffort(
   }
 
   if (isGoogleReasoningEffortModel(context)) {
+    const model = context?.model ?? '';
     switch (normalized) {
+      case 'none':
+        if (isGoogleGeminiMinimalThinkingLevelModel(model)) {
+          return 'minimal';
+        }
+        if (isGoogleGeminiThinkingLevelModel(model)) {
+          return 'default';
+        }
+        return 'none';
       case 'minimal':
-        return 'low';
+        if (isGoogleGeminiMinimalThinkingLevelModel(model)) {
+          return 'minimal';
+        }
+        if (isGoogleGeminiThinkingLevelModel(model)) {
+          return 'default';
+        }
+        return 'none';
       case 'xhigh':
       case 'max':
         return 'high';
       default:
-        return GOOGLE_REASONING_EFFORT_VALUES.has(normalized) ? normalized : 'default';
+        return googleReasoningEffortValuesForModel(model).has(normalized) ? normalized : 'default';
     }
   }
 

--- a/packages/agent-core/src/reasoning-effort.ts
+++ b/packages/agent-core/src/reasoning-effort.ts
@@ -4,6 +4,7 @@ import {
   isGatewayAnthropicClaudeModel,
   resolveGatewayAnthropicClaudeCapabilities,
 } from './openai/gateway-anthropic-thinking.js';
+import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
 import { isGatewayGoogleGeminiModel } from './openai/gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openai/openrouter-anthropic-reasoning.js';
 import { resolveRoutedAnthropicClaudeCapabilities } from './openai/routed-anthropic-claude-capabilities.js';
@@ -219,6 +220,11 @@ export function defaultModelReasoningEffort(
 export function modelReasoningEffortOptions(
   context?: ModelReasoningEffortContext,
 ): ReadonlyArray<ModelReasoningEffortOption<ModelReasoningEffort>> {
+  // DeepSeek 路由（直连或 Gateway deepseek/*）仅 V4 在 thinking 模式下有 reasoning_effort。
+  if (isDeepSeekRouteContext(context) && !isDeepSeekV4ReasoningEffortModel(context)) {
+    return [{ value: 'default', label: 'Default' }];
+  }
+
   if (isDeepSeekV4ReasoningEffortModel(context)) {
     return DEEPSEEK_V4_REASONING_EFFORT_OPTIONS;
   }
@@ -320,8 +326,10 @@ export function modelReasoningEffortLabel(value: ModelReasoningEffort): string {
 export function isDeepSeekV4ReasoningEffortModel(
   context?: ModelReasoningEffortContext,
 ): boolean {
-  return context?.provider === 'deepseek' &&
-    DEEPSEEK_V4_REASONING_MODEL_IDS.has(normalizeModelId(context.model));
+  if (!isDeepSeekRouteContext(context)) {
+    return false;
+  }
+  return DEEPSEEK_V4_REASONING_MODEL_IDS.has(normalizeDeepSeekModelId(context?.model ?? ''));
 }
 
 export function isMoonshotReasoningEffortModel(
@@ -373,6 +381,20 @@ export function isOpenRouterAnthropicClaudeReasoningModel(
 
 function normalizeModelId(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function normalizeDeepSeekModelId(model: string): string {
+  const normalized = normalizeModelId(model);
+  const slashIndex = normalized.lastIndexOf('/');
+  return slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+}
+
+function isDeepSeekRouteContext(context?: ModelReasoningEffortContext): boolean {
+  if (context?.provider === 'deepseek') {
+    return true;
+  }
+  return context?.provider === 'vercel-ai-gateway'
+    && parseGatewayUpstreamSlug(context.model ?? '') === 'deepseek';
 }
 
 function resolveCompatibleModelReasoningEffort(

--- a/packages/agent-core/src/reasoning-effort.ts
+++ b/packages/agent-core/src/reasoning-effort.ts
@@ -7,7 +7,10 @@ import {
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
 import { isGatewayGoogleGeminiModel } from './openai/gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openai/openrouter-anthropic-reasoning.js';
-import { resolveRoutedAnthropicClaudeCapabilities } from './openai/routed-anthropic-claude-capabilities.js';
+import {
+  isRoutedAnthropicClaudeModel,
+  resolveRoutedAnthropicClaudeCapabilities,
+} from './openai/routed-anthropic-claude-capabilities.js';
 import type { OpenAiTransportConfig } from './openai/openai-compat.js';
 
 export type ModelReasoningProvider =
@@ -245,22 +248,23 @@ export function modelReasoningEffortOptions(
   }
 
   if (isAnthropicReasoningEffortModel(context)) {
-    if (context?.supportedEfforts !== undefined) {
-      return anthropicReasoningEffortOptionsForSupportedEfforts(context.supportedEfforts);
-    }
-    return ANTHROPIC_REASONING_EFFORT_OPTIONS;
+    return anthropicClaudeReasoningEffortOptions(context);
   }
 
   if (isGatewayAnthropicClaudeReasoningModel(context)) {
-    const supportedEfforts = context?.supportedEfforts
-      ?? resolveGatewayAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts;
-    return anthropicReasoningEffortOptionsForSupportedEfforts(supportedEfforts);
+    return anthropicClaudeReasoningEffortOptions(
+      context,
+      context?.supportedEfforts
+        ?? resolveGatewayAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts,
+    );
   }
 
   if (isOpenRouterAnthropicClaudeReasoningModel(context)) {
-    const supportedEfforts = context?.supportedEfforts
-      ?? resolveRoutedAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts;
-    return anthropicReasoningEffortOptionsForSupportedEfforts(supportedEfforts);
+    return anthropicClaudeReasoningEffortOptions(
+      context,
+      context?.supportedEfforts
+        ?? resolveRoutedAnthropicClaudeCapabilities(context?.model ?? '').supportedEfforts,
+    );
   }
 
   return OPENAI_COMPATIBLE_REASONING_EFFORT_OPTIONS;
@@ -302,6 +306,10 @@ export function resolveAnthropicTransportReasoningEffortForContext(
   value: unknown,
   context?: ModelReasoningEffortContext,
 ): AnthropicTransportConfig['effort'] | undefined {
+  if (resolveRoutedAnthropicClaudeCapabilitiesForContext(context)?.thinkingMode === 'budget') {
+    return undefined;
+  }
+
   const normalized = resolveModelReasoningEffortForContext(value, {
     ...context,
     transportKind: 'anthropic',
@@ -528,6 +536,43 @@ function dedupeReasoningEffortOptions(
   }
 
   return deduped;
+}
+
+function resolveRoutedAnthropicClaudeCapabilitiesForContext(
+  context?: ModelReasoningEffortContext,
+) {
+  const model = context?.model?.trim();
+  if (!model) {
+    return undefined;
+  }
+  const routedModelId = isRoutedAnthropicClaudeModel(model)
+    ? model
+    : `anthropic/${model}`;
+  if (!isRoutedAnthropicClaudeModel(routedModelId)) {
+    return undefined;
+  }
+  return resolveRoutedAnthropicClaudeCapabilities(routedModelId);
+}
+
+function anthropicClaudeReasoningEffortOptions(
+  context?: ModelReasoningEffortContext,
+  supportedEffortsOverride?: readonly ModelReasoningEffort[],
+): ReadonlyArray<ModelReasoningEffortOption<ModelReasoningEffort>> {
+  const capabilities = resolveRoutedAnthropicClaudeCapabilitiesForContext(context);
+  if (capabilities?.thinkingMode === 'budget') {
+    return [{ value: 'default', label: 'Default' }];
+  }
+
+  const supportedEfforts = supportedEffortsOverride ?? capabilities?.supportedEfforts;
+  if (supportedEfforts !== undefined && supportedEfforts.length > 0) {
+    return anthropicReasoningEffortOptionsForSupportedEfforts(supportedEfforts);
+  }
+
+  if (isAnthropicReasoningEffortModel(context)) {
+    return ANTHROPIC_REASONING_EFFORT_OPTIONS;
+  }
+
+  return [{ value: 'default', label: 'Default' }];
 }
 
 function anthropicReasoningEffortValueForContext(

--- a/packages/host-internal/src/openai-models.test.ts
+++ b/packages/host-internal/src/openai-models.test.ts
@@ -226,7 +226,7 @@ test('parseVercelAiGatewayModelEntriesPayload infers supportedReasoningEfforts f
     },
     {
       id: 'google/gemini-2.5-flash',
-      supportedReasoningEfforts: ['low', 'medium', 'high'],
+      supportedReasoningEfforts: ['none', 'low', 'medium', 'high'],
     },
     {
       id: 'google/imagen-4',


### PR DESCRIPTION
## Summary

- Desktop 模型选择器 Inspector 新增 Thinking 开关，与 Reasoning Effort 联动；`thinkingEnabled` 持久化并在 Agent 路径按厂商注入传输 thinking 配置
- agent-core 新增 `model-thinking-controls` eligibility 解析；Claude adaptive/budget、DeepSeek V4、Moonshot kimi-k2.5+ 等分型号处理 Effort 与开关共存/互斥
- Vercel AI Gateway 按上游 slug 注入 `anthropic` / `google` / `deepseek` / `xiaomi` / `zai` / `alibaba` / `minimax` 等 providerOptions；Gemini Flash 系用 Minimal 替代 None 对齐 API
- 已知限制：本次仅适配**大部分**直连与 Gateway 上游厂商的思考开关；**部分聚合提供商**（如 OpenRouter 非 Claude 路由、Gateway 尚未接线的上游 slug 等）仍未覆盖，后续按需补齐
- Gateway Z.ai / MiniMax M3 经 open-responses 不返回可展示思考流，已追踪 #169、#170

## Test plan

- [x] `npm run build:agent-core` 与 Desktop 相关单测通过
- [x] Desktop 模型 Inspector：Thinking 开关显示/隐藏、与 Effort 联动、触发器灰字「Thinking」/「不思考」展示正确
- [x] 本次范围内直连与 Gateway 模型（Claude、Gemini、DeepSeek V4、Qwen、MiniMax、MiMo、Z.ai、Grok、Moonshot 等）思考开关开/关行为实测正常
- [x] Claude 4.5 及以下仅 Thinking 开关、4.6+ adaptive 与 Effort 共存验证通过