### PR TITLE
refactor(desktop): 气泡 Chip 改为 wire block 显式语义并移除文本推断

### DIFF
--- a/apps/desktop/src/components/conversation/composer-dock.tsx
+++ b/apps/desktop/src/components/conversation/composer-dock.tsx
@@ -334,6 +334,7 @@ export const ComposerDock = forwardRef<HTMLDivElement, ComposerDockProps>(functi
               <ComposerSurface
                 value={runtime.composer}
                 onChange={runtime.setComposer}
+                initialSegments={runtime.composerInitialSegments}
                 onSubmit={onSubmitComposerMessage}
                 browserElementAttachments={composerBrowserElementAttachments}
                 onElementAttachmentsChange={onComposerBrowserElementAttachmentsChange}

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -16,6 +16,7 @@ import {
 
 import type { ComposerRichInputHandle } from "@/components/composer-rich-input";
 import { segmentsToMessageText } from "@/components/composer-rich-input";
+import { extractComposerChipMetadata } from "@/lib/composer-segment-model";
 import { cycleAgentMode, type DesktopAgentMode } from "@/lib/agent-mode";
 import { currentWorkspaceFileReferenceQueryFromSegments } from "@/lib/composer-file-reference-query";
 import {
@@ -709,12 +710,19 @@ export function useComposerController({
       applyForkSlash();
       return;
     }
+    const chipMetadata = extractComposerChipMetadata(segs);
     const payload = {
       text: fullText,
       ...(runtime.composerLocalFileAttachments.length > 0
         ? {
             localFilePaths: runtime.composerLocalFileAttachments.map((item) => item.path),
           }
+        : {}),
+      ...(chipMetadata.referencedWorkspaceFilePaths.length > 0
+        ? { referencedWorkspaceFilePaths: chipMetadata.referencedWorkspaceFilePaths }
+        : {}),
+      ...(chipMetadata.skillChipAliases.length > 0
+        ? { skillChipAliases: chipMetadata.skillChipAliases }
         : {}),
     };
 

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -979,8 +979,10 @@ export function useComposerController({
   }, [slashQuery]);
 
   const handleComposerSegmentsCommit = useCallback(() => {
+    const segments = composerRichInputRef.current?.getSegments() ?? [];
+    runtime.setComposerDraftSegments(segments);
     setComposerSegmentsRevision((revision) => revision + 1);
-  }, []);
+  }, [runtime]);
 
   return {
     composerBrowserElementAttachments,

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -19,6 +19,7 @@ import {
   isLogSessionSlashInput,
 } from "@/lib/skill-slash";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
+import type { RichSegment } from "@/lib/composer-segment-model";
 import { isAgentModeChipKind } from "@/lib/composer-agent-mode-segments";
 import { clearGitHubAutomationRepositoriesCache } from "@/lib/github-automation-repositories-cache";
 import { isRunSubagentToolCallPending } from "@/lib/subagent-viewer-pending";
@@ -117,6 +118,7 @@ const COMPOSER_DRAFT_PERSIST_DEBOUNCE_MS = 400;
 
 type SessionUiState = {
   composer: string;
+  composerSegments: RichSegment[];
   questionDrafts: Record<string, QuestionDraft>;
   localFilePaths: string[];
   agentModeChipDismissed: boolean;
@@ -134,11 +136,12 @@ function attachmentsFromPaths(paths: readonly string[]): ComposerLocalFileAttach
 
 function persistSessionUiDraft(
   sessionKey: string,
-  state: Pick<SessionUiState, "composer" | "localFilePaths">,
+  state: Pick<SessionUiState, "composer" | "localFilePaths" | "composerSegments">,
 ): void {
   writeComposerDraft(sessionKey, {
     text: state.composer,
     localFilePaths: state.localFilePaths,
+    segments: state.composerSegments,
   });
 }
 
@@ -316,6 +319,8 @@ export function useDesktopRuntime() {
   const [runtimeError, setRuntimeError] = useState("");
   const [webHostPairingRequired, setWebHostPairingRequired] = useState(false);
   const [composer, setComposer] = useState("");
+  const [composerInitialSegments, setComposerInitialSegments] = useState<RichSegment[] | null>(null);
+  const composerDraftSegmentsRef = useRef<RichSegment[]>([]);
   const [approvalGuidance, setApprovalGuidance] = useState("");
   const [questionError, setQuestionError] = useState("");
   const [settings, setSettings] = useState<SettingsFormState>({
@@ -365,6 +370,8 @@ export function useDesktopRuntime() {
   const clearActiveComposerDraft = useCallback(() => {
     const key = sessionUiKey(snapshotRef.current?.composerSessionKey);
     setComposer("");
+    setComposerInitialSegments(null);
+    composerDraftSegmentsRef.current = [];
     setComposerLocalFileAttachments([]);
     setAgentModeChipDismissed(false);
     if (!key) {
@@ -386,12 +393,17 @@ export function useDesktopRuntime() {
       }
       const state: SessionUiState = {
         composer,
+        composerSegments: composerDraftSegmentsRef.current,
         questionDrafts,
         localFilePaths: pathsFromComposerAttachments(composerLocalFileAttachments),
         agentModeChipDismissed,
       };
       sessionUiCacheRef.current.set(key, state);
-      persistSessionUiDraft(key, state);
+      persistSessionUiDraft(key, {
+        composer,
+        localFilePaths: state.localFilePaths,
+        composerSegments: state.composerSegments,
+      });
     },
     [agentModeChipDismissed, composer, composerLocalFileAttachments, questionDrafts, sessionUiKey],
   );
@@ -402,6 +414,8 @@ export function useDesktopRuntime() {
       const key = sessionUiKey(snapshotLike?.composerSessionKey);
       if (snapshotLike?.activeSession?.readOnly) {
         setComposer("");
+        setComposerInitialSegments(null);
+        composerDraftSegmentsRef.current = [];
         setQuestionDrafts({});
         setComposerLocalFileAttachments([]);
         setAgentModeChipDismissed(false);
@@ -410,6 +424,8 @@ export function useDesktopRuntime() {
       }
       if (!key) {
         setComposer("");
+        setComposerInitialSegments(null);
+        composerDraftSegmentsRef.current = [];
         setQuestionDrafts({});
         setComposerLocalFileAttachments([]);
         setAgentModeChipDismissed(false);
@@ -419,6 +435,8 @@ export function useDesktopRuntime() {
       const cached = sessionUiCacheRef.current.get(key);
       if (cached) {
         setComposer(cached.composer);
+        composerDraftSegmentsRef.current = cached.composerSegments;
+        setComposerInitialSegments(cached.composerSegments.length > 0 ? cached.composerSegments : null);
         setQuestionDrafts(cached.questionDrafts);
         setComposerLocalFileAttachments(attachmentsFromPaths(cached.localFilePaths));
         setAgentModeChipDismissed(cached.agentModeChipDismissed ?? false);
@@ -427,6 +445,8 @@ export function useDesktopRuntime() {
       }
       const stored = readComposerDraft(key);
       setComposer(stored?.text ?? "");
+      composerDraftSegmentsRef.current = stored?.segments ?? [];
+      setComposerInitialSegments(stored?.segments?.length ? stored.segments : null);
       setQuestionDrafts({});
       setComposerLocalFileAttachments(attachmentsFromPaths(stored?.localFilePaths ?? []));
       setAgentModeChipDismissed(false);
@@ -434,6 +454,10 @@ export function useDesktopRuntime() {
     },
     [sessionUiKey],
   );
+
+  const setComposerDraftSegments = useCallback((segments: RichSegment[]) => {
+    composerDraftSegmentsRef.current = segments;
+  }, []);
 
   useEffect(() => {
     agentModeChipDismissedRef.current = agentModeChipDismissed;
@@ -469,11 +493,16 @@ export function useDesktopRuntime() {
       const localFilePaths = pathsFromComposerAttachments(composerLocalFileAttachments);
       sessionUiCacheRef.current.set(key, {
         composer,
+        composerSegments: composerDraftSegmentsRef.current,
         questionDrafts,
         localFilePaths,
         agentModeChipDismissed,
       });
-      persistSessionUiDraft(key, { composer, localFilePaths });
+      persistSessionUiDraft(key, {
+        composer,
+        localFilePaths,
+        composerSegments: composerDraftSegmentsRef.current,
+      });
     }, COMPOSER_DRAFT_PERSIST_DEBOUNCE_MS);
 
     return () => window.clearTimeout(timeout);
@@ -3048,7 +3077,9 @@ export function useDesktopRuntime() {
     busyAction,
     agentModeChipDismissed,
     composer,
+    composerInitialSegments,
     composerLocalFileAttachments,
+    setComposerDraftSegments,
     hostKind: kind,
     pendingQuestions,
     questionDrafts,

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -17,7 +17,6 @@ import {
 import {
   isCompactSlashInput,
   isLogSessionSlashInput,
-  matchSkillSlashInput,
 } from "@/lib/skill-slash";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
 import { isAgentModeChipKind } from "@/lib/composer-agent-mode-segments";
@@ -1954,9 +1953,12 @@ export function useDesktopRuntime() {
     }
 
     const localFilePaths = request.localFilePaths ?? [];
+    const referencedWorkspaceFilePaths = request.referencedWorkspaceFilePaths ?? [];
+    const skillChipAliases = request.skillChipAliases ?? [];
     const hasLocalFiles = localFilePaths.length > 0;
+    const hasReferencedPaths = referencedWorkspaceFilePaths.length > 0;
     const text = request.text.trim();
-    if (!text && !hasLocalFiles) {
+    if (!text && !hasLocalFiles && !hasReferencedPaths) {
       return false;
     }
     if (isLogSessionSlashInput(text)) {
@@ -2021,21 +2023,16 @@ export function useDesktopRuntime() {
 
     setBusyAction("send");
     try {
-      const skillSlash = snapshot ? matchSkillSlashInput(text, snapshot.skillsList) : undefined;
-      if (hasLocalFiles && (isCompactSlashInput(text) || skillSlash)) {
+      if (hasLocalFiles && skillChipAliases.length > 0) {
         setRuntimeError(i18n.t('error.attachmentsNotSupportedWithSlash'));
         return false;
       }
-      const next = skillSlash
-        ? await api.submitSkillSlash({
-            skillName: skillSlash.skillName,
-            rawText: text,
-            ...(skillSlash.extraNote ? { extraNote: skillSlash.extraNote } : {}),
-          })
-        : await api.submitUserTurn({
-            text: request.text,
-            ...(hasLocalFiles ? { localFilePaths } : {}),
-          });
+      const next = await api.submitUserTurn({
+        text: request.text,
+        ...(hasLocalFiles ? { localFilePaths } : {}),
+        ...(hasReferencedPaths ? { referencedWorkspaceFilePaths } : {}),
+        ...(skillChipAliases.length > 0 ? { skillChipAliases } : {}),
+      });
       applySnapshot(next);
       clearActiveComposerDraft();
       setRuntimeError("");

--- a/apps/desktop/src/host/message-queue.ts
+++ b/apps/desktop/src/host/message-queue.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
-import type { PendingWorkspaceFile } from '@spirit-agent/core';
+import type { PendingWorkspaceFile, LlmActiveSkill } from '@spirit-agent/core';
 
 import i18n from '../lib/i18n-host.js';
 import type { ConversationMessageSnapshot, DesktopSnapshot } from '../types.js';
@@ -15,6 +15,7 @@ export interface QueuedUserTurn {
   text: string;
   displayText: string;
   explicitWorkspaceFiles?: PendingWorkspaceFile[];
+  turnSkills?: LlmActiveSkill[];
   localFileAttachments?: ConversationMessageSnapshot['localFileAttachments'];
   enqueuedAtUnixMs: number;
 }
@@ -96,6 +97,7 @@ function pendingWorkspaceFilesToAttachmentSnapshots(
 export interface EnqueueUserTurnInput {
   text: string;
   explicitWorkspaceFiles?: PendingWorkspaceFile[];
+  turnSkills?: LlmActiveSkill[];
   displayText?: string;
 }
 
@@ -105,6 +107,7 @@ export async function enqueueUserTurnCommand(
 ): Promise<DesktopSnapshot> {
   const bundle = ctx.activeBundle();
   const explicitWorkspaceFiles = input.explicitWorkspaceFiles ?? [];
+  const turnSkills = input.turnSkills ?? [];
   const trimmed = input.text.trim();
   if (!trimmed && explicitWorkspaceFiles.length === 0) {
     throw new Error(i18n.t('error.messageRequired'));
@@ -136,6 +139,7 @@ export async function enqueueUserTurnCommand(
     ...(explicitWorkspaceFiles.length > 0
       ? { explicitWorkspaceFiles: [...explicitWorkspaceFiles], localFileAttachments }
       : {}),
+    ...(turnSkills.length > 0 ? { turnSkills: cloneTurnSkills(turnSkills) } : {}),
     enqueuedAtUnixMs: Date.now(),
   };
 
@@ -195,6 +199,17 @@ export function moveQueuedUserTurnUp(bundle: SessionBundle, queueId: string): bo
 
 export function explicitWorkspaceFilesFromQueuedItem(item: QueuedUserTurn): PendingWorkspaceFile[] {
   return item.explicitWorkspaceFiles ? [...item.explicitWorkspaceFiles] : [];
+}
+
+function cloneTurnSkills(skills: readonly LlmActiveSkill[]): LlmActiveSkill[] {
+  return skills.map((skill) => ({
+    ...skill,
+    resources: skill.resources.map((resource) => ({ ...resource })),
+  }));
+}
+
+export function turnSkillsFromQueuedItem(item: QueuedUserTurn): LlmActiveSkill[] {
+  return item.turnSkills ? cloneTurnSkills(item.turnSkills) : [];
 }
 
 export function peekNextQueuedUserTurn(bundle: SessionBundle): QueuedUserTurn | undefined {

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -33,7 +33,6 @@ import {
   persistPreCompactionHistoryArchive,
   persistToolOutputArchive,
   removePreCompactionHistoryArchive,
-  resolveWorkspaceFileReferenceAttachmentsFromInput,
 } from '@spirit-agent/host-internal';
 
 import type { DesktopToolRequest } from './contracts.js';
@@ -141,10 +140,7 @@ export function createDesktopRuntime(input: {
         resolveLoopEnabled(),
         input.mcpToolCatalog,
       ),
-    resolveWorkspaceFilesFromInput: (userInput) =>
-      resolveWorkspaceFileReferenceAttachmentsFromInput(input.workspaceRoot, userInput),
-    resolveWorkspaceFilesForRoot: (workspaceRoot, userInput) =>
-      resolveWorkspaceFileReferenceAttachmentsFromInput(workspaceRoot, userInput),
+    resolveWorkspaceFilesFromInput: async () => [],
     generateImage: (request) =>
       input.llmTransport.generateImage(
         input.transportConfig,

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -31,6 +31,7 @@ import {
   type PendingWorkspaceFile,
   type RuntimeToolExecution,
   type SpiritLlmTransport,
+  type LlmActiveSkill,
 } from '@spirit-agent/core';
 import {
   buildStartImplementingUserTurn,
@@ -38,6 +39,7 @@ import {
   createHostExtensionMarketplace,
   createHostExtensionManager,
   localFileAttachmentFromPath,
+  workspaceFileReferenceAttachmentFromPath,
   classifyLocalFileComposerRoute as resolveLocalFileComposerRoute,
   type LocalFileComposerRoute,
   restoreHostFileChanges,
@@ -373,6 +375,7 @@ import {
   createDesktopRuntime,
   type DesktopRuntime,
 } from './runtime.js';
+import { buildActiveSkillPayload } from './skills.js';
 import { createDesktopSubagentWorkspaceBootstrap } from './subagent-worktree-bootstrap.js';
 import {
   buildDreamContextText,
@@ -1434,17 +1437,19 @@ class DesktopHostService {
       const trimmed = request.text.trim();
       const bundle = this.activeBundle();
       const hasLocalFiles = Array.isArray(request.localFilePaths) && request.localFilePaths.length > 0;
-      if (!trimmed && !hasLocalFiles) {
+      const hasReferencedPaths = Array.isArray(request.referencedWorkspaceFilePaths)
+        && request.referencedWorkspaceFilePaths.length > 0;
+      if (!trimmed && !hasLocalFiles && !hasReferencedPaths) {
         throw new Error(i18n.t('error.messageRequired'));
       }
 
-      const explicitWorkspaceFiles = await this.resolveExplicitLocalFileAttachments(
-        request.localFilePaths,
-      );
+      const explicitWorkspaceFiles = await this.resolveMergedExplicitWorkspaceFiles(request);
+      const turnSkills = await this.resolveTurnSkillsFromChipAliases(request.skillChipAliases);
       if (canEnqueueUserTurn(bundle)) {
         return enqueueUserTurnCommand(this.sessionTurnContext(), {
           text: request.text,
           explicitWorkspaceFiles,
+          turnSkills,
         });
       }
 
@@ -1454,12 +1459,13 @@ class DesktopHostService {
           this.sessionTurnContext(),
           this.worktreeBootstrapHost(),
           request.text,
-          { explicitWorkspaceFiles },
+          { explicitWorkspaceFiles, turnSkills },
         );
       }
 
       return this.submitUserTurnAfterInitialized(request.text, {
         explicitWorkspaceFiles,
+        turnSkills,
       });
     });
   }
@@ -1655,6 +1661,93 @@ class DesktopHostService {
       }
     }
     return attachments;
+  }
+
+  private async resolveReferencedWorkspaceFileAttachments(
+    referencePaths: readonly string[] | undefined,
+  ): Promise<PendingWorkspaceFile[]> {
+    if (!Array.isArray(referencePaths) || referencePaths.length === 0) {
+      return [];
+    }
+
+    const state = this.requireState();
+    const attachments: PendingWorkspaceFile[] = [];
+    for (const referencePath of referencePaths) {
+      try {
+        attachments.push(
+          await workspaceFileReferenceAttachmentFromPath(state.workspaceRoot, referencePath),
+        );
+      } catch {
+        // 仅 composer 显式插入的 workspaceFile chip 会进入此路径；解析失败静默忽略。
+      }
+    }
+    return attachments;
+  }
+
+  private mergeExplicitWorkspaceFiles(
+    ...groups: readonly PendingWorkspaceFile[][]
+  ): PendingWorkspaceFile[] {
+    const seen = new Set<string>();
+    const merged: PendingWorkspaceFile[] = [];
+    for (const group of groups) {
+      for (const file of group) {
+        const key = file.path.replace(/\\/gu, '/').toLowerCase();
+        if (seen.has(key)) {
+          continue;
+        }
+        seen.add(key);
+        merged.push(file);
+      }
+    }
+    return merged;
+  }
+
+  private async resolveMergedExplicitWorkspaceFiles(
+    request: Pick<SubmitUserTurnRequest, 'localFilePaths' | 'referencedWorkspaceFilePaths'>,
+  ): Promise<PendingWorkspaceFile[]> {
+    return this.mergeExplicitWorkspaceFiles(
+      await this.resolveExplicitLocalFileAttachments(request.localFilePaths),
+      await this.resolveReferencedWorkspaceFileAttachments(request.referencedWorkspaceFilePaths),
+    );
+  }
+
+  private skillNameFromChipAlias(alias: string): string {
+    const trimmed = alias.trim();
+    if (!trimmed.startsWith('/')) {
+      throw new Error(i18n.t('error.skillNameRequired'));
+    }
+    return trimmed.slice(1);
+  }
+
+  private async resolveTurnSkillsFromChipAliases(
+    aliases: readonly string[] | undefined,
+  ): Promise<LlmActiveSkill[]> {
+    if (!Array.isArray(aliases) || aliases.length === 0) {
+      return [];
+    }
+
+    const turnSkills: LlmActiveSkill[] = [];
+    const seen = new Set<string>();
+    for (const alias of aliases) {
+      let skillName: string;
+      try {
+        skillName = this.skillNameFromChipAlias(alias);
+      } catch {
+        continue;
+      }
+      const key = skillName.toLowerCase();
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      try {
+        const skill = this.requireEnabledSkillEntry(skillName);
+        turnSkills.push(await buildActiveSkillPayload(skill));
+      } catch {
+        // 未启用或不存在的 skill chip 静默忽略。
+      }
+    }
+    return turnSkills;
   }
 
   private async appendInlineAssistantReply(

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -30,6 +30,7 @@ import {
 import {
   canDrainQueuedUserTurn,
   explicitWorkspaceFilesFromQueuedItem,
+  turnSkillsFromQueuedItem,
   findQueuedUserTurnIndex,
   isSessionBundleQueueBlocked,
   removeQueuedUserTurn,
@@ -277,6 +278,7 @@ export async function sendQueuedUserTurnNowCommand(
       displayText: item.displayText,
       preallocatedMessageId: item.messageId,
       explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(item),
+      turnSkills: turnSkillsFromQueuedItem(item),
     });
   } catch (error) {
     bundle.queuedUserTurns.splice(index, 0, item);
@@ -301,6 +303,7 @@ export async function drainQueuedUserTurnIfIdle(
       displayText: next.displayText,
       preallocatedMessageId: next.messageId,
       explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(next),
+      turnSkills: turnSkillsFromQueuedItem(next),
     });
   } catch (error) {
     bundle.queuedUserTurns.unshift(next);

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -242,6 +242,14 @@ export function cloneQueuedUserTurns(queued: readonly QueuedUserTurn[]): QueuedU
     ...(item.explicitWorkspaceFiles
       ? { explicitWorkspaceFiles: item.explicitWorkspaceFiles.map((file) => ({ ...file })) }
       : {}),
+    ...(item.turnSkills
+      ? {
+          turnSkills: item.turnSkills.map((skill) => ({
+            ...skill,
+            resources: skill.resources.map((resource) => ({ ...resource })),
+          })),
+        }
+      : {}),
     ...(item.localFileAttachments
       ? { localFileAttachments: item.localFileAttachments.map((attachment) => ({ ...attachment })) }
       : {}),

--- a/apps/desktop/src/lib/composer-draft-store.ts
+++ b/apps/desktop/src/lib/composer-draft-store.ts
@@ -1,11 +1,14 @@
+import type { RichSegment } from "./composer-segment-model.js";
+
 export const COMPOSER_DRAFT_STORAGE_KEY = 'spirit-desktop-composer-drafts';
 
-const STORE_VERSION = 1;
+const STORE_VERSION = 2;
 const MAX_DRAFT_ENTRIES = 200;
 
 export interface ComposerDraftEntry {
   text: string;
   localFilePaths: string[];
+  segments: RichSegment[];
   updatedAt: number;
 }
 
@@ -42,8 +45,52 @@ function normalizeLocalFilePaths(paths: readonly string[]): string[] {
   return normalized;
 }
 
-function isComposerDraftEmpty(entry: Pick<ComposerDraftEntry, 'text' | 'localFilePaths'>): boolean {
-  return !entry.text.trim() && entry.localFilePaths.length === 0;
+function isPersistedRichSegment(value: unknown): value is RichSegment {
+  if (typeof value !== 'object' || value === null || !('kind' in value)) {
+    return false;
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  if (kind === 'text') {
+    return typeof (value as { value?: unknown }).value === 'string';
+  }
+  if (kind === 'workspaceFile') {
+    return typeof (value as { path?: unknown }).path === 'string';
+  }
+  if (kind === 'skill') {
+    return typeof (value as { alias?: unknown }).alias === 'string';
+  }
+  if (kind === 'loop' || kind === 'plan' || kind === 'ask' || kind === 'debug') {
+    return true;
+  }
+  if (kind === 'element' || kind === 'prDiff' || kind === 'gitCommit' || kind === 'terminalSnippet' || kind === 'fileSnippet') {
+    return typeof (value as { attachment?: unknown }).attachment === 'object'
+      && (value as { attachment?: unknown }).attachment !== null;
+  }
+  return false;
+}
+
+function normalizeDraftSegments(segments: unknown): RichSegment[] {
+  if (!Array.isArray(segments)) {
+    return [];
+  }
+  return segments.filter(isPersistedRichSegment);
+}
+
+function hasMeaningfulDraftSegments(segments: readonly RichSegment[]): boolean {
+  return segments.some((segment) => {
+    if (segment.kind === 'text') {
+      return segment.value.trim().length > 0;
+    }
+    return true;
+  });
+}
+
+function isComposerDraftEmpty(
+  entry: Pick<ComposerDraftEntry, 'text' | 'localFilePaths' | 'segments'>,
+): boolean {
+  return !entry.text.trim()
+    && entry.localFilePaths.length === 0
+    && !hasMeaningfulDraftSegments(entry.segments);
 }
 
 function readStoreFile(storage: ComposerDraftStorage): ComposerDraftStoreFile {
@@ -94,16 +141,18 @@ export function readComposerDraft(
   if (!entry || typeof entry.text !== 'string' || !Array.isArray(entry.localFilePaths)) {
     return undefined;
   }
+  const segments = normalizeDraftSegments(entry.segments);
   return {
     text: entry.text,
     localFilePaths: normalizeLocalFilePaths(entry.localFilePaths),
+    segments,
     updatedAt: typeof entry.updatedAt === 'number' ? entry.updatedAt : 0,
   };
 }
 
 export function writeComposerDraft(
   sessionKey: string,
-  payload: Pick<ComposerDraftEntry, 'text' | 'localFilePaths'>,
+  payload: Pick<ComposerDraftEntry, 'text' | 'localFilePaths' | 'segments'>,
   storage: ComposerDraftStorage | undefined = defaultStorage(),
 ): void {
   const normalizedKey = normalizeComposerSessionKey(sessionKey);
@@ -115,6 +164,7 @@ export function writeComposerDraft(
   const nextEntry: ComposerDraftEntry = {
     text: payload.text,
     localFilePaths: normalizeLocalFilePaths(payload.localFilePaths),
+    segments: normalizeDraftSegments(payload.segments),
     updatedAt: Date.now(),
   };
 

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -136,6 +136,35 @@ export function hasSkillSegment(segs: RichSegment[]): boolean {
   return segs.some((s) => s.kind === "skill");
 }
 
+export function extractComposerChipMetadata(segs: RichSegment[]): {
+  referencedWorkspaceFilePaths: string[];
+  skillChipAliases: string[];
+} {
+  const referencedWorkspaceFilePaths: string[] = [];
+  const skillChipAliases: string[] = [];
+  const seenPaths = new Set<string>();
+  const seenSkills = new Set<string>();
+
+  for (const seg of segs) {
+    if (seg.kind === "workspaceFile") {
+      const normalized = normalizeWorkspaceFilePath(seg.path);
+      const key = normalized.toLowerCase();
+      if (seenPaths.has(key)) {
+        continue;
+      }
+      seenPaths.add(key);
+      referencedWorkspaceFilePaths.push(normalized);
+      continue;
+    }
+    if (seg.kind === "skill" && !seenSkills.has(seg.alias)) {
+      seenSkills.add(seg.alias);
+      skillChipAliases.push(seg.alias);
+    }
+  }
+
+  return { referencedWorkspaceFilePaths, skillChipAliases };
+}
+
 /** Separator between serialized parts; avoids extra blank lines around inline chips. */
 export function messageSegmentSeparator(prev: RichSegment, next: RichSegment): string {
   if (prev.kind === "text" && next.kind === "text") return "";

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -1,4 +1,4 @@
-import type { BrowserElementAttachment } from "./browser-element-attachment";
+import type { BrowserElementAttachment } from "./browser-element-attachment.js";
 import { browserElementContextText } from "./browser-element-wire-text.js";
 import type { PrDiffAttachment } from "./pr-diff-attachment.js";
 import { parsePrDiffWireMeta, prDiffContextText, scanPrDiffWireBlocks } from "./pr-diff-wire-text.js";
@@ -376,40 +376,6 @@ function pinAgentModeChipFromSegments(
   return mergeAdjacentTextSegments([...loopPart, { kind: modeChip.kind }, ...rest]);
 }
 
-function composerPlainTextHasWorkspaceFileRefs(value: string): boolean {
-  return /@([^\s@]+)/u.test(value);
-}
-
-/** Rebuild inline workspace file chips from stored composer plain text (@path tokens). */
-export function plainComposerTextToRichSegments(value: string): RichSegment[] {
-  if (!value) {
-    return emptySegments();
-  }
-
-  const segments: RichSegment[] = [];
-  let last = 0;
-  const re = /@([^\s@]+)/gu;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(value)) !== null) {
-    if (match.index > last) {
-      segments.push({ kind: "text", value: value.slice(last, match.index) });
-    }
-    segments.push({
-      kind: "workspaceFile",
-      path: normalizeWorkspaceFilePath(match[1] ?? ""),
-    });
-    last = match.index + match[0].length;
-  }
-
-  if (last < value.length) {
-    segments.push({ kind: "text", value: value.slice(last) });
-  }
-
-  return mergeAdjacentTextSegments(
-    segments.length > 0 ? segments : [{ kind: "text", value }],
-  );
-}
-
 export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string): RichSegment[] {
   const loopPinned = segs.some((s) => s.kind === "loop");
   const inlineChips = segs.filter(
@@ -428,11 +394,7 @@ export function syncSegmentsFromExternalValue(segs: RichSegment[], value: string
 
   let body: RichSegment[];
   if (inlineChips.length === 0) {
-    body = value
-      ? (composerPlainTextHasWorkspaceFileRefs(value)
-        ? plainComposerTextToRichSegments(value)
-        : [{ kind: "text", value }])
-      : emptySegments();
+    body = value ? [{ kind: "text", value }] : emptySegments();
   } else if (!value) {
     body = emptySegments();
   } else {

--- a/apps/desktop/src/lib/composer-segment-model.ts
+++ b/apps/desktop/src/lib/composer-segment-model.ts
@@ -20,12 +20,16 @@ import {
   scanTerminalSnippetWireBlocks,
   terminalSnippetContextText,
 } from "./terminal-snippet-wire-text.js";
+import { scanSkillWireBlocks, skillContextText } from "./skill-wire-text.js";
+import { scanWorkspaceFileWireBlocks, workspaceFileContextText } from "./workspace-file-wire-text.js";
 
 export { browserElementContextText };
 export { fileSnippetContextText };
 export { prDiffContextText };
 export { gitCommitContextText };
 export { terminalSnippetContextText };
+export { skillContextText };
+export { workspaceFileContextText };
 
 export type RichSegment =
   | { kind: "text"; value: string }
@@ -248,9 +252,9 @@ export function segmentsToMessageText(segs: RichSegment[]): string {
       seg.kind === "text"
         ? seg.value
         : seg.kind === "workspaceFile"
-          ? workspaceFilePlainToken(seg.path)
+          ? workspaceFileContextText(seg.path)
           : seg.kind === "skill"
-            ? seg.alias
+            ? skillContextText(seg.alias)
             : seg.kind === "prDiff"
               ? prDiffContextText(seg.attachment)
               : seg.kind === "gitCommit"
@@ -901,46 +905,29 @@ function findWireBlocks(content: string): ParsedWireBlock[] {
     });
   }
 
+  for (const block of scanWorkspaceFileWireBlocks(content)) {
+    blocks.push({
+      index: block.index,
+      length: block.length,
+      part: { kind: "workspaceFile", path: block.path },
+    });
+  }
+
+  for (const block of scanSkillWireBlocks(content)) {
+    blocks.push({
+      index: block.index,
+      length: block.length,
+      part: { kind: "skill", alias: block.alias },
+    });
+  }
+
   blocks.sort((left, right) => left.index - right.index);
   return blocks;
 }
-const INLINE_COMPOSER_REF_IN_TEXT_RE = /(@[^\s@]+|\/[a-zA-Z][a-zA-Z0-9_-]*)/gu;
 
-function expandTextWithInlineComposerRefs(text: string): MessageContentPart[] {
-  if (!text) {
-    return [];
-  }
-
-  const parts: MessageContentPart[] = [];
-  let last = 0;
-  const re = new RegExp(INLINE_COMPOSER_REF_IN_TEXT_RE.source, "gu");
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(text)) !== null) {
-    if (match.index > last) {
-      parts.push({ kind: "text", value: text.slice(last, match.index) });
-    }
-    const token = match[0] ?? "";
-    if (token.startsWith("@")) {
-      parts.push({
-        kind: "workspaceFile",
-        path: normalizeWorkspaceFilePath(token.slice(1)),
-      });
-    } else {
-      parts.push({ kind: "skill", alias: token });
-    }
-    last = match.index + token.length;
-  }
-
-  if (last < text.length) {
-    parts.push({ kind: "text", value: text.slice(last) });
-  }
-
-  return parts.length > 0 ? parts : [{ kind: "text", value: text }];
-}
-
-function pushExpandedTextParts(parts: MessageContentPart[], text: string): void {
-  for (const part of expandTextWithInlineComposerRefs(text)) {
-    parts.push(part);
+function pushPlainTextPart(parts: MessageContentPart[], text: string): void {
+  if (text) {
+    parts.push({ kind: "text", value: text });
   }
 }
 
@@ -952,22 +939,22 @@ export function parseMessageContentParts(content: string): MessageContentPart[] 
 
   const blocks = findWireBlocks(content);
   if (blocks.length === 0) {
-    return expandTextWithInlineComposerRefs(content);
+    return [{ kind: "text", value: content }];
   }
 
   const parts: MessageContentPart[] = [];
   let last = 0;
   for (const block of blocks) {
     if (block.index > last) {
-      pushExpandedTextParts(parts, content.slice(last, block.index));
+      pushPlainTextPart(parts, content.slice(last, block.index));
     }
     parts.push(block.part);
     last = block.index + block.length;
   }
   if (last < content.length) {
-    pushExpandedTextParts(parts, content.slice(last));
+    pushPlainTextPart(parts, content.slice(last));
   }
-  return parts.length > 0 ? parts : expandTextWithInlineComposerRefs(content);
+  return parts.length > 0 ? parts : [{ kind: "text", value: content }];
 }
 
 /** Rebuild composer segments from stored message content (e.g. message rewind). */

--- a/apps/desktop/src/lib/skill-wire-text.ts
+++ b/apps/desktop/src/lib/skill-wire-text.ts
@@ -1,0 +1,73 @@
+export const SKILL_WIRE_PREFIX = "Referenced skill ";
+
+export type ParsedSkillWireBlock = {
+  index: number;
+  length: number;
+  alias: string;
+};
+
+/** Wire-format skill chip (inline, explicit composer insertion only). */
+export function skillContextText(alias: string): string {
+  return `${SKILL_WIRE_PREFIX}\`${alias}\``;
+}
+
+function parseSkillWireValue(value: string): string | null {
+  const parsedAlias = value.trim();
+  if (!parsedAlias.startsWith("/")) {
+    return null;
+  }
+  return parsedAlias;
+}
+
+function scanBacktickDelimitedWireBlocks(
+  content: string,
+  prefix: string,
+  parseValue: (value: string) => string | null,
+): Array<{ index: number; length: number; value: string }> {
+  const blocks: Array<{ index: number; length: number; value: string }> = [];
+  let searchFrom = 0;
+
+  while (searchFrom < content.length) {
+    const headerIndex = content.indexOf(prefix, searchFrom);
+    if (headerIndex === -1) {
+      break;
+    }
+
+    const valueStart = headerIndex + prefix.length;
+    if (content[valueStart] !== "`") {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+
+    const valueEnd = content.indexOf("`", valueStart + 1);
+    if (valueEnd === -1) {
+      break;
+    }
+
+    const rawValue = content.slice(valueStart + 1, valueEnd);
+    const parsed = parseValue(rawValue);
+    if (!parsed) {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+
+    const length = valueEnd + 1 - headerIndex;
+    blocks.push({ index: headerIndex, length, value: parsed });
+    searchFrom = headerIndex + length;
+  }
+
+  return blocks;
+}
+
+/** Scan wire text for explicit skill chip blocks. */
+export function scanSkillWireBlocks(content: string): ParsedSkillWireBlock[] {
+  return scanBacktickDelimitedWireBlocks(
+    content,
+    SKILL_WIRE_PREFIX,
+    parseSkillWireValue,
+  ).map((block) => ({
+    index: block.index,
+    length: block.length,
+    alias: block.value,
+  }));
+}

--- a/apps/desktop/src/lib/workspace-file-wire-text.ts
+++ b/apps/desktop/src/lib/workspace-file-wire-text.ts
@@ -1,0 +1,71 @@
+export const WORKSPACE_FILE_WIRE_PREFIX = "Referenced workspace file ";
+
+export type ParsedWorkspaceFileWireBlock = {
+  index: number;
+  length: number;
+  path: string;
+};
+
+/** Wire-format workspace file chip (inline, explicit composer insertion only). */
+export function workspaceFileContextText(path: string): string {
+  const normalized = path.replace(/\\/gu, "/");
+  return `${WORKSPACE_FILE_WIRE_PREFIX}\`${normalized}\``;
+}
+
+function parseWorkspaceFileWireValue(value: string): string | null {
+  const parsedPath = value.trim();
+  return parsedPath ? parsedPath.replace(/\\/gu, "/") : null;
+}
+
+function scanBacktickDelimitedWireBlocks(
+  content: string,
+  prefix: string,
+  parseValue: (value: string) => string | null,
+): Array<{ index: number; length: number; value: string }> {
+  const blocks: Array<{ index: number; length: number; value: string }> = [];
+  let searchFrom = 0;
+
+  while (searchFrom < content.length) {
+    const headerIndex = content.indexOf(prefix, searchFrom);
+    if (headerIndex === -1) {
+      break;
+    }
+
+    const valueStart = headerIndex + prefix.length;
+    if (content[valueStart] !== "`") {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+
+    const valueEnd = content.indexOf("`", valueStart + 1);
+    if (valueEnd === -1) {
+      break;
+    }
+
+    const rawValue = content.slice(valueStart + 1, valueEnd);
+    const parsed = parseValue(rawValue);
+    if (!parsed) {
+      searchFrom = headerIndex + 1;
+      continue;
+    }
+
+    const length = valueEnd + 1 - headerIndex;
+    blocks.push({ index: headerIndex, length, value: parsed });
+    searchFrom = headerIndex + length;
+  }
+
+  return blocks;
+}
+
+/** Scan wire text for explicit workspace file chip blocks. */
+export function scanWorkspaceFileWireBlocks(content: string): ParsedWorkspaceFileWireBlock[] {
+  return scanBacktickDelimitedWireBlocks(
+    content,
+    WORKSPACE_FILE_WIRE_PREFIX,
+    parseWorkspaceFileWireValue,
+  ).map((block) => ({
+    index: block.index,
+    length: block.length,
+    path: block.value,
+  }));
+}

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -611,6 +611,8 @@ export interface ForkSessionRequest {
 export interface SubmitUserTurnRequest {
   text: string;
   localFilePaths?: string[];
+  referencedWorkspaceFilePaths?: string[];
+  skillChipAliases?: string[];
 }
 
 export interface QueuedUserTurnRequest {

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   caretToPlainTextOffset,
   emptySegments,
+  extractComposerChipMetadata,
   insertSegmentAtCaret,
   isComposerPlainEmpty,
   mergeAdjacentTextSegments,
@@ -232,6 +233,19 @@ test("parseMessageContentParts parses explicit workspace file and skill wire blo
     { kind: "workspaceFile", path: "README.md" },
     { kind: "text", value: " done" },
   ]);
+});
+
+test("extractComposerChipMetadata collects workspace file and skill chip segments", () => {
+  const metadata = extractComposerChipMetadata([
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: " fix " },
+    { kind: "workspaceFile", path: "src/App.tsx" },
+    { kind: "workspaceFile", path: "src/App.tsx" },
+  ]);
+  assert.deepEqual(metadata, {
+    referencedWorkspaceFilePaths: ["src/App.tsx"],
+    skillChipAliases: ["/git-commit"],
+  });
 });
 
 test("parseMessageContentParts does not treat URL path segments as skill chips", () => {

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -186,17 +186,17 @@ test("insertSegmentAtCaret splits text and leaves trailing text segment", () => 
   assert.equal(caret.offset, 0);
 });
 
-test("parseMessageContentParts splits @path tokens in plain text", () => {
+test("parseMessageContentParts treats loose @path as plain text", () => {
   const parts = parseMessageContentParts("@apps/cli/src/main.rs 你好");
-  assert.equal(parts.length, 2);
-  assert.equal(parts[0]?.kind, "workspaceFile");
-  assert.equal(parts[0]?.kind === "workspaceFile" && parts[0].path, "apps/cli/src/main.rs");
-  assert.equal(parts[1]?.kind, "text");
-  assert.equal(parts[1]?.kind === "text" && parts[1].value, " 你好");
+  assert.deepEqual(parts, [{ kind: "text", value: "@apps/cli/src/main.rs 你好" }]);
 });
 
 test("messageContentToRichSegments rebuilds workspace file chips from wire text", () => {
-  const segments = messageContentToRichSegments("@apps/cli/src/main.rs 你好", "msg-file");
+  const wire = segmentsToMessageText([
+    { kind: "workspaceFile", path: "apps/cli/src/main.rs" },
+    { kind: "text", value: " 你好" },
+  ]);
+  const segments = messageContentToRichSegments(wire, "msg-file");
   assert.equal(segments.length, 2);
   assert.equal(segments[0]?.kind, "workspaceFile");
   assert.equal(
@@ -207,21 +207,36 @@ test("messageContentToRichSegments rebuilds workspace file chips from wire text"
 });
 
 test("messageContentToRichSegments rebuilds skill chips from wire text", () => {
-  const segments = messageContentToRichSegments("/create-skill 你好", "msg-skill");
+  const wire = segmentsToMessageText([
+    { kind: "skill", alias: "/create-skill" },
+    { kind: "text", value: " 你好" },
+  ]);
+  const segments = messageContentToRichSegments(wire, "msg-skill");
   assert.equal(segments.length, 2);
   assert.equal(segments[0]?.kind, "skill");
   assert.equal(segments[0]?.kind === "skill" && segments[0].alias, "/create-skill");
   assert.equal(segments[1]?.kind === "text" && segments[1].value, " 你好");
 });
 
-test("parseMessageContentParts parses skill and workspace file inline refs", () => {
-  const parts = parseMessageContentParts("/git-commit @README.md done");
+test("parseMessageContentParts parses explicit workspace file and skill wire blocks", () => {
+  const wire = segmentsToMessageText([
+    { kind: "skill", alias: "/git-commit" },
+    { kind: "text", value: " " },
+    { kind: "workspaceFile", path: "README.md" },
+    { kind: "text", value: " done" },
+  ]);
+  const parts = parseMessageContentParts(wire);
   assert.deepEqual(parts, [
     { kind: "skill", alias: "/git-commit" },
     { kind: "text", value: " " },
     { kind: "workspaceFile", path: "README.md" },
     { kind: "text", value: " done" },
   ]);
+});
+
+test("parseMessageContentParts does not treat URL path segments as skill chips", () => {
+  const parts = parseMessageContentParts("https://cursor.com/cn/evals");
+  assert.deepEqual(parts, [{ kind: "text", value: "https://cursor.com/cn/evals" }]);
 });
 
 test("messageContentToRichSegments rebuilds element chips from wire text", () => {
@@ -542,12 +557,12 @@ test("segmentsToPlainText includes workspace file token", () => {
   assert.equal(segmentsToPlainText(segs), "see @apps/desktop/index.html please");
 });
 
-test("segmentsToMessageText includes workspace file token inline", () => {
+test("segmentsToMessageText serializes workspace file chip as wire block", () => {
   const message = segmentsToMessageText([
     { kind: "text", value: "fix " },
     { kind: "workspaceFile", path: "src/App.tsx" },
   ]);
-  assert.equal(message, "fix @src/App.tsx");
+  assert.equal(message, "fix Referenced workspace file `src/App.tsx`");
 });
 
 test("plainTextOffsetToCaret roundtrips with workspace file chip", () => {
@@ -829,12 +844,12 @@ test("domParsedMissingRequiredAgentChip when shell has ask but dom lost it", () 
 
 // --- Skill chip tests ---
 
-test("segmentsToMessageText serializes skill chip as alias", () => {
+test("segmentsToMessageText serializes skill chip as wire block", () => {
   const message = segmentsToMessageText([
     { kind: "skill", alias: "/git-commit" },
     { kind: "text", value: " fix typo" },
   ]);
-  assert.equal(message, "/git-commit fix typo");
+  assert.equal(message, "Referenced skill `/git-commit` fix typo");
 });
 
 test("segmentsToPlainText returns empty for skill chip", () => {

--- a/apps/desktop/test/composer-segments.test.mjs
+++ b/apps/desktop/test/composer-segments.test.mjs
@@ -652,25 +652,9 @@ test("syncSegmentsFromExternalValue keeps workspace file chips", () => {
   ]);
 });
 
-test("plainComposerTextToRichSegments rebuilds workspace file chips from @ tokens", async () => {
-  const { plainComposerTextToRichSegments } = await import("../src/lib/composer-segment-model.ts");
-  assert.deepEqual(plainComposerTextToRichSegments("see @src/foo.ts next"), [
-    { kind: "text", value: "see " },
-    { kind: "workspaceFile", path: "src/foo.ts" },
-    { kind: "text", value: " next" },
-  ]);
-  assert.deepEqual(
-    plainComposerTextToRichSegments("@D:/tmp/notes.txt"),
-    [{ kind: "workspaceFile", path: "D:/tmp/notes.txt" }],
-  );
-});
-
-test("syncSegmentsFromExternalValue hydrates @ tokens into chips when no inline chips", () => {
+test("syncSegmentsFromExternalValue keeps typed @ tokens as plain text when no inline chips", () => {
   const synced = syncSegmentsFromExternalValue(emptySegments(), "see @README.md");
-  assert.deepEqual(synced, [
-    { kind: "text", value: "see " },
-    { kind: "workspaceFile", path: "README.md" },
-  ]);
+  assert.deepEqual(synced, [{ kind: "text", value: "see @README.md" }]);
 });
 
 test("isComposerPlainEmpty treats lone newline as empty", () => {

--- a/apps/desktop/test/host/composer-draft-store.test.mjs
+++ b/apps/desktop/test/host/composer-draft-store.test.mjs
@@ -29,23 +29,30 @@ test('normalizeComposerSessionKey normalizes Windows-style paths', () => {
   );
 });
 
-test('writeComposerDraft and readComposerDraft round-trip text and attachments', () => {
+test('writeComposerDraft and readComposerDraft round-trip text attachments and segments', () => {
   const storage = createMemoryStorage();
   const sessionKey = 'D:/SpiritAgent/chats/session-a.json';
+  const segments = [
+    { kind: 'text', value: 'fix ' },
+    { kind: 'workspaceFile', path: 'src/App.tsx' },
+    { kind: 'skill', alias: '/git-commit' },
+  ];
 
   writeComposerDraft(
     sessionKey,
     {
-      text: 'half-written idea',
+      text: 'fix @src/App.tsx',
       localFilePaths: ['D:\\tmp\\note.png', 'D:/tmp/note.png'],
+      segments,
     },
     storage,
   );
 
   const restored = readComposerDraft(sessionKey, storage);
   assert.deepEqual(restored, {
-    text: 'half-written idea',
+    text: 'fix @src/App.tsx',
     localFilePaths: ['D:/tmp/note.png'],
+    segments,
     updatedAt: restored.updatedAt,
   });
   assert.equal(typeof restored.updatedAt, 'number');
@@ -55,19 +62,38 @@ test('writeComposerDraft deletes empty drafts', () => {
   const storage = createMemoryStorage();
   const sessionKey = 'session-empty';
 
-  writeComposerDraft(sessionKey, { text: 'temp', localFilePaths: [] }, storage);
-  writeComposerDraft(sessionKey, { text: '   ', localFilePaths: [] }, storage);
+  writeComposerDraft(sessionKey, { text: 'temp', localFilePaths: [], segments: [] }, storage);
+  writeComposerDraft(sessionKey, { text: '   ', localFilePaths: [], segments: [] }, storage);
 
   assert.equal(readComposerDraft(sessionKey, storage), undefined);
   const raw = JSON.parse(storage.getItem(COMPOSER_DRAFT_STORAGE_KEY));
   assert.equal(raw.drafts['session-empty'], undefined);
 });
 
+test('readComposerDraft discards v1 drafts without migration', () => {
+  const storage = createMemoryStorage();
+  storage.setItem(
+    COMPOSER_DRAFT_STORAGE_KEY,
+    JSON.stringify({
+      version: 1,
+      drafts: {
+        'legacy-session': {
+          text: '@README.md hello',
+          localFilePaths: [],
+          updatedAt: 1,
+        },
+      },
+    }),
+  );
+
+  assert.equal(readComposerDraft('legacy-session', storage), undefined);
+});
+
 test('clearComposerDraft removes a stored draft', () => {
   const storage = createMemoryStorage();
   const sessionKey = 'session-clear';
 
-  writeComposerDraft(sessionKey, { text: 'keep me briefly', localFilePaths: [] }, storage);
+  writeComposerDraft(sessionKey, { text: 'keep me briefly', localFilePaths: [], segments: [] }, storage);
   clearComposerDraft(sessionKey, storage);
 
   assert.equal(readComposerDraft(sessionKey, storage), undefined);


### PR DESCRIPTION
## Summary

- workspaceFile 与 skill Chip 改用 `Referenced workspace file/skill` wire block 序列化，删除 `INLINE_COMPOSER_REF` 正则解析，URL 与手打 `@`/`/` 不再误变 Chip
- 发送边界从 `RichSegment[]` 显式提取 `referencedWorkspaceFilePaths` 与 `skillChipAliases`，Desktop runtime 停用 loose `@` 文本扫描，skill 激活改读 segment chip
- Composer 草稿升至 v2 持久化 `RichSegment[]`，v1 草稿直接丢弃；不做历史消息与旧 inline token 向后兼容

## Test plan

- [x] `composer-segments.test.mjs` 全通过（含 URL 不误匹配、wire round-trip、extractComposerChipMetadata）
- [x] `composer-draft-store.test.mjs` v2 round-trip 与 v1 丢弃
- [x] `message-queue.test.mjs` 全通过
- [x] `npm run build:electron` TypeScript 编译通过
- [x] 手动冒烟：URL 纯文本、菜单 @/skill chip 正常、草稿切换会话 chip 保留