### PR TITLE
fix(host-internal): Alibaba cn-beijing 改用 WorkspaceId 式 MaaS 端点

### DIFF
--- a/apps/cli/src/model_provider_presets.rs
+++ b/apps/cli/src/model_provider_presets.rs
@@ -198,13 +198,21 @@ pub(crate) fn model_add_alibaba_site_id_from_choice(selected: usize) -> &'static
 pub(crate) fn model_add_alibaba_site_requires_workspace_id(site: &str) -> bool {
     matches!(
         site.trim(),
-        "ap-southeast-1" | "eu-central-1"
+        "cn-beijing" | "ap-southeast-1" | "eu-central-1"
     )
 }
 
 fn model_add_alibaba_compatible_site_api_base(site: &str, workspace_id: &str) -> Option<String> {
     match site.trim() {
-        "cn-beijing" => Some("https://dashscope.aliyuncs.com/compatible-mode/v1".to_string()),
+        "cn-beijing" => {
+            let workspace = workspace_id.trim();
+            if workspace.is_empty() {
+                return None;
+            }
+            Some(format!(
+                "https://{workspace}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+            ))
+        }
         "us-virginia" => Some("https://dashscope-us.aliyuncs.com/compatible-mode/v1".to_string()),
         "ap-southeast-1" => {
             let workspace = workspace_id.trim();
@@ -521,20 +529,28 @@ mod tests {
         assert_eq!(
             super::model_add_alibaba_site_api_base(
                 "cn-beijing",
-                "",
+                "ws-cn",
                 ModelTransportKind::OpenAiCompatible,
             )
             .as_deref(),
-            Some("https://dashscope.aliyuncs.com/compatible-mode/v1")
+            Some("https://ws-cn.cn-beijing.maas.aliyuncs.com/compatible-mode/v1")
         );
         assert_eq!(
             super::model_add_alibaba_site_api_base(
                 "cn-beijing",
-                "",
+                "ws-cn",
                 ModelTransportKind::Anthropic,
             )
             .as_deref(),
-            Some("https://dashscope.aliyuncs.com/apps/anthropic")
+            Some("https://ws-cn.cn-beijing.maas.aliyuncs.com/apps/anthropic")
+        );
+        assert!(
+            super::model_add_alibaba_site_api_base(
+                "cn-beijing",
+                "",
+                ModelTransportKind::OpenAiCompatible,
+            )
+            .is_none()
         );
         assert_eq!(
             super::model_add_alibaba_site_api_base(

--- a/apps/cli/src/shell/bottom_form.rs
+++ b/apps/cli/src/shell/bottom_form.rs
@@ -2575,6 +2575,8 @@ mod tests {
         }
         sync_model_add_form_fields(&mut form);
         assert_eq!(form.fields.len(), 6);
+        form.selected_field = 4;
+        insert_text(&mut form, "ws-cn");
         form.selected_field = 5;
         insert_text(&mut form, "sk-ali");
 
@@ -2582,10 +2584,13 @@ mod tests {
         assert_eq!(parsed.provider, ModelProvider::Alibaba);
         assert!(parsed.bulk);
         assert!(parsed.model_name.is_none());
-        assert_eq!(parsed.api_base, "https://dashscope.aliyuncs.com/compatible-mode/v1");
+        assert_eq!(
+            parsed.api_base,
+            "https://ws-cn.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
+        );
         assert_eq!(parsed.api_key, "sk-ali");
         assert_eq!(parsed.provider_site.as_deref(), Some("cn-beijing"));
-        assert!(parsed.alibaba_workspace_id.is_none());
+        assert_eq!(parsed.alibaba_workspace_id.as_deref(), Some("ws-cn"));
     }
 
     #[test]

--- a/packages/host-internal/src/model-provider-presets.json
+++ b/packages/host-internal/src/model-provider-presets.json
@@ -97,7 +97,8 @@
         "cn-beijing": {
           "labelKey": "cn-beijing",
           "fallbackLabel": "cn-beijing",
-          "apiBase": "https://dashscope.aliyuncs.com/compatible-mode/v1"
+          "apiBase": "https://{workspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+          "requiresWorkspaceId": true
         },
         "ap-southeast-1": {
           "labelKey": "ap-southeast-1",

--- a/packages/host-internal/src/model-provider-presets.test.ts
+++ b/packages/host-internal/src/model-provider-presets.test.ts
@@ -259,12 +259,22 @@ test('resolveProviderConnectApiBase prefers site apiBase for alibaba', () => {
   assert.equal(providerSupportsSiteSelection('alibaba'), true);
   assert.equal(defaultProviderConnectSite('alibaba'), 'cn-beijing');
   assert.equal(
-    resolveProviderConnectApiBase('alibaba', 'openai-compatible', { site: 'cn-beijing' }),
-    'https://dashscope.aliyuncs.com/compatible-mode/v1',
+    resolveProviderConnectApiBase('alibaba', 'openai-compatible', {
+      site: 'cn-beijing',
+      workspaceId: 'ws-cn',
+    }),
+    'https://ws-cn.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
   );
   assert.equal(
-    resolveProviderConnectApiBase('alibaba', 'anthropic', { site: 'cn-beijing' }),
-    'https://dashscope.aliyuncs.com/apps/anthropic',
+    resolveProviderConnectApiBase('alibaba', 'anthropic', {
+      site: 'cn-beijing',
+      workspaceId: 'ws-cn',
+    }),
+    'https://ws-cn.cn-beijing.maas.aliyuncs.com/apps/anthropic',
+  );
+  assert.throws(
+    () => resolveProviderConnectApiBase('alibaba', 'openai-compatible', { site: 'cn-beijing' }),
+    /requires a workspace ID/,
   );
   assert.equal(
     resolveProviderConnectApiBase('alibaba', 'open-responses', { site: 'us-virginia' }),


### PR DESCRIPTION
## Summary

- 将 Alibaba `cn-beijing` 地域端点从 `dashscope.aliyuncs.com` 改为 `{workspaceId}.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`，与新加坡、法兰克福站点一致
- 为 `cn-beijing` 标记 `requiresWorkspaceId`，Desktop / CLI 连接向导需填写 Workspace ID 后才能解析端点
- CLI 地域解析、连接表单校验与单测同步更新

Closes #173

## Test plan

- [x] `npx tsx --test packages/host-internal/src/model-provider-presets.test.ts`
- [x] `cargo test alibaba_site_api_base`
- [x] `cargo test model_add_form_parses_alibaba`
- [ ] Desktop 连接 Alibaba 并选择 cn-beijing 时验证 Workspace ID 必填与端点解析