### PR TITLE
feat(agent-core, host-internal, desktop): MiniMax M3 支持图片与视频输入

### DIFF
--- a/apps/desktop/src/host/model-catalog-startup-refresh.ts
+++ b/apps/desktop/src/host/model-catalog-startup-refresh.ts
@@ -243,13 +243,75 @@ export function mergeNewCatalogModelsIntoConfig(
   return toAdd.length;
 }
 
+function modelMatchesCatalogRefreshScope(
+  model: ModelProfileSnapshot,
+  provider: DesktopModelProvider,
+  transportKind: DesktopTransportKind,
+  apiBase: string,
+): boolean {
+  if (model.provider !== provider) {
+    return false;
+  }
+  if (resolveDesktopTransportKind(model) !== transportKind) {
+    return false;
+  }
+  const modelBase = model.apiBase.trim() || DEFAULT_API_BASE;
+  return normalizeOpenAiApiBase(modelBase) === normalizeOpenAiApiBase(apiBase);
+}
+
+/** 将目录中新标注的 image/video 能力补写到仅存 chat 的已入库模型（如 MiniMax-M3）。 */
+export function syncExistingModelCapabilitiesFromCatalog(
+  config: DesktopConfigFile,
+  profile: ModelProfileSnapshot,
+  result: LoadedPreviewModelsResult,
+): number {
+  const provider = profile.provider;
+  if (!provider) {
+    return 0;
+  }
+
+  const transportKind = resolveDesktopTransportKind(profile);
+  const apiBase = profile.apiBase.trim() || DEFAULT_API_BASE;
+  const catalogEntries = previewCatalogMapForTransport({
+    provider,
+    transportKind,
+    modelCatalog: result.modelCatalog,
+  });
+  if (catalogEntries.size === 0) {
+    return 0;
+  }
+
+  let updated = 0;
+  for (const model of config.models) {
+    if (!modelMatchesCatalogRefreshScope(model, provider, transportKind, apiBase)) {
+      continue;
+    }
+    const catalogEntry = catalogEntries.get(model.name);
+    if (!catalogEntry?.capabilities?.length) {
+      continue;
+    }
+    const stored = model.capabilities;
+    const onlyChat = stored?.length === 1 && stored[0] === 'chat';
+    const catalogHasMultimodalInput = catalogEntry.capabilities.some(
+      (capability) => capability === 'image' || capability === 'video',
+    );
+    if (!onlyChat || !catalogHasMultimodalInput) {
+      continue;
+    }
+    model.capabilities = catalogEntry.capabilities;
+    updated += 1;
+  }
+  return updated;
+}
+
 export async function refreshConfiguredModelCatalogsOnStartup(
   config: DesktopConfigFile,
-): Promise<{ attempted: number; refreshed: number; skipped: number; merged: number }> {
+): Promise<{ attempted: number; refreshed: number; skipped: number; merged: number; synced: number }> {
   const targets = collectModelCatalogRefreshTargets(config.models);
   let refreshed = 0;
   let skipped = 0;
   let merged = 0;
+  let synced = 0;
 
   for (const profile of targets) {
     try {
@@ -257,6 +319,7 @@ export async function refreshConfiguredModelCatalogsOnStartup(
       if (result) {
         refreshed += 1;
         merged += mergeNewCatalogModelsIntoConfig(config, profile, result);
+        synced += syncExistingModelCapabilitiesFromCatalog(config, profile, result);
       } else {
         skipped += 1;
       }
@@ -265,5 +328,5 @@ export async function refreshConfiguredModelCatalogsOnStartup(
     }
   }
 
-  return { attempted: targets.length, refreshed, skipped, merged };
+  return { attempted: targets.length, refreshed, skipped, merged, synced };
 }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -1108,13 +1108,13 @@ class DesktopHostService {
             return;
           }
           const summary = await refreshConfiguredModelCatalogsOnStartup(state.config);
-          if (summary.merged > 0) {
+          if (summary.merged > 0 || summary.synced > 0) {
             await saveConfig(state.config);
             if (this.runtime?.isBusy() !== true) {
               await this.refreshRuntime();
             }
           }
-          if (summary.refreshed > 0 || summary.merged > 0) {
+          if (summary.refreshed > 0 || summary.merged > 0 || summary.synced > 0) {
             this.emitLiveSnapshotUpdate();
           }
         });

--- a/apps/desktop/test/host/model-catalog-metadata.test.mjs
+++ b/apps/desktop/test/host/model-catalog-metadata.test.mjs
@@ -349,6 +349,40 @@ test('xiaomi provider consumes Xiaomi model catalog metadata', () => {
   ]);
 });
 
+test('minimax provider consumes MiniMax model catalog metadata', () => {
+  assert.equal(usesProviderListedModelCatalogMetadata({ provider: 'minimax' }), true);
+
+  const preview = previewModelCatalogForTransport({
+    provider: 'minimax',
+    transportKind: 'anthropic',
+    listedModels: [
+      {
+        id: 'MiniMax-M3',
+        supportsImageInput: true,
+        supportsVideoInput: true,
+      },
+      {
+        id: 'MiniMax-M2.5',
+        supportsImageInput: false,
+        supportsVideoInput: false,
+      },
+    ],
+  });
+
+  assert.deepEqual(preview, [
+    {
+      id: 'MiniMax-M3',
+      displayName: 'MiniMax M3',
+      capabilities: ['chat', 'image', 'video'],
+    },
+    {
+      id: 'MiniMax-M2.5',
+      displayName: 'MiniMax M2.5',
+      capabilities: ['chat'],
+    },
+  ]);
+});
+
 test('volcengine provider maps domain-derived traits to catalog capabilities', () => {
   assert.equal(usesProviderListedModelCatalogMetadata({ provider: 'volcengine' }), true);
 

--- a/apps/desktop/test/host/model-catalog-startup-refresh.test.mjs
+++ b/apps/desktop/test/host/model-catalog-startup-refresh.test.mjs
@@ -6,6 +6,7 @@ import {
   collectModelCatalogRefreshTargets,
   mergeNewCatalogModelsIntoConfig,
   modelCatalogScopeKey,
+  syncExistingModelCapabilitiesFromCatalog,
 } from '../../dist-electron/src/host/model-catalog-startup-refresh.js';
 
 test('providerSupportsModelCatalogListing includes OpenAI and excludes Azure', () => {
@@ -96,4 +97,43 @@ test('mergeNewCatalogModelsIntoConfig appends only new provider-scoped models', 
     ['zai/glm-5.1', 'zai/glm-5.2'],
   );
   assert.equal(config.activeModel, 'zai/glm-5.1');
+});
+
+test('syncExistingModelCapabilitiesFromCatalog upgrades chat-only profiles from catalog', () => {
+  const config = {
+    models: [
+      {
+        name: 'MiniMax-M3',
+        apiBase: 'https://api.minimaxi.com/v1',
+        provider: 'minimax',
+        capabilities: ['chat'],
+        reasoningEffort: 'medium',
+      },
+      {
+        name: 'MiniMax-M2.5',
+        apiBase: 'https://api.minimaxi.com/v1',
+        provider: 'minimax',
+        capabilities: ['chat'],
+        reasoningEffort: 'medium',
+      },
+    ],
+    activeModel: 'MiniMax-M3',
+  };
+
+  const synced = syncExistingModelCapabilitiesFromCatalog(
+    config,
+    config.models[0],
+    {
+      modelIds: ['MiniMax-M3', 'MiniMax-M2.5'],
+      fromCache: false,
+      modelCatalog: [
+        { id: 'MiniMax-M3', capabilities: ['chat', 'image', 'video'] },
+        { id: 'MiniMax-M2.5', capabilities: ['chat'] },
+      ],
+    },
+  );
+
+  assert.equal(synced, 1);
+  assert.deepEqual(config.models[0].capabilities, ['chat', 'image', 'video']);
+  assert.deepEqual(config.models[1].capabilities, ['chat']);
 });

--- a/packages/agent-core/src/anthropic/ai-sdk-transport.test.ts
+++ b/packages/agent-core/src/anthropic/ai-sdk-transport.test.ts
@@ -7,6 +7,31 @@ import {
 } from '../ports.js';
 import { AiSdkAnthropicTransport } from './ai-sdk-transport.js';
 
+test('llmHistoryAsApiMessages serializes image and video user parts', () => {
+  const transport = new AiSdkAnthropicTransport();
+  const history: LlmMessage[] = [{
+    role: 'user',
+    content: [
+      { type: 'text', text: 'describe this' },
+      { type: 'image', path: 'shot.png' },
+      { type: 'video', path: 'clip.mp4' },
+    ],
+  }];
+
+  const messages = transport.llmHistoryAsApiMessages(history);
+  assert.equal(messages.length, 1);
+
+  const user = messages[0] as {
+    role: string;
+    content: Array<Record<string, unknown>>;
+  };
+  assert.equal(user.role, 'user');
+  assert.equal(user.content.length, 3);
+  assert.equal(user.content[0]?.type, 'text');
+  assert.equal(user.content[1]?.type, 'image_url');
+  assert.equal(user.content[2]?.type, 'video_url');
+});
+
 test('llmHistoryAsApiMessages preserves anthropic providerState for assistant tool calls', () => {
   const transport = new AiSdkAnthropicTransport();
   const history: LlmMessage[] = [{

--- a/packages/agent-core/src/anthropic/ai-sdk-transport.ts
+++ b/packages/agent-core/src/anthropic/ai-sdk-transport.ts
@@ -60,8 +60,10 @@ import {
 import {
   isMinimaxAnthropicConfig,
   mapMinimaxAnthropicImageContentPart,
+  mapMinimaxAnthropicVideoContentPart,
 } from './minimax-multimodal.js';
 import { pathToLocalVideoReference } from '../openai/openai-multimodal-media-path.js';
+import { resolveMinimaxVideoInAnthropicMessages } from '../openai/minimax-video-messages.js';
 
 type AnthropicToolCall = {
   toolCallId: string;
@@ -132,6 +134,11 @@ export class AiSdkAnthropicTransport
       request,
     );
     const normalizedMessages = prepareAnthropicToolStateMessages(config, messages);
+    await resolveMinimaxVideoInAnthropicMessages(
+      config,
+      normalizedMessages,
+      anthropicTransportAssetRoot(config),
+    );
     const requestTrace = buildAnthropicRequestTrace(config, 1, normalizedMessages, []);
 
     try {
@@ -168,6 +175,11 @@ export class AiSdkAnthropicTransport
 
     const requestMessages = nextState.messages.map((message) => cloneJsonValue(message));
     const normalizedRequestMessages = prepareAnthropicToolStateMessages(config, requestMessages);
+    await resolveMinimaxVideoInAnthropicMessages(
+      config,
+      normalizedRequestMessages,
+      anthropicTransportAssetRoot(config),
+    );
     const normalizedTools = normalizeToolDefinitions(tools);
     const requestTrace = buildAnthropicRequestTrace(
       config,
@@ -244,6 +256,11 @@ export class AiSdkAnthropicTransport
 
     const requestMessages = nextState.messages.map((message) => cloneJsonValue(message));
     const normalizedRequestMessages = prepareAnthropicToolStateMessages(config, requestMessages);
+    await resolveMinimaxVideoInAnthropicMessages(
+      config,
+      normalizedRequestMessages,
+      anthropicTransportAssetRoot(config),
+    );
     const normalizedTools = normalizeToolDefinitions(tools);
     const requestTrace = buildAnthropicRequestTrace(
       config,
@@ -507,6 +524,12 @@ function prepareAnthropicToolStateMessages(
   );
 }
 
+function anthropicTransportAssetRoot(
+  config: Pick<AnthropicTransportConfig, 'workspaceRoot'>,
+): string {
+  return config.workspaceRoot ?? process.cwd();
+}
+
 function stripAnthropicUserMediaWithoutCapability(
   messages: JsonValue[],
   config: Pick<AnthropicTransportConfig, 'modelCapabilities'>,
@@ -630,6 +653,13 @@ function userContentToAiSdkContent(
             parts.push(mapMinimaxAnthropicImageContentPart(part.image_url.url));
           } else {
             parts.push({ type: 'image', image: part.image_url.url });
+          }
+        }
+        break;
+      case 'video_url':
+        if (isJsonObject(part.video_url) && typeof part.video_url.url === 'string') {
+          if (isMinimaxAnthropicConfig(config)) {
+            parts.push(mapMinimaxAnthropicVideoContentPart(part.video_url.url));
           }
         }
         break;

--- a/packages/agent-core/src/anthropic/ai-sdk-transport.ts
+++ b/packages/agent-core/src/anthropic/ai-sdk-transport.ts
@@ -41,7 +41,6 @@ import type {
   JsonObject,
   JsonValue,
   LlmMessage,
-  LlmModelCapabilities,
   LlmStreamEvent,
   LlmTransport,
   StartedToolAgentRound,
@@ -50,6 +49,7 @@ import type {
   ToolExecutionOutput,
 } from '../ports.js';
 import { llmMessageHasMedia, llmMessageTextContent } from '../ports.js';
+import type { LlmModelCapabilities } from '../llm-provider-shared.js';
 import type { JsonSchemaTransport } from '../json-schema.js';
 import {
   buildAnthropicProviderOptions,
@@ -538,9 +538,10 @@ function stripAnthropicUserMediaWithoutCapability(
     return messages;
   }
 
+  const capabilities = config.modelCapabilities;
   return messages.map((message) => sanitizeAnthropicMessageForCompatibility(
     message,
-    config.modelCapabilities,
+    capabilities,
   ));
 }
 

--- a/packages/agent-core/src/anthropic/ai-sdk-transport.ts
+++ b/packages/agent-core/src/anthropic/ai-sdk-transport.ts
@@ -41,6 +41,7 @@ import type {
   JsonObject,
   JsonValue,
   LlmMessage,
+  LlmModelCapabilities,
   LlmStreamEvent,
   LlmTransport,
   StartedToolAgentRound,
@@ -48,7 +49,7 @@ import type {
   ToolCallRequest,
   ToolExecutionOutput,
 } from '../ports.js';
-import { llmMessageTextContent } from '../ports.js';
+import { llmMessageHasMedia, llmMessageTextContent } from '../ports.js';
 import type { JsonSchemaTransport } from '../json-schema.js';
 import {
   buildAnthropicProviderOptions,
@@ -56,6 +57,11 @@ import {
   DEFAULT_ANTHROPIC_BASE_URL,
   type AnthropicTransportConfig,
 } from './anthropic-compat.js';
+import {
+  isMinimaxAnthropicConfig,
+  mapMinimaxAnthropicImageContentPart,
+} from './minimax-multimodal.js';
+import { pathToLocalVideoReference } from '../openai/openai-multimodal-media-path.js';
 
 type AnthropicToolCall = {
   toolCallId: string;
@@ -125,13 +131,13 @@ export class AiSdkAnthropicTransport
       { model: config.model },
       request,
     );
-    const normalizedMessages = normalizeMessagesForAnthropicPrompt(messages);
+    const normalizedMessages = prepareAnthropicToolStateMessages(config, messages);
     const requestTrace = buildAnthropicRequestTrace(config, 1, normalizedMessages, []);
 
     try {
       const result = await generateObject({
         model: createAnthropicLanguageModel(config),
-        messages: toolStateMessagesToAiSdkMessages(normalizedMessages) as any,
+        messages: toolStateMessagesToAiSdkMessages(normalizedMessages, config) as any,
         allowSystemInMessages: true,
         schema: jsonSchema(request.schema as Record<string, unknown>),
         schemaName: request.schemaName,
@@ -161,7 +167,7 @@ export class AiSdkAnthropicTransport
     };
 
     const requestMessages = nextState.messages.map((message) => cloneJsonValue(message));
-    const normalizedRequestMessages = normalizeMessagesForAnthropicPrompt(requestMessages);
+    const normalizedRequestMessages = prepareAnthropicToolStateMessages(config, requestMessages);
     const normalizedTools = normalizeToolDefinitions(tools);
     const requestTrace = buildAnthropicRequestTrace(
       config,
@@ -173,7 +179,7 @@ export class AiSdkAnthropicTransport
     try {
       const result: any = await generateText({
         model: createAnthropicLanguageModel(config),
-        messages: toolStateMessagesToAiSdkMessages(normalizedRequestMessages) as any,
+        messages: toolStateMessagesToAiSdkMessages(normalizedRequestMessages, config) as any,
         allowSystemInMessages: true,
         ...(normalizedTools.length === 0
           ? {}
@@ -237,7 +243,7 @@ export class AiSdkAnthropicTransport
     };
 
     const requestMessages = nextState.messages.map((message) => cloneJsonValue(message));
-    const normalizedRequestMessages = normalizeMessagesForAnthropicPrompt(requestMessages);
+    const normalizedRequestMessages = prepareAnthropicToolStateMessages(config, requestMessages);
     const normalizedTools = normalizeToolDefinitions(tools);
     const requestTrace = buildAnthropicRequestTrace(
       config,
@@ -251,7 +257,7 @@ export class AiSdkAnthropicTransport
     try {
       const result: any = streamText({
         model: createAnthropicLanguageModel(config),
-        messages: toolStateMessagesToAiSdkMessages(normalizedRequestMessages) as any,
+        messages: toolStateMessagesToAiSdkMessages(normalizedRequestMessages, config) as any,
         allowSystemInMessages: true,
         ...(normalizedTools.length === 0
           ? {}
@@ -315,6 +321,7 @@ export class AiSdkAnthropicTransport
           ? {}
           : { preCompactionArchivePath: context.preCompactionArchivePath }),
       }),
+      config,
     );
     const compactConfig: AnthropicTransportConfig = {
       ...config,
@@ -458,7 +465,10 @@ function buildAiSdkTools(
   );
 }
 
-function toolStateMessagesToAiSdkMessages(messages: JsonValue[]): Array<Record<string, unknown>> {
+function toolStateMessagesToAiSdkMessages(
+  messages: JsonValue[],
+  config: AnthropicTransportConfig,
+): Array<Record<string, unknown>> {
   const toolCallNames = buildToolCallNameIndex(messages);
 
   return messages.flatMap((message) => {
@@ -470,7 +480,7 @@ function toolStateMessagesToAiSdkMessages(messages: JsonValue[]): Array<Record<s
       case 'system':
         return typeof message.content === 'string' ? [{ role: 'system', content: message.content }] : [];
       case 'user': {
-        const content = userContentToAiSdkContent(message.content);
+        const content = userContentToAiSdkContent(message.content, config);
         return content === undefined ? [] : [{ role: 'user', content }];
       }
       case 'assistant': {
@@ -485,6 +495,64 @@ function toolStateMessagesToAiSdkMessages(messages: JsonValue[]): Array<Record<s
         return [];
     }
   });
+}
+
+function prepareAnthropicToolStateMessages(
+  config: AnthropicTransportConfig,
+  messages: JsonValue[],
+): JsonValue[] {
+  return stripAnthropicUserMediaWithoutCapability(
+    normalizeMessagesForAnthropicPrompt(messages),
+    config,
+  );
+}
+
+function stripAnthropicUserMediaWithoutCapability(
+  messages: JsonValue[],
+  config: Pick<AnthropicTransportConfig, 'modelCapabilities'>,
+): JsonValue[] {
+  if (config.modelCapabilities === undefined) {
+    return messages;
+  }
+
+  return messages.map((message) => sanitizeAnthropicMessageForCompatibility(
+    message,
+    config.modelCapabilities,
+  ));
+}
+
+function sanitizeAnthropicMessageForCompatibility(
+  message: JsonValue,
+  capabilities: LlmModelCapabilities,
+): JsonValue {
+  const cloned = cloneJsonValue(message);
+  if (!isJsonObject(cloned) || cloned.role !== 'user' || !Array.isArray(cloned.content)) {
+    return cloned;
+  }
+
+  let content = cloned.content;
+  if (!capabilities.imageInput) {
+    content = content.filter(
+      (part) => !(isJsonObject(part) && part.type === 'image_url'),
+    );
+  }
+  if (!capabilities.videoInput) {
+    content = content.filter(
+      (part) => !(isJsonObject(part) && part.type === 'video_url'),
+    );
+  }
+
+  if (content !== cloned.content) {
+    const textParts = content.filter(
+      (part) => isJsonObject(part) && part.type === 'text' && typeof part.text === 'string',
+    );
+    return {
+      ...cloned,
+      content: textParts.length > 0 ? textParts : '',
+    };
+  }
+
+  return cloned;
 }
 
 function normalizeMessagesForAnthropicPrompt(messages: JsonValue[]): JsonValue[] {
@@ -534,6 +602,7 @@ function projectSeparatedSystemMessageForAnthropic(message: JsonObject): JsonVal
 
 function userContentToAiSdkContent(
   content: JsonValue | undefined,
+  config: AnthropicTransportConfig,
 ): string | Array<Record<string, unknown>> | undefined {
   if (typeof content === 'string') {
     return content;
@@ -557,7 +626,11 @@ function userContentToAiSdkContent(
         break;
       case 'image_url':
         if (isJsonObject(part.image_url) && typeof part.image_url.url === 'string') {
-          parts.push({ type: 'image', image: part.image_url.url });
+          if (isMinimaxAnthropicConfig(config)) {
+            parts.push(mapMinimaxAnthropicImageContentPart(part.image_url.url));
+          } else {
+            parts.push({ type: 'image', image: part.image_url.url });
+          }
         }
         break;
       default:
@@ -1141,7 +1214,7 @@ function llmMessageToToolStateMessage(message: LlmMessage, assetRoot: string): J
     };
   }
 
-  if (message.role === 'user' && message.content.some((part) => part.type === 'image')) {
+  if (message.role === 'user' && llmMessageHasMedia(message.content)) {
     const parts: JsonValue[] = [];
 
     for (const part of message.content) {
@@ -1155,6 +1228,16 @@ function llmMessageToToolStateMessage(message: LlmMessage, assetRoot: string): J
           type: 'image_url',
           image_url: {
             url: pathToImageUrl(part.path, assetRoot),
+          },
+        });
+        continue;
+      }
+
+      if (part.type === 'video') {
+        parts.push({
+          type: 'video_url',
+          video_url: {
+            url: pathToLocalVideoReference(part.path, assetRoot),
           },
         });
       }

--- a/packages/agent-core/src/anthropic/minimax-multimodal.test.ts
+++ b/packages/agent-core/src/anthropic/minimax-multimodal.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  isMinimaxAnthropicConfig,
+  mapMinimaxAnthropicImageContentPart,
+  parseDataUrlToAnthropicImageSource,
+} from './minimax-multimodal.js';
+
+test('isMinimaxAnthropicConfig matches minimax anthropic base URLs', () => {
+  assert.equal(isMinimaxAnthropicConfig({ baseUrl: 'https://api.minimax.io/anthropic/v1' }), true);
+  assert.equal(isMinimaxAnthropicConfig({ baseUrl: 'https://api.minimaxi.com/anthropic/v1' }), true);
+  assert.equal(isMinimaxAnthropicConfig({ baseUrl: 'https://api.anthropic.com/v1' }), false);
+});
+
+test('parseDataUrlToAnthropicImageSource splits base64 data URLs', () => {
+  assert.deepEqual(
+    parseDataUrlToAnthropicImageSource('data:image/png;base64,QUJD'),
+    {
+      type: 'base64',
+      media_type: 'image/png',
+      data: 'QUJD',
+    },
+  );
+  assert.equal(parseDataUrlToAnthropicImageSource('https://example.com/a.png'), undefined);
+});
+
+test('mapMinimaxAnthropicImageContentPart maps base64 and public URLs', () => {
+  assert.deepEqual(
+    mapMinimaxAnthropicImageContentPart('data:image/jpeg;base64,abc'),
+    {
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/jpeg',
+        data: 'abc',
+      },
+    },
+  );
+  assert.deepEqual(
+    mapMinimaxAnthropicImageContentPart('https://cdn.example.com/a.png'),
+    {
+      type: 'image',
+      source: {
+        type: 'url',
+        url: 'https://cdn.example.com/a.png',
+      },
+    },
+  );
+});

--- a/packages/agent-core/src/anthropic/minimax-multimodal.ts
+++ b/packages/agent-core/src/anthropic/minimax-multimodal.ts
@@ -1,0 +1,58 @@
+import type { AnthropicTransportConfig } from './anthropic-compat.js';
+
+export function isMinimaxAnthropicConfig(
+  config: Pick<AnthropicTransportConfig, 'baseUrl'>,
+): boolean {
+  const base = config.baseUrl?.trim().toLowerCase() ?? '';
+  return base.includes('minimax');
+}
+
+export type MinimaxAnthropicImageSource =
+  | { type: 'url'; url: string }
+  | { type: 'base64'; media_type: string; data: string };
+
+export function parseDataUrlToAnthropicImageSource(
+  value: string,
+): MinimaxAnthropicImageSource | undefined {
+  const trimmed = value.trim();
+  const match = /^data:([^;]+);base64,(.+)$/i.exec(trimmed);
+  if (!match) {
+    return undefined;
+  }
+
+  const mediaType = match[1]?.trim();
+  const data = match[2]?.trim();
+  if (!mediaType || !data) {
+    return undefined;
+  }
+
+  return {
+    type: 'base64',
+    media_type: mediaType,
+    data,
+  };
+}
+
+export function mapMinimaxAnthropicImageContentPart(
+  imageUrl: string,
+): Record<string, unknown> {
+  const trimmed = imageUrl.trim();
+  const source = parseDataUrlToAnthropicImageSource(trimmed)
+    ?? { type: 'url' as const, url: trimmed };
+  return {
+    type: 'image',
+    source,
+  };
+}
+
+export function mapMinimaxAnthropicVideoContentPart(
+  videoUrl: string,
+): Record<string, unknown> {
+  return {
+    type: 'video',
+    source: {
+      type: 'url',
+      url: videoUrl.trim(),
+    },
+  };
+}

--- a/packages/agent-core/src/openai/ai-sdk-transport-minimax.test.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport-minimax.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { test } from 'node:test';
+
+import { setLlmFetchTransportOverrideForTests } from '../llm-fetch.js';
+import { clearMinimaxVideoUploadCache } from './minimax-files.js';
+import {
+  clearMoonshotChatCompletionMessages,
+  openAiMessagesContainVideoUrl,
+  peekMoonshotChatCompletionMessages,
+  stashMoonshotChatCompletionMessages,
+} from './moonshot-chat-completion-messages.js';
+import { AiSdkOpenAiCompatibleTransport } from './ai-sdk-transport.js';
+import { resolveOpenAiModelCompatibilityProfile } from './openai-compat.js';
+
+const MINIMAL_MP4_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
+]);
+
+test('resolveOpenAiModelCompatibilityProfile strips minimax media without explicit capabilities', () => {
+  const profile = resolveOpenAiModelCompatibilityProfile({
+    llmVendor: 'minimax',
+    model: 'MiniMax-M2.5',
+  });
+  assert.equal(profile.hasExplicitCapabilities, true);
+  assert.deepEqual(profile.capabilities, {});
+});
+
+test('MiniMax openai-compatible fetch restores stashed video messages with mm_file url', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-agent-core-minimax-openai-video-'));
+  const videoPath = join(workspaceRoot, 'clip.mp4');
+
+  try {
+    await writeFile(videoPath, MINIMAL_MP4_HEADER);
+    clearMinimaxVideoUploadCache();
+
+    const capturedBodies: Record<string, unknown>[] = [];
+    setLlmFetchTransportOverrideForTests(async (_input, init) => {
+      if (init?.body instanceof FormData) {
+        return new Response(JSON.stringify({ file_id: 'file-mm-1' }), { status: 200 });
+      }
+
+      const bodyText = String(init?.body ?? '');
+      const body = JSON.parse(bodyText) as Record<string, unknown>;
+      capturedBodies.push(body);
+      return new Response(JSON.stringify({ choices: [{ message: { role: 'assistant', content: 'ok' } }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    const transport = new AiSdkOpenAiCompatibleTransport();
+    const result = await transport.startToolAgentRound(
+      {
+        apiKey: 'test-key',
+        model: 'MiniMax-M3',
+        baseUrl: 'https://api.minimax.io/v1',
+        llmVendor: 'minimax',
+        workspaceRoot,
+        modelCapabilities: { imageInput: true, videoInput: true },
+      },
+      {
+        messages: [{
+          role: 'user',
+          content: [
+            { type: 'text', text: 'describe the video' },
+            { type: 'video_url', video_url: { url: videoPath } },
+          ],
+        }],
+        steps: 0,
+      },
+      [],
+    );
+
+    assert.equal(result.kind, 'success');
+    const chatCompletionBody = capturedBodies.find((body) =>
+      Array.isArray(body.messages) && JSON.stringify(body.messages).includes('mm_file://'),
+    );
+    assert.ok(chatCompletionBody);
+    assert.match(JSON.stringify(chatCompletionBody.messages), /mm_file:\/\/file-mm-1/);
+    assert.equal(peekMoonshotChatCompletionMessages(), undefined);
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+    clearMoonshotChatCompletionMessages();
+    clearMinimaxVideoUploadCache();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('MiniMax openai-compatible stashes video_url messages before SDK request', () => {
+  const requestMessages = [
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'describe the video' },
+        { type: 'video_url', video_url: { url: 'mm_file://file-mm-1' } },
+      ],
+    },
+  ];
+  assert.equal(openAiMessagesContainVideoUrl(requestMessages), true);
+  stashMoonshotChatCompletionMessages(requestMessages);
+  assert.ok(peekMoonshotChatCompletionMessages());
+  clearMoonshotChatCompletionMessages();
+});

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -145,6 +145,7 @@ import {
   resolveMoonshotVideoUrlsInOpenAiMessages,
 } from './openai-multimodal-messages.js';
 import { resolveXiaomiVideoUrlsInOpenAiMessages } from './xiaomi-video-messages.js';
+import { resolveMinimaxVideoUrlsInOpenAiMessages } from './minimax-video-messages.js';
 import { normalizeMoonshotApiBase } from './moonshot-files.js';
 import {
   buildJsonSchemaCompletionMessages,
@@ -1783,6 +1784,7 @@ async function resolveOpenAiCompatibleVideoInputsInMessages(
 ): Promise<void> {
   await resolveMoonshotVideoUrlsInOpenAiMessages(config, messages, assetRoot);
   resolveXiaomiVideoUrlsInOpenAiMessages(config, messages, assetRoot);
+  await resolveMinimaxVideoUrlsInOpenAiMessages(config, messages, assetRoot);
 }
 
 function prepareMoonshotChatCompletionRequest(
@@ -1806,7 +1808,7 @@ function clearMoonshotChatCompletionRequest(config: OpenAiTransportConfig): void
 function usesOpenAiCompatibleVideoMessageStash(
   vendor: OpenAiTransportConfig['llmVendor'],
 ): boolean {
-  return vendor === 'moonshot-ai' || vendor === 'xiaomi';
+  return vendor === 'moonshot-ai' || vendor === 'xiaomi' || vendor === 'minimax';
 }
 
 function normalizeMessagesForRequest(

--- a/packages/agent-core/src/openai/minimax-files.test.ts
+++ b/packages/agent-core/src/openai/minimax-files.test.ts
@@ -71,3 +71,37 @@ test('uploadMinimaxVideoFile posts multipart with purpose=video_understanding an
     await rm(workspaceRoot, { recursive: true, force: true });
   }
 });
+
+test('uploadMinimaxVideoFile reads nested numeric file.file_id from MiniMax CN response', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-agent-core-minimax-upload-nested-'));
+
+  try {
+    const videoPath = join(workspaceRoot, 'clip.mp4');
+    await writeFile(videoPath, MINIMAL_MP4_HEADER);
+    clearMinimaxVideoUploadCache();
+    setLlmFetchTransportOverrideForTests(async () => new Response(
+      JSON.stringify({
+        file: {
+          file_id: 413560385741067,
+          bytes: MINIMAL_MP4_HEADER.length,
+          created_at: 1782521293,
+          filename: 'clip.mp4',
+          purpose: 'video_understanding',
+        },
+        base_resp: { status_code: 0, status_msg: 'success' },
+      }),
+      { status: 200 },
+    ));
+
+    const url = await uploadMinimaxVideoFile(
+      { apiKey: 'test-key', baseUrl: 'https://api.minimaxi.com/v1' },
+      videoPath,
+    );
+
+    assert.equal(url, 'mm_file://413560385741067');
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+    clearMinimaxVideoUploadCache();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/agent-core/src/openai/minimax-files.test.ts
+++ b/packages/agent-core/src/openai/minimax-files.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import {
+  configureLlmClientVersion,
+  setLlmFetchTransportOverrideForTests,
+} from '../llm-fetch.js';
+import {
+  clearMinimaxVideoUploadCache,
+  normalizeMinimaxFilesApiBase,
+  uploadMinimaxVideoFile,
+} from './minimax-files.js';
+
+const MINIMAL_MP4_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
+]);
+
+test('normalizeMinimaxFilesApiBase strips anthropic suffix', () => {
+  assert.equal(
+    normalizeMinimaxFilesApiBase('https://api.minimax.io/anthropic/v1'),
+    'https://api.minimax.io/v1',
+  );
+  assert.equal(
+    normalizeMinimaxFilesApiBase('https://api.minimaxi.com/anthropic/v1'),
+    'https://api.minimaxi.com/v1',
+  );
+  assert.equal(
+    normalizeMinimaxFilesApiBase('https://api.minimax.io/v1'),
+    'https://api.minimax.io/v1',
+  );
+});
+
+test('uploadMinimaxVideoFile posts multipart with purpose=video_understanding and returns mm_file url', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-agent-core-minimax-upload-'));
+  const videoPath = join(workspaceRoot, 'clip.mp4');
+  let capturedUrl = '';
+  let capturedBody: FormData | undefined;
+
+  try {
+    await writeFile(videoPath, MINIMAL_MP4_HEADER);
+    clearMinimaxVideoUploadCache();
+    configureLlmClientVersion('1.2.3');
+    setLlmFetchTransportOverrideForTests(async (input, init) => {
+      capturedUrl = String(input);
+      capturedBody = init?.body as FormData;
+      return new Response(JSON.stringify({ file_id: 'file-xyz789' }), { status: 200 });
+    });
+
+    const url = await uploadMinimaxVideoFile(
+      { apiKey: 'test-key', baseUrl: 'https://api.minimax.io/anthropic/v1' },
+      videoPath,
+    );
+
+    assert.equal(url, 'mm_file://file-xyz789');
+    assert.equal(capturedUrl, 'https://api.minimax.io/v1/files/upload');
+    assert.equal(capturedBody?.get('purpose'), 'video_understanding');
+    assert.ok(capturedBody?.get('file'));
+
+    const cached = await uploadMinimaxVideoFile(
+      { apiKey: 'test-key', baseUrl: 'https://api.minimax.io/anthropic/v1' },
+      videoPath,
+    );
+    assert.equal(cached, 'mm_file://file-xyz789');
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+    configureLlmClientVersion('0.1.0');
+    clearMinimaxVideoUploadCache();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/agent-core/src/openai/minimax-files.ts
+++ b/packages/agent-core/src/openai/minimax-files.ts
@@ -1,0 +1,89 @@
+import { readFile, stat } from 'node:fs/promises';
+import { basename } from 'node:path';
+
+import { getLlmFetch } from '../llm-fetch.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { normalizeOpenAiCompatibleApiBase } from './moonshot-files.js';
+
+/**
+ * MiniMax 视频理解：经 Files API 上传，purpose 必须为 video_understanding。
+ * 文档：https://platform.minimaxi.com/docs/api-reference/file-management-upload
+ * 图片上传留待后续统一，本次不走 Files API。
+ */
+const DEFAULT_MINIMAX_FILES_API_BASE = 'https://api.minimax.io/v1';
+
+const uploadCache = new Map<string, string>();
+
+/** 从 Chat / Anthropic baseUrl 推导 Files API 根（`.../v1`）。 */
+export function normalizeMinimaxFilesApiBase(baseUrl: string | undefined): string {
+  const trimmed = normalizeOpenAiCompatibleApiBase(baseUrl ?? DEFAULT_MINIMAX_FILES_API_BASE);
+  if (!trimmed) {
+    return DEFAULT_MINIMAX_FILES_API_BASE;
+  }
+
+  const withoutAnthropic = trimmed.replace(/\/anthropic\/v1$/i, '/v1');
+  if (withoutAnthropic !== trimmed) {
+    return withoutAnthropic;
+  }
+
+  return trimmed.endsWith('/v1') ? trimmed : `${trimmed}/v1`;
+}
+
+export async function uploadMinimaxVideoFile(
+  config: Pick<OpenAiTransportConfig, 'apiKey' | 'baseUrl'>,
+  absolutePath: string,
+): Promise<string> {
+  const apiBase = normalizeMinimaxFilesApiBase(config.baseUrl);
+  if (!apiBase) {
+    throw new Error('MiniMax video upload requires baseUrl');
+  }
+
+  const metadata = await stat(absolutePath);
+  const cacheKey = `${absolutePath}\0${metadata.mtimeMs}`;
+  const cached = uploadCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const bytes = await readFile(absolutePath);
+  const form = new FormData();
+  form.append('file', new Blob([bytes]), basename(absolutePath));
+  form.append('purpose', 'video_understanding');
+
+  const response = await getLlmFetch()(`${apiBase}/files/upload`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+    },
+    body: form,
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`MiniMax video upload failed (${response.status}): ${body}`);
+  }
+
+  const payload = (await response.json()) as { file_id?: unknown; id?: unknown };
+  const fileId = readMinimaxUploadedFileId(payload);
+  if (!fileId) {
+    throw new Error('MiniMax video upload returned no file id');
+  }
+
+  const url = `mm_file://${fileId}`;
+  uploadCache.set(cacheKey, url);
+  return url;
+}
+
+function readMinimaxUploadedFileId(payload: { file_id?: unknown; id?: unknown }): string | undefined {
+  if (typeof payload.file_id === 'string' && payload.file_id.trim().length > 0) {
+    return payload.file_id.trim();
+  }
+  if (typeof payload.id === 'string' && payload.id.trim().length > 0) {
+    return payload.id.trim();
+  }
+  return undefined;
+}
+
+export function clearMinimaxVideoUploadCache(): void {
+  uploadCache.clear();
+}

--- a/packages/agent-core/src/openai/minimax-files.ts
+++ b/packages/agent-core/src/openai/minimax-files.ts
@@ -1,6 +1,8 @@
 import { readFile, stat } from 'node:fs/promises';
 import { basename } from 'node:path';
 
+import { FormData } from 'undici';
+
 import { getLlmFetch } from '../llm-fetch.js';
 import type { OpenAiTransportConfig } from './openai-compat.js';
 import { normalizeOpenAiCompatibleApiBase } from './moonshot-files.js';
@@ -55,7 +57,10 @@ export async function uploadMinimaxVideoFile(
     headers: {
       Authorization: `Bearer ${config.apiKey}`,
     },
-    body: form,
+    // 必须用 undici 的 FormData：getLlmFetch 走 undici 包 fetch，与全局 FormData 非同源，
+    // 全局 FormData 会被当普通对象字符串化、丢失 multipart 边界头（MiniMax 报 2013）。
+    // 全局 fetch 类型不认 undici FormData，故此处断言桥接。
+    body: form as unknown as BodyInit,
   });
 
   if (!response.ok) {
@@ -63,7 +68,7 @@ export async function uploadMinimaxVideoFile(
     throw new Error(`MiniMax video upload failed (${response.status}): ${body}`);
   }
 
-  const payload = (await response.json()) as { file_id?: unknown; id?: unknown };
+  const payload = (await response.json()) as unknown;
   const fileId = readMinimaxUploadedFileId(payload);
   if (!fileId) {
     throw new Error('MiniMax video upload returned no file id');
@@ -74,12 +79,25 @@ export async function uploadMinimaxVideoFile(
   return url;
 }
 
-function readMinimaxUploadedFileId(payload: { file_id?: unknown; id?: unknown }): string | undefined {
-  if (typeof payload.file_id === 'string' && payload.file_id.trim().length > 0) {
-    return payload.file_id.trim();
+/**
+ * MiniMax Files API 实际返回 `{ file: { file_id: <number> } }`，file_id 为数字且嵌套在 file 下。
+ * 文档：https://platform.minimaxi.com/docs/api-reference/file-management-upload
+ * 兼容顶层 file_id/id 仅作兜底；同时接受 string 与 number。
+ */
+function readMinimaxUploadedFileId(payload: unknown): string | undefined {
+  if (typeof payload !== 'object' || payload === null) {
+    return undefined;
   }
-  if (typeof payload.id === 'string' && payload.id.trim().length > 0) {
-    return payload.id.trim();
+  const root = payload as Record<string, unknown>;
+  const file = typeof root.file === 'object' && root.file !== null ? (root.file as Record<string, unknown>) : undefined;
+  const candidates: unknown[] = [file?.file_id, file?.id, root.file_id, root.id];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+    if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+      return String(candidate);
+    }
   }
   return undefined;
 }

--- a/packages/agent-core/src/openai/minimax-video-messages.test.ts
+++ b/packages/agent-core/src/openai/minimax-video-messages.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import {
+  configureLlmClientVersion,
+  setLlmFetchTransportOverrideForTests,
+} from '../llm-fetch.js';
+import { clearMinimaxVideoUploadCache } from './minimax-files.js';
+import { resolveMinimaxVideoInAnthropicMessages } from './minimax-video-messages.js';
+
+const MINIMAL_MP4_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
+]);
+
+test('resolveMinimaxVideoInAnthropicMessages uploads local video_url to mm_file reference', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-agent-core-minimax-video-msg-'));
+  const videoPath = join(workspaceRoot, 'clip.mp4');
+
+  try {
+    await writeFile(videoPath, MINIMAL_MP4_HEADER);
+    clearMinimaxVideoUploadCache();
+    configureLlmClientVersion('1.2.3');
+    setLlmFetchTransportOverrideForTests(async () => new Response(
+      JSON.stringify({ file_id: 'file-video-1' }),
+      { status: 200 },
+    ));
+
+    const messages = [{
+      role: 'user',
+      content: [{
+        type: 'video_url',
+        video_url: { url: videoPath },
+      }],
+    }];
+
+    await resolveMinimaxVideoInAnthropicMessages(
+      {
+        apiKey: 'test-key',
+        baseUrl: 'https://api.minimax.io/anthropic/v1',
+        model: 'MiniMax-M3',
+        modelCapabilities: { videoInput: true },
+      },
+      messages,
+      workspaceRoot,
+    );
+
+    const part = (messages[0] as { content: Array<{ video_url: { url: string } }> }).content[0];
+    assert.equal(part.video_url.url, 'mm_file://file-video-1');
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+    configureLlmClientVersion('0.1.0');
+    clearMinimaxVideoUploadCache();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('resolveMinimaxVideoInAnthropicMessages skips when videoInput is disabled', async () => {
+  const messages = [{
+    role: 'user',
+    content: [{
+      type: 'video_url',
+      video_url: { url: 'clip.mp4' },
+    }],
+  }];
+
+  await resolveMinimaxVideoInAnthropicMessages(
+    {
+      apiKey: 'test-key',
+      baseUrl: 'https://api.minimax.io/anthropic/v1',
+      model: 'MiniMax-M3',
+      modelCapabilities: {},
+    },
+    messages,
+    process.cwd(),
+  );
+
+  const part = (messages[0] as { content: Array<{ video_url: { url: string } }> }).content[0];
+  assert.equal(part.video_url.url, 'clip.mp4');
+});

--- a/packages/agent-core/src/openai/minimax-video-messages.test.ts
+++ b/packages/agent-core/src/openai/minimax-video-messages.test.ts
@@ -9,7 +9,7 @@ import {
   setLlmFetchTransportOverrideForTests,
 } from '../llm-fetch.js';
 import { clearMinimaxVideoUploadCache } from './minimax-files.js';
-import { resolveMinimaxVideoInAnthropicMessages } from './minimax-video-messages.js';
+import { resolveMinimaxVideoInAnthropicMessages, resolveMinimaxVideoUrlsInOpenAiMessages } from './minimax-video-messages.js';
 
 const MINIMAL_MP4_HEADER = Buffer.from([
   0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d,
@@ -79,4 +79,44 @@ test('resolveMinimaxVideoInAnthropicMessages skips when videoInput is disabled',
 
   const part = (messages[0] as { content: Array<{ video_url: { url: string } }> }).content[0];
   assert.equal(part.video_url.url, 'clip.mp4');
+});
+
+test('resolveMinimaxVideoUrlsInOpenAiMessages uploads for minimax vendor with videoInput', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-agent-core-minimax-openai-video-resolve-'));
+  const videoPath = join(workspaceRoot, 'clip.mp4');
+
+  try {
+    await writeFile(videoPath, MINIMAL_MP4_HEADER);
+    clearMinimaxVideoUploadCache();
+    setLlmFetchTransportOverrideForTests(async (_input, init) => {
+      if (init?.body instanceof FormData) {
+        return new Response(JSON.stringify({ file_id: 'file-openai-1' }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+
+    const messages = [{
+      role: 'user',
+      content: [{ type: 'video_url', video_url: { url: videoPath } }],
+    }];
+
+    await resolveMinimaxVideoUrlsInOpenAiMessages(
+      {
+        apiKey: 'test-key',
+        baseUrl: 'https://api.minimax.io/v1',
+        llmVendor: 'minimax',
+        model: 'MiniMax-M3',
+        modelCapabilities: { videoInput: true },
+      },
+      messages,
+      workspaceRoot,
+    );
+
+    const part = (messages[0] as { content: Array<{ video_url: { url: string } }> }).content[0];
+    assert.equal(part.video_url.url, 'mm_file://file-openai-1');
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+    clearMinimaxVideoUploadCache();
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
 });

--- a/packages/agent-core/src/openai/minimax-video-messages.test.ts
+++ b/packages/agent-core/src/openai/minimax-video-messages.test.ts
@@ -48,6 +48,7 @@ test('resolveMinimaxVideoInAnthropicMessages uploads local video_url to mm_file 
     );
 
     const part = (messages[0] as { content: Array<{ video_url: { url: string } }> }).content[0];
+    assert.ok(part);
     assert.equal(part.video_url.url, 'mm_file://file-video-1');
   } finally {
     setLlmFetchTransportOverrideForTests(undefined);
@@ -78,6 +79,7 @@ test('resolveMinimaxVideoInAnthropicMessages skips when videoInput is disabled',
   );
 
   const part = (messages[0] as { content: Array<{ video_url: { url: string } }> }).content[0];
+  assert.ok(part);
   assert.equal(part.video_url.url, 'clip.mp4');
 });
 
@@ -113,6 +115,7 @@ test('resolveMinimaxVideoUrlsInOpenAiMessages uploads for minimax vendor with vi
     );
 
     const part = (messages[0] as { content: Array<{ video_url: { url: string } }> }).content[0];
+    assert.ok(part);
     assert.equal(part.video_url.url, 'mm_file://file-openai-1');
   } finally {
     setLlmFetchTransportOverrideForTests(undefined);

--- a/packages/agent-core/src/openai/minimax-video-messages.ts
+++ b/packages/agent-core/src/openai/minimax-video-messages.ts
@@ -1,0 +1,101 @@
+import type { JsonObject, JsonValue } from '../ports.js';
+import type { AnthropicTransportConfig } from '../anthropic/anthropic-compat.js';
+import { isMinimaxAnthropicConfig } from '../anthropic/minimax-multimodal.js';
+import { isMinimaxM3ThinkingSwitchModel } from './gateway-minimax-thinking.js';
+import { uploadMinimaxVideoFile } from './minimax-files.js';
+import type { OpenAiTransportConfig } from './openai-compat.js';
+import { resolveOpenAiModelCompatibilityProfile } from './openai-compat.js';
+import { resolveLocalMediaPath } from './openai-multimodal-media-path.js';
+
+function isJsonObject(value: JsonValue): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function needsMinimaxVideoUpload(url: string): boolean {
+  return (
+    url.length > 0
+    && !url.startsWith('http://')
+    && !url.startsWith('https://')
+    && !url.startsWith('data:')
+    && !url.startsWith('mm_file://')
+  );
+}
+
+async function resolveMinimaxVideoUrlsInMessages(
+  config: Pick<OpenAiTransportConfig, 'apiKey' | 'baseUrl'>,
+  messages: JsonValue[],
+  assetRoot: string,
+): Promise<void> {
+  for (const message of messages) {
+    if (!isJsonObject(message) || message.role !== 'user' || !Array.isArray(message.content)) {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (!isJsonObject(part) || part.type !== 'video_url') {
+        continue;
+      }
+
+      const rawVideoUrl = part['video_url'];
+      if (typeof rawVideoUrl !== 'object' || rawVideoUrl === null || Array.isArray(rawVideoUrl)) {
+        continue;
+      }
+
+      const urlValue = rawVideoUrl['url'];
+      if (typeof urlValue !== 'string') {
+        continue;
+      }
+
+      const url = urlValue.trim();
+      if (!needsMinimaxVideoUpload(url)) {
+        continue;
+      }
+
+      const absolutePath = resolveLocalMediaPath(url, assetRoot);
+      rawVideoUrl['url'] = await uploadMinimaxVideoFile(config, absolutePath);
+    }
+  }
+}
+
+/** MiniMax Anthropic Messages API：本地视频上传为 mm_file:// 引用。 */
+export async function resolveMinimaxVideoInAnthropicMessages(
+  config: Pick<AnthropicTransportConfig, 'apiKey' | 'baseUrl' | 'model' | 'modelCapabilities'>,
+  messages: JsonValue[],
+  assetRoot = process.cwd(),
+): Promise<void> {
+  if (!isMinimaxAnthropicConfig(config)) {
+    return;
+  }
+
+  if (!config.modelCapabilities?.videoInput) {
+    return;
+  }
+
+  if (!isMinimaxM3ThinkingSwitchModel(config.model)) {
+    return;
+  }
+
+  await resolveMinimaxVideoUrlsInMessages(config, messages, assetRoot);
+}
+
+/** MiniMax OpenAI-compatible Chat Completions：本地视频上传为 mm_file:// 引用。 */
+export async function resolveMinimaxVideoUrlsInOpenAiMessages(
+  config: OpenAiTransportConfig,
+  messages: JsonValue[],
+  assetRoot = process.cwd(),
+): Promise<void> {
+  if (config.llmVendor !== 'minimax') {
+    return;
+  }
+
+  const profile = resolveOpenAiModelCompatibilityProfile(config);
+  if (!profile.capabilities.videoInput) {
+    return;
+  }
+
+  if (!isMinimaxM3ThinkingSwitchModel(config.model)) {
+    return;
+  }
+
+  await resolveMinimaxVideoUrlsInMessages(config, messages, assetRoot);
+}

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -172,6 +172,13 @@ export function resolveOpenAiModelCompatibilityProfile(
     };
   }
 
+  if (config.llmVendor === 'minimax') {
+    return {
+      hasExplicitCapabilities: true,
+      capabilities: {},
+    };
+  }
+
   if (config.llmVendor === 'siliconflow') {
     return {
       hasExplicitCapabilities: true,

--- a/packages/host-internal/src/openai-models.test.ts
+++ b/packages/host-internal/src/openai-models.test.ts
@@ -546,6 +546,15 @@ test('parseOpenAiCompatibleModelEntriesPayload routes minimax provider to minima
   ]);
 });
 
+test('parseOpenAiCompatibleModelEntriesPayload without provider omits minimax multimodal flags', () => {
+  const entries = parseOpenAiCompatibleModelEntriesPayload({
+    object: 'list',
+    data: [{ id: 'MiniMax-M3', object: 'model' }],
+  });
+
+  assert.deepEqual(entries, [{ id: 'MiniMax-M3' }]);
+});
+
 test('parseSiliconFlowModelEntriesPayload marks capabilities by list kind', () => {
   const chatEntries = parseSiliconFlowModelEntriesPayload(
     {

--- a/packages/host-internal/src/openai-models.test.ts
+++ b/packages/host-internal/src/openai-models.test.ts
@@ -12,6 +12,7 @@ import {
   parseVercelAiGatewayModelEntriesPayload,
   parseVolcengineModelEntriesPayload,
   parseXiaomiModelEntriesPayload,
+  parseMinimaxModelEntriesPayload,
 } from './openai-models.js';
 
 test('parseAnthropicModelEntriesPayload extracts image input and supported effort levels', () => {
@@ -488,6 +489,59 @@ test('parseXiaomiModelEntriesPayload marks multimodal allowlist models', () => {
       id: 'mimo-v2-flash',
       supportsImageInput: false,
       supportsVideoInput: false,
+    },
+  ]);
+});
+
+test('parseMinimaxModelEntriesPayload marks M3 multimodal models only', () => {
+  const entries = parseMinimaxModelEntriesPayload({
+    object: 'list',
+    data: [
+      { id: 'MiniMax-M3', object: 'model' },
+      { id: 'minimax-m3', object: 'model' },
+      { id: 'MiniMax-M2.5', object: 'model' },
+      { id: 'MiniMax-M2.5-highspeed', object: 'model' },
+    ],
+  });
+
+  assert.deepEqual(entries, [
+    {
+      id: 'MiniMax-M3',
+      supportsImageInput: true,
+      supportsVideoInput: true,
+    },
+    {
+      id: 'minimax-m3',
+      supportsImageInput: true,
+      supportsVideoInput: true,
+    },
+    {
+      id: 'MiniMax-M2.5',
+      supportsImageInput: false,
+      supportsVideoInput: false,
+    },
+    {
+      id: 'MiniMax-M2.5-highspeed',
+      supportsImageInput: false,
+      supportsVideoInput: false,
+    },
+  ]);
+});
+
+test('parseOpenAiCompatibleModelEntriesPayload routes minimax provider to minimax parser', () => {
+  const entries = parseOpenAiCompatibleModelEntriesPayload(
+    {
+      object: 'list',
+      data: [{ id: 'MiniMax-M3', object: 'model' }],
+    },
+    'minimax',
+  );
+
+  assert.deepEqual(entries, [
+    {
+      id: 'MiniMax-M3',
+      supportsImageInput: true,
+      supportsVideoInput: true,
     },
   ]);
 });

--- a/packages/host-internal/src/openai-models.ts
+++ b/packages/host-internal/src/openai-models.ts
@@ -99,6 +99,10 @@ export function parseOpenAiCompatibleModelEntriesPayload(
     return parseXiaomiModelEntriesPayload(body);
   }
 
+  if (provider === 'minimax') {
+    return parseMinimaxModelEntriesPayload(body);
+  }
+
   if (provider === 'siliconflow') {
     return parseSiliconFlowModelEntriesPayload(body, 'chat');
   }
@@ -331,6 +335,44 @@ export function parseXiaomiModelEntriesPayload(body: unknown): ProviderListedMod
 
     const modelId = id.trim();
     const isMultimodal = XIAOMI_MULTIMODAL_MODEL_IDS.has(modelId);
+    entries.push({
+      id: modelId,
+      supportsImageInput: isMultimodal,
+      supportsVideoInput: isMultimodal,
+    });
+  }
+  return entries;
+}
+
+/** MiniMax：上游 /models 不返回多模态能力字段；仅 M3 支持图片与视频输入。 */
+function isMinimaxM3MultimodalModelId(modelId: string): boolean {
+  const normalized = modelId.trim().toLowerCase();
+  const slashIndex = normalized.lastIndexOf('/');
+  const id = slashIndex >= 0 ? normalized.slice(slashIndex + 1) : normalized;
+  return id.includes('m3') || id.includes('minimax-m3');
+}
+
+export function parseMinimaxModelEntriesPayload(body: unknown): ProviderListedModelEntry[] {
+  if (typeof body !== 'object' || body === null || !('data' in body)) {
+    return [];
+  }
+  const raw = (body as { data?: unknown }).data;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  const entries: ProviderListedModelEntry[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null || !('id' in entry)) {
+      continue;
+    }
+    const id = (entry as { id?: unknown }).id;
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      continue;
+    }
+
+    const modelId = id.trim();
+    const isMultimodal = isMinimaxM3MultimodalModelId(modelId);
     entries.push({
       id: modelId,
       supportsImageInput: isMultimodal,

--- a/packages/host-internal/src/openai-models.ts
+++ b/packages/host-internal/src/openai-models.ts
@@ -1016,6 +1016,10 @@ export async function listProviderModels(
     return listMoonshotModels(options);
   }
 
+  if (options.provider === 'minimax') {
+    return listMinimaxModels(options);
+  }
+
   if (options.provider === 'xiaomi') {
     return listXiaomiModels(options);
   }
@@ -1119,6 +1123,12 @@ export async function listMoonshotModels(
   options: ListOpenAiCompatibleModelIdsOptions,
 ): Promise<ProviderListedModelEntry[]> {
   return listOpenAiCompatibleModelsForProvider(options, 'moonshot-ai');
+}
+
+export async function listMinimaxModels(
+  options: ListOpenAiCompatibleModelIdsOptions,
+): Promise<ProviderListedModelEntry[]> {
+  return listOpenAiCompatibleModelsForProvider(options, 'minimax');
 }
 
 export async function listXiaomiModels(

--- a/packages/host-internal/src/smoke/openai-models-parse-smoke.ts
+++ b/packages/host-internal/src/smoke/openai-models-parse-smoke.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-import { parseOpenAiModelsPayload, parseXiaomiModelEntriesPayload } from '../openai-models.js';
+import { parseMinimaxModelEntriesPayload, parseOpenAiModelsPayload, parseXiaomiModelEntriesPayload } from '../openai-models.js';
 
 function run(): void {
   assert.deepEqual(parseOpenAiModelsPayload(undefined), []);
@@ -30,6 +30,17 @@ function run(): void {
     [
       { id: 'mimo-v2.5', supportsImageInput: true, supportsVideoInput: true },
       { id: 'mimo-v2-flash', supportsImageInput: false, supportsVideoInput: false },
+    ],
+  );
+
+  assert.deepEqual(
+    parseMinimaxModelEntriesPayload({
+      object: 'list',
+      data: [{ id: 'MiniMax-M3' }, { id: 'MiniMax-M2.5' }],
+    }),
+    [
+      { id: 'MiniMax-M3', supportsImageInput: true, supportsVideoInput: true },
+      { id: 'MiniMax-M2.5', supportsImageInput: false, supportsVideoInput: false },
     ],
   );
 


### PR DESCRIPTION
## Summary

- host-internal：MiniMax 目录仅 M3 标注图片/视频输入能力，并修复 listMinimaxModels 路由使能力写入 config
- agent-core：图片走 Base64 data URL，视频经 Files API 上传为 mm_file://；覆盖 Anthropic 与 OpenAI-compatible transport
- desktop：启动目录刷新时把仅存 chat 的已入库 M3 capabilities 与目录对齐并落盘
- 修复视频上传使用 undici FormData 及嵌套 file.file_id 数字解析，避免发送后卡在 Thinking

## Test plan

- [x] `npm run build:agent-core` 与 minimax-files / minimax-video-messages 相关单测
- [x] Desktop 实测 MiniMax M3 图片输入与视频输入可正常回复
- [ ] eval:compare（模型可见文案无大段增删，可跳过）