### PR TITLE
feat(agent-core, desktop, cli): ask_questions v2 契约重构与 Desktop 关注修复

### DIFF
--- a/apps/cli/src/ask_questions.rs
+++ b/apps/cli/src/ask_questions.rs
@@ -2,17 +2,10 @@ use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AskQuestionsQuestionKind {
-    SingleSelect,
-    MultiSelect,
-    Text,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AskQuestionsOptionSpec {
+    pub id: String,
     pub label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
@@ -23,17 +16,10 @@ pub struct AskQuestionsOptionSpec {
 pub struct AskQuestionsQuestionSpec {
     pub id: String,
     pub title: String,
-    pub kind: AskQuestionsQuestionKind,
     #[serde(default)]
-    pub required: bool,
+    pub allow_multiple: bool,
     #[serde(default)]
     pub options: Vec<AskQuestionsOptionSpec>,
-    #[serde(default)]
-    pub allow_custom_input: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_input_placeholder: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_input_label: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,24 +49,21 @@ impl AskQuestionsRequest {
                 return Err(anyhow!("ask_questions 问题标题不能为空: {}", id));
             }
 
-            match question.kind {
-                AskQuestionsQuestionKind::SingleSelect | AskQuestionsQuestionKind::MultiSelect => {
-                    if question.options.is_empty() && !question.allow_custom_input {
-                        return Err(anyhow!(
-                            "ask_questions 选择题至少需要一个预设选项或开启自定义输入: {}",
-                            id
-                        ));
-                    }
-                    for option in &question.options {
-                        if option.label.trim().is_empty() {
-                            return Err(anyhow!("ask_questions 选项文本不能为空: {}", id));
-                        }
-                    }
+            let mut seen_option_ids = HashSet::new();
+            for option in &question.options {
+                let option_id = option.id.trim();
+                if option_id.is_empty() {
+                    return Err(anyhow!("ask_questions 选项 id 不能为空: {}", id));
                 }
-                AskQuestionsQuestionKind::Text => {
-                    if !question.options.is_empty() {
-                        return Err(anyhow!("ask_questions 文本题不能包含 options: {}", id));
-                    }
+                if !seen_option_ids.insert(option_id.to_string()) {
+                    return Err(anyhow!(
+                        "ask_questions 选项 id 不能重复: {}/{}",
+                        id,
+                        option_id
+                    ));
+                }
+                if option.label.trim().is_empty() {
+                    return Err(anyhow!("ask_questions 选项文本不能为空: {}", id));
                 }
             }
         }
@@ -100,17 +83,10 @@ pub enum AskQuestionsStatus {
 #[serde(rename_all = "camelCase")]
 pub struct AskQuestionsAnswer {
     pub question_id: String,
-    pub title: String,
-    pub kind: AskQuestionsQuestionKind,
-    pub answered: bool,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub selected_option_indexes: Vec<usize>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub selected_option_labels: Vec<String>,
+    pub selected_option_ids: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_input: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
+    pub custom_text: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/apps/cli/src/shell/ask_questions.rs
+++ b/apps/cli/src/shell/ask_questions.rs
@@ -1,9 +1,7 @@
 use rust_i18n::t;
 
 use crate::{
-    ask_questions::{
-        AskQuestionsAnswer, AskQuestionsQuestionKind, AskQuestionsRequest, AskQuestionsResult,
-    },
+    ask_questions::{AskQuestionsAnswer, AskQuestionsRequest, AskQuestionsResult},
     view::{
         AskQuestionsInputFieldView, AskQuestionsOptionView, AskQuestionsQuestionView,
         BottomFormFieldEditorView, BottomFormFieldView, BottomFormKind, BottomFormView,
@@ -34,53 +32,25 @@ pub(crate) fn new_form(
             editor: BottomFormFieldEditorView::AskQuestion {
                 question: AskQuestionsQuestionView {
                     id: question.id.clone(),
-                    kind: question.kind,
-                    required: question.required,
+                    allow_multiple: question.allow_multiple,
                     options: question
                         .options
                         .iter()
                         .map(|option| AskQuestionsOptionView {
+                            id: option.id.clone(),
                             label: option.label.clone(),
                             summary: option.summary.clone(),
                             selected: false,
                         })
                         .collect(),
                     selected_row: 0,
-                    custom_input: (question.allow_custom_input
-                        || matches!(question.kind, AskQuestionsQuestionKind::Text))
-                    .then(|| AskQuestionsInputFieldView {
-                        label: question.custom_input_label.clone().unwrap_or_else(|| {
-                            if matches!(question.kind, AskQuestionsQuestionKind::Text) {
-                                t!("form.ask_questions.text_input.label").into_owned()
-                            } else {
-                                t!("form.ask_questions.custom_input.label").into_owned()
-                            }
-                        }),
-                        placeholder: question.custom_input_placeholder.clone().unwrap_or_else(
-                            || {
-                                if matches!(question.kind, AskQuestionsQuestionKind::Text) {
-                                    t!("form.ask_questions.text_input.placeholder").into_owned()
-                                } else {
-                                    t!("form.ask_questions.custom_input.placeholder").into_owned()
-                                }
-                            },
-                        ),
+                    custom_input: AskQuestionsInputFieldView {
+                        label: t!("form.ask_questions.custom_input.label").into_owned(),
+                        placeholder: t!("form.ask_questions.custom_input.placeholder")
+                            .into_owned(),
                         value: String::new(),
                         cursor: 0,
-                    })
-                    .filter(|_| !matches!(question.kind, AskQuestionsQuestionKind::Text)),
-                    text_input: matches!(question.kind, AskQuestionsQuestionKind::Text).then(
-                        || AskQuestionsInputFieldView {
-                            label: question.custom_input_label.clone().unwrap_or_else(|| {
-                                t!("form.ask_questions.text_input.label").into_owned()
-                            }),
-                            placeholder: question.custom_input_placeholder.clone().unwrap_or_else(
-                                || t!("form.ask_questions.text_input.placeholder").into_owned(),
-                            ),
-                            value: String::new(),
-                            cursor: 0,
-                        },
-                    ),
+                    },
                 },
             },
         })
@@ -208,8 +178,8 @@ pub(crate) fn move_home(form: &mut BottomFormView) {
         form.scroll_offset = 0;
         return;
     }
-    if let Some(input) = active_input_mut(form) {
-        input.cursor = 0;
+    if is_custom_input_row(form) {
+        question_mut(form).custom_input.cursor = 0;
     } else if let Some(question) = current_question_mut(form) {
         question.selected_row = 0;
     }
@@ -220,8 +190,9 @@ pub(crate) fn move_end(form: &mut BottomFormView) {
     if submit_selected(form) {
         return;
     }
-    if let Some(input) = active_input_mut(form) {
-        input.cursor = input.value.chars().count();
+    if is_custom_input_row(form) {
+        let question = question_mut(form);
+        question.custom_input.cursor = question.custom_input.value.chars().count();
     } else if let Some(question) = current_question_mut(form) {
         question.selected_row = question_row_count(question).saturating_sub(1);
     }
@@ -232,17 +203,14 @@ pub(crate) fn insert_char(form: &mut BottomFormView, ch: char) {
         return;
     }
     clear_validation(form);
-    let Some(question) = current_question_mut(form) else {
+    if !is_custom_input_row(form) {
         return;
-    };
-    if matches!(question.kind, AskQuestionsQuestionKind::SingleSelect)
-        && question.selected_row >= question.options.len()
-    {
+    }
+    let question = question_mut(form);
+    if !question.allow_multiple {
         clear_option_selections(question);
     }
-    let Some(input) = active_input_for_question_mut(question) else {
-        return;
-    };
+    let input = &mut question.custom_input;
     let index = char_cursor_to_byte_index(&input.value, input.cursor);
     input.value.insert(index, ch);
     input.cursor += 1;
@@ -254,17 +222,14 @@ pub(crate) fn insert_text(form: &mut BottomFormView, text: &str) {
         return;
     }
     clear_validation(form);
-    let Some(question) = current_question_mut(form) else {
+    if !is_custom_input_row(form) {
         return;
-    };
-    if matches!(question.kind, AskQuestionsQuestionKind::SingleSelect)
-        && question.selected_row >= question.options.len()
-    {
+    }
+    let question = question_mut(form);
+    if !question.allow_multiple {
         clear_option_selections(question);
     }
-    let Some(input) = active_input_for_question_mut(question) else {
-        return;
-    };
+    let input = &mut question.custom_input;
     let index = char_cursor_to_byte_index(&input.value, input.cursor);
     input.value.insert_str(index, normalized.as_str());
     input.cursor += normalized.chars().count();
@@ -272,9 +237,10 @@ pub(crate) fn insert_text(form: &mut BottomFormView, text: &str) {
 
 pub(crate) fn backspace(form: &mut BottomFormView) {
     clear_validation(form);
-    let Some(input) = active_input_mut(form) else {
+    if !is_custom_input_row(form) {
         return;
-    };
+    }
+    let input = &mut question_mut(form).custom_input;
     if input.cursor == 0 {
         return;
     }
@@ -286,9 +252,10 @@ pub(crate) fn backspace(form: &mut BottomFormView) {
 
 pub(crate) fn delete(form: &mut BottomFormView) {
     clear_validation(form);
-    let Some(input) = active_input_mut(form) else {
+    if !is_custom_input_row(form) {
         return;
-    };
+    }
+    let input = &mut question_mut(form).custom_input;
     if input.cursor >= input.value.chars().count() {
         return;
     }
@@ -314,65 +281,30 @@ pub(crate) fn activate(form: &mut BottomFormView) -> Result<AskQuestionsActivate
     };
 
     let mut should_advance = false;
-    let mut validation: Option<String> = None;
 
     {
         let Some(question) = question_by_index_mut(form, selected_question_index) else {
             return Ok(AskQuestionsActivateOutcome::None);
         };
 
-        match question.kind {
-            AskQuestionsQuestionKind::SingleSelect => {
-                let row = question.selected_row;
-                if row < question.options.len() {
-                    clear_option_selections(question);
-                    if let Some(option) = question.options.get_mut(row) {
-                        option.selected = true;
-                    }
-                    if let Some(input) = question.custom_input.as_mut() {
-                        input.value.clear();
-                        input.cursor = 0;
-                    }
-                } else if let Some(input) = question.custom_input.as_mut() {
-                    if input.value.trim().is_empty() {
-                        validation =
-                            Some(t!("form.ask_questions.validation.custom_required").into_owned());
-                    } else {
-                        clear_option_selections(question);
-                        should_advance = true;
-                    }
-                } else {
-                    should_advance = true;
+        let row = question.selected_row;
+        if row < question.options.len() {
+            if question.allow_multiple {
+                if let Some(option) = question.options.get_mut(row) {
+                    option.selected = !option.selected;
                 }
-                if row < question.options.len() {
-                    should_advance = true;
+            } else {
+                clear_option_selections(question);
+                if let Some(option) = question.options.get_mut(row) {
+                    option.selected = true;
                 }
+                question.custom_input.value.clear();
+                question.custom_input.cursor = 0;
+                should_advance = true;
             }
-            AskQuestionsQuestionKind::MultiSelect => {
-                let row = question.selected_row;
-                if row < question.options.len() {
-                    if let Some(option) = question.options.get_mut(row) {
-                        option.selected = !option.selected;
-                    }
-                }
-            }
-            AskQuestionsQuestionKind::Text => {
-                let Some(input) = question.text_input.as_ref() else {
-                    return Ok(AskQuestionsActivateOutcome::None);
-                };
-                if question.required && input.value.trim().is_empty() {
-                    validation =
-                        Some(t!("form.ask_questions.validation.text_required").into_owned());
-                } else {
-                    should_advance = true;
-                }
-            }
+        } else {
+            should_advance = true;
         }
-    }
-
-    if let Some(message) = validation {
-        set_validation(form, message);
-        return Ok(AskQuestionsActivateOutcome::None);
     }
 
     if should_advance {
@@ -383,90 +315,35 @@ pub(crate) fn activate(form: &mut BottomFormView) -> Result<AskQuestionsActivate
 }
 
 pub(crate) fn question_answered(question: &AskQuestionsQuestionView) -> bool {
-    match question.kind {
-        AskQuestionsQuestionKind::SingleSelect => {
-            question.options.iter().any(|option| option.selected)
-                || question
-                    .custom_input
-                    .as_ref()
-                    .is_some_and(|input| !input.value.trim().is_empty())
-        }
-        AskQuestionsQuestionKind::MultiSelect => {
-            question.options.iter().any(|option| option.selected)
-                || question
-                    .custom_input
-                    .as_ref()
-                    .is_some_and(|input| !input.value.trim().is_empty())
-        }
-        AskQuestionsQuestionKind::Text => question
-            .text_input
-            .as_ref()
-            .is_some_and(|input| !input.value.trim().is_empty()),
-    }
+    question.options.iter().any(|option| option.selected)
+        || !question.custom_input.value.trim().is_empty()
 }
 
 pub(crate) fn question_row_count(question: &AskQuestionsQuestionView) -> usize {
-    match question.kind {
-        AskQuestionsQuestionKind::Text => usize::from(question.text_input.is_some()),
-        AskQuestionsQuestionKind::SingleSelect | AskQuestionsQuestionKind::MultiSelect => {
-            question.options.len() + usize::from(question.custom_input.is_some())
-        }
-    }
+    question.options.len() + 1
 }
 
 fn build_answered_result(form: &mut BottomFormView) -> Result<AskQuestionsResult, String> {
-    let mut first_missing: Option<(usize, String)> = None;
-    for index in 0..form.fields.len() {
-        let Some(field) = form.fields.get(index) else {
-            continue;
-        };
-        let BottomFormFieldEditorView::AskQuestion { question } = &field.editor else {
-            continue;
-        };
-        if question.required && !question_answered(question) {
-            first_missing = Some((index, field.label.clone()));
-            break;
-        }
-    }
-
-    if let Some((index, title)) = first_missing {
-        form.selected_field = index;
-        form.scroll_offset = 0;
-        set_submit_selected(form, false);
-        return Err(t!("form.ask_questions.validation.required", title = title).into_owned());
-    }
-
     let answers = form
         .fields
         .iter()
         .filter_map(|field| match &field.editor {
             BottomFormFieldEditorView::AskQuestion { question } => Some(AskQuestionsAnswer {
                 question_id: question.id.clone(),
-                title: field.label.clone(),
-                kind: question.kind,
-                answered: question_answered(question),
-                selected_option_indexes: question
-                    .options
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(index, option)| option.selected.then_some(index))
-                    .collect(),
-                selected_option_labels: question
+                selected_option_ids: question
                     .options
                     .iter()
                     .filter(|option| option.selected)
-                    .map(|option| option.label.clone())
+                    .map(|option| option.id.clone())
                     .collect(),
-                custom_input: question
-                    .custom_input
-                    .as_ref()
-                    .map(|input| input.value.trim().to_string())
-                    .filter(|value| !value.is_empty()),
-                text: question
-                    .text_input
-                    .as_ref()
-                    .map(|input| input.value.trim().to_string())
-                    .filter(|value| !value.is_empty()),
+                custom_text: {
+                    let value = question.custom_input.value.trim().to_string();
+                    if value.is_empty() {
+                        None
+                    } else {
+                        Some(value)
+                    }
+                },
             }),
             _ => None,
         })
@@ -494,28 +371,13 @@ fn clear_option_selections(question: &mut AskQuestionsQuestionView) {
     }
 }
 
-fn active_input_mut(form: &mut BottomFormView) -> Option<&mut AskQuestionsInputFieldView> {
-    if submit_selected(form) {
-        return None;
-    }
-
-    let question = current_question_mut(form)?;
-    active_input_for_question_mut(question)
+fn is_custom_input_row(form: &BottomFormView) -> bool {
+    current_question(form)
+        .is_some_and(|question| question.selected_row >= question.options.len())
 }
 
-fn active_input_for_question_mut(
-    question: &mut AskQuestionsQuestionView,
-) -> Option<&mut AskQuestionsInputFieldView> {
-    match question.kind {
-        AskQuestionsQuestionKind::Text => question.text_input.as_mut(),
-        AskQuestionsQuestionKind::SingleSelect | AskQuestionsQuestionKind::MultiSelect => {
-            if question.selected_row >= question.options.len() {
-                question.custom_input.as_mut()
-            } else {
-                None
-            }
-        }
-    }
+fn question_mut(form: &mut BottomFormView) -> &mut AskQuestionsQuestionView {
+    current_question_mut(form).expect("ask question field must exist")
 }
 
 fn current_question_mut(form: &mut BottomFormView) -> Option<&mut AskQuestionsQuestionView> {
@@ -584,9 +446,7 @@ fn char_cursor_to_byte_index(text: &str, cursor_chars: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ask_questions::{
-        AskQuestionsOptionSpec, AskQuestionsQuestionSpec, AskQuestionsStatus,
-    };
+    use crate::ask_questions::{AskQuestionsOptionSpec, AskQuestionsQuestionSpec, AskQuestionsStatus};
 
     fn build_form(questions: Vec<AskQuestionsQuestionSpec>) -> BottomFormView {
         new_form(
@@ -603,21 +463,19 @@ mod tests {
         AskQuestionsQuestionSpec {
             id: id.to_string(),
             title: title.to_string(),
-            kind: AskQuestionsQuestionKind::SingleSelect,
-            required: true,
+            allow_multiple: false,
             options: vec![
                 AskQuestionsOptionSpec {
+                    id: "a".to_string(),
                     label: "A".to_string(),
                     summary: Some("Option A".to_string()),
                 },
                 AskQuestionsOptionSpec {
+                    id: "b".to_string(),
                     label: "B".to_string(),
                     summary: Some("Option B".to_string()),
                 },
             ],
-            allow_custom_input: false,
-            custom_input_placeholder: None,
-            custom_input_label: None,
         }
     }
 
@@ -641,17 +499,20 @@ mod tests {
     }
 
     #[test]
-    fn submit_requires_required_answers() {
+    fn submit_without_selection_is_allowed() {
         let mut form = build_form(vec![single_select_question("q1", "First")]);
 
         move_right(&mut form);
         assert!(submit_selected(&form));
 
-        let outcome = activate(&mut form).expect("submit should stay in form when invalid");
-        assert!(matches!(outcome, AskQuestionsActivateOutcome::None));
-        assert!(!submit_selected(&form));
-        assert_eq!(form.selected_field, 0);
-        assert!(validation_message(&form).is_some());
+        let outcome = activate(&mut form).expect("submit should succeed without answers");
+        let AskQuestionsActivateOutcome::Submit(result) = outcome else {
+            panic!("expected submit outcome");
+        };
+        assert_eq!(result.status, AskQuestionsStatus::Answered);
+        assert_eq!(result.answers.len(), 1);
+        assert!(result.answers[0].selected_option_ids.is_empty());
+        assert!(result.answers[0].custom_text.is_none());
     }
 
     #[test]
@@ -669,12 +530,7 @@ mod tests {
         assert_eq!(result.status, AskQuestionsStatus::Answered);
         assert_eq!(result.answers.len(), 1);
         assert_eq!(result.answers[0].question_id, "q1");
-        assert_eq!(result.answers[0].selected_option_indexes, vec![0]);
-        assert_eq!(
-            result.answers[0].selected_option_labels,
-            vec!["A".to_string()]
-        );
-        assert!(result.answers[0].answered);
+        assert_eq!(result.answers[0].selected_option_ids, vec!["a".to_string()]);
     }
 
     #[test]

--- a/apps/cli/src/ui/forms.rs
+++ b/apps/cli/src/ui/forms.rs
@@ -322,23 +322,10 @@ pub(in crate::ui) fn ask_questions_block_height(form: &BottomFormView, panel_wid
 }
 
 pub(in crate::ui) fn ask_questions_title_text(form: &BottomFormView) -> String {
-    let Some(question) = ask_questions_form::current_question(form) else {
-        return String::new();
-    };
-    let label = form
-        .fields
+    form.fields
         .get(form.selected_field.min(form.fields.len().saturating_sub(1)))
         .map(|field| field.label.clone())
-        .unwrap_or_default();
-    if question.required {
-        format!(
-            "{} {}",
-            label,
-            t!("form.ask_questions.required_badge").into_owned()
-        )
-    } else {
-        label
-    }
+        .unwrap_or_default()
 }
 
 pub(in crate::ui) fn ask_questions_row_block_height(
@@ -347,18 +334,12 @@ pub(in crate::ui) fn ask_questions_row_block_height(
     field_width: usize,
 ) -> u16 {
     let inner_width = field_width.saturating_sub(2).max(1);
-    if matches!(
-        question.kind,
-        crate::ask_questions::AskQuestionsQuestionKind::Text
-    ) {
-        let Some(input) = question.text_input.as_ref() else {
-            return 0;
-        };
+    if row_index >= question.options.len() {
         return bottom_form_text_field_outer_height(
-            &input.label,
+            &question.custom_input.label,
             "",
-            &input.value,
-            &input.placeholder,
+            &question.custom_input.value,
+            &question.custom_input.placeholder,
             field_width,
             inner_width,
         );
@@ -373,17 +354,7 @@ pub(in crate::ui) fn ask_questions_row_block_height(
         return (1 + summary_lines).max(1) as u16 + 2;
     }
 
-    let Some(input) = question.custom_input.as_ref() else {
-        return 0;
-    };
-    bottom_form_text_field_outer_height(
-        &input.label,
-        "",
-        &input.value,
-        &input.placeholder,
-        field_width,
-        inner_width,
-    )
+    0
 }
 
 pub(in crate::ui) fn ask_questions_selection_visible(
@@ -609,37 +580,18 @@ pub(in crate::ui) fn draw_ask_questions_form(
                 !ask_questions_form::submit_selected(form) && row_index == question.selected_row;
             let row_cursor = if let Some(option) = question.options.get(row_index) {
                 draw_ask_questions_option_row(frame, row_area, question, option, row_selected)
-            } else if matches!(
-                question.kind,
-                crate::ask_questions::AskQuestionsQuestionKind::Text
-            ) {
-                question.text_input.as_ref().and_then(|input| {
-                    draw_bottom_form_text_field(
-                        frame,
-                        row_area,
-                        &input.label,
-                        "",
-                        &input.value,
-                        &input.placeholder,
-                        input.cursor,
-                        row_selected,
-                        false,
-                    )
-                })
             } else {
-                question.custom_input.as_ref().and_then(|input| {
-                    draw_bottom_form_text_field(
-                        frame,
-                        row_area,
-                        &input.label,
-                        "",
-                        &input.value,
-                        &input.placeholder,
-                        input.cursor,
-                        row_selected,
-                        false,
-                    )
-                })
+                draw_bottom_form_text_field(
+                    frame,
+                    row_area,
+                    &question.custom_input.label,
+                    "",
+                    &question.custom_input.value,
+                    &question.custom_input.placeholder,
+                    question.custom_input.cursor,
+                    row_selected,
+                    false,
+                )
             };
             if row_selected {
                 cursor = row_cursor;
@@ -708,22 +660,16 @@ pub(in crate::ui) fn draw_ask_questions_option_row(
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let marker = match question.kind {
-        crate::ask_questions::AskQuestionsQuestionKind::SingleSelect => {
-            if option.selected {
-                "(x)"
-            } else {
-                "( )"
-            }
+    let marker = if question.allow_multiple {
+        if option.selected {
+            "[x]"
+        } else {
+            "[ ]"
         }
-        crate::ask_questions::AskQuestionsQuestionKind::MultiSelect => {
-            if option.selected {
-                "[x]"
-            } else {
-                "[ ]"
-            }
-        }
-        crate::ask_questions::AskQuestionsQuestionKind::Text => "   ",
+    } else if option.selected {
+        "(x)"
+    } else {
+        "( )"
     };
     let mut lines = vec![Line::from(Span::styled(
         format!("{} {}", marker, option.label),

--- a/apps/cli/src/view.rs
+++ b/apps/cli/src/view.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ask_questions::{AskQuestionsQuestionKind, AskQuestionsRequest};
+use crate::ask_questions::AskQuestionsRequest;
 use crate::model_registry::AppConfig;
 use crate::ports::SubagentSessionStatus;
 use crate::session::PendingMcpResource;
@@ -140,6 +140,7 @@ pub struct BottomFormFieldView {
 
 #[derive(Clone, Debug)]
 pub struct AskQuestionsOptionView {
+    pub id: String,
     pub label: String,
     pub summary: Option<String>,
     pub selected: bool,
@@ -156,12 +157,10 @@ pub struct AskQuestionsInputFieldView {
 #[derive(Clone, Debug)]
 pub struct AskQuestionsQuestionView {
     pub id: String,
-    pub kind: AskQuestionsQuestionKind,
-    pub required: bool,
+    pub allow_multiple: bool,
     pub options: Vec<AskQuestionsOptionView>,
     pub selected_row: usize,
-    pub custom_input: Option<AskQuestionsInputFieldView>,
-    pub text_input: Option<AskQuestionsInputFieldView>,
+    pub custom_input: AskQuestionsInputFieldView,
 }
 
 #[derive(Clone, Debug)]

--- a/apps/desktop/electron/desktop-attention.ts
+++ b/apps/desktop/electron/desktop-attention.ts
@@ -6,9 +6,24 @@ let pendingQuestions = false;
 let pendingTaskComplete = false;
 let flashFrameActive = false;
 let dockBounceId: number | undefined;
+let attentionBlockKey: string | undefined;
+/** 用户在前台见过该阻挡后，同一 block 不再重复请求任务栏关注。 */
+let attentionSuppressedForKey: string | undefined;
 
 function shouldRequestAttention(away: boolean): boolean {
-  return away && (pendingApproval || pendingQuestions || pendingTaskComplete);
+  if (!away) {
+    return false;
+  }
+  if (pendingTaskComplete) {
+    return true;
+  }
+  if (!(pendingApproval || pendingQuestions)) {
+    return false;
+  }
+  if (attentionBlockKey && attentionSuppressedForKey === attentionBlockKey) {
+    return false;
+  }
+  return true;
 }
 
 export function registerDesktopAttention(mainWindow: BrowserWindow): void {
@@ -19,7 +34,10 @@ export function setDesktopAttentionPending(flags: {
   needsApproval?: boolean;
   needsQuestions?: boolean;
   needsTaskComplete?: boolean;
+  attentionBlockKey?: string;
 }): void {
+  const prevKey = attentionBlockKey;
+
   if (typeof flags.needsApproval === 'boolean') {
     pendingApproval = flags.needsApproval;
   }
@@ -29,12 +47,26 @@ export function setDesktopAttentionPending(flags: {
   if (typeof flags.needsTaskComplete === 'boolean') {
     pendingTaskComplete = flags.needsTaskComplete;
   }
+
+  if (typeof flags.attentionBlockKey === 'string' && flags.attentionBlockKey.length > 0) {
+    attentionBlockKey = flags.attentionBlockKey;
+  } else if (!pendingApproval && !pendingQuestions) {
+    attentionBlockKey = undefined;
+    attentionSuppressedForKey = undefined;
+  }
+
+  if (attentionBlockKey !== prevKey && attentionBlockKey !== undefined) {
+    attentionSuppressedForKey = undefined;
+  }
 }
 
 /** Sync taskbar flash when user is away and something needs attention. */
 export function refreshDesktopAttention(away: boolean): void {
   if (!away) {
     pendingTaskComplete = false;
+    if ((pendingApproval || pendingQuestions) && attentionBlockKey) {
+      attentionSuppressedForKey = attentionBlockKey;
+    }
   }
 
   const active = shouldRequestAttention(away);

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1249,12 +1249,19 @@ if (gotSpiritSingleInstanceLock) {
     'desktop:sync-attention-pending',
     (
       _event,
-      payload: { needsApproval?: boolean; needsQuestions?: boolean; needsTaskComplete?: boolean },
+      payload: {
+        needsApproval?: boolean;
+        needsQuestions?: boolean;
+        needsTaskComplete?: boolean;
+        attentionBlockKey?: string;
+      },
     ) => {
       setDesktopAttentionPending({
         needsApproval: payload?.needsApproval === true,
         needsQuestions: payload?.needsQuestions === true,
         needsTaskComplete: payload?.needsTaskComplete === true,
+        attentionBlockKey:
+          typeof payload?.attentionBlockKey === 'string' ? payload.attentionBlockKey : undefined,
       });
       refreshDesktopAttention(getAppAwayFromUser());
     },

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -651,6 +651,7 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
     needsApproval: boolean;
     needsQuestions: boolean;
     needsTaskComplete: boolean;
+    attentionBlockKey?: string;
   }) {
     return ipcRenderer.invoke('desktop:sync-attention-pending', flags) as Promise<void>;
   },

--- a/apps/desktop/src/components/pending-questions-card.tsx
+++ b/apps/desktop/src/components/pending-questions-card.tsx
@@ -4,22 +4,46 @@ import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import type { QuestionDraft } from "@/hooks/useDesktopRuntime";
 import {
   DESKTOP_CHROME_TOGGLE_ICON_BTN,
-  DESKTOP_FORM_INPUT_SHELL,
-  DESKTOP_FORM_TEXTAREA_INNER,
   instantHoverMotionClass,
 } from "@/lib/desktop-chrome";
 import { cn } from "@/lib/utils";
-import type { AskQuestionsQuestionSpec, PendingQuestionsSnapshot } from "@/types";
+import type { PendingQuestionsSnapshot } from "@/types";
+
+const questionRowBleedClass = "-mx-2 box-border w-[calc(100%+1rem)] px-2";
+
+const questionOptionSurfaceClass =
+  "rounded-lg border-0 bg-transparent py-1.5 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10";
+
+const questionRowIndexClass = "text-muted-foreground [font-variant-numeric:lining-nums]";
+
+const questionRowLayoutClass =
+  "grid grid-cols-[1.125rem_minmax(0,1fr)] items-start gap-x-1";
+
+const questionRowTextClass = "text-foreground/80";
 
 const questionOptionClass = cn(
-  "rounded-xl border px-3 py-2.5 text-left outline-none transition-none",
+  questionRowLayoutClass,
+  "text-left outline-none transition-none leading-snug",
+  questionRowBleedClass,
+  questionOptionSurfaceClass,
   instantHoverMotionClass,
   "active:!translate-y-0",
+);
+
+const questionInputRowClass = cn(
+  "grid grid-cols-[1.125rem_minmax(0,1fr)] items-center gap-x-1",
+  questionRowBleedClass,
+);
+
+const questionInputInnerClass = cn(
+  "h-7 min-h-7 min-w-0 flex-1 border-0 bg-transparent px-0 py-0 text-sm shadow-none dark:!bg-transparent",
+  questionRowTextClass,
+  "placeholder:text-muted-foreground focus-visible:border-transparent focus-visible:ring-0",
+  "hover:bg-transparent focus-visible:bg-transparent",
 );
 
 type PendingQuestionsCardProps = {
@@ -132,10 +156,10 @@ export function PendingQuestionsCard({
           </div>
         </div>
       </CardHeader>
-      <CardContent className="grid gap-1.5 px-3 pb-2 pt-0">
+      <CardContent className="grid gap-1 px-3 pb-2 pt-0">
         {question.options.length > 0 ? (
-          <div className="grid gap-1.5">
-            {question.options.map((option) => {
+          <div className="grid gap-1">
+            {question.options.map((option, optionIndex) => {
               const selected = question.allowMultiple
                 ? draft.selectedOptionIds.includes(option.id)
                 : draft.selectedOptionIds[0] === option.id;
@@ -145,9 +169,7 @@ export function PendingQuestionsCard({
                   type="button"
                   className={cn(
                     questionOptionClass,
-                    selected
-                      ? "border-primary/60 bg-primary/8"
-                      : "border-border/60 bg-card/70 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10",
+                    selected && "bg-primary/8",
                   )}
                   disabled={questionsBusy}
                   onClick={() =>
@@ -156,8 +178,16 @@ export function PendingQuestionsCard({
                       : handleSingleSelect(option.id)
                   }
                 >
-                  <div className="space-y-0.5">
-                    <span className="font-medium">{option.label}</span>
+                  <span className={questionRowIndexClass}>{optionIndex + 1}.</span>
+                  <div className="min-w-0 flex-1 space-y-0.5">
+                    <span
+                      className={cn(
+                        "font-medium",
+                        selected ? "text-foreground/90" : questionRowTextClass,
+                      )}
+                    >
+                      {option.label}
+                    </span>
                     {option.summary ? (
                       <p className="text-xs leading-relaxed text-muted-foreground">
                         {option.summary}
@@ -170,34 +200,35 @@ export function PendingQuestionsCard({
           </div>
         ) : null}
 
-        <div className={cn("space-y-1", question.options.length > 0 && "mt-2.5")}>
-          <Label htmlFor={`${question.id}-custom`} className="text-xs">
-            {t("app.customAnswer")}
-          </Label>
-          <div className={DESKTOP_FORM_INPUT_SHELL}>
-            <Textarea
-              id={`${question.id}-custom`}
-              value={draft.customText}
-              onChange={(event) =>
-                onUpdateDraft(question.id, (current) => ({
-                  ...current,
-                  customText: event.target.value,
-                }))
-              }
-              placeholder={t("app.customAnswerPlaceholder")}
-              className={cn(DESKTOP_FORM_TEXTAREA_INNER, "min-h-20")}
-              disabled={questionsBusy}
-            />
-          </div>
+        <div
+          className={cn(
+            questionInputRowClass,
+            question.options.length > 0 && "mt-0",
+          )}
+        >
+          <span className={questionRowIndexClass}>{question.options.length + 1}.</span>
+          <Input
+            id={`${question.id}-custom`}
+            value={draft.customText}
+            onChange={(event) =>
+              onUpdateDraft(question.id, (current) => ({
+                ...current,
+                customText: event.target.value,
+              }))
+            }
+            placeholder={t("app.customAnswerPlaceholder")}
+            className={questionInputInnerClass}
+            disabled={questionsBusy}
+          />
         </div>
 
-        <div className="flex items-center justify-between gap-2">
+        <div className="mt-4 flex items-center justify-end gap-2">
           <Button
             type="button"
             variant="ghost"
             size="sm"
             className={cn(
-              "h-8 px-2 text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10",
+              "px-2 text-muted-foreground hover:bg-foreground/[0.06] dark:hover:bg-foreground/10",
               instantHoverMotionClass,
               "active:!translate-y-0",
             )}
@@ -209,7 +240,7 @@ export function PendingQuestionsCard({
           <Button
             type="button"
             size="sm"
-            className={cn("h-8 min-w-20", instantHoverMotionClass, "active:!translate-y-0")}
+            className={cn("min-w-20", instantHoverMotionClass, "active:!translate-y-0")}
             disabled={questionsBusy}
             onClick={handleContinue}
           >

--- a/apps/desktop/src/components/pending-questions-card.tsx
+++ b/apps/desktop/src/components/pending-questions-card.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { DesktopFormInput } from "@/components/ui/desktop-form-field";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import type { QuestionDraft } from "@/hooks/useDesktopRuntime";
@@ -37,21 +36,9 @@ type PendingQuestionsCardProps = {
 
 function emptyQuestionDraft(): QuestionDraft {
   return {
-    selectedOptionIndexes: [],
-    customInput: "",
-    text: "",
+    selectedOptionIds: [],
+    customText: "",
   };
-}
-
-function isQuestionDraftAnswered(
-  question: AskQuestionsQuestionSpec,
-  draft: QuestionDraft,
-): boolean {
-  if (question.kind === "text") {
-    return draft.text.trim().length > 0;
-  }
-
-  return draft.selectedOptionIndexes.length > 0 || draft.customInput.trim().length > 0;
 }
 
 export function PendingQuestionsCard({
@@ -78,40 +65,18 @@ export function PendingQuestionsCard({
   const draft = questionDrafts[question.id] ?? emptyQuestionDraft();
   const isLastQuestion = currentIndex >= questions.length - 1;
 
-  const goToNextQuestion = () => {
+  const handleContinue = () => {
     if (!isLastQuestion) {
       setCurrentIndex((index) => Math.min(index + 1, questions.length - 1));
-    }
-  };
-
-  const handleContinue = () => {
-    if (question.required && !isQuestionDraftAnswered(question, draft)) {
       return;
-    }
-
-    if (!isLastQuestion) {
-      goToNextQuestion();
-      return;
-    }
-
-    const missingRequiredIndex = questions.findIndex(
-      (item) =>
-        item.required
-        && !isQuestionDraftAnswered(
-          item,
-          questionDrafts[item.id] ?? emptyQuestionDraft(),
-        ),
-    );
-    if (missingRequiredIndex >= 0 && missingRequiredIndex !== currentIndex) {
-      setCurrentIndex(missingRequiredIndex);
     }
     onSubmitQuestions();
   };
 
-  const handleSingleSelect = (index: number) => {
+  const handleSingleSelect = (optionId: string) => {
     onUpdateDraft(question.id, (current) => ({
       ...current,
-      selectedOptionIndexes: [index],
+      selectedOptionIds: [optionId],
     }));
 
     if (!isLastQuestion) {
@@ -119,21 +84,18 @@ export function PendingQuestionsCard({
     }
   };
 
-  const handleMultiSelectToggle = (index: number) => {
+  const handleMultiSelectToggle = (optionId: string) => {
     onUpdateDraft(question.id, (current) => {
-      const selected = current.selectedOptionIndexes.includes(index);
+      const selected = current.selectedOptionIds.includes(optionId);
       const next = selected
-        ? current.selectedOptionIndexes.filter((item) => item !== index)
-        : [...current.selectedOptionIndexes, index];
+        ? current.selectedOptionIds.filter((item) => item !== optionId)
+        : [...current.selectedOptionIds, optionId];
       return {
         ...current,
-        selectedOptionIndexes: Array.from(new Set(next)).sort((left, right) => left - right),
+        selectedOptionIds: Array.from(new Set(next)),
       };
     });
   };
-
-  const continueDisabled =
-    questionsBusy || (question.required && !isQuestionDraftAnswered(question, draft));
 
   return (
     <Card className="gap-0 border-border/50 bg-background/55 py-0 text-sm shadow-sm backdrop-blur-xl dark:border-white/12 supports-[backdrop-filter]:bg-background/40">
@@ -171,13 +133,15 @@ export function PendingQuestionsCard({
         </div>
       </CardHeader>
       <CardContent className="grid gap-1.5 px-3 pb-2 pt-0">
-        {question.kind === "single_select" ? (
+        {question.options.length > 0 ? (
           <div className="grid gap-1.5">
-            {question.options.map((option, index) => {
-              const selected = draft.selectedOptionIndexes[0] === index;
+            {question.options.map((option) => {
+              const selected = question.allow_multiple
+                ? draft.selectedOptionIds.includes(option.id)
+                : draft.selectedOptionIds[0] === option.id;
               return (
                 <button
-                  key={`${question.id}-single-${index}`}
+                  key={option.id}
                   type="button"
                   className={cn(
                     questionOptionClass,
@@ -186,7 +150,11 @@ export function PendingQuestionsCard({
                       : "border-border/60 bg-card/70 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10",
                   )}
                   disabled={questionsBusy}
-                  onClick={() => handleSingleSelect(index)}
+                  onClick={() =>
+                    question.allow_multiple
+                      ? handleMultiSelectToggle(option.id)
+                      : handleSingleSelect(option.id)
+                  }
                 >
                   <div className="space-y-0.5">
                     <span className="font-medium">{option.label}</span>
@@ -202,85 +170,26 @@ export function PendingQuestionsCard({
           </div>
         ) : null}
 
-        {question.kind === "multi_select" ? (
-          <div className="grid gap-1.5">
-            {question.options.map((option, index) => {
-              const selected = draft.selectedOptionIndexes.includes(index);
-              return (
-                <button
-                  key={`${question.id}-multi-${index}`}
-                  type="button"
-                  className={cn(
-                    questionOptionClass,
-                    selected
-                      ? "border-primary/60 bg-primary/8"
-                      : "border-border/60 bg-card/70 hover:bg-foreground/[0.06] dark:hover:bg-foreground/10",
-                  )}
-                  disabled={questionsBusy}
-                  onClick={() => handleMultiSelectToggle(index)}
-                >
-                  <div className="space-y-0.5">
-                    <span className="font-medium">{option.label}</span>
-                    {option.summary ? (
-                      <p className="text-xs leading-relaxed text-muted-foreground">
-                        {option.summary}
-                      </p>
-                    ) : null}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        ) : null}
-
-        {question.kind === "text" ? (
-          <div className="space-y-1">
-            <Label htmlFor={`${question.id}-text`} className="text-xs">
-              {question.customInputLabel ?? t("app.answer")}
-            </Label>
-            <div className={DESKTOP_FORM_INPUT_SHELL}>
-              <Textarea
-                id={`${question.id}-text`}
-                value={draft.text}
-                onChange={(event) =>
-                  onUpdateDraft(question.id, (current) => ({
-                    ...current,
-                    text: event.target.value,
-                  }))
-                }
-                placeholder={question.customInputPlaceholder ?? t("app.enterAnswer")}
-                className={cn(DESKTOP_FORM_TEXTAREA_INNER, "min-h-20")}
-                disabled={questionsBusy}
-              />
-            </div>
-          </div>
-        ) : null}
-
-        {question.allowCustomInput ? (
-          <div
-            className={cn(
-              "space-y-1",
-              (question.kind === "single_select" || question.kind === "multi_select")
-                && "mt-2.5",
-            )}
-          >
-            <Label htmlFor={`${question.id}-custom`} className="text-xs">
-              {question.customInputLabel ?? t("app.customInput")}
-            </Label>
-            <DesktopFormInput
+        <div className={cn("space-y-1", question.options.length > 0 && "mt-2.5")}>
+          <Label htmlFor={`${question.id}-custom`} className="text-xs">
+            {t("app.customAnswer")}
+          </Label>
+          <div className={DESKTOP_FORM_INPUT_SHELL}>
+            <Textarea
               id={`${question.id}-custom`}
-              value={draft.customInput}
+              value={draft.customText}
               onChange={(event) =>
                 onUpdateDraft(question.id, (current) => ({
                   ...current,
-                  customInput: event.target.value,
+                  customText: event.target.value,
                 }))
               }
-              placeholder={question.customInputPlaceholder ?? t("app.supplementOption")}
+              placeholder={t("app.customAnswerPlaceholder")}
+              className={cn(DESKTOP_FORM_TEXTAREA_INNER, "min-h-20")}
               disabled={questionsBusy}
             />
           </div>
-        ) : null}
+        </div>
 
         <div className="flex items-center justify-between gap-2">
           <Button
@@ -301,7 +210,7 @@ export function PendingQuestionsCard({
             type="button"
             size="sm"
             className={cn("h-8 min-w-20", instantHoverMotionClass, "active:!translate-y-0")}
-            disabled={continueDisabled}
+            disabled={questionsBusy}
             onClick={handleContinue}
           >
             {questionsBusy ? <LoaderCircle className="size-4 animate-spin" /> : null}

--- a/apps/desktop/src/components/pending-questions-card.tsx
+++ b/apps/desktop/src/components/pending-questions-card.tsx
@@ -136,7 +136,7 @@ export function PendingQuestionsCard({
         {question.options.length > 0 ? (
           <div className="grid gap-1.5">
             {question.options.map((option) => {
-              const selected = question.allow_multiple
+              const selected = question.allowMultiple
                 ? draft.selectedOptionIds.includes(option.id)
                 : draft.selectedOptionIds[0] === option.id;
               return (
@@ -151,7 +151,7 @@ export function PendingQuestionsCard({
                   )}
                   disabled={questionsBusy}
                   onClick={() =>
-                    question.allow_multiple
+                    question.allowMultiple
                       ? handleMultiSelectToggle(option.id)
                       : handleSingleSelect(option.id)
                   }

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -310,6 +310,7 @@ declare global {
       needsApproval: boolean;
       needsQuestions: boolean;
       needsTaskComplete: boolean;
+      attentionBlockKey?: string;
     }): Promise<void>;
     getWindowFullScreen(): Promise<boolean>;
     subscribeWindowFullScreen(callback: (fullScreen: boolean) => void): () => void;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -146,9 +146,8 @@ function persistSessionUiDraft(
 }
 
 export interface QuestionDraft {
-  selectedOptionIndexes: number[];
-  customInput: string;
-  text: string;
+  selectedOptionIds: string[];
+  customText: string;
 }
 
 function describeError(error: unknown): string {
@@ -227,43 +226,20 @@ function updateConfigFromSettingsForm(
   };
 }
 
-function toUniqueIndexes(indexes: number[]): number[] {
-  return Array.from(new Set(indexes)).sort((left, right) => left - right);
-}
-
 function buildAskQuestionsAnswer(
   question: AskQuestionsQuestionSpec,
   draft: QuestionDraft,
 ): AskQuestionsAnswer {
-  const selectedOptionIndexes = toUniqueIndexes(draft.selectedOptionIndexes).filter(
-    (index) => index >= 0 && index < question.options.length,
+  const validOptionIds = new Set(question.options.map((option) => option.id));
+  const selectedOptionIds = Array.from(new Set(draft.selectedOptionIds)).filter((id) =>
+    validOptionIds.has(id),
   );
-  const selectedOptionLabels = selectedOptionIndexes
-    .map((index) => question.options[index]?.label)
-    .filter((label): label is string => typeof label === "string" && label.trim().length > 0);
-  const customInput = draft.customInput.trim();
-  const text = draft.text.trim();
-
-  if (question.kind === "text") {
-    return {
-      questionId: question.id,
-      title: question.title,
-      kind: question.kind,
-      answered: text.length > 0,
-      text: text || undefined,
-    };
-  }
+  const customText = draft.customText.trim();
 
   return {
     questionId: question.id,
-    title: question.title,
-    kind: question.kind,
-    answered: selectedOptionIndexes.length > 0 || customInput.length > 0,
-    selectedOptionIndexes:
-      selectedOptionIndexes.length > 0 ? selectedOptionIndexes : undefined,
-    selectedOptionLabels:
-      selectedOptionLabels.length > 0 ? selectedOptionLabels : undefined,
-    customInput: customInput || undefined,
+    selectedOptionIds,
+    ...(customText ? { customText } : {}),
   };
 }
 
@@ -275,16 +251,6 @@ function buildAskQuestionsResult(
     buildAskQuestionsAnswer(question, drafts[question.id] ?? emptyQuestionDraft()),
   );
 
-  const missingRequired = request.questions.find((question, index) => {
-    return question.required && !answers[index]?.answered;
-  });
-
-  if (missingRequired) {
-    return {
-      error: i18n.t('error.completeRequiredQuestion', { title: missingRequired.title }),
-    };
-  }
-
   return {
     result: {
       status: "answered",
@@ -295,9 +261,8 @@ function buildAskQuestionsResult(
 
 function emptyQuestionDraft(): QuestionDraft {
   return {
-    selectedOptionIndexes: [],
-    customInput: "",
-    text: "",
+    selectedOptionIds: [],
+    customText: "",
   };
 }
 

--- a/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
+++ b/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
@@ -79,29 +79,27 @@ function askQuestionsNotificationPayload(
       ? i18n.t('notification.askQuestions.nQuestions', { count: questionCount })
       : i18n.t('notification.askQuestions.fallback'));
 
-  const singleTextQuestion =
-    pending.request.questions.length === 1 && pending.request.questions[0]?.kind === 'text'
-      ? pending.request.questions[0]
-      : undefined;
+  const singleQuestion =
+    pending.request.questions.length === 1 ? pending.request.questions[0] : undefined;
 
   return {
     kind: 'ask-questions',
     tag: `spirit-ask-${pending.toolCallId}`,
     title: formatSessionPrefixedTitle(sessionName, i18n.t('notification.askQuestions.title')),
     body: detail,
-    ...(singleTextQuestion && window.spiritDesktop?.platform === 'darwin'
+    ...(singleQuestion && window.spiritDesktop?.platform === 'darwin'
       ? {
           actions: [
             {
               type: 'text' as const,
               text: i18n.t('notification.askQuestions.reply'),
-              placeholder: singleTextQuestion.title,
+              placeholder: singleQuestion.title,
               action: 'reply' as const,
             },
           ],
           context: {
             questionToolCallId: pending.toolCallId,
-            questionId: singleTextQuestion.id,
+            questionId: singleQuestion.id,
           },
         }
       : {}),

--- a/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
+++ b/apps/desktop/src/hooks/useDesktopSystemNotifications.ts
@@ -15,10 +15,38 @@ type AttentionFlags = {
   needsApproval: boolean;
   needsQuestions: boolean;
   needsTaskComplete: boolean;
+  attentionBlockKey?: string;
 };
 
 function attentionFlagsKey(flags: AttentionFlags): string {
-  return `${flags.needsApproval}:${flags.needsQuestions}:${flags.needsTaskComplete}`;
+  return `${flags.needsApproval}:${flags.needsQuestions}:${flags.needsTaskComplete}:${flags.attentionBlockKey ?? ''}`;
+}
+
+function resolveAttentionBlockKey(
+  approval: PendingToolApprovalSnapshot | undefined,
+  questions: PendingQuestionsSnapshot | undefined,
+): string | undefined {
+  if (approval) {
+    return `approval:${approval.toolName}:${approval.prompt}`;
+  }
+  if (questions) {
+    return `questions:${questions.toolCallId}`;
+  }
+  return undefined;
+}
+
+function buildAttentionFlags(
+  snapshot: DesktopSnapshot | null | undefined,
+  needsTaskComplete: boolean,
+): AttentionFlags {
+  const approval = snapshot?.conversation.pendingToolApproval;
+  const questions = snapshot?.conversation.pendingQuestions;
+  return {
+    needsApproval: Boolean(approval),
+    needsQuestions: Boolean(questions),
+    needsTaskComplete,
+    attentionBlockKey: resolveAttentionBlockKey(approval, questions),
+  };
 }
 
 function sessionDisplayName(snapshot: DesktopSnapshot | null | undefined): string {
@@ -143,12 +171,7 @@ export function useDesktopSystemNotifications(options: {
 
   const markTaskCompleteAttention = (bridge: NotificationBridge) => {
     taskCompleteAttentionRef.current = true;
-    const current = snapshotRef.current;
-    syncAttentionPending(bridge, {
-      needsApproval: Boolean(current?.conversation.pendingToolApproval),
-      needsQuestions: Boolean(current?.conversation.pendingQuestions),
-      needsTaskComplete: true,
-    });
+    syncAttentionPending(bridge, buildAttentionFlags(snapshotRef.current, true));
   };
 
   useEffect(() => {
@@ -194,12 +217,7 @@ export function useDesktopSystemNotifications(options: {
         return;
       }
       taskCompleteAttentionRef.current = false;
-      const current = snapshotRef.current;
-      syncAttentionPending(bridge, {
-        needsApproval: Boolean(current?.conversation.pendingToolApproval),
-        needsQuestions: Boolean(current?.conversation.pendingQuestions),
-        needsTaskComplete: false,
-      });
+      syncAttentionPending(bridge, buildAttentionFlags(snapshotRef.current, false));
     });
   }, [apiKind, enabled]);
 
@@ -214,11 +232,10 @@ export function useDesktopSystemNotifications(options: {
     const questions = snapshot?.conversation.pendingQuestions;
     const isBusy = snapshot?.conversation.isBusy === true;
 
-    syncAttentionPending(bridge, {
-      needsApproval: Boolean(approval),
-      needsQuestions: Boolean(questions),
-      needsTaskComplete: taskCompleteAttentionRef.current,
-    });
+    syncAttentionPending(
+      bridge,
+      buildAttentionFlags(snapshot, taskCompleteAttentionRef.current),
+    );
 
     if (isBusy && prevBusyRef.current !== true) {
       busyCycleRef.current += 1;

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -335,19 +335,12 @@ export function mapPendingQuestions(
       questions: pending.questions.questions.map((question) => ({
         id: question.id,
         title: question.title,
-        kind: question.kind,
-        required: question.required === true,
+        allow_multiple: question.allow_multiple === true,
         options: (question.options ?? []).map((option) => ({
+          id: option.id,
           label: option.label,
           ...(option.summary ? { summary: option.summary } : {}),
         })),
-        allowCustomInput: question.allowCustomInput === true,
-        ...(question.customInputPlaceholder
-          ? { customInputPlaceholder: question.customInputPlaceholder }
-          : {}),
-        ...(question.customInputLabel
-          ? { customInputLabel: question.customInputLabel }
-          : {}),
       })),
     },
   };

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -335,7 +335,7 @@ export function mapPendingQuestions(
       questions: pending.questions.questions.map((question) => ({
         id: question.id,
         title: question.title,
-        allow_multiple: question.allow_multiple === true,
+        allowMultiple: question.allowMultiple === true,
         options: (question.options ?? []).map((option) => ({
           id: option.id,
           label: option.label,

--- a/apps/desktop/src/lib/ask-questions-notification-reply.ts
+++ b/apps/desktop/src/lib/ask-questions-notification-reply.ts
@@ -16,13 +16,12 @@ export function buildSingleTextQuestionNotificationReplyResult(
   }
 
   const question = current.request.questions[0];
-  const text = payload.text.trim();
+  const customText = payload.text.trim();
   if (
     current.request.questions.length !== 1 ||
     !question ||
-    question.kind !== 'text' ||
     payload.context?.questionId !== question.id ||
-    !text
+    !customText
   ) {
     return undefined;
   }
@@ -32,10 +31,8 @@ export function buildSingleTextQuestionNotificationReplyResult(
     answers: [
       {
         questionId: question.id,
-        title: question.title,
-        kind: question.kind,
-        answered: true,
-        text,
+        selectedOptionIds: [],
+        customText,
       },
     ],
   };

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -688,7 +688,6 @@
     "answer": "Answer",
     "enterAnswer": "Please enter your answer",
     "customInput": "Custom Input",
-    "customAnswer": "Custom answer",
     "customAnswerPlaceholder": "Add details or an unlisted option",
     "supplementOption": "Supplement an unlisted option"
   },

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -688,6 +688,8 @@
     "answer": "Answer",
     "enterAnswer": "Please enter your answer",
     "customInput": "Custom Input",
+    "customAnswer": "Custom answer",
+    "customAnswerPlaceholder": "Add details or an unlisted option",
     "supplementOption": "Supplement an unlisted option"
   },
   "workspace": {

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -685,7 +685,6 @@
     "answer": "回答",
     "enterAnswer": "请输入回答",
     "customInput": "自定义输入",
-    "customAnswer": "自定义回答",
     "customAnswerPlaceholder": "补充说明或未列出的选项",
     "supplementOption": "补充一个未列出的选项"
   },

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -685,6 +685,8 @@
     "answer": "回答",
     "enterAnswer": "请输入回答",
     "customInput": "自定义输入",
+    "customAnswer": "自定义回答",
+    "customAnswerPlaceholder": "补充说明或未列出的选项",
     "supplementOption": "补充一个未列出的选项"
   },
   "workspace": {

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1360,7 +1360,7 @@ export interface AskQuestionsRequest {
 export interface AskQuestionsQuestionSpec {
   id: string;
   title: string;
-  allow_multiple: boolean;
+  allowMultiple: boolean;
   options: AskQuestionsOptionSpec[];
 }
 

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1360,28 +1360,20 @@ export interface AskQuestionsRequest {
 export interface AskQuestionsQuestionSpec {
   id: string;
   title: string;
-  kind: 'single_select' | 'multi_select' | 'text';
-  required: boolean;
+  allow_multiple: boolean;
   options: AskQuestionsOptionSpec[];
-  allowCustomInput: boolean;
-  customInputPlaceholder?: string;
-  customInputLabel?: string;
 }
 
 export interface AskQuestionsOptionSpec {
+  id: string;
   label: string;
   summary?: string;
 }
 
 export interface AskQuestionsAnswer {
   questionId: string;
-  title: string;
-  kind: 'single_select' | 'multi_select' | 'text';
-  answered: boolean;
-  selectedOptionIndexes?: number[];
-  selectedOptionLabels?: string[];
-  customInput?: string;
-  text?: string;
+  selectedOptionIds: string[];
+  customText?: string;
 }
 
 export interface AskQuestionsResult {

--- a/apps/desktop/test/lib/ask-questions-notification-reply.test.mjs
+++ b/apps/desktop/test/lib/ask-questions-notification-reply.test.mjs
@@ -11,7 +11,7 @@ function pendingQuestions(overrides = {}) {
         {
           id: 'question-1',
           title: 'What should happen next?',
-          allow_multiple: false,
+          allowMultiple: false,
           options: [],
         },
       ],
@@ -64,13 +64,13 @@ test('buildSingleTextQuestionNotificationReplyResult ignores multi-question prom
             {
               id: 'question-1',
               title: 'First?',
-              allow_multiple: false,
+              allowMultiple: false,
               options: [],
             },
             {
               id: 'question-2',
               title: 'Second?',
-              allow_multiple: false,
+              allowMultiple: false,
               options: [],
             },
           ],

--- a/apps/desktop/test/lib/ask-questions-notification-reply.test.mjs
+++ b/apps/desktop/test/lib/ask-questions-notification-reply.test.mjs
@@ -10,9 +10,8 @@ function pendingQuestions(overrides = {}) {
       questions: [
         {
           id: 'question-1',
-          kind: 'text',
           title: 'What should happen next?',
-          required: true,
+          allow_multiple: false,
           options: [],
         },
       ],
@@ -35,10 +34,8 @@ test('buildSingleTextQuestionNotificationReplyResult maps matching text reply', 
       answers: [
         {
           questionId: 'question-1',
-          title: 'What should happen next?',
-          kind: 'text',
-          answered: true,
-          text: 'Proceed carefully',
+          selectedOptionIds: [],
+          customText: 'Proceed carefully',
         },
       ],
     },
@@ -58,7 +55,7 @@ test('buildSingleTextQuestionNotificationReplyResult ignores stale tool call', (
   );
 });
 
-test('buildSingleTextQuestionNotificationReplyResult ignores non-text or multi-question prompts', () => {
+test('buildSingleTextQuestionNotificationReplyResult ignores multi-question prompts', () => {
   assert.equal(
     buildSingleTextQuestionNotificationReplyResult(
       pendingQuestions({
@@ -66,16 +63,14 @@ test('buildSingleTextQuestionNotificationReplyResult ignores non-text or multi-q
           questions: [
             {
               id: 'question-1',
-              kind: 'text',
               title: 'First?',
-              required: true,
+              allow_multiple: false,
               options: [],
             },
             {
               id: 'question-2',
-              kind: 'text',
               title: 'Second?',
-              required: true,
+              allow_multiple: false,
               options: [],
             },
           ],

--- a/packages/agent-core/src/host-tools.ts
+++ b/packages/agent-core/src/host-tools.ts
@@ -328,7 +328,7 @@ export function buildBuiltinHostToolDefinitions(
     ),
     functionTool(
       'ask_questions',
-      'Ask the user a structured follow-up questionnaire when their request is underspecified. The host UI will present the questionnaire, collect answers, and return a JSON tool result. Use this only when targeted structured questions are needed to continue.',
+      'Ask structured follow-up questions when a user decision is required to continue. The host always shows a custom text field per question.',
       {
         type: 'object',
         properties: {
@@ -338,8 +338,7 @@ export function buildBuiltinHostToolDefinitions(
           },
           questions: {
             type: 'array',
-            description:
-              'Ordered list of questions to ask. Keep it concise and only include the fields you need.',
+            description: 'Ordered list of questions to ask.',
             items: {
               type: 'object',
               properties: {
@@ -351,22 +350,22 @@ export function buildBuiltinHostToolDefinitions(
                   type: 'string',
                   description: 'Question title shown to the user.',
                 },
-                kind: {
-                  type: 'string',
-                  enum: ['single_select', 'multi_select', 'text'],
-                  description:
-                    'single_select confirms one answer, multi_select allows multiple answers, text asks for freeform text.',
-                },
-                required: {
+                allow_multiple: {
                   type: 'boolean',
-                  description: 'Whether the question must be answered before submission.',
+                  description:
+                    'When true, the user may select multiple preset options. Defaults to false.',
                 },
                 options: {
                   type: 'array',
-                  description: 'Preset options for single_select or multi_select questions.',
+                  description:
+                    'Preset options for this question. Omit or use an empty array for a custom-text-only question.',
                   items: {
                     type: 'object',
                     properties: {
+                      id: {
+                        type: 'string',
+                        description: 'Stable machine-readable option id used in the returned JSON.',
+                      },
                       label: {
                         type: 'string',
                         description: 'Visible option label.',
@@ -374,27 +373,15 @@ export function buildBuiltinHostToolDefinitions(
                       summary: {
                         type: 'string',
                         description:
-                          'Optional short gray summary shown under single_select options.',
+                          'Optional short gray summary shown under the option label.',
                       },
                     },
-                    required: ['label'],
+                    required: ['id', 'label'],
                     additionalProperties: false,
                   },
                 },
-                allowCustomInput: {
-                  type: 'boolean',
-                  description: 'Whether to show an additional custom input field for this question.',
-                },
-                customInputPlaceholder: {
-                  type: 'string',
-                  description: 'Optional placeholder for the custom input field.',
-                },
-                customInputLabel: {
-                  type: 'string',
-                  description: 'Optional label for the custom input field.',
-                },
               },
-              required: ['id', 'title', 'kind'],
+              required: ['id', 'title'],
               additionalProperties: false,
             },
           },

--- a/packages/agent-core/src/host-tools.ts
+++ b/packages/agent-core/src/host-tools.ts
@@ -350,7 +350,7 @@ export function buildBuiltinHostToolDefinitions(
                   type: 'string',
                   description: 'Question title shown to the user.',
                 },
-                allow_multiple: {
+                allowMultiple: {
                   type: 'boolean',
                   description:
                     'When true, the user may select multiple preset options. Defaults to false.',

--- a/packages/agent-core/src/ports.ts
+++ b/packages/agent-core/src/ports.ts
@@ -519,7 +519,7 @@ export interface AskQuestionsOption {
 export interface AskQuestionsQuestion {
   id: string;
   title: string;
-  allow_multiple?: boolean;
+  allowMultiple?: boolean;
   options?: AskQuestionsOption[];
 }
 

--- a/packages/agent-core/src/ports.ts
+++ b/packages/agent-core/src/ports.ts
@@ -510,9 +510,8 @@ export interface StartedToolAgentRound<State = JsonValue> {
   cancel?: () => void;
 }
 
-export type AskQuestionsQuestionKind = 'single_select' | 'multi_select' | 'text';
-
 export interface AskQuestionsOption {
+  id: string;
   label: string;
   summary?: string;
 }
@@ -520,12 +519,8 @@ export interface AskQuestionsOption {
 export interface AskQuestionsQuestion {
   id: string;
   title: string;
-  kind: AskQuestionsQuestionKind;
-  required?: boolean;
+  allow_multiple?: boolean;
   options?: AskQuestionsOption[];
-  allowCustomInput?: boolean;
-  customInputPlaceholder?: string;
-  customInputLabel?: string;
 }
 
 export interface AskQuestionsRequest {
@@ -535,13 +530,8 @@ export interface AskQuestionsRequest {
 
 export interface AskQuestionsAnswer {
   questionId: string;
-  title: string;
-  kind: AskQuestionsQuestionKind;
-  answered: boolean;
-  selectedOptionIndexes?: number[];
-  selectedOptionLabels?: string[];
-  customInput?: string;
-  text?: string;
+  selectedOptionIds: string[];
+  customText?: string;
 }
 
 export type AskQuestionsResult =

--- a/packages/agent-core/src/runtime/turn-machine.test.ts
+++ b/packages/agent-core/src/runtime/turn-machine.test.ts
@@ -320,7 +320,7 @@ test('resumePendingQuestions syncs native ask_questions answers into historyStor
   const request = { name: 'ask_questions' };
   const answersResult = {
     status: 'answered' as const,
-    answers: [{ questionId: 'q1', title: 'Q1', kind: 'text' as const, answered: true, text: 'alpha' }],
+    answers: [{ questionId: 'q1', selectedOptionIds: [], customText: 'alpha' }],
   };
   const historyStore = [
     {

--- a/packages/host-internal/src/tools.test.ts
+++ b/packages/host-internal/src/tools.test.ts
@@ -799,10 +799,8 @@ test('authorize still requires ask_questions under full-approval approval level'
       questions: [{
         id: 'q1',
         title: 'Choose one',
-        kind: 'single_select',
-        required: true,
-        options: [{ label: 'A' }],
-        allowCustomInput: false,
+        allow_multiple: false,
+        options: [{ id: 'a', label: 'A' }],
       }],
     });
 

--- a/packages/host-internal/src/tools.test.ts
+++ b/packages/host-internal/src/tools.test.ts
@@ -799,7 +799,7 @@ test('authorize still requires ask_questions under full-approval approval level'
       questions: [{
         id: 'q1',
         title: 'Choose one',
-        allow_multiple: false,
+        allowMultiple: false,
         options: [{ id: 'a', label: 'A' }],
       }],
     });

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -200,7 +200,7 @@ export interface HostAskQuestionsOptionSpec {
 export interface HostAskQuestionsQuestionSpec {
   id: string;
   title: string;
-  allow_multiple: boolean;
+  allowMultiple: boolean;
   options: HostAskQuestionsOptionSpec[];
 }
 
@@ -2324,7 +2324,7 @@ function parseQuestion(value: HostJsonValue, index: number): HostAskQuestionsQue
   return {
     id: requiredString(value, 'id'),
     title: requiredString(value, 'title'),
-    allow_multiple: optionalBoolean(value, 'allow_multiple') ?? false,
+    allowMultiple: optionalBoolean(value, 'allowMultiple') ?? false,
     options,
   };
 }
@@ -2437,7 +2437,7 @@ function buildExtensionQuestionsAuthorization<QuestionSpec>(
         {
           id: 'execution_note',
           title: '补充执行说明',
-          allow_multiple: false,
+          allowMultiple: false,
           options: [],
         } as QuestionSpec,
       ],

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -192,6 +192,7 @@ export interface HostOperatingSystemInfo {
 }
 
 export interface HostAskQuestionsOptionSpec {
+  id: string;
   label: string;
   summary?: string;
 }
@@ -199,12 +200,8 @@ export interface HostAskQuestionsOptionSpec {
 export interface HostAskQuestionsQuestionSpec {
   id: string;
   title: string;
-  kind: 'single_select' | 'multi_select' | 'text';
-  required: boolean;
+  allow_multiple: boolean;
   options: HostAskQuestionsOptionSpec[];
-  allowCustomInput: boolean;
-  customInputPlaceholder?: string;
-  customInputLabel?: string;
 }
 
 export interface HostAskQuestionsRequest<QuestionSpec = HostAskQuestionsQuestionSpec> {
@@ -2306,11 +2303,6 @@ function parseQuestion(value: HostJsonValue, index: number): HostAskQuestionsQue
     throw new Error(`questions[${index}] 必须是对象。`);
   }
 
-  const kind = requiredString(value, 'kind');
-  if (kind !== 'single_select' && kind !== 'multi_select' && kind !== 'text') {
-    throw new Error(`questions[${index}].kind 非法: ${kind}`);
-  }
-
   const optionsValue = value.options;
   const options = Array.isArray(optionsValue)
     ? optionsValue.map((option, optionIndex) => {
@@ -2319,6 +2311,7 @@ function parseQuestion(value: HostJsonValue, index: number): HostAskQuestionsQue
         }
         const summary = optionalString(option, 'summary');
         const parsedOption: HostAskQuestionsOptionSpec = {
+          id: requiredString(option, 'id'),
           label: requiredString(option, 'label'),
         };
         if (summary) {
@@ -2328,18 +2321,11 @@ function parseQuestion(value: HostJsonValue, index: number): HostAskQuestionsQue
       })
     : [];
 
-  const customInputPlaceholder = optionalString(value, 'customInputPlaceholder');
-  const customInputLabel = optionalString(value, 'customInputLabel');
-
   return {
     id: requiredString(value, 'id'),
     title: requiredString(value, 'title'),
-    kind,
-    required: optionalBoolean(value, 'required') ?? false,
+    allow_multiple: optionalBoolean(value, 'allow_multiple') ?? false,
     options,
-    allowCustomInput: optionalBoolean(value, 'allowCustomInput') ?? false,
-    ...(customInputPlaceholder ? { customInputPlaceholder } : {}),
-    ...(customInputLabel ? { customInputLabel } : {}),
   };
 }
 
@@ -2358,17 +2344,16 @@ function validateQuestions(questions: HostAskQuestionsQuestionSpec[]): void {
       throw new Error(`ask_questions 问题标题不能为空: ${id}`);
     }
 
-    if (question.kind === 'text') {
-      if (question.options.length > 0) {
-        throw new Error(`ask_questions 文本题不能包含 options: ${id}`);
-      }
-      continue;
-    }
-
-    if (question.options.length === 0 && !question.allowCustomInput) {
-      throw new Error(`ask_questions 选择题至少需要一个预设选项或开启自定义输入: ${id}`);
-    }
+    const seenOptionIds = new Set<string>();
     for (const option of question.options) {
+      const optionId = option.id.trim();
+      if (!optionId) {
+        throw new Error(`ask_questions 选项 id 不能为空: ${id}`);
+      }
+      if (seenOptionIds.has(optionId)) {
+        throw new Error(`ask_questions 选项 id 不能重复: ${id}/${optionId}`);
+      }
+      seenOptionIds.add(optionId);
       if (!option.label.trim()) {
         throw new Error(`ask_questions 选项文本不能为空: ${id}`);
       }
@@ -2452,12 +2437,8 @@ function buildExtensionQuestionsAuthorization<QuestionSpec>(
         {
           id: 'execution_note',
           title: '补充执行说明',
-          kind: 'text',
-          required: true,
+          allow_multiple: false,
           options: [],
-          allowCustomInput: true,
-          customInputLabel: '说明',
-          customInputPlaceholder: '补充这次扩展工具调用需要携带的执行说明。',
         } as QuestionSpec,
       ],
     },


### PR DESCRIPTION
## Summary

- 简化 `ask_questions` 工具契约：移除 kind/required/allowCustomInput 等字段，新增 `allowMultiple` 与 option `id`，宿主固定展示自定义输入
- Desktop / CLI 宿主 UI、通知回复与解析逻辑对齐 v2 返回 `{ questionId, selectedOptionIds, customText? }`
- 重构 PendingQuestionsCard 样式：序号 grid 布局、收紧行距、底部按钮右对齐
- 修复 Windows 任务栏在用户已回前台见过阻挡后，再次切后台仍反复「需要关注」的问题

## Test plan

- [x] `packages/agent-core` turn-machine 单测
- [x] `packages/host-internal` tools 单测
- [x] Desktop ask-questions 通知回复单测
- [x] CLI ask_questions 相关测试
- [x] Windows Desktop 手动验证：阻挡切后台仅首次请求关注，回前台后再次最小化不再闪烁