### PR TITLE
feat(desktop): 工作区文件树支持创建文件与目录

### DIFF
--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -362,6 +362,13 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   renameWorkspaceEntry(relativePath: string, newName: string) {
     return ipcRenderer.invoke('desktop:invoke', 'renameWorkspaceEntry', { relativePath, newName });
   },
+  createWorkspaceEntry(parentDirectoryRel: string, name: string, kind: 'file' | 'dir') {
+    return ipcRenderer.invoke('desktop:invoke', 'createWorkspaceEntry', {
+      parentDirectoryRel,
+      name,
+      kind,
+    });
+  },
   moveWorkspaceEntry(relativePath: string, targetDirectoryRel: string) {
     return ipcRenderer.invoke('desktop:invoke', 'moveWorkspaceEntry', {
       relativePath,

--- a/apps/desktop/src/adapters/electron.ts
+++ b/apps/desktop/src/adapters/electron.ts
@@ -318,6 +318,9 @@ export async function createElectronHostApi(): Promise<HostApi> {
     renameWorkspaceEntry(relativePath, newName) {
       return bridge.renameWorkspaceEntry(relativePath, newName);
     },
+    createWorkspaceEntry(parentDirectoryRel, name, kind) {
+      return bridge.createWorkspaceEntry(parentDirectoryRel, name, kind);
+    },
     moveWorkspaceEntry(relativePath, targetDirectoryRel) {
       return bridge.moveWorkspaceEntry(relativePath, targetDirectoryRel);
     },

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -389,6 +389,11 @@ export function createWebHostApi(): HostApi {
         new Error('Workspace file shell actions are only available in the Electron desktop app.'),
       );
     },
+    createWorkspaceEntry() {
+      return Promise.reject(
+        new Error('Workspace file shell actions are only available in the Electron desktop app.'),
+      );
+    },
     moveWorkspaceEntry() {
       return Promise.reject(
         new Error('Workspace file shell actions are only available in the Electron desktop app.'),

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type KeyboardEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -84,6 +84,17 @@ function isExplorerListChromeDragTarget(target: EventTarget | null): boolean {
   }
   const tag = target.tagName;
   return tag === "UL" || tag === "LI";
+}
+
+/** 文件树空白区域（容器 / 列表间隙），用于清除目录暂留。 */
+function isExplorerTreeBlankTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  if (target.getAttribute("role") === "tree") {
+    return true;
+  }
+  return isExplorerListChromeDragTarget(target);
 }
 
 export { workspaceExplorerIcon } from "@/lib/workspace-explorer-icon";
@@ -363,6 +374,8 @@ export function WorkspaceFilesPanel({
   const [moveBusy, setMoveBusy] = useState(false);
   const [moveError, setMoveError] = useState("");
   const [revealError, setRevealError] = useState("");
+  /** 目录点击暂留；`""` 为工作区根。与文件 selected 高亮互斥。 */
+  const [focusedDirectoryRel, setFocusedDirectoryRel] = useState<string | null>(null);
   const renameCommitInFlightRef = useRef(false);
   const prevGitRevisionRef = useRef<number | undefined>(undefined);
   const cacheRef = useRef(cache);
@@ -450,6 +463,7 @@ export function WorkspaceFilesPanel({
     setCache({});
     setExpanded({});
     setRootOpen(true);
+    setFocusedDirectoryRel(null);
     void loadDirRef.current("");
   }, [workspaceRoot]);
 
@@ -775,6 +789,31 @@ export function WorkspaceFilesPanel({
     [workspaceRootLabel],
   );
 
+  const clearFocusedDirectory = useCallback(() => {
+    setFocusedDirectoryRel(null);
+  }, []);
+
+  const handleTreeBlankMouseDown = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (!isExplorerTreeBlankTarget(event.target)) {
+        return;
+      }
+      clearFocusedDirectory();
+    },
+    [clearFocusedDirectory],
+  );
+
+  const fileRowSelected = useCallback(
+    (childRel: string) =>
+      focusedDirectoryRel === null && selectedEntryKey === `workspace:${childRel}`,
+    [focusedDirectoryRel, selectedEntryKey],
+  );
+
+  const directoryRowFocused = useCallback(
+    (dirRel: string) => focusedDirectoryRel !== null && focusedDirectoryRel === dirRel,
+    [focusedDirectoryRel],
+  );
+
   if (!workspaceRoot.trim()) {
     return <p className="text-muted-foreground">{t("workspace.connectToShowFiles")}</p>;
   }
@@ -790,11 +829,18 @@ export function WorkspaceFilesPanel({
             "flex w-full min-w-0 items-center gap-1 rounded px-1 py-0.5 text-left",
             "text-foreground/90 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10",
             onOpenPlan && "cursor-pointer",
-            selectedEntryKey === "plan" && "bg-foreground/[0.08] dark:bg-foreground/12",
+            selectedEntryKey === "plan"
+              && focusedDirectoryRel === null
+              && "bg-foreground/[0.08] dark:bg-foreground/12",
           )}
           style={{ paddingLeft: "4px" }}
-          aria-current={selectedEntryKey === "plan" ? "true" : undefined}
-          onClick={() => onOpenPlan?.()}
+          aria-current={
+            selectedEntryKey === "plan" && focusedDirectoryRel === null ? "true" : undefined
+          }
+          onClick={() => {
+            clearFocusedDirectory();
+            onOpenPlan?.();
+          }}
           title={plan.path}
         >
           <span className="inline-block size-3.5 shrink-0" aria-hidden />
@@ -875,7 +921,7 @@ export function WorkspaceFilesPanel({
           };
 
           if (!isDir) {
-            const selected = selectedEntryKey === `workspace:${childRel}`;
+            const selected = fileRowSelected(childRel);
             return (
               <ExplorerRow
                 key={childRel}
@@ -895,7 +941,10 @@ export function WorkspaceFilesPanel({
                 onRenameValueChange={setRenameValue}
                 onRenameCommit={() => void handleRenameCommit()}
                 onRenameCancel={handleRenameCancel}
-                onClick={() => onOpenFile?.(childRel)}
+                onClick={() => {
+                  clearFocusedDirectory();
+                  onOpenFile?.(childRel);
+                }}
                 leading={EXPLORER_ROW_LEADING_SPACER}
                 icon={Icon}
                 draggable
@@ -910,7 +959,7 @@ export function WorkspaceFilesPanel({
               target={target}
               workspaceRoot={workspaceRoot}
               depth={depth}
-              selected={false}
+              selected={directoryRowFocused(dirRel)}
               ignored={ignored}
               isElectron={isElectron}
               renaming={renamingPath === dirRel}
@@ -923,7 +972,10 @@ export function WorkspaceFilesPanel({
               onRenameValueChange={setRenameValue}
               onRenameCommit={() => void handleRenameCommit()}
               onRenameCancel={handleRenameCancel}
-              onClick={() => onToggleDir(dirRel, collapsedDir?.chainRels ?? [dirRel])}
+              onClick={() => {
+                setFocusedDirectoryRel(dirRel);
+                onToggleDir(dirRel, collapsedDir?.chainRels ?? [dirRel]);
+              }}
               label={collapsedDir?.displayName}
               leading={EXPLORER_ROW_LEADING_SPACER}
               icon={open ? ChevronDown : ChevronRight}
@@ -992,6 +1044,7 @@ export function WorkspaceFilesPanel({
             role="tree"
             aria-label={t("workspace.fileList")}
             aria-busy={cache[""]?.status === "loading" ? true : undefined}
+            onMouseDown={handleTreeBlankMouseDown}
           >
             {renderDirBody("", 0)}
             <div className="mt-1">{renderPlanItem()}</div>

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -1349,13 +1349,8 @@ export function WorkspaceFilesPanel({
                 <span className="min-w-0 truncate">{rootLabel}</span>
               </button>
             </WorkspaceFileContextMenu>
-            {isElectron ? (
-              <div
-                className={cn(
-                  "pointer-events-none absolute inset-y-0 right-0.5 flex items-center gap-0 opacity-0 transition-opacity",
-                  treeHovered && "pointer-events-auto opacity-100",
-                )}
-              >
+            {isElectron && treeHovered ? (
+              <div className="absolute inset-y-0 right-0.5 flex items-center gap-0">
                 <button
                   type="button"
                   className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -497,6 +497,7 @@ export function WorkspaceFilesPanel({
   const renameCommitInFlightRef = useRef(false);
   const createCommitInFlightRef = useRef(false);
   const treeHoverContainerRef = useRef<HTMLDivElement>(null);
+  const explorerTreeRef = useRef<HTMLDivElement>(null);
   const prevGitRevisionRef = useRef<number | undefined>(undefined);
   const cacheRef = useRef(cache);
   cacheRef.current = cache;
@@ -955,16 +956,21 @@ export function WorkspaceFilesPanel({
     setFocusedDirectoryRel(null);
   }, []);
 
-  const handleTreeBlankMouseDown = useCallback(
-    (event: MouseEvent<HTMLDivElement>) => {
-      if (!isExplorerTreeBlankTarget(event.target)) {
-        return;
-      }
+  const handleScrollAreaMouseDownCapture = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    const target = event.target instanceof Element ? event.target : null;
+    const treeRect = explorerTreeRef.current?.getBoundingClientRect();
+    const clickBelowTreeContent = treeRect ? event.clientY > treeRect.bottom : false;
+    const clickedTreeItem = target?.closest('[role="treeitem"]');
+    const clickedButton = target?.closest("button");
+    const isBlank =
+      !clickedTreeItem
+      && !clickedButton
+      && (isExplorerTreeBlankTarget(event.target) || clickBelowTreeContent);
+    if (isBlank) {
       clearFocusedDirectory();
       handleCreateCancel();
-    },
-    [clearFocusedDirectory, handleCreateCancel],
-  );
+    }
+  }, [clearFocusedDirectory, handleCreateCancel]);
 
   const fileRowSelected = useCallback(
     (childRel: string) =>
@@ -1379,17 +1385,22 @@ export function WorkspaceFilesPanel({
           </div>
         </div>
         {rootOpen ? (
+        <div
+          className="flex min-h-0 min-w-0 flex-1 flex-col"
+          onMouseDownCapture={handleScrollAreaMouseDownCapture}
+        >
         <ScrollArea className="min-h-0 min-w-0 flex-1" type="auto">
           <div
+            ref={explorerTreeRef}
             role="tree"
             aria-label={t("workspace.fileList")}
             aria-busy={cache[""]?.status === "loading" ? true : undefined}
-            onMouseDown={handleTreeBlankMouseDown}
           >
             {renderDirBody("", 0)}
             <div className="mt-1">{renderPlanItem()}</div>
           </div>
         </ScrollArea>
+        </div>
       ) : (
         <div className="mb-1">{renderPlanItem()}</div>
       )}

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -361,6 +361,95 @@ function ExplorerRow({
   );
 }
 
+type ExplorerCreateRowProps = {
+  depth: number;
+  kind: CreatingEntryState["kind"];
+  value: string;
+  error: string;
+  onValueChange: (value: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+};
+
+function ExplorerCreateRow({
+  depth,
+  kind,
+  value,
+  error,
+  onValueChange,
+  onCommit,
+  onCancel,
+}: ExplorerCreateRowProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const skipBlurCommitRef = useRef(false);
+  const Icon = kind === "dir" ? ChevronRight : workspaceExplorerIcon("untitled.txt", "file");
+
+  useLayoutEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      const input = inputRef.current;
+      if (!input) {
+        return;
+      }
+      input.focus({ preventScroll: true });
+      input.select();
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      skipBlurCommitRef.current = true;
+      onCommit();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onCancel();
+    }
+  };
+
+  const rowStyle = { paddingLeft: `${explorerRowPaddingLeft(depth)}px` };
+
+  return (
+    <li className="min-w-0">
+      <div
+        className={cn(
+          EXPLORER_ROW_TRIGGER_CLASS,
+          "bg-foreground/[0.08] dark:bg-foreground/12",
+        )}
+        style={rowStyle}
+        role="treeitem"
+      >
+        {EXPLORER_ROW_LEADING_SPACER}
+        <Icon className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
+        <input
+          ref={inputRef}
+          type="text"
+          className="min-w-0 flex-1 rounded border border-border/60 bg-background px-1 py-0 text-xs outline-none focus:border-ring"
+          value={value}
+          aria-invalid={error ? true : undefined}
+          onClick={(event) => event.stopPropagation()}
+          onChange={(event) => onValueChange(event.target.value)}
+          onBlur={() => {
+            if (skipBlurCommitRef.current) {
+              skipBlurCommitRef.current = false;
+              return;
+            }
+            onCommit();
+          }}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      {error ? (
+        <p className="py-0.5 pl-1 text-destructive/90" style={{ paddingLeft: `${depth * 12 + 4}px` }}>
+          {error}
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
 export function WorkspaceFilesPanel({
   workspaceRoot,
   plan,
@@ -406,6 +495,7 @@ export function WorkspaceFilesPanel({
   const [treeHasFocus, setTreeHasFocus] = useState(false);
   const [creatingEntry, setCreatingEntry] = useState<CreatingEntryState | null>(null);
   const renameCommitInFlightRef = useRef(false);
+  const createCommitInFlightRef = useRef(false);
   const treeFocusContainerRef = useRef<HTMLDivElement>(null);
   const prevGitRevisionRef = useRef<number | undefined>(undefined);
   const cacheRef = useRef(cache);
@@ -625,6 +715,46 @@ export function WorkspaceFilesPanel({
     setRenameError("");
   }, []);
 
+  const handleCreateCancel = useCallback(() => {
+    setCreatingEntry(null);
+  }, []);
+
+  const handleCreateCommit = useCallback(async () => {
+    if (createCommitInFlightRef.current) {
+      return;
+    }
+    if (!creatingEntry || !api) {
+      handleCreateCancel();
+      return;
+    }
+    const trimmed = creatingEntry.value.trim();
+    if (!trimmed) {
+      handleCreateCancel();
+      return;
+    }
+    createCommitInFlightRef.current = true;
+    try {
+      const result = await api.createWorkspaceEntry(
+        creatingEntry.parentRel,
+        trimmed,
+        creatingEntry.kind,
+      );
+      const parentRel = creatingEntry.parentRel;
+      const createdKind = creatingEntry.kind;
+      handleCreateCancel();
+      invalidateDir(parentRel);
+      if (createdKind === "file") {
+        onOpenFile?.(result.relativePath);
+      }
+    } catch (error) {
+      setCreatingEntry((current) =>
+        current ? { ...current, error: describeError(error) } : null,
+      );
+    } finally {
+      createCommitInFlightRef.current = false;
+    }
+  }, [api, creatingEntry, handleCreateCancel, invalidateDir, onOpenFile]);
+
   const handleRenameCommit = useCallback(async () => {
     if (renameCommitInFlightRef.current) {
       return;
@@ -830,9 +960,9 @@ export function WorkspaceFilesPanel({
         return;
       }
       clearFocusedDirectory();
-      setCreatingEntry(null);
+      handleCreateCancel();
     },
-    [clearFocusedDirectory],
+    [clearFocusedDirectory, handleCreateCancel],
   );
 
   const fileRowSelected = useCallback(
@@ -952,6 +1082,9 @@ export function WorkspaceFilesPanel({
     if (state.status === "error") {
       return <p className="py-1 pl-1 text-destructive/90">{state.message}</p>;
     }
+    const firstFileIndex = state.entries.findIndex((entry) => entry.kind === "file");
+    const creatingHere =
+      creatingEntry !== null && creatingEntry.parentRel === rel ? creatingEntry : null;
     return (
       <div
         onDragOver={(event) => {
@@ -983,9 +1116,44 @@ export function WorkspaceFilesPanel({
         }}
       >
         <ul className="list-none space-y-0.5 p-0">
-        {state.entries.map((entry) => {
+        {creatingEntry?.parentRel === rel && creatingEntry.kind === "dir" ? (
+          <ExplorerCreateRow
+            depth={depth}
+            kind="dir"
+            value={creatingEntry.value}
+            error={creatingEntry.error}
+            onValueChange={(value) => {
+              setCreatingEntry((current) =>
+                current ? { ...current, value, error: "" } : null,
+              );
+            }}
+            onCommit={() => void handleCreateCommit()}
+            onCancel={handleCreateCancel}
+          />
+        ) : null}
+        {state.entries.map((entry, index) => {
           const childRel = joinExplorerRel(rel, entry.name);
           const isDir = entry.kind === "dir";
+          const showFileCreateBefore =
+            creatingHere?.kind === "file"
+            && entry.kind === "file"
+            && index === firstFileIndex;
+          const fileCreateRow = showFileCreateBefore ? (
+            <ExplorerCreateRow
+              key="__creating-file__"
+              depth={depth}
+              kind="file"
+              value={creatingHere.value}
+              error={creatingHere.error}
+              onValueChange={(value) => {
+                setCreatingEntry((current) =>
+                  current ? { ...current, value, error: "" } : null,
+                );
+              }}
+              onCommit={() => void handleCreateCommit()}
+              onCancel={handleCreateCancel}
+            />
+          ) : null;
           if (isDir) {
             for (const prefetchRel of collectWorkspaceExplorerDirCollapsePrefetchRels(
               childRel,
@@ -1016,8 +1184,10 @@ export function WorkspaceFilesPanel({
           if (!isDir) {
             const selected = fileRowSelected(childRel);
             return (
-              <ExplorerRow
-                key={childRel}
+              <>
+                {fileCreateRow}
+                <ExplorerRow
+                  key={childRel}
                 target={target}
                 workspaceRoot={workspaceRoot}
                 depth={depth}
@@ -1043,12 +1213,15 @@ export function WorkspaceFilesPanel({
                 draggable
                 onDragStart={(event) => handleDragStart(event, target)}
               />
+              </>
             );
           }
 
           return (
-            <ExplorerRow
-              key={dirRel}
+            <>
+              {fileCreateRow}
+              <ExplorerRow
+                key={dirRel}
               target={target}
               workspaceRoot={workspaceRoot}
               depth={depth}
@@ -1091,8 +1264,24 @@ export function WorkspaceFilesPanel({
             >
               {open ? <div className="min-w-0">{renderDirBody(dirRel, depth + 1)}</div> : null}
             </ExplorerRow>
+            </>
           );
         })}
+        {creatingHere?.kind === "file" && firstFileIndex === -1 ? (
+          <ExplorerCreateRow
+            depth={depth}
+            kind="file"
+            value={creatingHere.value}
+            error={creatingHere.error}
+            onValueChange={(value) => {
+              setCreatingEntry((current) =>
+                current ? { ...current, value, error: "" } : null,
+              );
+            }}
+            onCommit={() => void handleCreateCommit()}
+            onCancel={handleCreateCancel}
+          />
+        ) : null}
         </ul>
       </div>
     );

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -1,9 +1,11 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type FocusEvent, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
   ChevronDown,
   ChevronRight,
+  FilePlus,
+  FolderPlus,
   ListTodo,
 } from "lucide-react";
 
@@ -49,6 +51,19 @@ function fileBasename(abs: string): string {
   const n = abs.replace(/\\/g, "/");
   const i = n.lastIndexOf("/");
   return i >= 0 ? n.slice(i + 1) || abs : abs;
+}
+
+function parentWorkspaceRelativePath(relativePath: string): string {
+  const posix = relativePath.replace(/\\/g, "/");
+  const index = posix.lastIndexOf("/");
+  return index >= 0 ? posix.slice(0, index) : "";
+}
+
+function workspaceRelFromSelectedEntryKey(selectedEntryKey: string | null | undefined): string | null {
+  if (!selectedEntryKey?.startsWith("workspace:")) {
+    return null;
+  }
+  return selectedEntryKey.slice("workspace:".length);
 }
 
 /** 重命名聚焦时预选文件名主体，不含最后一个扩展名（如 App.tsx → App）。 */
@@ -125,6 +140,18 @@ type PendingMoveTarget = {
   targetDirectoryRel: string;
   targetDirectoryLabel: string;
 };
+
+type CreatingEntryState = {
+  parentRel: string;
+  kind: "file" | "dir";
+  value: string;
+  error: string;
+};
+
+const EXPLORER_CREATE_ROW_BUTTON_CLASS = cn(
+  "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+  "enabled:hover:bg-foreground/[0.06] enabled:hover:text-foreground dark:enabled:hover:bg-foreground/10",
+);
 
 export type WorkspaceFilesPanelProps = {
   workspaceRoot: string;
@@ -376,7 +403,10 @@ export function WorkspaceFilesPanel({
   const [revealError, setRevealError] = useState("");
   /** 目录点击暂留；`""` 为工作区根。与文件 selected 高亮互斥。 */
   const [focusedDirectoryRel, setFocusedDirectoryRel] = useState<string | null>(null);
+  const [treeHasFocus, setTreeHasFocus] = useState(false);
+  const [creatingEntry, setCreatingEntry] = useState<CreatingEntryState | null>(null);
   const renameCommitInFlightRef = useRef(false);
+  const treeFocusContainerRef = useRef<HTMLDivElement>(null);
   const prevGitRevisionRef = useRef<number | undefined>(undefined);
   const cacheRef = useRef(cache);
   cacheRef.current = cache;
@@ -583,6 +613,7 @@ export function WorkspaceFilesPanel({
   );
 
   const handleRenameStart = useCallback((target: WorkspaceExplorerContextTarget) => {
+    setCreatingEntry(null);
     setRenamingPath(target.relativePath);
     setRenameValue(target.name);
     setRenameError("");
@@ -799,6 +830,7 @@ export function WorkspaceFilesPanel({
         return;
       }
       clearFocusedDirectory();
+      setCreatingEntry(null);
     },
     [clearFocusedDirectory],
   );
@@ -813,6 +845,67 @@ export function WorkspaceFilesPanel({
     (dirRel: string) => focusedDirectoryRel !== null && focusedDirectoryRel === dirRel,
     [focusedDirectoryRel],
   );
+
+  const resolveCreateParentDir = useCallback((): string => {
+    if (focusedDirectoryRel !== null) {
+      return focusedDirectoryRel;
+    }
+    const fileRel = workspaceRelFromSelectedEntryKey(selectedEntryKey);
+    if (fileRel) {
+      return parentWorkspaceRelativePath(fileRel);
+    }
+    return "";
+  }, [focusedDirectoryRel, selectedEntryKey]);
+
+  const ensureParentDirectoryExpanded = useCallback(
+    (parentRel: string) => {
+      setRootOpen(true);
+      const directoriesToExpand = [""];
+      if (parentRel) {
+        let current = "";
+        for (const segment of parentRel.split("/").filter((part) => part.length > 0)) {
+          current = current ? `${current}/${segment}` : segment;
+          directoriesToExpand.push(current);
+        }
+      }
+      setExpanded((previous) => {
+        const next = { ...previous };
+        for (const directory of directoriesToExpand) {
+          next[directory] = true;
+        }
+        return next;
+      });
+      for (const directory of directoriesToExpand) {
+        void loadDir(directory);
+      }
+    },
+    [loadDir],
+  );
+
+  const handleCreateStart = useCallback(
+    (kind: CreatingEntryState["kind"]) => {
+      if (!isElectron) {
+        return;
+      }
+      handleRenameCancel();
+      const parentRel = resolveCreateParentDir();
+      ensureParentDirectoryExpanded(parentRel);
+      setCreatingEntry({ parentRel, kind, value: "", error: "" });
+    },
+    [ensureParentDirectoryExpanded, handleRenameCancel, isElectron, resolveCreateParentDir],
+  );
+
+  const handleTreeFocusIn = useCallback(() => {
+    setTreeHasFocus(true);
+  }, []);
+
+  const handleTreeFocusOut = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget;
+    if (next instanceof Node && treeFocusContainerRef.current?.contains(next)) {
+      return;
+    }
+    setTreeHasFocus(false);
+  }, []);
 
   if (!workspaceRoot.trim()) {
     return <p className="text-muted-foreground">{t("workspace.connectToShowFiles")}</p>;
@@ -1012,32 +1105,69 @@ export function WorkspaceFilesPanel({
   };
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden text-xs">
+    <div
+      ref={treeFocusContainerRef}
+      className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden text-xs"
+      onFocusCapture={handleTreeFocusIn}
+      onBlurCapture={handleTreeFocusOut}
+    >
       {revealError ? (
         <p className="mb-1 shrink-0 text-destructive/90" role="alert">
           {revealError}
         </p>
       ) : null}
-      <WorkspaceFileContextMenu
-        target={rootTarget}
-        workspaceRoot={workspaceRoot}
-        isElectron={isElectron}
-        onReveal={handleReveal}
-      >
-        <button
-          type="button"
-          className={cn(EXPLORER_ROW_TRIGGER_CLASS, "mb-1 shrink-0")}
-          aria-expanded={rootOpen}
-          onClick={() => setRootOpen((o) => !o)}
+      <div className="mb-1 flex shrink-0 items-center gap-0.5">
+        <WorkspaceFileContextMenu
+          target={rootTarget}
+          workspaceRoot={workspaceRoot}
+          isElectron={isElectron}
+          onReveal={handleReveal}
         >
-          {rootOpen ? (
-            <ChevronDown className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
-          ) : (
-            <ChevronRight className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
-          )}
-          <span className="min-w-0 truncate">{rootLabel}</span>
-        </button>
-      </WorkspaceFileContextMenu>
+          <button
+            type="button"
+            className={cn(
+              EXPLORER_ROW_TRIGGER_CLASS,
+              "min-w-0 flex-1",
+              focusedDirectoryRel === "" && "bg-foreground/[0.08] dark:bg-foreground/12",
+            )}
+            aria-expanded={rootOpen}
+            aria-current={focusedDirectoryRel === "" ? "true" : undefined}
+            onClick={() => {
+              setFocusedDirectoryRel("");
+              setRootOpen((open) => !open);
+            }}
+          >
+            {rootOpen ? (
+              <ChevronDown className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
+            ) : (
+              <ChevronRight className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
+            )}
+            <span className="min-w-0 truncate">{rootLabel}</span>
+          </button>
+        </WorkspaceFileContextMenu>
+        {isElectron && treeHasFocus ? (
+          <div className="flex shrink-0 items-center gap-0.5">
+            <button
+              type="button"
+              className={EXPLORER_CREATE_ROW_BUTTON_CLASS}
+              aria-label={t("workspace.createFile")}
+              title={t("workspace.createFile")}
+              onClick={() => handleCreateStart("file")}
+            >
+              <FilePlus className="size-3.5" aria-hidden />
+            </button>
+            <button
+              type="button"
+              className={EXPLORER_CREATE_ROW_BUTTON_CLASS}
+              aria-label={t("workspace.createFolder")}
+              title={t("workspace.createFolder")}
+              onClick={() => handleCreateStart("dir")}
+            >
+              <FolderPlus className="size-3.5" aria-hidden />
+            </button>
+          </div>
+        ) : null}
+      </div>
       {rootOpen ? (
         <ScrollArea className="min-h-0 min-w-0 flex-1" type="auto">
           <div

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+import { Fragment, useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -1194,10 +1194,9 @@ export function WorkspaceFilesPanel({
           if (!isDir) {
             const selected = fileRowSelected(childRel);
             return (
-              <>
+              <Fragment key={childRel}>
                 {fileCreateRow}
                 <ExplorerRow
-                  key={childRel}
                 target={target}
                 workspaceRoot={workspaceRoot}
                 depth={depth}
@@ -1223,15 +1222,14 @@ export function WorkspaceFilesPanel({
                 draggable
                 onDragStart={(event) => handleDragStart(event, target)}
               />
-              </>
+              </Fragment>
             );
           }
 
           return (
-            <>
+            <Fragment key={dirRel}>
               {fileCreateRow}
               <ExplorerRow
-                key={dirRel}
               target={target}
               workspaceRoot={workspaceRoot}
               depth={depth}
@@ -1274,7 +1272,7 @@ export function WorkspaceFilesPanel({
             >
               {open ? <div className="min-w-0">{renderDirBody(dirRel, depth + 1)}</div> : null}
             </ExplorerRow>
-            </>
+            </Fragment>
           );
         })}
         {creatingHere?.kind === "file" && firstFileIndex === -1 ? (

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -406,6 +406,7 @@ function ExplorerCreateRow({
     }
     if (event.key === "Escape") {
       event.preventDefault();
+      skipBlurCommitRef.current = true;
       onCancel();
     }
   };

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useHostApi } from "@/hooks/useHostApi";
 import { runAfterRadixOverlayClose } from "@/lib/overlay-motion";
 import { workspaceExplorerIcon } from "@/lib/workspace-explorer-icon";
@@ -1351,30 +1352,42 @@ export function WorkspaceFilesPanel({
             </WorkspaceFileContextMenu>
             {isElectron && treeHovered ? (
               <div className="absolute inset-y-0 right-0.5 flex items-center gap-0">
-                <button
-                  type="button"
-                  className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
-                  aria-label={t("workspace.createFile")}
-                  title={t("workspace.createFile")}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleCreateStart("file");
-                  }}
-                >
-                  <FilePlus className="size-3" aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
-                  aria-label={t("workspace.createFolder")}
-                  title={t("workspace.createFolder")}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    handleCreateStart("dir");
-                  }}
-                >
-                  <FolderPlus className="size-3" aria-hidden />
-                </button>
+                <Tooltip delayDuration={300} disableHoverableContent>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
+                      aria-label={t("workspace.createFile")}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleCreateStart("file");
+                      }}
+                    >
+                      <FilePlus className="size-3" aria-hidden />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={4}>
+                    {t("workspace.createFile")}
+                  </TooltipContent>
+                </Tooltip>
+                <Tooltip delayDuration={300} disableHoverableContent>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
+                      aria-label={t("workspace.createFolder")}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleCreateStart("dir");
+                      }}
+                    >
+                      <FolderPlus className="size-3" aria-hidden />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={4}>
+                    {t("workspace.createFolder")}
+                  </TooltipContent>
+                </Tooltip>
               </div>
             ) : null}
           </div>

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type FocusEvent, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type DragEvent, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -148,9 +148,9 @@ type CreatingEntryState = {
   error: string;
 };
 
-const EXPLORER_CREATE_ROW_BUTTON_CLASS = cn(
-  "inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
-  "enabled:hover:bg-foreground/[0.06] enabled:hover:text-foreground dark:enabled:hover:bg-foreground/10",
+const EXPLORER_ROOT_CREATE_BUTTON_CLASS = cn(
+  "inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground",
+  "hover:bg-foreground/[0.08] hover:text-foreground dark:hover:bg-foreground/12",
 );
 
 export type WorkspaceFilesPanelProps = {
@@ -492,11 +492,11 @@ export function WorkspaceFilesPanel({
   const [revealError, setRevealError] = useState("");
   /** 目录点击暂留；`""` 为工作区根。与文件 selected 高亮互斥。 */
   const [focusedDirectoryRel, setFocusedDirectoryRel] = useState<string | null>(null);
-  const [treeHasFocus, setTreeHasFocus] = useState(false);
+  const [treeHovered, setTreeHovered] = useState(false);
   const [creatingEntry, setCreatingEntry] = useState<CreatingEntryState | null>(null);
   const renameCommitInFlightRef = useRef(false);
   const createCommitInFlightRef = useRef(false);
-  const treeFocusContainerRef = useRef<HTMLDivElement>(null);
+  const treeHoverContainerRef = useRef<HTMLDivElement>(null);
   const prevGitRevisionRef = useRef<number | undefined>(undefined);
   const cacheRef = useRef(cache);
   cacheRef.current = cache;
@@ -704,6 +704,7 @@ export function WorkspaceFilesPanel({
 
   const handleRenameStart = useCallback((target: WorkspaceExplorerContextTarget) => {
     setCreatingEntry(null);
+    setFocusedDirectoryRel(null);
     setRenamingPath(target.relativePath);
     setRenameValue(target.name);
     setRenameError("");
@@ -1019,22 +1020,23 @@ export function WorkspaceFilesPanel({
       }
       handleRenameCancel();
       const parentRel = resolveCreateParentDir();
+      setFocusedDirectoryRel(null);
       ensureParentDirectoryExpanded(parentRel);
       setCreatingEntry({ parentRel, kind, value: "", error: "" });
     },
     [ensureParentDirectoryExpanded, handleRenameCancel, isElectron, resolveCreateParentDir],
   );
 
-  const handleTreeFocusIn = useCallback(() => {
-    setTreeHasFocus(true);
+  const handleTreeMouseEnter = useCallback(() => {
+    setTreeHovered(true);
   }, []);
 
-  const handleTreeFocusOut = useCallback((event: FocusEvent<HTMLDivElement>) => {
-    const next = event.relatedTarget;
-    if (next instanceof Node && treeFocusContainerRef.current?.contains(next)) {
+  const handleTreeMouseLeave = useCallback((event: MouseEvent<HTMLDivElement>) => {
+    const related = event.relatedTarget;
+    if (related instanceof Node && treeHoverContainerRef.current?.contains(related)) {
       return;
     }
-    setTreeHasFocus(false);
+    setTreeHovered(false);
   }, []);
 
   if (!workspaceRoot.trim()) {
@@ -1294,70 +1296,89 @@ export function WorkspaceFilesPanel({
   };
 
   return (
-    <div
-      ref={treeFocusContainerRef}
-      className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden text-xs"
-      onFocusCapture={handleTreeFocusIn}
-      onBlurCapture={handleTreeFocusOut}
-    >
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden text-xs">
       {revealError ? (
         <p className="mb-1 shrink-0 text-destructive/90" role="alert">
           {revealError}
         </p>
       ) : null}
-      <div className="mb-1 flex shrink-0 items-center gap-0.5">
-        <WorkspaceFileContextMenu
-          target={rootTarget}
-          workspaceRoot={workspaceRoot}
-          isElectron={isElectron}
-          onReveal={handleReveal}
-        >
-          <button
-            type="button"
+      <div
+        ref={treeHoverContainerRef}
+        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+        onMouseEnter={handleTreeMouseEnter}
+        onMouseLeave={handleTreeMouseLeave}
+      >
+        <div className="mb-1 shrink-0">
+          <div
             className={cn(
-              EXPLORER_ROW_TRIGGER_CLASS,
-              "min-w-0 flex-1",
+              "relative flex min-w-0 items-center rounded text-foreground/90",
+              "hover:bg-foreground/[0.06] dark:hover:bg-foreground/10",
               focusedDirectoryRel === "" && "bg-foreground/[0.08] dark:bg-foreground/12",
             )}
-            aria-expanded={rootOpen}
-            aria-current={focusedDirectoryRel === "" ? "true" : undefined}
-            onClick={() => {
-              setFocusedDirectoryRel("");
-              setRootOpen((open) => !open);
-            }}
           >
-            {rootOpen ? (
-              <ChevronDown className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
-            ) : (
-              <ChevronRight className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
-            )}
-            <span className="min-w-0 truncate">{rootLabel}</span>
-          </button>
-        </WorkspaceFileContextMenu>
-        {isElectron && treeHasFocus ? (
-          <div className="flex shrink-0 items-center gap-0.5">
-            <button
-              type="button"
-              className={EXPLORER_CREATE_ROW_BUTTON_CLASS}
-              aria-label={t("workspace.createFile")}
-              title={t("workspace.createFile")}
-              onClick={() => handleCreateStart("file")}
+            <WorkspaceFileContextMenu
+              target={rootTarget}
+              workspaceRoot={workspaceRoot}
+              isElectron={isElectron}
+              onReveal={handleReveal}
             >
-              <FilePlus className="size-3.5" aria-hidden />
-            </button>
-            <button
-              type="button"
-              className={EXPLORER_CREATE_ROW_BUTTON_CLASS}
-              aria-label={t("workspace.createFolder")}
-              title={t("workspace.createFolder")}
-              onClick={() => handleCreateStart("dir")}
-            >
-              <FolderPlus className="size-3.5" aria-hidden />
-            </button>
+              <button
+                type="button"
+                className={cn(
+                  "flex min-w-0 flex-1 items-center gap-1 px-1 py-0.5 text-left",
+                  isElectron && "pr-11",
+                )}
+                aria-expanded={rootOpen}
+                aria-current={focusedDirectoryRel === "" ? "true" : undefined}
+                onClick={() => {
+                  setFocusedDirectoryRel("");
+                  setRootOpen((open) => !open);
+                }}
+              >
+                {rootOpen ? (
+                  <ChevronDown className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
+                ) : (
+                  <ChevronRight className={EXPLORER_ROW_ICON_CLASS} aria-hidden />
+                )}
+                <span className="min-w-0 truncate">{rootLabel}</span>
+              </button>
+            </WorkspaceFileContextMenu>
+            {isElectron ? (
+              <div
+                className={cn(
+                  "pointer-events-none absolute inset-y-0 right-0.5 flex items-center gap-0 opacity-0 transition-opacity",
+                  treeHovered && "pointer-events-auto opacity-100",
+                )}
+              >
+                <button
+                  type="button"
+                  className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
+                  aria-label={t("workspace.createFile")}
+                  title={t("workspace.createFile")}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleCreateStart("file");
+                  }}
+                >
+                  <FilePlus className="size-3" aria-hidden />
+                </button>
+                <button
+                  type="button"
+                  className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
+                  aria-label={t("workspace.createFolder")}
+                  title={t("workspace.createFolder")}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleCreateStart("dir");
+                  }}
+                >
+                  <FolderPlus className="size-3" aria-hidden />
+                </button>
+              </div>
+            ) : null}
           </div>
-        ) : null}
-      </div>
-      {rootOpen ? (
+        </div>
+        {rootOpen ? (
         <ScrollArea className="min-h-0 min-w-0 flex-1" type="auto">
           <div
             role="tree"
@@ -1372,6 +1393,7 @@ export function WorkspaceFilesPanel({
       ) : (
         <div className="mb-1">{renderPlanItem()}</div>
       )}
+      </div>
 
       <Dialog
         open={deleteDialogOpen}

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -1359,6 +1359,7 @@ export function WorkspaceFilesPanel({
                       type="button"
                       className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
                       aria-label={t("workspace.createFile")}
+                      onMouseDown={(event) => event.preventDefault()}
                       onClick={(event) => {
                         event.stopPropagation();
                         handleCreateStart("file");
@@ -1377,6 +1378,7 @@ export function WorkspaceFilesPanel({
                       type="button"
                       className={EXPLORER_ROOT_CREATE_BUTTON_CLASS}
                       aria-label={t("workspace.createFolder")}
+                      onMouseDown={(event) => event.preventDefault()}
                       onClick={(event) => {
                         event.stopPropagation();
                         handleCreateStart("dir");

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -194,6 +194,11 @@ declare global {
     writeWorkspaceTextFile(request: WriteWorkspaceTextFileRequest): Promise<void>;
     revealWorkspaceEntry(relativePath: string, workspaceRoot?: string): Promise<void>;
     renameWorkspaceEntry(relativePath: string, newName: string): Promise<{ relativePath: string }>;
+    createWorkspaceEntry(
+      parentDirectoryRel: string,
+      name: string,
+      kind: 'file' | 'dir',
+    ): Promise<{ relativePath: string }>;
     moveWorkspaceEntry(
       relativePath: string,
       targetDirectoryRel: string,

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -223,6 +223,11 @@ export interface HostApi {
   writeWorkspaceTextFile(request: WriteWorkspaceTextFileRequest): Promise<void>;
   revealWorkspaceEntry(relativePath: string, workspaceRoot?: string): Promise<void>;
   renameWorkspaceEntry(relativePath: string, newName: string): Promise<{ relativePath: string }>;
+  createWorkspaceEntry(
+    parentDirectoryRel: string,
+    name: string,
+    kind: 'file' | 'dir',
+  ): Promise<{ relativePath: string }>;
   moveWorkspaceEntry(
     relativePath: string,
     targetDirectoryRel: string,

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -105,6 +105,7 @@ export type HostCommandName =
   | 'writeWorkspaceTextFile'
   | 'revealWorkspaceEntry'
   | 'renameWorkspaceEntry'
+  | 'createWorkspaceEntry'
   | 'moveWorkspaceEntry'
   | 'trashWorkspaceEntry'
   | 'forceDeleteWorkspaceEntry'

--- a/apps/desktop/src/host/host-command-payloads.ts
+++ b/apps/desktop/src/host/host-command-payloads.ts
@@ -152,6 +152,11 @@ export type CommandPayloads = {
   writeWorkspaceTextFile: { request: WriteWorkspaceTextFileRequest };
   revealWorkspaceEntry: { relativePath: string; workspaceRoot?: string };
   renameWorkspaceEntry: { relativePath: string; newName: string };
+  createWorkspaceEntry: {
+    parentDirectoryRel: string;
+    name: string;
+    kind: 'file' | 'dir';
+  };
   moveWorkspaceEntry: { relativePath: string; targetDirectoryRel: string };
   trashWorkspaceEntry: { relativePath: string };
   forceDeleteWorkspaceEntry: { relativePath: string };

--- a/apps/desktop/src/host/host-invoke-dispatch.ts
+++ b/apps/desktop/src/host/host-invoke-dispatch.ts
@@ -119,6 +119,11 @@ export interface HostCommandDelegate {
     relativePath: string,
     newName: string,
   ): Promise<unknown>;
+  createWorkspaceEntry(
+    parentDirectoryRel: string,
+    name: string,
+    kind: 'file' | 'dir',
+  ): Promise<unknown>;
   moveWorkspaceEntry(
     relativePath: string,
     targetDirectoryRel: string,
@@ -249,6 +254,8 @@ const hostCommandDispatch = {
     host.revealWorkspaceEntry(payload.relativePath, payload.workspaceRoot),
   renameWorkspaceEntry: (host, payload) =>
     host.renameWorkspaceEntry(payload.relativePath, payload.newName),
+  createWorkspaceEntry: (host, payload) =>
+    host.createWorkspaceEntry(payload.parentDirectoryRel, payload.name, payload.kind),
   moveWorkspaceEntry: (host, payload) =>
     host.moveWorkspaceEntry(payload.relativePath, payload.targetDirectoryRel),
   trashWorkspaceEntry: (host, payload) => host.trashWorkspaceEntry(payload.relativePath),

--- a/apps/desktop/src/host/host-workspace-git-commands.ts
+++ b/apps/desktop/src/host/host-workspace-git-commands.ts
@@ -55,11 +55,13 @@ import {
   writeWorkspaceTextFile as writeWorkspaceTextFileToDisk,
 } from './workspace-files.js';
 import {
+  createWorkspaceEntry as createWorkspaceEntryOnDisk,
   forceDeleteWorkspaceEntry as forceDeleteWorkspaceEntryOnDisk,
   moveWorkspaceEntry as moveWorkspaceEntryOnDisk,
   renameWorkspaceEntry as renameWorkspaceEntryOnDisk,
   revealWorkspaceEntry as revealWorkspaceEntryOnDisk,
   trashWorkspaceEntry as trashWorkspaceEntryOnDisk,
+  type WorkspaceEntryKind,
 } from './workspace-file-operations.js';
 import {
   listStoredSessions,
@@ -436,6 +438,19 @@ export async function renameWorkspaceEntryCommand(
     await ctx.ensureInitialized();
     const state = ctx.requireState();
     return renameWorkspaceEntryOnDisk(state.workspaceRoot, relativePath, newName);
+  });
+}
+
+export async function createWorkspaceEntryCommand(
+  ctx: HostWorkspaceGitCommandContext,
+  parentDirectoryRel: string,
+  name: string,
+  kind: WorkspaceEntryKind,
+): Promise<{ relativePath: string }> {
+  return ctx.runSerialized(async () => {
+    await ctx.ensureInitialized();
+    const state = ctx.requireState();
+    return createWorkspaceEntryOnDisk(state.workspaceRoot, parentDirectoryRel, name, kind);
   });
 }
 

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -198,6 +198,7 @@ import {
   writeWorkspaceTextFileCommand,
   revealWorkspaceEntryCommand,
   renameWorkspaceEntryCommand,
+  createWorkspaceEntryCommand,
   moveWorkspaceEntryCommand,
   trashWorkspaceEntryCommand,
   forceDeleteWorkspaceEntryCommand,
@@ -2035,6 +2036,19 @@ class DesktopHostService {
     newName: string,
   ): Promise<{ relativePath: string }> {
     return renameWorkspaceEntryCommand(this.workspaceGitCommandContext(), relativePath, newName);
+  }
+
+  async createWorkspaceEntry(
+    parentDirectoryRel: string,
+    name: string,
+    kind: 'file' | 'dir',
+  ): Promise<{ relativePath: string }> {
+    return createWorkspaceEntryCommand(
+      this.workspaceGitCommandContext(),
+      parentDirectoryRel,
+      name,
+      kind,
+    );
   }
 
   async moveWorkspaceEntry(

--- a/apps/desktop/src/host/workspace-file-operations.ts
+++ b/apps/desktop/src/host/workspace-file-operations.ts
@@ -1,4 +1,4 @@
-import { lstat, rename, rm, stat, unlink } from 'node:fs/promises';
+import { lstat, mkdir, rename, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import i18n from '../lib/i18n-host.js';
@@ -50,6 +50,42 @@ async function assertTargetDoesNotExist(
       throw error;
     }
   }
+}
+
+async function assertParentDirectoryExists(
+  workspaceRoot: string,
+  parentDirectoryRel: string,
+): Promise<void> {
+  const parentAbs = await resolveWorkspaceRelativePath(workspaceRoot, parentDirectoryRel);
+  const parentStat = await stat(parentAbs);
+  if (!parentStat.isDirectory()) {
+    throw new Error(i18n.t('error.notADirectory'));
+  }
+}
+
+export type WorkspaceEntryKind = 'file' | 'dir';
+
+export async function createWorkspaceEntry(
+  workspaceRoot: string,
+  parentDirectoryRel: string,
+  name: string,
+  kind: WorkspaceEntryKind,
+): Promise<{ relativePath: string }> {
+  validateEntryName(name);
+  const parentRel = parentDirectoryRel.replace(/\\/g, '/').trim();
+  const trimmedName = name.trim();
+  const newRel = joinWorkspaceRelativePath(parentRel, trimmedName);
+
+  await assertParentDirectoryExists(workspaceRoot, parentRel);
+  await assertTargetDoesNotExist(workspaceRoot, newRel);
+
+  const absPath = await resolveWorkspaceRelativePath(workspaceRoot, newRel);
+  if (kind === 'dir') {
+    await mkdir(absPath);
+  } else {
+    await writeFile(absPath, '', 'utf8');
+  }
+  return { relativePath: newRel };
 }
 
 export async function renameWorkspaceEntry(

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -812,6 +812,8 @@
       "linux": "Reveal in File Manager"
     },
     "rename": "Rename",
+    "createFile": "New File",
+    "createFolder": "New Folder",
     "delete": "Delete",
     "deleteEntryConfirm": "Delete \"{{name}}\"?",
     "move": "Move",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -809,6 +809,8 @@
       "linux": "在文件管理器中显示"
     },
     "rename": "重命名",
+    "createFile": "新建文件",
+    "createFolder": "新建文件夹",
     "delete": "删除",
     "deleteEntryConfirm": "确定删除「{{name}}」吗？",
     "move": "移动",

--- a/apps/desktop/test/host/workspace-file-operations.test.mjs
+++ b/apps/desktop/test/host/workspace-file-operations.test.mjs
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { test } from 'node:test';
 
 import {
+  createWorkspaceEntry,
   forceDeleteWorkspaceEntry,
   isDescendantOrSelf,
   moveWorkspaceEntry,
@@ -25,6 +26,57 @@ test('isDescendantOrSelf detects self and nested paths', () => {
   assert.equal(isDescendantOrSelf('src', 'src/components'), true);
   assert.equal(isDescendantOrSelf('src/components', 'src'), false);
   assert.equal(isDescendantOrSelf('', 'src'), false);
+});
+
+test('createWorkspaceEntry creates a file and directory at workspace root', async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'spirit-ws-create-root-'));
+
+  try {
+    const file = await createWorkspaceEntry(workspaceRoot, '', 'notes.txt', 'file');
+    assert.equal(file.relativePath, 'notes.txt');
+    await access(path.join(workspaceRoot, 'notes.txt'));
+
+    const dir = await createWorkspaceEntry(workspaceRoot, '', 'lib', 'dir');
+    assert.equal(dir.relativePath, 'lib');
+    await access(path.join(workspaceRoot, 'lib'));
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('createWorkspaceEntry creates nested entries under a parent directory', async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'spirit-ws-create-nested-'));
+  await mkdir(path.join(workspaceRoot, 'src'));
+
+  try {
+    const file = await createWorkspaceEntry(workspaceRoot, 'src', 'App.tsx', 'file');
+    assert.equal(file.relativePath, 'src/App.tsx');
+    await access(path.join(workspaceRoot, 'src', 'App.tsx'));
+
+    const dir = await createWorkspaceEntry(workspaceRoot, 'src', 'components', 'dir');
+    assert.equal(dir.relativePath, 'src/components');
+    await access(path.join(workspaceRoot, 'src', 'components'));
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('createWorkspaceEntry rejects duplicate names and invalid names', async () => {
+  const workspaceRoot = await mkdtemp(path.join(os.tmpdir(), 'spirit-ws-create-reject-'));
+  await writeFile(path.join(workspaceRoot, 'exists.txt'), 'x', 'utf8');
+
+  try {
+    await assert.rejects(
+      () => createWorkspaceEntry(workspaceRoot, '', 'exists.txt', 'file'),
+      /already exists|已存在同名/u,
+    );
+    await assert.rejects(
+      () => createWorkspaceEntry(workspaceRoot, '', 'bad/name', 'file'),
+      /Invalid file name|无效文件名/u,
+    );
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
 });
 
 test('renameWorkspaceEntry renames a file within the workspace', async () => {


### PR DESCRIPTION
## Summary

- 新增 `createWorkspaceEntry` Host API 与 IPC 全链路，支持在工作区创建文件或目录
- 文件树增加目录点击暂留指示器，与文件高亮互斥，空白区域点击可清除
- 根行提供创建文件/目录按钮，内联空态创建行支持提交与取消，创建文件后自动打开

## Test plan

- [x] 根行 hover 显示创建按钮，点击后在目标目录插入内联创建行
- [x] Enter 提交、Escape 取消、空白点击清除目录暂留
- [x] 创建文件后在工作区打开新文件；创建目录后刷新树
- [x] `npm test` workspace-file-operations 单测通过