### PR TITLE
feat(agent-core, desktop): Xiaomi 提供商 Responses API 适配

### DIFF
--- a/apps/desktop/src/components/settings/models/connect-transport.ts
+++ b/apps/desktop/src/components/settings/models/connect-transport.ts
@@ -42,6 +42,11 @@ export function connectTransportOptionsForProvider(provider: DesktopModelProvide
     case "minimax":
     case "deepseek":
     case "xiaomi":
+      return [
+        connectTransportOptionCatalog.chatCompletions,
+        connectTransportOptionCatalog.messagesApi,
+        connectTransportOptionCatalog.openResponsesApi,
+      ];
     case "siliconflow":
       return [connectTransportOptionCatalog.chatCompletions, connectTransportOptionCatalog.messagesApi];
     case "alibaba":
@@ -139,6 +144,10 @@ export function connectTransportOptionSummary(
 
   if (option.value === "open-responses" && provider === "alibaba") {
     return i18n.t('settings.transportAlibabaResponses');
+  }
+
+  if (option.value === "open-responses" && provider === "xiaomi") {
+    return i18n.t('settings.transportResponsesApi');
   }
 
   return option.summaryKey ? i18n.t(option.summaryKey) : undefined;

--- a/apps/desktop/src/components/settings/models/connect-transport.ts
+++ b/apps/desktop/src/components/settings/models/connect-transport.ts
@@ -41,14 +41,14 @@ export function connectTransportOptionsForProvider(provider: DesktopModelProvide
       return [connectTransportOptionCatalog.chatCompletions];
     case "minimax":
     case "deepseek":
+    case "siliconflow":
+      return [connectTransportOptionCatalog.chatCompletions, connectTransportOptionCatalog.messagesApi];
     case "xiaomi":
       return [
         connectTransportOptionCatalog.chatCompletions,
         connectTransportOptionCatalog.messagesApi,
         connectTransportOptionCatalog.openResponsesApi,
       ];
-    case "siliconflow":
-      return [connectTransportOptionCatalog.chatCompletions, connectTransportOptionCatalog.messagesApi];
     case "alibaba":
       return [
         connectTransportOptionCatalog.chatCompletions,

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -8,7 +8,6 @@ import {
 } from '@spirit-agent/core';
 import {
   isXiaomiResponsesReasoningEffortContext,
-  normalizeModelReasoningEffort,
   resolveAnthropicTransportReasoningEffortForContext,
   resolveOpenAiTransportReasoningEffortForContext,
   type ModelReasoningEffortContext,
@@ -219,10 +218,7 @@ function resolveAgentOpenAiReasoningEffort(
     isXiaomiResponsesReasoningEffortContext(context)
     && profile?.thinkingEnabled === false
   ) {
-    const legacyEffort = normalizeModelReasoningEffort(profile?.reasoningEffort);
-    if (legacyEffort === undefined || legacyEffort === 'default' || legacyEffort === 'medium') {
-      return 'none';
-    }
+    return 'none';
   }
   if (
     modelSupportsThinkingSwitch(context)

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -7,6 +7,8 @@ import {
   type OpenResponsesSdkProvider,
 } from '@spirit-agent/core';
 import {
+  isXiaomiResponsesReasoningEffortContext,
+  normalizeModelReasoningEffort,
   resolveAnthropicTransportReasoningEffortForContext,
   resolveOpenAiTransportReasoningEffortForContext,
   type ModelReasoningEffortContext,
@@ -213,6 +215,15 @@ function resolveAgentOpenAiReasoningEffort(
     transportKind,
   };
   const thinkingEnabled = profile?.thinkingEnabled !== false;
+  if (
+    isXiaomiResponsesReasoningEffortContext(context)
+    && profile?.thinkingEnabled === false
+  ) {
+    const legacyEffort = normalizeModelReasoningEffort(profile?.reasoningEffort);
+    if (legacyEffort === undefined || legacyEffort === 'default' || legacyEffort === 'medium') {
+      return 'none';
+    }
+  }
   if (
     modelSupportsThinkingSwitch(context)
     && shouldPinReasoningEffortToDefault(thinkingEnabled, context)

--- a/apps/desktop/test/host/model-config-thinking.test.mjs
+++ b/apps/desktop/test/host/model-config-thinking.test.mjs
@@ -127,3 +127,75 @@ test('buildPrimaryTransportConfig wires Gateway Claude adaptive thinking on with
   assert.equal(config.vendorExtendedThinking, undefined);
   assert.equal(config.reasoningEffort, 'high');
 });
+
+test('buildPrimaryTransportConfig wires Gateway Xiaomi responses reasoningEffort none', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'xiaomi/mimo-v2.5',
+    baseUrl: 'https://ai-gateway.vercel.sh/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'vercel-ai-gateway',
+      transportKind: 'open-responses',
+      reasoningEffort: 'none',
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.transportKind, 'open-responses');
+  assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, 'none');
+});
+
+test('buildPrimaryTransportConfig maps legacy Gateway Xiaomi thinkingEnabled false to reasoningEffort none', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'xiaomi/mimo-v2.5',
+    baseUrl: 'https://ai-gateway.vercel.sh/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'vercel-ai-gateway',
+      transportKind: 'open-responses',
+      reasoningEffort: 'default',
+      thinkingEnabled: false,
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.transportKind, 'open-responses');
+  assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, 'none');
+});
+
+test('buildPrimaryTransportConfig wires direct Xiaomi responses reasoningEffort none', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'mimo-v2.5-pro',
+    baseUrl: 'https://api.xiaomimimo.com/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'xiaomi',
+      transportKind: 'open-responses',
+      reasoningEffort: 'none',
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.transportKind, 'open-responses');
+  assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, 'none');
+});
+
+test('buildPrimaryTransportConfig keeps direct Xiaomi chat thinking switch', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'mimo-v2.5',
+    baseUrl: 'https://api.xiaomimimo.com/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'xiaomi',
+      transportKind: 'openai-compatible',
+      thinkingEnabled: false,
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.vendorExtendedThinking, false);
+  assert.equal(config.reasoningEffort, undefined);
+});

--- a/apps/desktop/test/host/model-config-thinking.test.mjs
+++ b/apps/desktop/test/host/model-config-thinking.test.mjs
@@ -165,6 +165,25 @@ test('buildPrimaryTransportConfig maps legacy Gateway Xiaomi thinkingEnabled fal
   assert.equal(config.reasoningEffort, 'none');
 });
 
+test('buildPrimaryTransportConfig maps legacy Gateway Xiaomi thinkingEnabled false with high effort to none', () => {
+  const config = buildPrimaryTransportConfig({
+    apiKey: 'test-key',
+    model: 'xiaomi/mimo-v2.5',
+    baseUrl: 'https://ai-gateway.vercel.sh/v1',
+    workspaceRoot: '/tmp',
+    profile: {
+      provider: 'vercel-ai-gateway',
+      transportKind: 'open-responses',
+      reasoningEffort: 'high',
+      thinkingEnabled: false,
+      capabilities: ['chat'],
+    },
+  });
+  assert.equal(config.transportKind, 'open-responses');
+  assert.equal(config.vendorExtendedThinking, undefined);
+  assert.equal(config.reasoningEffort, 'none');
+});
+
 test('buildPrimaryTransportConfig wires direct Xiaomi responses reasoningEffort none', () => {
   const config = buildPrimaryTransportConfig({
     apiKey: 'test-key',

--- a/packages/agent-core/src/model-thinking-controls.test.ts
+++ b/packages/agent-core/src/model-thinking-controls.test.ts
@@ -120,15 +120,39 @@ test('Gateway Moonshot kimi-k2.5 supports thinking switch', () => {
   assert.equal(modelShowsReasoningEffortControl(context, false), false);
 });
 
-test('Gateway Xiaomi mimo-v2.5 supports thinking switch', () => {
+test('Gateway Xiaomi mimo-v2.5 supports thinking switch on chat transport', () => {
   const context = {
     provider: 'vercel-ai-gateway' as const,
     model: 'xiaomi/mimo-v2.5',
     transportKind: 'openai-compatible' as const,
   };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), false);
   assert.equal(modelSupportsThinkingSwitch(context), true);
   assert.equal(modelShowsReasoningEffortControl(context, false), false);
   assert.equal(shouldPinReasoningEffortToDefault(false, context), true);
+});
+
+test('Gateway Xiaomi mimo-v2.5 uses reasoning effort primary control on responses transport', () => {
+  const context = {
+    provider: 'vercel-ai-gateway' as const,
+    model: 'xiaomi/mimo-v2.5',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+  assert.equal(modelShowsReasoningEffortControl(context, false), true);
+  assert.equal(shouldPinReasoningEffortToDefault(false, context), false);
+});
+
+test('direct Xiaomi mimo-v2.5 uses reasoning effort primary control on responses transport', () => {
+  const context = {
+    provider: 'xiaomi' as const,
+    model: 'mimo-v2.5',
+    transportKind: 'open-responses' as const,
+  };
+  assert.equal(modelUsesReasoningEffortPrimaryControl(context), true);
+  assert.equal(modelSupportsThinkingSwitch(context), false);
+  assert.equal(modelShowsReasoningEffortControl(context, false), true);
 });
 
 test('Gateway Xiaomi mimo-v2-flash has no thinking switch', () => {

--- a/packages/agent-core/src/model-thinking-controls.ts
+++ b/packages/agent-core/src/model-thinking-controls.ts
@@ -10,7 +10,7 @@ import {
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
 import { isMinimaxM3ThinkingSwitchModel } from './openai/gateway-minimax-thinking.js';
 import { isMoonshotThinkingSwitchModel } from './openai/moonshot-thinking-switch.js';
-import { isXiaomiThinkingSwitchEligibleModel } from './openai/gateway-xiaomi-thinking.js';
+import { isXiaomiResponsesReasoningEffortContext, isXiaomiThinkingSwitchEligibleModel } from './openai/gateway-xiaomi-thinking.js';
 import { isZaiThinkingSwitchEligibleModel } from './openai/gateway-zai-thinking.js';
 import {
   isRoutedAnthropicClaudeModel,
@@ -137,6 +137,9 @@ function isGatewayThinkingSwitchModel(context?: ModelReasoningEffortContext): bo
     return isMoonshotThinkingSwitchModel(context);
   }
   if (slug === 'xiaomi') {
+    if (context.transportKind === 'open-responses') {
+      return false;
+    }
     return isXiaomiThinkingSwitchEligibleModel(context.model ?? '');
   }
   if (slug === 'zai') {
@@ -197,6 +200,9 @@ export function modelUsesReasoningEffortPrimaryControl(
   if (isOpenRouterAnthropicClaudeReasoningModel(context)) {
     return true;
   }
+  if (isXiaomiResponsesReasoningEffortContext(context)) {
+    return true;
+  }
 
   return false;
 }
@@ -217,6 +223,9 @@ export function modelSupportsThinkingSwitch(context?: ModelReasoningEffortContex
     return isMinimaxM3ThinkingSwitchModel(context?.model ?? '');
   }
   if (provider !== undefined && DIRECT_THINKING_SWITCH_PROVIDERS.has(provider)) {
+    if (provider === 'xiaomi' && context?.transportKind === 'open-responses') {
+      return false;
+    }
     return true;
   }
   if (isDeepSeekThinkingSwitchModel(context)) {

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -158,7 +158,7 @@ test('buildResponsesProviderOptions maps gateway xiaomi reasoning via openai nam
   );
 });
 
-test('buildResponsesProviderOptions maps direct xiaomi reasoning via openai namespace', () => {
+test('buildResponsesProviderOptions maps direct xiaomi reasoning via xiaomi namespace', () => {
   assert.deepEqual(
     buildResponsesProviderOptions({
       transportKind: 'open-responses',
@@ -168,7 +168,7 @@ test('buildResponsesProviderOptions maps direct xiaomi reasoning via openai name
       reasoningEffort: 'none',
     }),
     {
-      openai: {
+      xiaomi: {
         reasoningEffort: 'none',
       },
     },

--- a/packages/agent-core/src/open-responses/model-factory.test.ts
+++ b/packages/agent-core/src/open-responses/model-factory.test.ts
@@ -125,6 +125,56 @@ test('buildResponsesProviderOptions maps gateway openai reasoning options', () =
   });
 });
 
+test('buildResponsesProviderOptions maps gateway xiaomi reasoning via openai namespace', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'xiaomi/mimo-v2.5',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'none',
+    }),
+    {
+      openai: {
+        reasoningEffort: 'none',
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'xiaomi/mimo-v2.5',
+      llmVendor: 'vercel-ai-gateway',
+      reasoningEffort: 'medium',
+    }),
+    {
+      openai: {
+        reasoningEffort: 'medium',
+        reasoningSummary: 'auto',
+      },
+    },
+  );
+});
+
+test('buildResponsesProviderOptions maps direct xiaomi reasoning via openai namespace', () => {
+  assert.deepEqual(
+    buildResponsesProviderOptions({
+      transportKind: 'open-responses',
+      apiKey: 'test-key',
+      model: 'mimo-v2.5-pro',
+      llmVendor: 'xiaomi',
+      reasoningEffort: 'none',
+    }),
+    {
+      openai: {
+        reasoningEffort: 'none',
+      },
+    },
+  );
+});
+
 test('buildResponsesProviderOptions maps gateway xai reasoning via xai namespace', () => {
   assert.deepEqual(
     buildResponsesProviderOptions({

--- a/packages/agent-core/src/open-responses/model-factory.ts
+++ b/packages/agent-core/src/open-responses/model-factory.ts
@@ -53,7 +53,8 @@ import {
   isGatewayMoonshotModel,
 } from '../openai/moonshot-thinking-switch.js';
 import {
-  buildGatewayXiaomiProviderOptions,
+  buildDirectXiaomiResponsesProviderOptions,
+  buildGatewayXiaomiResponsesProviderOptions,
   isGatewayXiaomiModel,
 } from '../openai/gateway-xiaomi-thinking.js';
 import {
@@ -268,7 +269,11 @@ export function buildResponsesProviderOptions(
     }
 
     if (isGatewayXiaomiModel(config.llmVendor, config.model)) {
-      const xiaomiOptions = buildGatewayXiaomiProviderOptions(config);
+      const xiaomiOptions = buildGatewayXiaomiResponsesProviderOptions(
+        config,
+        reasoningEffort,
+        reasoningSummary,
+      );
       if (Object.keys(xiaomiOptions).length > 0) {
         return xiaomiOptions;
       }
@@ -355,6 +360,17 @@ export function buildResponsesProviderOptions(
   if (provider !== 'openai') {
     if (isOpenRouterAnthropicClaudeModel(config.llmVendor, config.model)) {
       return {};
+    }
+
+    if (config.llmVendor === 'xiaomi') {
+      const xiaomiOptions = buildDirectXiaomiResponsesProviderOptions(
+        config,
+        reasoningEffort,
+        reasoningSummary,
+      );
+      if (Object.keys(xiaomiOptions).length > 0) {
+        return xiaomiOptions;
+      }
     }
 
     const providerOptions: JsonObject = {

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.test.ts
@@ -147,8 +147,9 @@ test('buildGatewayCodeCompletionProviderOptions routes zai alibaba minimax xiaom
       model: 'xiaomi/mimo-v2',
     }),
     {
-      xiaomi: {
-        thinking: { type: 'disabled' },
+      openai: {
+        reasoningEffort: 'none',
+        reasoningSummary: 'off',
       },
     },
   );

--- a/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-code-completion-thinking.ts
@@ -93,7 +93,7 @@ export function buildGatewayCodeCompletionProviderOptions(
         vendorExtendedThinking: false,
       });
     case 'xiaomi':
-      return thinkingTypeDisabledOptions('xiaomi');
+      return openAiNoneReasoningOptions();
     default:
       return openAiNoneReasoningOptions();
   }

--- a/packages/agent-core/src/openai/gateway-xiaomi-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-xiaomi-thinking.test.ts
@@ -139,7 +139,7 @@ test('buildGatewayXiaomiResponsesProviderOptions maps reasoningEffort via openai
   );
 });
 
-test('buildDirectXiaomiResponsesProviderOptions maps reasoningEffort via openai namespace', () => {
+test('buildDirectXiaomiResponsesProviderOptions maps reasoningEffort via xiaomi namespace', () => {
   assert.deepEqual(
     buildDirectXiaomiResponsesProviderOptions(
       {
@@ -149,7 +149,7 @@ test('buildDirectXiaomiResponsesProviderOptions maps reasoningEffort via openai 
       'none',
     ),
     {
-      openai: {
+      xiaomi: {
         reasoningEffort: 'none',
       },
     },

--- a/packages/agent-core/src/openai/gateway-xiaomi-thinking.test.ts
+++ b/packages/agent-core/src/openai/gateway-xiaomi-thinking.test.ts
@@ -2,8 +2,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  buildDirectXiaomiResponsesProviderOptions,
   buildGatewayXiaomiProviderOptions,
+  buildGatewayXiaomiResponsesProviderOptions,
   isGatewayXiaomiModel,
+  isXiaomiResponsesReasoningEffortContext,
   isXiaomiThinkingSwitchEligibleModel,
 } from './gateway-xiaomi-thinking.js';
 
@@ -53,5 +56,102 @@ test('buildGatewayXiaomiProviderOptions toggles thinking for MiMo on Gateway', (
       vendorExtendedThinking: false,
     }),
     {},
+  );
+});
+
+test('isXiaomiResponsesReasoningEffortContext matches open-responses MiMo routes only', () => {
+  assert.equal(
+    isXiaomiResponsesReasoningEffortContext({
+      provider: 'vercel-ai-gateway',
+      model: 'xiaomi/mimo-v2.5',
+      transportKind: 'open-responses',
+    }),
+    true,
+  );
+  assert.equal(
+    isXiaomiResponsesReasoningEffortContext({
+      provider: 'xiaomi',
+      model: 'mimo-v2.5',
+      transportKind: 'open-responses',
+    }),
+    true,
+  );
+  assert.equal(
+    isXiaomiResponsesReasoningEffortContext({
+      provider: 'vercel-ai-gateway',
+      model: 'xiaomi/mimo-v2.5',
+      transportKind: 'openai-compatible',
+    }),
+    false,
+  );
+  assert.equal(
+    isXiaomiResponsesReasoningEffortContext({
+      provider: 'vercel-ai-gateway',
+      model: 'xiaomi/mimo-v2-flash',
+      transportKind: 'open-responses',
+    }),
+    false,
+  );
+});
+
+test('buildGatewayXiaomiResponsesProviderOptions maps reasoningEffort via openai namespace', () => {
+  assert.deepEqual(
+    buildGatewayXiaomiResponsesProviderOptions(
+      {
+        llmVendor: 'vercel-ai-gateway',
+        model: 'xiaomi/mimo-v2.5',
+      },
+      'none',
+    ),
+    {
+      openai: {
+        reasoningEffort: 'none',
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayXiaomiResponsesProviderOptions(
+      {
+        llmVendor: 'vercel-ai-gateway',
+        model: 'xiaomi/mimo-v2.5',
+      },
+      'medium',
+      'auto',
+    ),
+    {
+      openai: {
+        reasoningEffort: 'medium',
+        reasoningSummary: 'auto',
+      },
+    },
+  );
+
+  assert.deepEqual(
+    buildGatewayXiaomiResponsesProviderOptions(
+      {
+        llmVendor: 'vercel-ai-gateway',
+        model: 'xiaomi/mimo-v2-flash',
+      },
+      'none',
+    ),
+    {},
+  );
+});
+
+test('buildDirectXiaomiResponsesProviderOptions maps reasoningEffort via openai namespace', () => {
+  assert.deepEqual(
+    buildDirectXiaomiResponsesProviderOptions(
+      {
+        llmVendor: 'xiaomi',
+        model: 'mimo-v2.5-pro',
+      },
+      'none',
+    ),
+    {
+      openai: {
+        reasoningEffort: 'none',
+      },
+    },
   );
 });

--- a/packages/agent-core/src/openai/gateway-xiaomi-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-xiaomi-thinking.ts
@@ -1,3 +1,5 @@
+import type { ModelReasoningEffortContext } from '../reasoning-effort.js';
+import type { OpenResponsesReasoningSummary } from '../open-responses/responses-compat.js';
 import type { JsonObject } from '../ports.js';
 import type { OpenAiTransportConfig } from './openai-compat.js';
 import { parseGatewayUpstreamSlug } from './gateway-code-completion-thinking.js';
@@ -25,7 +27,69 @@ export function isGatewayXiaomiModel(
   return llmVendor === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'xiaomi';
 }
 
-/** Gateway Xiaomi MiMo：经 xiaomi 命名空间注入 thinking.type（非 openai 命名空间）。 */
+/** MiMo Responses API：Reasoning Effort 主控（与 OpenAI 一致），非 Chat thinking.type。 */
+export function isXiaomiResponsesReasoningEffortContext(
+  context?: ModelReasoningEffortContext,
+): boolean {
+  if (context?.transportKind !== 'open-responses') {
+    return false;
+  }
+  const model = context.model ?? '';
+  if (context.provider === 'xiaomi') {
+    return isXiaomiThinkingSwitchEligibleModel(model);
+  }
+  if (context.provider === 'vercel-ai-gateway' && parseGatewayUpstreamSlug(model) === 'xiaomi') {
+    return isXiaomiThinkingSwitchEligibleModel(model);
+  }
+  return false;
+}
+
+function buildXiaomiOpenAiReasoningOptions(
+  model: string,
+  reasoningEffort: string | undefined,
+  reasoningSummary: OpenResponsesReasoningSummary | undefined,
+): Record<string, JsonObject> {
+  if (!isXiaomiThinkingSwitchEligibleModel(model)) {
+    return {};
+  }
+
+  const openaiOptions: JsonObject = {
+    ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
+    ...(reasoningSummary !== undefined ? { reasoningSummary } : {}),
+  };
+
+  if (Object.keys(openaiOptions).length === 0) {
+    return {};
+  }
+
+  return { openai: openaiOptions };
+}
+
+/** Gateway Xiaomi MiMo Responses：经 openai 命名空间注入 reasoningEffort。 */
+export function buildGatewayXiaomiResponsesProviderOptions(
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model'>,
+  reasoningEffort: string | undefined,
+  reasoningSummary?: OpenResponsesReasoningSummary,
+): Record<string, JsonObject> {
+  if (!isGatewayXiaomiModel(config.llmVendor, config.model)) {
+    return {};
+  }
+  return buildXiaomiOpenAiReasoningOptions(config.model, reasoningEffort, reasoningSummary);
+}
+
+/** 直连 Xiaomi MiMo Responses：经 openai 命名空间注入 reasoningEffort。 */
+export function buildDirectXiaomiResponsesProviderOptions(
+  config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model'>,
+  reasoningEffort: string | undefined,
+  reasoningSummary?: OpenResponsesReasoningSummary,
+): Record<string, JsonObject> {
+  if (config.llmVendor !== 'xiaomi') {
+    return {};
+  }
+  return buildXiaomiOpenAiReasoningOptions(config.model, reasoningEffort, reasoningSummary);
+}
+
+/** Gateway Xiaomi MiMo Chat：经 xiaomi 命名空间注入 thinking.type（非 openai 命名空间）。 */
 export function buildGatewayXiaomiProviderOptions(
   config: Pick<
     OpenAiTransportConfig,

--- a/packages/agent-core/src/openai/gateway-xiaomi-thinking.ts
+++ b/packages/agent-core/src/openai/gateway-xiaomi-thinking.ts
@@ -44,25 +44,26 @@ export function isXiaomiResponsesReasoningEffortContext(
   return false;
 }
 
-function buildXiaomiOpenAiReasoningOptions(
+function buildXiaomiResponsesReasoningOptions(
   model: string,
   reasoningEffort: string | undefined,
   reasoningSummary: OpenResponsesReasoningSummary | undefined,
+  providerOptionsKey: 'openai' | 'xiaomi',
 ): Record<string, JsonObject> {
   if (!isXiaomiThinkingSwitchEligibleModel(model)) {
     return {};
   }
 
-  const openaiOptions: JsonObject = {
+  const reasoningOptions: JsonObject = {
     ...(reasoningEffort !== undefined ? { reasoningEffort } : {}),
     ...(reasoningSummary !== undefined ? { reasoningSummary } : {}),
   };
 
-  if (Object.keys(openaiOptions).length === 0) {
+  if (Object.keys(reasoningOptions).length === 0) {
     return {};
   }
 
-  return { openai: openaiOptions };
+  return { [providerOptionsKey]: reasoningOptions };
 }
 
 /** Gateway Xiaomi MiMo Responses：经 openai 命名空间注入 reasoningEffort。 */
@@ -74,10 +75,13 @@ export function buildGatewayXiaomiResponsesProviderOptions(
   if (!isGatewayXiaomiModel(config.llmVendor, config.model)) {
     return {};
   }
-  return buildXiaomiOpenAiReasoningOptions(config.model, reasoningEffort, reasoningSummary);
+  return buildXiaomiResponsesReasoningOptions(config.model, reasoningEffort, reasoningSummary, 'openai');
 }
 
-/** 直连 Xiaomi MiMo Responses：经 openai 命名空间注入 reasoningEffort。 */
+/**
+ * 直连 Xiaomi MiMo Responses：经 xiaomi 命名空间注入 reasoningEffort。
+ * @ai-sdk/open-responses 的 providerOptionsName 与 createOpenResponses({ name }) 一致，须用 xiaomi 而非 openai。
+ */
 export function buildDirectXiaomiResponsesProviderOptions(
   config: Pick<OpenAiTransportConfig, 'llmVendor' | 'model'>,
   reasoningEffort: string | undefined,
@@ -86,7 +90,7 @@ export function buildDirectXiaomiResponsesProviderOptions(
   if (config.llmVendor !== 'xiaomi') {
     return {};
   }
-  return buildXiaomiOpenAiReasoningOptions(config.model, reasoningEffort, reasoningSummary);
+  return buildXiaomiResponsesReasoningOptions(config.model, reasoningEffort, reasoningSummary, 'xiaomi');
 }
 
 /** Gateway Xiaomi MiMo Chat：经 xiaomi 命名空间注入 thinking.type（非 openai 命名空间）。 */

--- a/packages/agent-core/src/reasoning-effort.ts
+++ b/packages/agent-core/src/reasoning-effort.ts
@@ -5,6 +5,9 @@ import {
   resolveGatewayAnthropicClaudeCapabilities,
 } from './openai/gateway-anthropic-thinking.js';
 import { parseGatewayUpstreamSlug } from './openai/gateway-code-completion-thinking.js';
+import { isXiaomiResponsesReasoningEffortContext } from './openai/gateway-xiaomi-thinking.js';
+
+export { isXiaomiResponsesReasoningEffortContext } from './openai/gateway-xiaomi-thinking.js';
 import { isGatewayGoogleGeminiModel, isGoogleGeminiMinimalThinkingLevelModel, isGoogleGeminiThinkingLevelModel } from './openai/gateway-google-thinking.js';
 import { isOpenRouterAnthropicClaudeModel } from './openai/openrouter-anthropic-reasoning.js';
 import {
@@ -236,6 +239,10 @@ export function defaultModelReasoningEffort(
     return 'default';
   }
 
+  if (isXiaomiResponsesReasoningEffortContext(context)) {
+    return 'default';
+  }
+
   return DEFAULT_MODEL_REASONING_EFFORT;
 }
 
@@ -286,6 +293,10 @@ export function modelReasoningEffortOptions(
     );
   }
 
+  if (isXiaomiResponsesReasoningEffortContext(context)) {
+    return OPENAI_COMPATIBLE_REASONING_EFFORT_OPTIONS;
+  }
+
   return OPENAI_COMPATIBLE_REASONING_EFFORT_OPTIONS;
 }
 
@@ -302,7 +313,7 @@ export function resolveOpenAiTransportReasoningEffortForContext(
 ): OpenAiTransportConfig['reasoningEffort'] | undefined {
   const normalized = resolveModelReasoningEffortForContext(value, {
     ...context,
-    transportKind: 'openai-compatible',
+    transportKind: context?.transportKind ?? 'openai-compatible',
   });
 
   switch (normalized) {

--- a/packages/host-internal/src/model-provider-presets.json
+++ b/packages/host-internal/src/model-provider-presets.json
@@ -31,7 +31,8 @@
     },
     "xiaomi": {
       "openai-compatible": "https://api.xiaomimimo.com/v1",
-      "anthropic": "https://api.xiaomimimo.com/anthropic"
+      "anthropic": "https://api.xiaomimimo.com/anthropic",
+      "open-responses": "https://api.xiaomimimo.com/v1"
     },
     "alibaba": {
       "openai-compatible": "https://dashscope.aliyuncs.com/compatible-mode/v1",

--- a/packages/host-internal/src/model-provider-presets.test.ts
+++ b/packages/host-internal/src/model-provider-presets.test.ts
@@ -78,6 +78,10 @@ test('resolveProviderConnectApiBase uses transport-specific preset bases', () =>
     'https://api.xiaomimimo.com/anthropic',
   );
   assert.equal(
+    resolveProviderConnectApiBase('xiaomi', 'open-responses'),
+    'https://api.xiaomimimo.com/v1',
+  );
+  assert.equal(
     resolveProviderConnectApiBase('alibaba', 'openai-compatible'),
     'https://dashscope.aliyuncs.com/compatible-mode/v1',
   );


### PR DESCRIPTION
## Summary

- Responses transport 下 Gateway/直连 Xiaomi 经 `reasoningEffort` 控制思考（关思考为 `none`），Chat Completions / Anthropic Messages 仍保留 `thinking.type`
- Desktop 连接向导与 preset 暴露 Xiaomi Open Responses API；Responses 路径 UI 切换为 Reasoning Effort 主控，并兼容存量 `thinkingEnabled: false`
- 修复直连 Xiaomi：`@ai-sdk/open-responses` 须用 `xiaomi` 命名空间注入 `reasoningEffort`，否则请求体缺失 `reasoning.effort` 导致 None 仍思考

Closes #175

## Test plan

- [x] `packages/agent-core`：`gateway-xiaomi-thinking`、`model-factory`、`model-thinking-controls`、`gateway-code-completion-thinking` 单测
- [x] `packages/host-internal`：`model-provider-presets` 单测（含 xiaomi open-responses base URL）
- [x] `apps/desktop`：`model-config-thinking` 单测（Gateway/直连 xiaomi Responses + 存量 thinkingEnabled 桥接）
- [x] `packages/agent-core`：`npm run typecheck`
- [x] 手动：Xiaomi 直连 + Responses API + Mimo V2.5 Pro + Reasoning Effort None，确认无 Thought 块