### PR TITLE
feat(agent-core, desktop, cli): Moonshot Formula web_search 接入与 history 修复

### DIFF
--- a/.github/instructions/agent-core-host-boundary.instructions.md
+++ b/.github/instructions/agent-core-host-boundary.instructions.md
@@ -22,6 +22,13 @@ applyTo: "**/*"
   - **Open Responses**：经 HTTP `tools` 注入 `{ type: web_search }`、`code_interpreter`（不含 `web_extractor`；URL 正文用宿主 `web_fetch`）。
 - 可见性由 eligibility 与 fetch 层门控。**勿**在 system message 追加 provider built-in 使用说明（模型已从请求 `tools` 看见）；Chat Completions 能力经 `extra_body`，亦无 function 名可声明时**不**写 system 小作文。细则见 `llm-visible-copy.instructions.md`。
 
+## Moonshot Formula（Chat Completions）
+
+- **Moonshot AI 直连**（`llmVendor: moonshot-ai`，`openai-compatible`）：经 Formula API 注入 `moonshot/web-search:latest` 远端 schema，模型触发 `web_search` 时由 `agent-core` 调用 `/formulas/{uri}/fibers` 并将 `encrypted_output` 写回 tool message。
+- **不在范围**：Kimi Code（`kimi-code`）、Vercel Gateway 路由的 Moonshot、遗留 `$web_search` builtin_function。
+- **不在** `host-internal` 注册可执行 `web_search`；Formula 执行留在 `agent-core` `moonshot/formula/`。
+- UI：`encrypted_output` 不可展示；Moonshot Formula `web_search` 卡片经 `_spiritUi.suppressExpand` 禁止展开。
+
 ## 术语
 
 ### 工具定义

--- a/apps/cli/src/host_runtime.rs
+++ b/apps/cli/src/host_runtime.rs
@@ -166,12 +166,34 @@ fn truncate_output_for_tool_ui(text: &str, max_chars: usize) -> String {
     truncate_for_preview(text, max_chars)
 }
 
+fn spirit_ui_suppresses_expand(arguments: &Value) -> bool {
+    arguments
+        .get("_spiritUi")
+        .and_then(|ui| ui.get("suppressExpand"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn spirit_ui_input_excerpt(arguments: &Value) -> Option<String> {
+    arguments
+        .get("_spiritUi")
+        .and_then(|ui| ui.get("inputExcerpt"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
 pub(crate) fn build_tool_preview_block(
     tool_name: &str,
     tool_call_id: &str,
     request: &ToolUiRequest,
 ) -> ToolUiBlock {
     let (headline, detail_lines) = preview_summary_for_tool(tool_name, request);
+    let suppress_expand = spirit_ui_suppresses_expand(&request.arguments);
+    let args_excerpt = if suppress_expand {
+        spirit_ui_input_excerpt(&request.arguments)
+    } else {
+        Some(tool_request_args_excerpt(request))
+    };
     ToolUiBlock {
         tool_call_id: Some(tool_call_id.to_string()),
         tool_name: tool_name.to_string(),
@@ -180,8 +202,9 @@ pub(crate) fn build_tool_preview_block(
         detail_lines,
         image_paths: Vec::new(),
         video_paths: Vec::new(),
-        args_excerpt: Some(tool_request_args_excerpt(request)),
+        args_excerpt,
         output_excerpt: None,
+        suppress_expand: suppress_expand.then_some(true),
     }
 }
 
@@ -252,6 +275,12 @@ fn preview_summary_for_tool(tool_name: &str, request: &ToolUiRequest) -> (String
             };
             (headline, lines)
         }
+        "web_search" => {
+            if let Some(query) = spirit_ui_input_excerpt(&request.arguments) {
+                return ("联网搜索".to_string(), vec![query]);
+            }
+            ("联网搜索".to_string(), Vec::new())
+        }
         _ => (
             format!("调用 {}", tool_name),
             Vec::new(),
@@ -291,6 +320,7 @@ pub(crate) fn tool_approval_block(
         video_paths: Vec::new(),
         args_excerpt: None,
         output_excerpt: None,
+        suppress_expand: None,
     }
 }
 
@@ -310,6 +340,7 @@ pub(crate) fn tool_failed_block(
         video_paths: Vec::new(),
         args_excerpt: None,
         output_excerpt: Some(truncate_output_for_tool_ui(err, 2000)),
+        suppress_expand: None,
     }
 }
 
@@ -341,6 +372,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         "web_fetch" => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -355,6 +387,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         "list_directory_files" => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -369,6 +402,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         "glob" => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -383,6 +417,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         "read_file" => {
             let (offset, end) = read_file_range_display(request);
@@ -402,6 +437,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
                 args_excerpt: Some(args_excerpt),
                 output_excerpt: None,
+            suppress_expand: None,
             }
         }
         "grep" => ToolUiBlock {
@@ -417,6 +453,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         "run_subagent" => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -431,6 +468,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         "ask_questions" => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -442,6 +480,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         "generate_image" => {
             let image_paths = generated_image_paths_from_output(output);
@@ -458,6 +497,7 @@ pub(crate) fn build_tool_result_block(
                 video_paths: Vec::new(),
                 args_excerpt: Some(args_excerpt),
                 output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+                suppress_expand: None,
             }
         }
         "generate_video" => {
@@ -475,6 +515,7 @@ pub(crate) fn build_tool_result_block(
                 video_paths,
                 args_excerpt: Some(args_excerpt),
                 output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+                suppress_expand: None,
             }
         }
         "create_file" => ToolUiBlock {
@@ -490,6 +531,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: None,
+        suppress_expand: None,
         },
         "edit_file" => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -504,6 +546,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: None,
+        suppress_expand: None,
         },
         "delete_file" => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -518,6 +561,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: None,
+        suppress_expand: None,
         },
         "apply_patch" => {
             let path = apply_patch_path(request).unwrap_or("<unknown>");
@@ -537,6 +581,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
                 args_excerpt: Some(args_excerpt),
                 output_excerpt: None,
+            suppress_expand: None,
             }
         }
         "shell" => ToolUiBlock {
@@ -552,6 +597,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
         _ => ToolUiBlock {
             tool_call_id: tool_call_id.map(String::from),
@@ -563,6 +609,7 @@ pub(crate) fn build_tool_result_block(
             video_paths: Vec::new(),
             args_excerpt: Some(args_excerpt),
             output_excerpt: Some(truncate_output_for_tool_ui(output, 3600)),
+            suppress_expand: None,
         },
     }
 }
@@ -869,5 +916,28 @@ mod tests {
                 .as_deref()
                 .is_some_and(|text| text.contains("src/app.ts"))
         );
+    }
+
+    #[test]
+    fn moonshot_formula_web_search_preview_sets_suppress_expand_and_query_excerpt() {
+        let block = build_tool_preview_block(
+            "web_search",
+            "call_formula_01",
+            &ToolUiRequest::new(
+                "web_search",
+                json!({
+                    "status": "in_progress",
+                    "_spiritUi": {
+                        "inputExcerpt": "latest AI news",
+                        "suppressExpand": true
+                    }
+                }),
+            ),
+        );
+
+        assert_eq!(block.suppress_expand, Some(true));
+        assert_eq!(block.args_excerpt.as_deref(), Some("latest AI news"));
+        assert_eq!(block.headline, "联网搜索");
+        assert_eq!(block.detail_lines, vec!["latest AI news".to_string()]);
     }
 }

--- a/apps/cli/src/rewind.rs
+++ b/apps/cli/src/rewind.rs
@@ -848,6 +848,7 @@ fn tool_block_from_snapshot(snapshot: &ToolBlockSnapshot) -> ToolUiBlock {
         video_paths: snapshot.video_paths.clone(),
         args_excerpt: snapshot.args_excerpt.clone(),
         output_excerpt: snapshot.output_excerpt.clone(),
+        suppress_expand: None,
     }
 }
 

--- a/apps/cli/src/subagent_display.rs
+++ b/apps/cli/src/subagent_display.rs
@@ -203,6 +203,7 @@ mod tests {
                 video_paths: vec![],
                 args_excerpt: None,
                 output_excerpt: None,
+                suppress_expand: None,
             },
         )];
         assert!(has_active_run_subagent_tool_in_messages(&messages));

--- a/apps/cli/src/ui/conversation.rs
+++ b/apps/cli/src/ui/conversation.rs
@@ -783,11 +783,12 @@ pub(in crate::ui) fn render_tool_card_lines(
     );
     let rail_sym = "▌ ";
     let indent = message_gutter_padding();
-    let expand_details = show_aux_details
-        || matches!(
-            tool.phase,
-            ToolUiPhase::Preview | ToolUiPhase::PendingApproval | ToolUiPhase::Failed
-        );
+    let expand_details = !tool.suppress_expand.unwrap_or(false)
+        && (show_aux_details
+            || matches!(
+                tool.phase,
+                ToolUiPhase::Preview | ToolUiPhase::PendingApproval | ToolUiPhase::Failed
+            ));
 
     let mut out = Vec::new();
 

--- a/apps/cli/src/ui/tests.rs
+++ b/apps/cli/src/ui/tests.rs
@@ -717,8 +717,9 @@ fn rewind_picker_deemphasizes_tool_messages() {
             image_paths: Vec::new(),
         video_paths: Vec::new(),
             args_excerpt: None,
-            output_excerpt: None,
-        },
+        output_excerpt: None,
+        suppress_expand: None,
+    },
     ));
     app.rewind_picker = Some(RewindPickerView {
         selected_message_id: 2,
@@ -772,8 +773,9 @@ fn streaming_tool_preview_renders_tool_card_on_separate_message_row() {
             image_paths: Vec::new(),
         video_paths: Vec::new(),
             args_excerpt: None,
-            output_excerpt: None,
-        },
+        output_excerpt: None,
+        suppress_expand: None,
+    },
     ));
 
     let body_lines = render_text_lines(render_message_lines(&app, &app.messages[0], 0));
@@ -1212,6 +1214,7 @@ fn subagent_tool_card_hides_output_when_aux_details_collapsed() {
         video_paths: Vec::new(),
         args_excerpt: Some("{\n  \"limit\": 3\n}".to_string()),
         output_excerpt: Some("命中 3 个结果。".to_string()),
+        suppress_expand: None,
     };
     let message = ChatMessage::with_tool_block(MessageRole::Agent, String::new(), tool);
 
@@ -1234,6 +1237,7 @@ fn subagent_tool_card_shows_output_when_aux_details_expanded() {
         video_paths: Vec::new(),
         args_excerpt: Some("{\n  \"limit\": 3\n}".to_string()),
         output_excerpt: Some("命中 3 个结果。".to_string()),
+        suppress_expand: None,
     };
     let message = ChatMessage::with_tool_block(MessageRole::Agent, String::new(), tool);
 
@@ -1261,8 +1265,9 @@ fn shell_pending_approval_title_line_shows_reason_instead_of_call_id() {
             image_paths: Vec::new(),
         video_paths: Vec::new(),
             args_excerpt: None,
-            output_excerpt: None,
-        },
+        output_excerpt: None,
+        suppress_expand: None,
+    },
     ));
 
     let lines = render_text_lines(render_message_lines(&app, &app.messages[0], 0));
@@ -1292,6 +1297,7 @@ fn generate_image_tool_card_shows_structured_path_when_aux_details_collapsed() {
             video_paths: Vec::new(),
             args_excerpt: Some("{\n  \"prompt\": \"画一张图\"\n}".to_string()),
             output_excerpt: Some("[generated image]\npath: C:/Users/pc/AppData/Roaming/SpiritAgent/generated-images/example.png".to_string()),
+            suppress_expand: None,
         },
     ));
     app.show_aux_details = false;
@@ -1328,6 +1334,7 @@ fn generate_video_tool_card_shows_managed_uri_when_aux_details_collapsed() {
                 "[generated video]\nvideo_ref: spirit://generated/video/example.mp4"
                     .to_string(),
             ),
+            suppress_expand: None,
         },
     ));
     app.show_aux_details = false;
@@ -1357,8 +1364,9 @@ fn generate_image_tool_card_keeps_rail_on_wrapped_path_lines() {
             image_paths: Vec::new(),
         video_paths: Vec::new(),
             args_excerpt: None,
-            output_excerpt: None,
-        },
+        output_excerpt: None,
+        suppress_expand: None,
+    },
     ));
     app.show_aux_details = false;
 
@@ -1398,8 +1406,9 @@ fn generate_image_tool_card_selection_highlights_wrapped_rail_consistently() {
             image_paths: Vec::new(),
         video_paths: Vec::new(),
             args_excerpt: None,
-            output_excerpt: None,
-        },
+        output_excerpt: None,
+        suppress_expand: None,
+    },
     ));
     app.show_aux_details = false;
 
@@ -1462,8 +1471,9 @@ fn generate_image_history_render_reserves_image_block() {
             image_paths: vec!["demo.png".to_string()],
             video_paths: Vec::new(),
             args_excerpt: None,
-            output_excerpt: None,
-        },
+        output_excerpt: None,
+        suppress_expand: None,
+    },
     ));
 
     let render = build_history_render_result(&app, 80);
@@ -1494,8 +1504,9 @@ fn generate_image_ui_renders_halfblock_preview_from_local_file() {
             image_paths: vec![file_path.to_string_lossy().to_string()],
             video_paths: Vec::new(),
             args_excerpt: None,
-            output_excerpt: None,
-        },
+        output_excerpt: None,
+        suppress_expand: None,
+    },
     ));
 
     let (lines, buffer) = render_ui_snapshot(&app, 80, 36);

--- a/apps/cli/src/view.rs
+++ b/apps/cli/src/view.rs
@@ -218,6 +218,8 @@ pub struct ToolUiBlock {
     pub args_excerpt: Option<String>,
     /// 可选：输出摘要（已截断）。
     pub output_excerpt: Option<String>,
+    /// Moonshot Formula 等 provider 工具：禁止展开详情（encrypted 乱码）。
+    pub suppress_expand: Option<bool>,
 }
 
 #[derive(Clone, Debug)]

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -901,9 +901,9 @@ export class DesktopRuntimeEventOrchestrator {
         this.activeGenerateVideoTools.delete(execution.toolCallId);
       }
       const callId = execution.toolCallId || `tool:${execution.toolName}`;
+      const existingSnapshot = this.findExistingToolSnapshot(callId);
       if (source === 'turn-result') {
-        const integrated = this.findExistingToolSnapshot(callId);
-        if (integrated?.phase === 'succeeded' || integrated?.phase === 'failed') {
+        if (existingSnapshot?.phase === 'succeeded' || existingSnapshot?.phase === 'failed') {
           continue;
         }
       }
@@ -939,7 +939,9 @@ export class DesktopRuntimeEventOrchestrator {
                     }
                   : this.toolSummaryOptions(),
             );
-      const argsExcerpt = truncateJson(execution.request);
+      const argsExcerpt = existingSnapshot?.argsExcerpt?.trim()
+        ? existingSnapshot.argsExcerpt
+        : truncateJson(execution.request);
       const fileToolDiffArgumentsJson = FILE_DIFF_TOOL_NAMES.has(execution.toolName)
         ? serializeFileToolDiffArgumentsJson(execution.request)
         : undefined;
@@ -953,6 +955,7 @@ export class DesktopRuntimeEventOrchestrator {
             detailLines: [],
             argsExcerpt,
             outputExcerpt: truncateText(execution.output, 4_000),
+            ...(existingSnapshot?.suppressExpand ? { suppressExpand: true } : {}),
             ...(fileToolDiffArgumentsJson ? { fileToolDiffArgumentsJson } : {}),
             ...(imagePaths.length > 0 ? { imagePaths } : {}),
             ...(videoPaths.length > 0 ? { videoPaths } : {}),

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -1,5 +1,6 @@
 import {
   isResponsesBuiltInToolName,
+  parseMoonshotFormulaSpiritUiFromArgumentsJson,
   parseResponsesBuiltInToolUiFromArgumentsJson,
   previewRequestFromStreamingArguments,
   resolveResponsesBuiltInToolStreamPhaseFromArgumentsJson,
@@ -594,9 +595,13 @@ export class DesktopRuntimeEventOrchestrator {
       // 工具预览前先把 defer 在正文 aux 上的思考固化为独立行（before-tools），避免插入工具后 strip 抹掉。
       this.flushDeferredAfterStreamThinking('before-next-tool');
       const isResponsesBuiltIn = isResponsesBuiltInToolName(event.toolName);
+      const formulaUi = isResponsesBuiltIn
+        ? parseMoonshotFormulaSpiritUiFromArgumentsJson(event.argumentsJson)
+        : undefined;
       const providerUi = isResponsesBuiltIn
         ? parseResponsesBuiltInToolUiFromArgumentsJson(event.argumentsJson)
         : undefined;
+      const suppressExpand = formulaUi?.suppressExpand === true;
       const previewRequest = previewRequestFromStreamingArguments(
         event.toolName,
         event.argumentsJson,
@@ -640,6 +645,7 @@ export class DesktopRuntimeEventOrchestrator {
             detailLines: providerUi?.detailLines ?? [],
             argsExcerpt,
             ...(providerUi?.outputExcerpt ? { outputExcerpt: providerUi.outputExcerpt } : {}),
+            ...(suppressExpand ? { suppressExpand: true } : {}),
             ...(FILE_DIFF_TOOL_NAMES.has(event.toolName)
               ? { streamingArgumentsJson: event.argumentsJson }
               : {}),

--- a/apps/desktop/src/lib/tool-call-display.ts
+++ b/apps/desktop/src/lib/tool-call-display.ts
@@ -364,6 +364,9 @@ function fileDiffToolHasExpandableContent(tool: ToolBlockSnapshot): boolean {
 }
 
 function responsesBuiltInToolHasExpandableContent(tool: ToolBlockSnapshot): boolean {
+  if (tool.suppressExpand) {
+    return false;
+  }
   if (!isResponsesBuiltInToolCard(tool.toolName)) {
     return false;
   }
@@ -375,6 +378,9 @@ function responsesBuiltInToolHasExpandableContent(tool: ToolBlockSnapshot): bool
 }
 
 export function toolHasExpandableContent(tool: ToolBlockSnapshot): boolean {
+  if (tool.suppressExpand) {
+    return false;
+  }
   if (tool.toolName === 'read_file') {
     return false;
   }

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1322,6 +1322,8 @@ export interface ToolBlockSnapshot {
   videoPaths?: string[];
   /** 写文件类工具 LSP 自动检查后的 error/warning 摘要（供工具卡徽章与 hover）。 */
   lspWriteDiagnostics?: LspWriteDiagnosticsUi;
+  /** Moonshot Formula 等 provider 工具：禁止展开以防展示 encrypted 乱码。 */
+  suppressExpand?: boolean;
 }
 
 export interface MessageAuxSnapshot {

--- a/apps/desktop/test/host/runtime-event-orchestrator.test.mjs
+++ b/apps/desktop/test/host/runtime-event-orchestrator.test.mjs
@@ -902,6 +902,47 @@ test('edit_file tool-execution-finished preserves lspWriteDiagnostics on tool sn
   assert.equal(toolMessage?.tool?.lspWriteDiagnostics?.items[0]?.severity, 'error');
 });
 
+test('Moonshot Formula web_search tool-execution-finished preserves preview suppressExpand and argsExcerpt', () => {
+  const harness = createHarness();
+  harness.pushUser('search DeepSeek');
+
+  const argumentsJson = JSON.stringify({
+    status: 'completed',
+    _spiritUi: {
+      inputExcerpt: 'DeepSeek 是什么',
+      headlineDetail: 'DeepSeek 是什么',
+      suppressExpand: true,
+    },
+  });
+
+  harness.orchestrator.applyRuntimeHostEvents([
+    { kind: 'begin-assistant-response' },
+    {
+      kind: 'streaming-tool-preview',
+      toolCallId: 'ws_formula_1',
+      toolName: 'web_search',
+      argumentsJson,
+    },
+    {
+      kind: 'tool-execution-finished',
+      execution: {
+        toolCallId: 'ws_formula_1',
+        toolName: 'web_search',
+        request: { name: 'web_search', argumentsJson: '{"query":"DeepSeek 是什么"}' },
+        output: '[moonshot formula web_search] completed',
+        failed: false,
+      },
+    },
+  ]);
+
+  const tool = harness.timeline
+    .toMessages()
+    .find((message) => message.tool?.toolCallId === 'ws_formula_1')?.tool;
+  assert.equal(tool?.phase, 'succeeded');
+  assert.equal(tool?.suppressExpand, true);
+  assert.equal(tool?.argsExcerpt, 'DeepSeek 是什么');
+});
+
 function createContextUsageHarness(options = {}) {
   let messages = [];
   let nextMessageId = 1;

--- a/apps/desktop/test/lib/tool-call-display.test.mjs
+++ b/apps/desktop/test/lib/tool-call-display.test.mjs
@@ -36,6 +36,33 @@ test('toolHasExpandableContent: read_file is never expandable', () => {
   );
 });
 
+test('toolHasExpandableContent: Moonshot Formula web_search with suppressExpand is not expandable', () => {
+  assert.equal(
+    toolHasExpandableContent({
+      toolName: 'web_search',
+      phase: 'succeeded',
+      headline: 'Web search',
+      headlineDetail: 'latest AI news',
+      detailLines: [],
+      argsExcerpt: 'latest AI news',
+      suppressExpand: true,
+    }),
+    false,
+  );
+  assert.equal(
+    toolHasExpandableContent({
+      toolName: 'web_search',
+      phase: 'succeeded',
+      headline: 'Web search',
+      headlineDetail: 'latest AI news',
+      detailLines: [],
+      argsExcerpt: '1. https://example.com',
+      outputExcerpt: '1. https://example.com',
+    }),
+    true,
+  );
+});
+
 test('getToolCallSummaryParts: shell prefixes reason and keeps command as detail', () => {
   assert.deepEqual(
     getToolCallSummaryParts({

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -12,6 +12,7 @@ export * from './openai/index.js';
 export * from './anthropic/index.js';
 export * from './bedrock/index.js';
 export * from './open-responses/index.js';
+export * from './moonshot/index.js';
 export * from './host-tools.js';
 export * from './shell-tool-result.js';
 export * from './unknown-tool-error.js';

--- a/packages/agent-core/src/moonshot/formula/formula-client.test.ts
+++ b/packages/agent-core/src/moonshot/formula/formula-client.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { setLlmFetchTransportOverrideForTests } from '../../llm-fetch.js';
+import {
+  fetchFormulaTools,
+  invokeFormulaFiber,
+} from './formula-client.js';
+import { MOONSHOT_FORMULA_WEB_SEARCH_URI } from './formula-registry.js';
+
+const config = {
+  apiKey: 'test-key',
+  baseUrl: 'https://api.moonshot.ai/v1',
+};
+
+test('fetchFormulaTools returns tools from Formula API', async () => {
+  const fetchImpl = async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    assert.match(url, /\/formulas\/moonshot\/web-search:latest\/tools$/);
+    return new Response(
+      JSON.stringify({
+        object: 'list',
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'web_search',
+              description: 'Search the web for information',
+              parameters: {
+                type: 'object',
+                properties: {
+                  query: { type: 'string' },
+                },
+                required: ['query'],
+              },
+            },
+          },
+        ],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  };
+
+  setLlmFetchTransportOverrideForTests(fetchImpl);
+  try {
+    const tools = await fetchFormulaTools(config, MOONSHOT_FORMULA_WEB_SEARCH_URI);
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0]?.function.name, 'web_search');
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
+});
+
+test('invokeFormulaFiber returns encrypted_output on success', async () => {
+  const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    assert.match(url, /\/formulas\/moonshot\/web-search:latest\/fibers$/);
+    assert.equal(init?.method, 'POST');
+    const body = JSON.parse(String(init?.body)) as { name: string; arguments: string };
+    assert.equal(body.name, 'web_search');
+    assert.equal(body.arguments, '{"query":"latest news"}');
+    return new Response(
+      JSON.stringify({
+        status: 'succeeded',
+        context: {
+          encrypted_output: '----MOONSHOT ENCRYPTED BEGIN----+nf6----MOONSHOT ENCRYPTED END----',
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  };
+
+  setLlmFetchTransportOverrideForTests(fetchImpl);
+  try {
+    const result = await invokeFormulaFiber(
+      config,
+      MOONSHOT_FORMULA_WEB_SEARCH_URI,
+      'web_search',
+      '{"query":"latest news"}',
+    );
+    assert.deepEqual(result, {
+      kind: 'succeeded',
+      content: '----MOONSHOT ENCRYPTED BEGIN----+nf6----MOONSHOT ENCRYPTED END----',
+    });
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
+});
+
+test('invokeFormulaFiber falls back to output when encrypted_output is absent', async () => {
+  const fetchImpl = async () => new Response(
+    JSON.stringify({
+      status: 'succeeded',
+      context: {
+        output: 'plain output',
+      },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+
+  setLlmFetchTransportOverrideForTests(fetchImpl);
+  try {
+    const result = await invokeFormulaFiber(
+      config,
+      MOONSHOT_FORMULA_WEB_SEARCH_URI,
+      'web_search',
+      '{}',
+    );
+    assert.deepEqual(result, { kind: 'succeeded', content: 'plain output' });
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
+});
+
+test('invokeFormulaFiber returns failed on non-succeeded status', async () => {
+  const fetchImpl = async () => new Response(
+    JSON.stringify({
+      status: 'failed',
+      context: {
+        error: 'rate limited',
+      },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+
+  setLlmFetchTransportOverrideForTests(fetchImpl);
+  try {
+    const result = await invokeFormulaFiber(
+      config,
+      MOONSHOT_FORMULA_WEB_SEARCH_URI,
+      'web_search',
+      '{}',
+    );
+    assert.equal(result.kind, 'failed');
+    if (result.kind === 'failed') {
+      assert.match(result.error, /rate limited/);
+    }
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+  }
+});

--- a/packages/agent-core/src/moonshot/formula/formula-client.ts
+++ b/packages/agent-core/src/moonshot/formula/formula-client.ts
@@ -1,0 +1,158 @@
+import { getLlmFetch } from '../../llm-fetch.js';
+import { normalizeMoonshotApiBase } from '../../openai/moonshot-files.js';
+import type { JsonObject } from '../../ports.js';
+import { isJsonObject } from '../../tool-agent.js';
+import type {
+  FormulaFiberInvokeResult,
+  FormulaFiberResponse,
+  FormulaToolDefinition,
+  FormulaToolsListResponse,
+  FormulaUri,
+} from './formula-types.js';
+
+export type FormulaClientConfig = {
+  apiKey: string;
+  baseUrl?: string;
+};
+
+function buildFormulaAuthorizationHeader(apiKey: string): string {
+  return `Bearer ${apiKey.trim()}`;
+}
+
+function buildFormulaApiUrl(baseUrl: string | undefined, path: string): string {
+  const apiBase = normalizeMoonshotApiBase(baseUrl);
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${apiBase}${normalizedPath}`;
+}
+
+function readFiberError(fiber: FormulaFiberResponse): string | undefined {
+  if (typeof fiber.error === 'string' && fiber.error.trim()) {
+    return fiber.error.trim();
+  }
+
+  const context = fiber.context;
+  if (!context) {
+    return undefined;
+  }
+
+  if (typeof context.error === 'string' && context.error.trim()) {
+    return context.error.trim();
+  }
+
+  if (
+    typeof context.output === 'string'
+    && context.output.trim()
+    && fiber.status !== 'succeeded'
+  ) {
+    return context.output.trim();
+  }
+
+  return undefined;
+}
+
+function readFiberSucceededContent(fiber: FormulaFiberResponse): string | undefined {
+  const context = fiber.context;
+  if (!context) {
+    return undefined;
+  }
+
+  const encrypted = typeof context.encrypted_output === 'string'
+    ? context.encrypted_output
+    : undefined;
+  if (encrypted && encrypted.length > 0) {
+    return encrypted;
+  }
+
+  const output = typeof context.output === 'string' ? context.output : undefined;
+  if (output && output.length > 0) {
+    return output;
+  }
+
+  return undefined;
+}
+
+export async function fetchFormulaTools(
+  config: FormulaClientConfig,
+  formulaUri: FormulaUri,
+  fetchImpl: typeof fetch = getLlmFetch(),
+): Promise<FormulaToolDefinition[]> {
+  const response = await fetchImpl(
+    buildFormulaApiUrl(config.baseUrl, `/formulas/${formulaUri}/tools`),
+    {
+      method: 'GET',
+      headers: {
+        Authorization: buildFormulaAuthorizationHeader(config.apiKey),
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(
+      `Moonshot Formula tools request failed (${response.status}): ${body.trim() || response.statusText}`,
+    );
+  }
+
+  const payload = await response.json() as FormulaToolsListResponse;
+  const tools = Array.isArray(payload.tools) ? payload.tools : [];
+  return tools.filter(isFormulaToolDefinition);
+}
+
+export async function invokeFormulaFiber(
+  config: FormulaClientConfig,
+  formulaUri: FormulaUri,
+  functionName: string,
+  argumentsJson: string,
+  fetchImpl: typeof fetch = getLlmFetch(),
+): Promise<FormulaFiberInvokeResult> {
+  const response = await fetchImpl(
+    buildFormulaApiUrl(config.baseUrl, `/formulas/${formulaUri}/fibers`),
+    {
+      method: 'POST',
+      headers: {
+        Authorization: buildFormulaAuthorizationHeader(config.apiKey),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: functionName,
+        arguments: argumentsJson,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    return {
+      kind: 'failed',
+      error: `Moonshot Formula fiber request failed (${response.status}): ${body.trim() || response.statusText}`,
+    };
+  }
+
+  const fiber = await response.json() as FormulaFiberResponse;
+  const status = typeof fiber.status === 'string' ? fiber.status.trim().toLowerCase() : '';
+
+  if (status === 'succeeded') {
+    const content = readFiberSucceededContent(fiber);
+    if (content !== undefined) {
+      return { kind: 'succeeded', content };
+    }
+    return { kind: 'failed', error: 'Moonshot Formula fiber succeeded without output.' };
+  }
+
+  const error = readFiberError(fiber) ?? `Moonshot Formula fiber failed (status=${status || 'unknown'}).`;
+  return { kind: 'failed', error };
+}
+
+function isFormulaToolDefinition(value: unknown): value is FormulaToolDefinition {
+  if (!isJsonObject(value as JsonObject)) {
+    return false;
+  }
+
+  const record = value as JsonObject;
+  if (record.type !== 'function' || !isJsonObject(record.function as JsonObject)) {
+    return false;
+  }
+
+  const fn = record.function as JsonObject;
+  return typeof fn.name === 'string' && fn.name.trim().length > 0;
+}

--- a/packages/agent-core/src/moonshot/formula/formula-eligibility.test.ts
+++ b/packages/agent-core/src/moonshot/formula/formula-eligibility.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  isMoonshotFormulaWebSearchTool,
+  shouldUseMoonshotFormulaWebSearch,
+} from './formula-eligibility.js';
+import {
+  isRegisteredMoonshotFormulaFunctionName,
+  resolveMoonshotFormulaUri,
+} from './formula-registry.js';
+import {
+  buildMoonshotFormulaToolPreviewArgumentsJson,
+  moonshotFormulaSpiritUiSuppressesExpand,
+} from './formula-spirit-ui.js';
+
+test('shouldUseMoonshotFormulaWebSearch enables moonshot-ai chat completions only', () => {
+  assert.equal(
+    shouldUseMoonshotFormulaWebSearch({
+      apiKey: 'k',
+      model: 'kimi-k2.5',
+      llmVendor: 'moonshot-ai',
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseMoonshotFormulaWebSearch({
+      transportKind: 'openai-compatible',
+      apiKey: 'k',
+      model: 'kimi-k2.5',
+      llmVendor: 'moonshot-ai',
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseMoonshotFormulaWebSearch({
+      apiKey: 'k',
+      model: 'kimi-for-coding',
+      llmVendor: 'kimi-code',
+    }),
+    false,
+  );
+  assert.equal(
+    shouldUseMoonshotFormulaWebSearch({
+      transportKind: 'open-responses',
+      apiKey: 'k',
+      model: 'kimi-k2.5',
+      llmVendor: 'moonshot-ai',
+    }),
+    false,
+  );
+  assert.equal(
+    shouldUseMoonshotFormulaWebSearch({
+      transportKind: 'open-responses',
+      apiKey: 'k',
+      model: 'moonshotai/kimi-k2.5',
+      llmVendor: 'vercel-ai-gateway',
+    }),
+    false,
+  );
+});
+
+test('isMoonshotFormulaWebSearchTool matches web_search under eligible config', () => {
+  const config = {
+    apiKey: 'k',
+    model: 'kimi-k2.5',
+    llmVendor: 'moonshot-ai' as const,
+  };
+  assert.equal(isMoonshotFormulaWebSearchTool('web_search', config), true);
+  assert.equal(isMoonshotFormulaWebSearchTool('read_file', config), false);
+});
+
+test('resolveMoonshotFormulaUri maps web_search to web-search formula', () => {
+  assert.equal(
+    resolveMoonshotFormulaUri('web_search'),
+    'moonshot/web-search:latest',
+  );
+  assert.equal(isRegisteredMoonshotFormulaFunctionName('web_search'), true);
+  assert.equal(isRegisteredMoonshotFormulaFunctionName('read_file'), false);
+});
+
+test('buildMoonshotFormulaToolPreviewArgumentsJson sets suppressExpand', () => {
+  const argumentsJson = buildMoonshotFormulaToolPreviewArgumentsJson({
+    query: 'latest AI news',
+    status: 'completed',
+  });
+  assert.equal(moonshotFormulaSpiritUiSuppressesExpand(argumentsJson), true);
+  const parsed = JSON.parse(argumentsJson) as { _spiritUi: { inputExcerpt: string } };
+  assert.equal(parsed._spiritUi.inputExcerpt, 'latest AI news');
+});

--- a/packages/agent-core/src/moonshot/formula/formula-eligibility.ts
+++ b/packages/agent-core/src/moonshot/formula/formula-eligibility.ts
@@ -1,0 +1,29 @@
+import type { LlmTransportConfig } from '../../provider-config.js';
+import { transportKindForConfig } from '../../provider-config.js';
+import type { OpenAiTransportConfig } from '../../openai/openai-compat.js';
+
+export function shouldUseMoonshotFormulaWebSearch(config: LlmTransportConfig): boolean {
+  return isMoonshotAiDirectChatCompletionsConfig(config);
+}
+
+function isMoonshotAiDirectChatCompletionsConfig(
+  config: LlmTransportConfig,
+): config is OpenAiTransportConfig {
+  if (transportKindForConfig(config) !== 'openai-compatible') {
+    return false;
+  }
+
+  const openAiConfig = config as OpenAiTransportConfig;
+  if (openAiConfig.llmVendor === 'kimi-code' || openAiConfig.llmVendor === 'vercel-ai-gateway') {
+    return false;
+  }
+
+  return openAiConfig.llmVendor === 'moonshot-ai';
+}
+
+export function isMoonshotFormulaWebSearchTool(
+  toolName: string,
+  config: LlmTransportConfig,
+): boolean {
+  return toolName === 'web_search' && shouldUseMoonshotFormulaWebSearch(config);
+}

--- a/packages/agent-core/src/moonshot/formula/formula-registry.ts
+++ b/packages/agent-core/src/moonshot/formula/formula-registry.ts
@@ -1,0 +1,33 @@
+import type { FormulaUri } from './formula-types.js';
+
+export const MOONSHOT_FORMULA_WEB_SEARCH_URI = 'moonshot/web-search:latest' as const satisfies FormulaUri;
+
+export const MOONSHOT_FORMULA_WEB_SEARCH_FUNCTION_NAME = 'web_search' as const;
+
+export type MoonshotFormulaRegistration = {
+  formulaUri: FormulaUri;
+  functionName: string;
+};
+
+const MOONSHOT_FORMULA_REGISTRATIONS: readonly MoonshotFormulaRegistration[] = [
+  {
+    formulaUri: MOONSHOT_FORMULA_WEB_SEARCH_URI,
+    functionName: MOONSHOT_FORMULA_WEB_SEARCH_FUNCTION_NAME,
+  },
+];
+
+const functionNameToFormulaUri = new Map<string, FormulaUri>(
+  MOONSHOT_FORMULA_REGISTRATIONS.map((entry) => [entry.functionName, entry.formulaUri]),
+);
+
+export function listMoonshotFormulaRegistrations(): readonly MoonshotFormulaRegistration[] {
+  return MOONSHOT_FORMULA_REGISTRATIONS;
+}
+
+export function resolveMoonshotFormulaUri(functionName: string): FormulaUri | undefined {
+  return functionNameToFormulaUri.get(functionName);
+}
+
+export function isRegisteredMoonshotFormulaFunctionName(functionName: string): boolean {
+  return functionNameToFormulaUri.has(functionName);
+}

--- a/packages/agent-core/src/moonshot/formula/formula-spirit-ui.ts
+++ b/packages/agent-core/src/moonshot/formula/formula-spirit-ui.ts
@@ -1,0 +1,80 @@
+import type { JsonObject } from '../../ports.js';
+import { RESPONSES_BUILT_IN_SPIRIT_UI_KEY } from '../../open-responses/responses-built-in-tools.js';
+import { isJsonObject } from '../../tool-agent.js';
+
+export const MOONSHOT_FORMULA_SPIRIT_UI_SUPPRESS_EXPAND_KEY = 'suppressExpand';
+
+export type MoonshotFormulaSpiritUi = {
+  inputExcerpt: string;
+  headlineDetail?: string;
+  suppressExpand: true;
+};
+
+export function buildMoonshotFormulaWebSearchSpiritUi(query: string): MoonshotFormulaSpiritUi {
+  const trimmedQuery = query.trim();
+  return {
+    inputExcerpt: trimmedQuery.length > 0 ? trimmedQuery : 'Web search',
+    ...(trimmedQuery.length > 0 ? { headlineDetail: trimmedQuery } : {}),
+    suppressExpand: true,
+  };
+}
+
+export function buildMoonshotFormulaToolPreviewArgumentsJson(input: {
+  query?: string;
+  status?: string;
+  failed?: boolean;
+}): string {
+  const query = typeof input.query === 'string' ? input.query.trim() : '';
+  const spiritUi = buildMoonshotFormulaWebSearchSpiritUi(query);
+  const payload: JsonObject = {
+    status: input.failed ? 'failed' : (input.status ?? 'completed'),
+    [RESPONSES_BUILT_IN_SPIRIT_UI_KEY]: spiritUi as JsonObject,
+  };
+  return JSON.stringify(payload);
+}
+
+export type ParsedMoonshotFormulaSpiritUi = {
+  inputExcerpt: string;
+  headlineDetail?: string;
+  suppressExpand: boolean;
+};
+
+export function parseMoonshotFormulaSpiritUiFromArgumentsJson(
+  argumentsJson: string,
+): ParsedMoonshotFormulaSpiritUi | undefined {
+  try {
+    const parsed = JSON.parse(argumentsJson) as JsonObject;
+    if (!isJsonObject(parsed)) {
+      return undefined;
+    }
+
+    const raw = parsed[RESPONSES_BUILT_IN_SPIRIT_UI_KEY];
+    if (!isJsonObject(raw as JsonObject)) {
+      return undefined;
+    }
+
+    const ui = raw as JsonObject;
+    const inputExcerpt = typeof ui.inputExcerpt === 'string' ? ui.inputExcerpt : '';
+    if (!inputExcerpt.trim()) {
+      return undefined;
+    }
+
+    const headlineDetail =
+      typeof ui.headlineDetail === 'string' && ui.headlineDetail.trim()
+        ? ui.headlineDetail.trim()
+        : undefined;
+    const suppressExpand = ui[MOONSHOT_FORMULA_SPIRIT_UI_SUPPRESS_EXPAND_KEY] === true;
+
+    return {
+      inputExcerpt,
+      ...(headlineDetail ? { headlineDetail } : {}),
+      suppressExpand,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function moonshotFormulaSpiritUiSuppressesExpand(argumentsJson: string): boolean {
+  return parseMoonshotFormulaSpiritUiFromArgumentsJson(argumentsJson)?.suppressExpand === true;
+}

--- a/packages/agent-core/src/moonshot/formula/formula-types.ts
+++ b/packages/agent-core/src/moonshot/formula/formula-types.ts
@@ -1,0 +1,38 @@
+import type { JsonObject } from '../../ports.js';
+
+/** Moonshot Formula semantic URI, e.g. `moonshot/web-search:latest`. */
+export type FormulaUri = string;
+
+export type FormulaToolDefinition = {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: JsonObject;
+  };
+};
+
+export type FormulaToolsListResponse = {
+  object?: string;
+  tools?: FormulaToolDefinition[];
+};
+
+export type FormulaFiberContext = {
+  input?: string;
+  output?: string;
+  encrypted_output?: string;
+  error?: string;
+};
+
+export type FormulaFiberResponse = {
+  id?: string;
+  object?: string;
+  status?: string;
+  context?: FormulaFiberContext;
+  formula?: FormulaUri;
+  error?: string;
+};
+
+export type FormulaFiberInvokeResult =
+  | { kind: 'succeeded'; content: string }
+  | { kind: 'failed'; error: string };

--- a/packages/agent-core/src/moonshot/formula/index.ts
+++ b/packages/agent-core/src/moonshot/formula/index.ts
@@ -1,0 +1,33 @@
+export {
+  fetchFormulaTools,
+  invokeFormulaFiber,
+  type FormulaClientConfig,
+} from './formula-client.js';
+export {
+  isMoonshotFormulaWebSearchTool,
+  shouldUseMoonshotFormulaWebSearch,
+} from './formula-eligibility.js';
+export {
+  isRegisteredMoonshotFormulaFunctionName,
+  listMoonshotFormulaRegistrations,
+  MOONSHOT_FORMULA_WEB_SEARCH_FUNCTION_NAME,
+  MOONSHOT_FORMULA_WEB_SEARCH_URI,
+  resolveMoonshotFormulaUri,
+  type MoonshotFormulaRegistration,
+} from './formula-registry.js';
+export {
+  buildMoonshotFormulaToolPreviewArgumentsJson,
+  buildMoonshotFormulaWebSearchSpiritUi,
+  moonshotFormulaSpiritUiSuppressesExpand,
+  MOONSHOT_FORMULA_SPIRIT_UI_SUPPRESS_EXPAND_KEY,
+  parseMoonshotFormulaSpiritUiFromArgumentsJson,
+  type MoonshotFormulaSpiritUi,
+} from './formula-spirit-ui.js';
+export type {
+  FormulaFiberContext,
+  FormulaFiberInvokeResult,
+  FormulaFiberResponse,
+  FormulaToolDefinition,
+  FormulaToolsListResponse,
+  FormulaUri,
+} from './formula-types.js';

--- a/packages/agent-core/src/moonshot/formula/index.ts
+++ b/packages/agent-core/src/moonshot/formula/index.ts
@@ -31,3 +31,21 @@ export type {
   FormulaToolsListResponse,
   FormulaUri,
 } from './formula-types.js';
+export {
+  buildMoonshotFormulaTraceToolEntries,
+  clearMoonshotFormulaToolsCacheForTests,
+  createMoonshotFormulaChatCompletionsAwareFetch,
+  mergeMoonshotFormulaToolsIntoChatCompletionsTools,
+} from './moonshot-chat-completions-fetch.js';
+export {
+  buildMoonshotFormulaStreamingToolPreviewArgumentsJson,
+  executeMoonshotFormulaToolCall,
+  isMoonshotFormulaManagedToolCall,
+  readMoonshotFormulaWebSearchQuery,
+} from './moonshot-formula-tool-loop.js';
+export {
+  handleManagedProviderToolCallInTurn,
+  handleManagedProviderToolCallInTurnAsync,
+  shouldSkipEarlyExecutionForManagedProviderTool,
+  type ManagedProviderToolCallOutcome,
+} from './moonshot-formula-turn-handler.js';

--- a/packages/agent-core/src/moonshot/formula/moonshot-chat-completions-fetch.test.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-chat-completions-fetch.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { setLlmFetchTransportOverrideForTests } from '../../llm-fetch.js';
+import {
+  clearMoonshotFormulaToolsCacheForTests,
+  createMoonshotFormulaChatCompletionsAwareFetch,
+  mergeMoonshotFormulaToolsIntoChatCompletionsTools,
+} from './moonshot-chat-completions-fetch.js';
+
+const moonshotConfig = {
+  apiKey: 'test-key',
+  model: 'kimi-k2.5',
+  llmVendor: 'moonshot-ai' as const,
+  baseUrl: 'https://api.moonshot.ai/v1',
+};
+
+test('mergeMoonshotFormulaToolsIntoChatCompletionsTools appends unique function tools', () => {
+  const merged = mergeMoonshotFormulaToolsIntoChatCompletionsTools(
+    [
+      {
+        type: 'function',
+        function: { name: 'read_file', description: 'Read a file' },
+      },
+    ],
+    [
+      {
+        type: 'function',
+        function: { name: 'web_search', description: 'Search the web' },
+      },
+    ],
+  );
+
+  assert.equal(merged.length, 2);
+  assert.equal((merged[1] as { function: { name: string } }).function.name, 'web_search');
+});
+
+test('createMoonshotFormulaChatCompletionsAwareFetch injects formula tools into chat body', async () => {
+  clearMoonshotFormulaToolsCacheForTests();
+
+  const calls: Array<{ url: string; body?: string | undefined }> = [];
+  const fetchImpl = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const body = typeof init?.body === 'string' ? init.body : undefined;
+    calls.push(body === undefined ? { url } : { url, body });
+
+    if (url.includes('/formulas/')) {
+      return new Response(
+        JSON.stringify({
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'web_search',
+                description: 'Search the web for information',
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    return new Response('{}', { status: 200 });
+  };
+
+  setLlmFetchTransportOverrideForTests(fetchImpl);
+  try {
+    const patchedFetch = createMoonshotFormulaChatCompletionsAwareFetch(moonshotConfig, fetchImpl);
+    await patchedFetch('https://api.moonshot.ai/v1/chat/completions', {
+      method: 'POST',
+      body: JSON.stringify({
+        model: 'kimi-k2.5',
+        messages: [{ role: 'user', content: 'hi' }],
+        tools: [
+          {
+            type: 'function',
+            function: { name: 'read_file' },
+          },
+        ],
+      }),
+    });
+
+    const chatCall = calls.find((call) => call.url.includes('/chat/completions'));
+    assert.ok(chatCall?.body);
+    const body = JSON.parse(chatCall.body) as { tools: Array<{ function: { name: string } }> };
+    assert.equal(body.tools.length, 2);
+    assert.equal(body.tools[1]?.function.name, 'web_search');
+  } finally {
+    setLlmFetchTransportOverrideForTests(undefined);
+    clearMoonshotFormulaToolsCacheForTests();
+  }
+});

--- a/packages/agent-core/src/moonshot/formula/moonshot-chat-completions-fetch.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-chat-completions-fetch.ts
@@ -1,0 +1,164 @@
+import type { JsonObject, JsonValue } from '../../ports.js';
+import { isJsonObject } from '../../tool-agent.js';
+import type { OpenAiTransportConfig } from '../../openai/openai-compat.js';
+import { fetchFormulaTools } from './formula-client.js';
+import { shouldUseMoonshotFormulaWebSearch } from './formula-eligibility.js';
+import {
+  listMoonshotFormulaRegistrations,
+  type MoonshotFormulaRegistration,
+} from './formula-registry.js';
+import type { FormulaToolDefinition } from './formula-types.js';
+
+type FetchFn = typeof fetch;
+
+type FormulaToolsCacheEntry = {
+  expiresAt: number;
+  tools: FormulaToolDefinition[];
+};
+
+const FORMULA_TOOLS_CACHE_TTL_MS = 5 * 60 * 1000;
+const formulaToolsCache = new Map<string, FormulaToolsCacheEntry>();
+
+function buildFormulaToolsCacheKey(config: OpenAiTransportConfig): string {
+  return `${config.baseUrl ?? ''}\0${config.apiKey}`;
+}
+
+async function loadMoonshotFormulaToolsForConfig(
+  config: OpenAiTransportConfig,
+  fetchImpl: FetchFn,
+): Promise<FormulaToolDefinition[]> {
+  const cacheKey = buildFormulaToolsCacheKey(config);
+  const cached = formulaToolsCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.tools;
+  }
+
+  const registrations = listMoonshotFormulaRegistrations();
+  const mergedTools: FormulaToolDefinition[] = [];
+  const seenFunctionNames = new Set<string>();
+
+  for (const registration of registrations) {
+    const tools = await fetchFormulaTools(
+      {
+        apiKey: config.apiKey,
+        ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+      },
+      registration.formulaUri,
+      fetchImpl,
+    );
+    for (const tool of tools) {
+      const functionName = tool.function.name;
+      if (seenFunctionNames.has(functionName)) {
+        continue;
+      }
+      seenFunctionNames.add(functionName);
+      mergedTools.push(tool);
+    }
+  }
+
+  formulaToolsCache.set(cacheKey, {
+    expiresAt: Date.now() + FORMULA_TOOLS_CACHE_TTL_MS,
+    tools: mergedTools,
+  });
+  return mergedTools;
+}
+
+export function buildMoonshotFormulaTraceToolEntries(): JsonObject[] {
+  return listMoonshotFormulaRegistrations().map((registration: MoonshotFormulaRegistration) => ({
+    type: 'moonshot_formula',
+    formula_uri: registration.formulaUri,
+    function_name: registration.functionName,
+  }));
+}
+
+export function mergeMoonshotFormulaToolsIntoChatCompletionsTools(
+  existingTools: unknown[],
+  formulaTools: readonly FormulaToolDefinition[],
+): unknown[] {
+  const merged = [...existingTools];
+  const seenFunctionNames = new Set(
+    existingTools.flatMap((tool) => {
+      if (!isJsonObject(tool as JsonValue)) {
+        return [];
+      }
+      const record = tool as JsonObject;
+      if (record.type !== 'function' || !isJsonObject(record.function as JsonValue)) {
+        return [];
+      }
+      const name = (record.function as JsonObject).name;
+      return typeof name === 'string' ? [name] : [];
+    }),
+  );
+
+  for (const tool of formulaTools) {
+    if (seenFunctionNames.has(tool.function.name)) {
+      continue;
+    }
+    seenFunctionNames.add(tool.function.name);
+    merged.push(tool);
+  }
+
+  return merged;
+}
+
+export function createMoonshotFormulaChatCompletionsAwareFetch(
+  config: OpenAiTransportConfig,
+  baseFetch: FetchFn,
+): FetchFn {
+  if (!shouldUseMoonshotFormulaWebSearch(config)) {
+    return baseFetch;
+  }
+
+  return async (input, init) => {
+    const requestUrl =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : '';
+    if (!requestUrl.includes('/chat/completions')) {
+      return baseFetch(input, init);
+    }
+
+    const patchedInit = await patchMoonshotChatCompletionsRequestInit(config, init, baseFetch);
+    return baseFetch(input, patchedInit);
+  };
+}
+
+async function patchMoonshotChatCompletionsRequestInit(
+  config: OpenAiTransportConfig,
+  init: RequestInit | undefined,
+  fetchImpl: FetchFn,
+): Promise<RequestInit | undefined> {
+  if (!init?.body || typeof init.body !== 'string') {
+    return init;
+  }
+
+  try {
+    const body = JSON.parse(init.body) as JsonObject;
+    if (!isJsonObject(body as JsonValue)) {
+      return init;
+    }
+
+    const formulaTools = await loadMoonshotFormulaToolsForConfig(config, fetchImpl);
+    if (formulaTools.length === 0) {
+      return init;
+    }
+
+    const existingTools = Array.isArray(body.tools) ? body.tools : [];
+    return {
+      ...init,
+      body: JSON.stringify({
+        ...body,
+        tools: mergeMoonshotFormulaToolsIntoChatCompletionsTools(existingTools, formulaTools),
+      }),
+    };
+  } catch {
+    return init;
+  }
+}
+
+/** @internal Test helper */
+export function clearMoonshotFormulaToolsCacheForTests(): void {
+  formulaToolsCache.clear();
+}

--- a/packages/agent-core/src/moonshot/formula/moonshot-formula-tool-loop.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-formula-tool-loop.ts
@@ -1,0 +1,103 @@
+import type { JsonObject } from '../../ports.js';
+import { isJsonObject } from '../../tool-agent.js';
+import type { OpenAiTransportConfig } from '../../openai/openai-compat.js';
+import type { ToolCallRequest } from '../../ports.js';
+import { invokeFormulaFiber } from './formula-client.js';
+import {
+  isMoonshotFormulaWebSearchTool,
+  shouldUseMoonshotFormulaWebSearch,
+} from './formula-eligibility.js';
+import { resolveMoonshotFormulaUri } from './formula-registry.js';
+import { buildMoonshotFormulaToolPreviewArgumentsJson } from './formula-spirit-ui.js';
+
+export function isMoonshotFormulaManagedToolCall(
+  toolName: string,
+  config: unknown,
+): boolean {
+  if (!shouldUseMoonshotFormulaWebSearch(config as OpenAiTransportConfig)) {
+    return false;
+  }
+
+  return resolveMoonshotFormulaUri(toolName) !== undefined;
+}
+
+export function readMoonshotFormulaWebSearchQuery(argumentsJson: string): string {
+  try {
+    const parsed = JSON.parse(argumentsJson) as JsonObject;
+    if (!isJsonObject(parsed)) {
+      return '';
+    }
+    const query = parsed.query;
+    return typeof query === 'string' ? query.trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+export type MoonshotFormulaToolExecutionResult =
+  | { kind: 'succeeded'; content: string; previewArgumentsJson: string }
+  | { kind: 'failed'; error: string; previewArgumentsJson: string };
+
+export async function executeMoonshotFormulaToolCall(
+  config: OpenAiTransportConfig,
+  call: Pick<ToolCallRequest, 'name' | 'argumentsJson'>,
+): Promise<MoonshotFormulaToolExecutionResult> {
+  const formulaUri = resolveMoonshotFormulaUri(call.name);
+  if (!formulaUri) {
+    return {
+      kind: 'failed',
+      error: `Unknown Moonshot Formula tool: ${call.name}`,
+      previewArgumentsJson: buildMoonshotFormulaToolPreviewArgumentsJson({ failed: true }),
+    };
+  }
+
+  const query = isMoonshotFormulaWebSearchTool(call.name, config)
+    ? readMoonshotFormulaWebSearchQuery(call.argumentsJson)
+    : '';
+
+  const fiberResult = await invokeFormulaFiber(
+    {
+      apiKey: config.apiKey,
+      ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    },
+    formulaUri,
+    call.name,
+    call.argumentsJson,
+  );
+
+  if (fiberResult.kind === 'failed') {
+    return {
+      kind: 'failed',
+      error: fiberResult.error,
+      previewArgumentsJson: buildMoonshotFormulaToolPreviewArgumentsJson({
+        query,
+        failed: true,
+        status: 'failed',
+      }),
+    };
+  }
+
+  return {
+    kind: 'succeeded',
+    content: fiberResult.content,
+    previewArgumentsJson: buildMoonshotFormulaToolPreviewArgumentsJson({
+      query,
+      status: 'completed',
+    }),
+  };
+}
+
+export function buildMoonshotFormulaStreamingToolPreviewArgumentsJson(
+  config: OpenAiTransportConfig,
+  toolName: string,
+  argumentsJson: string,
+): string | undefined {
+  if (!isMoonshotFormulaWebSearchTool(toolName, config)) {
+    return undefined;
+  }
+
+  return buildMoonshotFormulaToolPreviewArgumentsJson({
+    query: readMoonshotFormulaWebSearchQuery(argumentsJson),
+    status: 'in_progress',
+  });
+}

--- a/packages/agent-core/src/moonshot/formula/moonshot-formula-tool-result-sync.test.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-formula-tool-result-sync.test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLlmMessageContentFromText, llmMessageTextContent, type LlmMessage } from '../../ports.js';
+import { TOOL_OUTPUT_TRUNCATION_LABEL } from '../../tool-agent.js';
+import { prepareAndSyncRuntimeToolResultToHistory } from '../../runtime/tool-output-append.js';
+
+test('prepareAndSyncRuntimeToolResultToHistory truncates oversized Formula tool output', async () => {
+  const encryptedOutput = `----MOONSHOT ENCRYPTED BEGIN----+nf6${'x'.repeat(20_000)}----MOONSHOT ENCRYPTED END----`;
+  const historyStore: LlmMessage[] = [
+    {
+      role: 'assistant',
+      content: [],
+      toolCalls: [{
+        id: 'web_search_0',
+        name: 'web_search',
+        argumentsJson: '{"query":"latest news"}',
+      }],
+    },
+  ];
+
+  const prepared = await prepareAndSyncRuntimeToolResultToHistory(
+    {
+      options: {
+        persistToolOutputArchive: async () => '/tmp/archive/web_search_0.txt',
+      } as never,
+      historyStore,
+    },
+    'web_search_0',
+    encryptedOutput,
+  );
+
+  assert.ok(prepared.length < encryptedOutput.length);
+  assert.match(prepared, new RegExp(TOOL_OUTPUT_TRUNCATION_LABEL.replace(/[[\]]/g, '\\$&')));
+
+  const toolMessage = historyStore.find(
+    (message) => message.role === 'tool' && message.toolCallId === 'web_search_0',
+  );
+  assert.ok(toolMessage);
+  assert.equal(llmMessageTextContent(toolMessage.content), prepared);
+});

--- a/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
@@ -110,14 +110,17 @@ async function executeAndCommitMoonshotFormulaToolCall<
     failed: false,
   });
 
-  await prepareAndSyncRuntimeToolResultToHistory(runtime, call.id, execution.content);
-
-  const resumedState = runtime.options.appendToolResultMessage(
-    state,
+  const preparedContent = await prepareAndSyncRuntimeToolResultToHistory(
+    runtime,
     call.id,
     execution.content,
   );
-  return { state: resumedState, failed: false, modelContent: execution.content };
+  const resumedState = runtime.options.appendToolResultMessage(
+    state,
+    call.id,
+    preparedContent,
+  );
+  return { state: resumedState, failed: false, modelContent: preparedContent };
 }
 
 export async function handleManagedProviderToolCallInTurn<

--- a/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
@@ -10,6 +10,7 @@ import {
   startToolAgentRoundAsync,
   type TurnMachineRuntime,
 } from '../../runtime/turn-machine.js';
+import { prepareAndSyncRuntimeToolResultToHistory } from '../../runtime/tool-output-append.js';
 import type {
   RuntimeTurnContext,
   RuntimeTurnResult,
@@ -108,6 +109,8 @@ async function executeAndCommitMoonshotFormulaToolCall<
     },
     failed: false,
   });
+
+  await prepareAndSyncRuntimeToolResultToHistory(runtime, call.id, execution.content);
 
   const resumedState = runtime.options.appendToolResultMessage(
     state,

--- a/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
@@ -1,0 +1,222 @@
+import type { OpenAiTransportConfig } from '../../openai/openai-compat.js';
+import type { ToolCallRequest } from '../../ports.js';
+import { createLlmMessageContentFromText } from '../../ports.js';
+import {
+  commitSyntheticToolExecutionFailure,
+  commitToolExecutionOutput,
+  processToolCalls,
+  processToolCallsAsync,
+  runTurnLoop,
+  startToolAgentRoundAsync,
+  type TurnMachineRuntime,
+} from '../../runtime/turn-machine.js';
+import type {
+  RuntimeTurnContext,
+  RuntimeTurnResult,
+} from '../../runtime/types.js';
+import { executeMoonshotFormulaToolCall, isMoonshotFormulaManagedToolCall } from './moonshot-formula-tool-loop.js';
+import { buildMoonshotFormulaToolPreviewArgumentsJson } from './formula-spirit-ui.js';
+import { readMoonshotFormulaWebSearchQuery } from './moonshot-formula-tool-loop.js';
+
+function readPreviewQuery(argumentsJson: string): string {
+  return readMoonshotFormulaWebSearchQuery(argumentsJson);
+}
+
+export type ManagedProviderToolCallOutcome<
+  State,
+  ToolRequest,
+  TrustTarget,
+> =
+  | { kind: 'not-handled' }
+  | { kind: 'advance'; state: State }
+  | { kind: 'turn-result'; result: RuntimeTurnResult<State, ToolRequest, TrustTarget> };
+
+function providerFormulaToolRequestStub<ToolRequest>(
+  call: ToolCallRequest,
+): ToolRequest {
+  return {
+    kind: 'moonshot-formula-tool',
+    toolName: call.name,
+    argumentsJson: call.argumentsJson,
+  } as ToolRequest;
+}
+
+function moonshotFormulaToolSummaryText(toolName: string, failed: boolean): string {
+  if (failed) {
+    return `[moonshot formula ${toolName}] failed`;
+  }
+  return `[moonshot formula ${toolName}] completed`;
+}
+
+async function executeAndCommitMoonshotFormulaToolCall<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget,
+>(
+  runtime: TurnMachineRuntime<Config, State, ToolRequest, TrustTarget>,
+  state: State,
+  call: ToolCallRequest,
+  turn: RuntimeTurnContext<ToolRequest>,
+): Promise<{ state: State; failed: boolean; modelContent: string }> {
+  const config = runtime.options.config as OpenAiTransportConfig;
+  const request = providerFormulaToolRequestStub<ToolRequest>(call);
+
+  runtime.emitEvent({
+    kind: 'streaming-tool-preview',
+    toolCallId: call.id,
+    toolName: call.name,
+    argumentsJson: buildMoonshotFormulaToolPreviewArgumentsJson({
+      query: readPreviewQuery(call.argumentsJson),
+      status: 'in_progress',
+    }),
+  });
+
+  const execution = await executeMoonshotFormulaToolCall(config, call);
+  runtime.emitEvent({
+    kind: 'streaming-tool-preview',
+    toolCallId: call.id,
+    toolName: call.name,
+    argumentsJson: execution.previewArgumentsJson,
+  });
+
+  if (execution.kind === 'failed') {
+    commitSyntheticToolExecutionFailure(
+      runtime,
+      turn,
+      request,
+      call.id,
+      call.name,
+      execution.error,
+    );
+    const resumedState = runtime.options.appendToolResultMessage(
+      state,
+      call.id,
+      execution.error,
+    );
+    return { state: resumedState, failed: true, modelContent: execution.error };
+  }
+
+  const summaryText = moonshotFormulaToolSummaryText(call.name, false);
+  const content = createLlmMessageContentFromText(summaryText);
+  commitToolExecutionOutput(runtime, turn, {
+    toolCallId: call.id,
+    toolName: call.name,
+    request,
+    output: {
+      content,
+      summaryText,
+    },
+    failed: false,
+  });
+
+  const resumedState = runtime.options.appendToolResultMessage(
+    state,
+    call.id,
+    execution.content,
+  );
+  return { state: resumedState, failed: false, modelContent: execution.content };
+}
+
+export async function handleManagedProviderToolCallInTurn<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget,
+>(
+  runtime: TurnMachineRuntime<Config, State, ToolRequest, TrustTarget>,
+  pendingUserInput: string,
+  state: State,
+  call: ToolCallRequest,
+  remainingCalls: ToolCallRequest[],
+  turn: RuntimeTurnContext<ToolRequest>,
+): Promise<ManagedProviderToolCallOutcome<State, ToolRequest, TrustTarget>> {
+  if (!isMoonshotFormulaManagedToolCall(call.name, runtime.options.config)) {
+    return { kind: 'not-handled' };
+  }
+
+  const { state: resumedState } = await executeAndCommitMoonshotFormulaToolCall(
+    runtime,
+    state,
+    call,
+    turn,
+  );
+
+  if (remainingCalls.length > 0) {
+    return {
+      kind: 'turn-result',
+      result: await processToolCalls(
+        runtime,
+        resumedState,
+        pendingUserInput,
+        remainingCalls,
+        turn,
+      ),
+    };
+  }
+
+  return {
+    kind: 'turn-result',
+    result: await runTurnLoop(runtime, resumedState, pendingUserInput, turn),
+  };
+}
+
+export async function handleManagedProviderToolCallInTurnAsync<
+  Config,
+  State,
+  ToolRequest,
+  TrustTarget,
+>(
+  runtime: TurnMachineRuntime<Config, State, ToolRequest, TrustTarget>,
+  pendingUserInput: string,
+  state: State,
+  call: ToolCallRequest,
+  remainingCalls: ToolCallRequest[],
+  turn: RuntimeTurnContext<ToolRequest>,
+  resumeAsStreaming = false,
+  streamingEmitBeginResponse = true,
+): Promise<boolean> {
+  if (!isMoonshotFormulaManagedToolCall(call.name, runtime.options.config)) {
+    return false;
+  }
+
+  const { state: resumedState } = await executeAndCommitMoonshotFormulaToolCall(
+    runtime,
+    state,
+    call,
+    turn,
+  );
+
+  if (remainingCalls.length > 0) {
+    await processToolCallsAsync(
+      runtime,
+      resumedState,
+      pendingUserInput,
+      remainingCalls,
+      turn,
+      resumeAsStreaming,
+      streamingEmitBeginResponse,
+    );
+    return true;
+  }
+
+  if (resumeAsStreaming) {
+    await runtime.startStreamingRound(
+      resumedState,
+      pendingUserInput,
+      turn,
+      streamingEmitBeginResponse,
+    );
+    return true;
+  }
+
+  startToolAgentRoundAsync(runtime, resumedState, pendingUserInput, turn);
+  return true;
+}
+
+export function shouldSkipEarlyExecutionForManagedProviderTool(
+  toolName: string,
+  config: unknown,
+): boolean {
+  return isMoonshotFormulaManagedToolCall(toolName, config);
+}

--- a/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
@@ -35,8 +35,7 @@ function providerFormulaToolRequestStub<ToolRequest>(
   call: ToolCallRequest,
 ): ToolRequest {
   return {
-    kind: 'moonshot-formula-tool',
-    toolName: call.name,
+    name: call.name,
     argumentsJson: call.argumentsJson,
   } as ToolRequest;
 }

--- a/packages/agent-core/src/moonshot/index.ts
+++ b/packages/agent-core/src/moonshot/index.ts
@@ -1,0 +1,1 @@
+export * from './formula/index.js';

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -153,6 +153,12 @@ import { resolveXiaomiVideoUrlsInOpenAiMessages } from './xiaomi-video-messages.
 import { resolveMinimaxVideoUrlsInOpenAiMessages } from './minimax-video-messages.js';
 import { normalizeMoonshotApiBase } from './moonshot-files.js';
 import {
+  buildMoonshotFormulaTraceToolEntries,
+  createMoonshotFormulaChatCompletionsAwareFetch,
+} from '../moonshot/formula/moonshot-chat-completions-fetch.js';
+import { shouldUseMoonshotFormulaWebSearch } from '../moonshot/formula/formula-eligibility.js';
+import { buildMoonshotFormulaStreamingToolPreviewArgumentsJson } from '../moonshot/formula/moonshot-formula-tool-loop.js';
+import {
   buildJsonSchemaCompletionMessages,
   stringifyJsonSchemaCompletionOutput,
   type OpenAiJsonSchemaCompletionRequest,
@@ -500,6 +506,7 @@ export class AiSdkOpenAiCompatibleTransport
           requestTrace,
           completion,
           usesStructuredReasoningStreamEvents(config),
+          config,
         ),
         completion: completionPromise,
         cancel: () => {
@@ -692,12 +699,24 @@ function buildAiSdkRequestTrace(
     && shouldUseAlibabaChatCompletionsBuiltInTools(config)
     ? buildAlibabaChatCompletionsExtraBody({ streaming: stream })
     : undefined;
+  const moonshotFormulaTraceTools = isMoonshotOfficialAiSdkProvider(config)
+    && shouldUseMoonshotFormulaWebSearch(config)
+    ? buildMoonshotFormulaTraceToolEntries()
+    : undefined;
 
   return [
     {
       ...firstTrace,
       kind,
       ...(alibabaExtraBody ? { extra_body: alibabaExtraBody } : {}),
+      ...(moonshotFormulaTraceTools && isJsonObject(firstTrace)
+        ? {
+            tools: [
+              ...((Array.isArray(firstTrace.tools) ? firstTrace.tools : []) as JsonValue[]),
+              ...moonshotFormulaTraceTools.map((tool) => tool as JsonValue),
+            ],
+          }
+        : {}),
     },
     ...requestTrace.slice(1),
   ];
@@ -803,10 +822,11 @@ function createAiSdkOpenAiCompatibleProvider(
 
 function createAiSdkMoonshotProvider(config: OpenAiTransportConfig) {
   const reasoningEffort = openAiReasoningEffort(config);
+  const formulaAwareFetch = createMoonshotFormulaChatCompletionsAwareFetch(config, getLlmFetch());
   const fetchWrapper = async (input: RequestInfo | URL, init?: RequestInit) => {
     const body = tryParseRequestBody(init?.body);
     if (!isJsonObject(body)) {
-      return getLlmFetch()(input, init);
+      return formulaAwareFetch(input, init);
     }
 
     const requestUrl =
@@ -818,7 +838,7 @@ function createAiSdkMoonshotProvider(config: OpenAiTransportConfig) {
     const moonshotMessages = requestUrl.includes('/chat/completions')
       ? takeMoonshotChatCompletionMessages()
       : undefined;
-    return getLlmFetch()(input, {
+    return formulaAwareFetch(input, {
       ...init,
       body: JSON.stringify({
         ...body,
@@ -1443,6 +1463,7 @@ async function* aiSdkEventStreamToRuntimeEvents(
   requestTrace: JsonValue[],
   completion: Deferred<ToolAgentRoundCompletion<ToolAgentState>>,
   useStructuredReasoningEvents: boolean,
+  config: OpenAiTransportConfig,
 ): AsyncGenerator<LlmStreamEvent, void, undefined> {
   const toolCalls = new Map<number, AggregatedStreamingToolCall>();
   let assistantContent = '';
@@ -1487,6 +1508,7 @@ async function* aiSdkEventStreamToRuntimeEvents(
           const rawToolUpdates = accumulateStreamingToolCallProgressFromRawChunk(
             toolCalls,
             part.rawValue,
+            config,
           );
           if (rawToolUpdates.length > 0) {
             sawAnswerOrToolOutput = true;
@@ -1555,9 +1577,19 @@ function extractFallbackStreamingThinkingTextFromRawChunk(rawValue: unknown): st
   return chunks || undefined;
 }
 
+function resolveStreamingToolPreviewArgumentsJson(
+  config: OpenAiTransportConfig,
+  toolName: string,
+  argumentsJson: string,
+): string {
+  return buildMoonshotFormulaStreamingToolPreviewArgumentsJson(config, toolName, argumentsJson)
+    ?? argumentsJson;
+}
+
 function accumulateStreamingToolCallProgressFromRawChunk(
   toolCalls: Map<number, AggregatedStreamingToolCall>,
   rawValue: unknown,
+  config: OpenAiTransportConfig,
 ): LlmStreamEvent[] {
   if (!isJsonObjectUnknown(rawValue) || !Array.isArray(rawValue.choices)) {
     return [];
@@ -1606,7 +1638,11 @@ function accumulateStreamingToolCallProgressFromRawChunk(
           kind: 'streaming-tool-preview',
           toolCallId: current.id,
           toolName: current.functionName,
-          argumentsJson: current.functionArguments,
+          argumentsJson: resolveStreamingToolPreviewArgumentsJson(
+            config,
+            current.functionName,
+            current.functionArguments,
+          ),
         });
       }
 
@@ -1642,7 +1678,11 @@ function accumulateStreamingToolCallProgressFromRawChunk(
             kind: 'streaming-tool-preview',
             toolCallId: current.id,
             toolName: current.functionName,
-            argumentsJson: current.functionArguments,
+            argumentsJson: resolveStreamingToolPreviewArgumentsJson(
+              config,
+              current.functionName,
+              current.functionArguments,
+            ),
           });
           current.readyPreviewEmitted = decision.nextState.readyPreviewEmitted;
           if (decision.nextState.lastPreviewArgsLen !== undefined) {

--- a/packages/agent-core/src/runtime/streaming.ts
+++ b/packages/agent-core/src/runtime/streaming.ts
@@ -31,6 +31,7 @@ import type { ToolExecutionResult } from './tool-execution.js';
 import type { EarlyInternalToolCallResult, TurnMachineRuntime } from './turn-machine.js';
 import { prepareStateForContextRetryAsync } from './compaction.js';
 import { isResponsesBuiltInToolName } from '../open-responses/responses-built-in-tools.js';
+import { shouldSkipEarlyExecutionForManagedProviderTool } from '../moonshot/formula/moonshot-formula-turn-handler.js';
 import { startEarlyToolExecution } from './turn-machine.js';
 
 export interface StreamingRuntime<
@@ -474,6 +475,7 @@ export async function handlePendingStreamEvent<
       event.toolName === 'read_file' || event.toolName === 'list_directory_files';
     if (
       !isResponsesBuiltInToolName(event.toolName)
+      && !shouldSkipEarlyExecutionForManagedProviderTool(event.toolName, runtime.options.config)
       && (allowEarlyExecutionDuringStream || pending.streamConsumerFinished)
     ) {
       startEarlyToolExecution(

--- a/packages/agent-core/src/runtime/turn-machine.ts
+++ b/packages/agent-core/src/runtime/turn-machine.ts
@@ -18,6 +18,10 @@ import {
 import { emitContextUsageUpdated } from './context-usage.js';
 import { isOpenResponsesTransportConfig } from '../provider-config.js';
 import {
+  handleManagedProviderToolCallInTurn,
+  handleManagedProviderToolCallInTurnAsync,
+} from '../moonshot/formula/moonshot-formula-turn-handler.js';
+import {
   buildApplyPatchToolResultProviderState,
   registerPendingApplyPatchCallIds,
 } from '../open-responses/apply-patch-bridge.js';
@@ -594,6 +598,22 @@ export async function processToolCalls<
       break;
     }
 
+    const managedOutcome = await handleManagedProviderToolCallInTurn(
+      runtime,
+      pendingUserInput,
+      currentState,
+      call,
+      remaining,
+      turn,
+    );
+    if (managedOutcome.kind === 'turn-result') {
+      return managedOutcome.result;
+    }
+    if (managedOutcome.kind === 'advance') {
+      currentState = managedOutcome.state;
+      continue;
+    }
+
     let request: ToolRequest;
     let preGate: PreToolUseGateResult<ToolRequest>;
     try {
@@ -1119,6 +1139,20 @@ export async function processToolCallsAsync<
     const call = remaining.shift();
     if (!call) {
       break;
+    }
+
+    const managedHandled = await handleManagedProviderToolCallInTurnAsync(
+      runtime,
+      pendingUserInput,
+      currentState,
+      call,
+      remaining,
+      turn,
+      resumeAsStreaming,
+      streamingEmitBeginResponse,
+    );
+    if (managedHandled) {
+      return;
     }
 
     const earlyOutcome = await matchingEarlyToolExecutionOutcome(call, earlyToolExecutions);


### PR DESCRIPTION
## Summary

- 新增 `moonshot/formula` 子模块：eligibility、Formula client/registry、Chat Completions fetch 注入 `moonshot/web-search:latest`
- runtime 执行 Formula fibers 循环，成功路径将加密 tool 结果经 `prepareAndSyncRuntimeToolResultToHistory` 写入 `historyStore`，避免下轮用户消息触发 `repairMissingToolResultsInHistory` 占位符
- Desktop/CLI 工具卡对 Moonshot Formula `web_search` 设置 `suppressExpand`，禁止展开加密结果

## Test plan

- [x] `packages/agent-core` 单测（formula-client、eligibility、chat-completions-fetch）
- [x] Desktop `tool-call-display` 单测
- [x] CLI `ui/tests` 覆盖 suppressExpand 展示
- [x] 手动冒烟：Moonshot 直连触发 web_search 后追问，导出 LLM 上下文确认 tool 结果未变为 placeholder
- [x] eval:compare 未跑（主要为 transport/runtime 与 UI 展示，无 system/tool 大段文案变更）