### PR TITLE
refactor(desktop): 统一弹窗 DialogFooter 托底区与按钮布局

### DIFF
--- a/apps/desktop/src/components/automations-view.tsx
+++ b/apps/desktop/src/components/automations-view.tsx
@@ -13,6 +13,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -172,7 +174,8 @@ export function AutomationsView({
               {t("automations.deleteAutomationConfirm", { name: deleteTarget?.title ?? "" })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -201,7 +204,8 @@ export function AutomationsView({
               {automationBusy ? <LoaderCircle className="size-4 animate-spin" aria-hidden /> : null}
               {t("common.delete")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/branch-checkout-dialog.tsx
+++ b/apps/desktop/src/components/branch-checkout-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogDescription,
   DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -57,7 +58,8 @@ export function BranchCheckoutDialog({
             )}
           </DialogDescription>
         </DialogHeader>
-        <DialogFooter className="gap-2 sm:justify-end">
+        <DialogFooter>
+          <DialogFooterActions>
           <Button
             type="button"
             variant="outline"
@@ -89,6 +91,7 @@ export function BranchCheckoutDialog({
               {t("app.switchAndSend")}
             </Button>
           )}
+          </DialogFooterActions>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/components/create-automation-dialog.tsx
+++ b/apps/desktop/src/components/create-automation-dialog.tsx
@@ -13,6 +13,7 @@ import {
   Dialog,
   DialogContent,
   DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -135,7 +136,7 @@ export function CreateAutomationDialog({
             )}
           />
         </div>
-        <DialogFooter className="mx-0 mb-0 flex-col gap-3 border-t border-border/40 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <DialogFooter layout="split" inset>
           <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1">
             <AutomationTriggerMenu
               trigger={trigger}
@@ -188,7 +189,7 @@ export function CreateAutomationDialog({
               </>
             ) : null}
           </div>
-          <div className="flex shrink-0 items-center justify-end gap-2">
+          <DialogFooterActions>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={disabled}>
               {t("common.cancel")}
             </Button>
@@ -210,7 +211,7 @@ export function CreateAutomationDialog({
             >
               {t("common.create")}
             </Button>
-          </div>
+          </DialogFooterActions>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/apps/desktop/src/components/github-device-login-dialog.tsx
+++ b/apps/desktop/src/components/github-device-login-dialog.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -74,19 +76,21 @@ export function GitHubDeviceLoginDialog({
           <p className="text-center text-sm text-destructive">{error}</p>
         ) : null}
 
-        <div className="flex justify-end pt-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={loading && !challenge}
-            onClick={() => {
-              onOpenChange(false);
-            }}
-          >
-            {t("common.cancel")}
-          </Button>
-        </div>
+        <DialogFooter>
+          <DialogFooterActions>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={loading && !challenge}
+              onClick={() => {
+                onOpenChange(false);
+              }}
+            >
+              {t("common.cancel")}
+            </Button>
+          </DialogFooterActions>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/apps/desktop/src/components/marketplace-view.tsx
+++ b/apps/desktop/src/components/marketplace-view.tsx
@@ -11,6 +11,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -792,7 +794,8 @@ export function MarketplaceView({
             {t('marketplace.switchAdvice')}
           </div>
 
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button type="button" variant="outline" onClick={() => setPendingInstall(null)} disabled={marketplaceBusy}>
               {t('common.cancel')}
             </Button>
@@ -813,7 +816,8 @@ export function MarketplaceView({
               {marketplaceBusy ? <LoaderCircle className="size-4 animate-spin" aria-hidden /> : null}
               {t('marketplace.continueSwitch')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -54,6 +54,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -1803,7 +1805,8 @@ function SessionSidebarInner({
               {t("sidebar.deleteSessionConfirm", { name: deleteTarget?.displayName ?? "" })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1836,7 +1839,8 @@ function SessionSidebarInner({
               {deleteSessionBusy ? <LoaderCircle className="size-4 animate-spin" aria-hidden /> : null}
               {t("common.delete")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -1868,7 +1872,8 @@ function SessionSidebarInner({
                   })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1918,7 +1923,8 @@ function SessionSidebarInner({
               {sectionDeleteBusy ? <LoaderCircle className="size-4 animate-spin" aria-hidden /> : null}
               {t("common.delete")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -1942,7 +1948,8 @@ function SessionSidebarInner({
               })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1975,7 +1982,8 @@ function SessionSidebarInner({
               {deleteWorkspaceBusy ? <LoaderCircle className="size-4 animate-spin" aria-hidden /> : null}
               {t("common.delete")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </aside>

--- a/apps/desktop/src/components/settings/models/models-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/models/models-settings-panel.tsx
@@ -35,6 +35,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -1214,7 +1216,8 @@ export function ModelsSettingsPanel({
               </div>
             ) : null}
           </div>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1241,7 +1244,8 @@ export function ModelsSettingsPanel({
               {modelsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.save')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -1260,7 +1264,8 @@ export function ModelsSettingsPanel({
               {t('settings.deleteModelConfirm', { name: deleteTarget ?? '' })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1293,7 +1298,8 @@ export function ModelsSettingsPanel({
               {modelsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.delete')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -1312,7 +1318,8 @@ export function ModelsSettingsPanel({
               {t('settings.deleteProviderGroupConfirm', { provider: deleteGroupTarget ? providerLabel(deleteGroupTarget) : '' })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1345,7 +1352,8 @@ export function ModelsSettingsPanel({
               {modelsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('settings.deleteGroup')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -1869,7 +1877,9 @@ export function ModelsSettingsPanel({
                 </p>
               </>
             ) : null}
-            <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row sm:justify-between">
+          </div>
+          <DialogFooter>
+            <DialogFooterActions>
               <Button
                 type="button"
                 variant="outline"
@@ -1879,7 +1889,6 @@ export function ModelsSettingsPanel({
               >
                 {t('common.cancel')}
               </Button>
-              <div className="flex flex-col-reverse gap-2 sm:flex-row">
                 {selectedProvider === "custom" && customConnectMode === "single" ? (
                   <Button
                     type="button"
@@ -2081,9 +2090,8 @@ export function ModelsSettingsPanel({
                     {t('settings.addProvider')}
                   </Button>
                 ) : null}
-              </div>
-            </div>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/settings/panels/agents-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/agents-settings-panel.tsx
@@ -8,6 +8,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -169,7 +171,8 @@ export function AgentsSettingsPanel({
               })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -193,7 +196,8 @@ export function AgentsSettingsPanel({
               {lspInstallBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t("settings.lspInstallConfirmAction")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/settings/panels/extensions-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/extensions-settings-panel.tsx
@@ -10,6 +10,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -194,7 +196,8 @@ export function ExtensionsSettingsPanel({
               {t('settings.deleteExtensionConfirm', { name: deleteTarget?.displayName ?? '' })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -227,7 +230,8 @@ export function ExtensionsSettingsPanel({
               {extensionsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.delete')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
@@ -10,6 +10,7 @@ import {
   DialogContent,
   DialogDescription,
   DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -233,7 +234,8 @@ export function HooksSettingsPanel({
           {deleteError ? (
             <p className="text-xs text-destructive">{deleteError}</p>
           ) : null}
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -273,7 +275,8 @@ export function HooksSettingsPanel({
               {hooksBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t("common.delete")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -384,19 +387,21 @@ export function HooksSettingsPanel({
               {t("settings.hooksFailClosed")}
             </label>
           </div>
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button type="button" variant="outline" size="sm" onClick={() => setAddDialogOpen(false)}>
-              {t("common.cancel")}
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              disabled={hooksBusy || !command.trim()}
-              onClick={() => void handleCreate()}
-            >
-              {hooksBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
-              {t("common.save")}
-            </Button>
+          <DialogFooter>
+            <DialogFooterActions>
+              <Button type="button" variant="outline" size="sm" onClick={() => setAddDialogOpen(false)}>
+                {t("common.cancel")}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                disabled={hooksBusy || !command.trim()}
+                onClick={() => void handleCreate()}
+              >
+                {hooksBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
+                {t("common.save")}
+              </Button>
+            </DialogFooterActions>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
@@ -10,6 +10,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -355,7 +357,8 @@ export function McpsSettingsPanel({
               {t('settings.deleteMcpConfirm', { name: deleteTarget?.name ?? '' })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -388,7 +391,8 @@ export function McpsSettingsPanel({
               {mcpsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.delete')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -521,7 +525,8 @@ export function McpsSettingsPanel({
             </div>
           </div>
 
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -557,7 +562,8 @@ export function McpsSettingsPanel({
               {mcpsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.create')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
@@ -10,6 +10,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -198,7 +200,8 @@ export function RulesSettingsPanel({
               })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -231,7 +234,8 @@ export function RulesSettingsPanel({
               {rulesBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.delete')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -293,7 +297,8 @@ export function RulesSettingsPanel({
               />
             </div>
           </div>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -326,7 +331,8 @@ export function RulesSettingsPanel({
               {rulesBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.create')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
@@ -10,6 +10,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -170,7 +172,8 @@ export function SkillsSettingsPanel({
               {t('settings.deleteSkillConfirm', { name: deleteTarget?.name ?? '', location: deleteTarget ? skillRootKindLabel(deleteTarget.rootKind) : '' })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -203,7 +206,8 @@ export function SkillsSettingsPanel({
               {skillsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.delete')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -276,7 +280,8 @@ export function SkillsSettingsPanel({
               />
             </div>
           </div>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -312,7 +317,8 @@ export function SkillsSettingsPanel({
               {skillsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}
               {t('common.create')}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -103,19 +103,29 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+type DialogFooterLayout = "actions" | "split"
+
 function DialogFooter({
   className,
+  layout = "actions",
+  inset = false,
   showCloseButton = false,
   children,
   ...props
 }: React.ComponentProps<"div"> & {
+  layout?: DialogFooterLayout
+  inset?: boolean
   showCloseButton?: boolean
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "flex rounded-b-xl border-t border-border/40 bg-muted/50",
+        inset ? "mx-0 mb-0 gap-3 px-6 py-4" : "-mx-4 -mb-4 gap-2 p-4",
+        layout === "split"
+          ? "flex-col sm:flex-row sm:items-center sm:justify-between"
+          : "flex-col-reverse sm:flex-row sm:justify-end",
         className
       )}
       {...props}
@@ -127,6 +137,22 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
+  )
+}
+
+function DialogFooterActions({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-footer-actions"
+      className={cn(
+        "flex shrink-0 flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-end",
+        className
+      )}
+      {...props}
+    />
   )
 }
 
@@ -168,6 +194,7 @@ export {
   DialogContent,
   DialogDescription,
   DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogOverlay,
   DialogPortal,

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -19,6 +19,8 @@ import {
   Dialog,
   DialogContent,
   DialogDescription,
+  DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -1017,7 +1019,8 @@ export function WorkspaceFilesPanel({
               {t("workspace.deleteEntryConfirm", { name: deleteTarget?.name ?? "" })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1040,7 +1043,8 @@ export function WorkspaceFilesPanel({
             >
               {moveToTrashLabel}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -1069,7 +1073,8 @@ export function WorkspaceFilesPanel({
               {moveError}
             </p>
           ) : null}
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1091,7 +1096,8 @@ export function WorkspaceFilesPanel({
             >
               {t("workspace.move")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 
@@ -1112,7 +1118,8 @@ export function WorkspaceFilesPanel({
               {t("workspace.forceDeleteConfirm", { reason: forceDeleteReason })}
             </DialogDescription>
           </DialogHeader>
-          <div className="flex flex-col-reverse justify-end gap-2 pt-2 sm:flex-row">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button
               type="button"
               variant="outline"
@@ -1135,7 +1142,8 @@ export function WorkspaceFilesPanel({
             >
               {t("workspace.forceDelete")}
             </Button>
-          </div>
+            </DialogFooterActions>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </div>

--- a/apps/desktop/src/components/workspace-tools-panel.tsx
+++ b/apps/desktop/src/components/workspace-tools-panel.tsx
@@ -27,6 +27,7 @@ import {
   DialogContent,
   DialogDescription,
   DialogFooter,
+  DialogFooterActions,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -1000,13 +1001,15 @@ const WorkspaceToolsDockContent = memo(function WorkspaceToolsDockContent({
             <DialogTitle>{t("workspace.unsavedChangesCloseConfirm")}</DialogTitle>
             <DialogDescription>{t("app.discardChangesWarning")}</DialogDescription>
           </DialogHeader>
-          <DialogFooter className="gap-2 sm:justify-end">
+          <DialogFooter>
+            <DialogFooterActions>
             <Button type="button" variant="outline" size="sm" onClick={() => setPendingCloseTabId(null)}>
               {t("common.cancel")}
             </Button>
             <Button type="button" size="sm" variant="destructive" onClick={handleConfirmCloseTab}>
               {t("common.close")}
             </Button>
+            </DialogFooterActions>
           </DialogFooter>
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
## Summary

- 强化 `DialogFooter`（`layout`/`inset` 变体）并新增 `DialogFooterActions` 作为右对齐按钮组单一来源
- 将 Settings、模型、会话、工作区等约 26 处内联 footer 迁移至统一托底区样式
- 修复 Hooks 添加弹窗 `sm:gap-0` 导致按钮贴紧，以及提供商连接弹窗取消按钮被推到左侧的问题

## Test plan

- [x] 全仓已无内联 `flex-col-reverse pt-2` footer 模式
- [x] 改动文件无 linter 报错
- [ ] `npm run build:desktop`（仓库内既有无关 TS 错误，本次未阻塞验证）
- [ ] 手动：Hooks 添加 / 提供商连接 / 创建自动化 split footer / 分支切换确认弹窗