### PR TITLE
feat(desktop,host-internal): 工作区侧栏图片预览与 ico 支持

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1312,6 +1312,8 @@ function imagePreviewMimeType(extension: string): string | undefined {
       return 'image/png';
     case '.webp':
       return 'image/webp';
+    case '.ico':
+      return 'image/x-icon';
     default:
       return undefined;
   }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -20,6 +20,8 @@ import {
   type WebContents,
 } from 'electron';
 
+import { detectSupportedImageFile } from '@spirit-agent/host-internal/image-file-support';
+
 import {
   registerDesktopNotifications,
   registerWindowsToastActivationHandler,
@@ -1373,12 +1375,6 @@ function managedGeneratedVideoRefFromPath(filePath: string): string | null {
 }
 
 async function readImagePreviewDataUrlFromPath(filePath: string): Promise<string | null> {
-  const extension = path.extname(filePath).toLowerCase();
-  const mimeType = imagePreviewMimeType(extension);
-  if (!mimeType) {
-    return null;
-  }
-
   try {
     const metadata = await stat(filePath);
     if (!metadata.isFile() || metadata.size > LOCAL_IMAGE_PREVIEW_MAX_BYTES) {
@@ -1386,7 +1382,11 @@ async function readImagePreviewDataUrlFromPath(filePath: string): Promise<string
     }
 
     const bytes = await readFile(filePath);
-    return `data:${mimeType};base64,${bytes.toString('base64')}`;
+    const detected = detectSupportedImageFile(filePath, bytes);
+    if (!detected) {
+      return null;
+    }
+    return `data:${detected.mimeType};base64,${bytes.toString('base64')}`;
   } catch {
     return null;
   }

--- a/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
+++ b/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
@@ -23,6 +23,7 @@ const RENDERER_SAFE_HOST_INTERNAL_SUBPATHS = new Set([
   'github-pull-request-url',
   'github-pull-request-checks-pages',
   'github-pull-request-conversation-pages',
+  'image-file-support',
 ]);
 
 const RENDERER_SCAN_ROOTS = ['components', 'hooks', 'lib', 'App.tsx'];

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -416,6 +416,7 @@ export function ConversationView({
           readHostTextFile={list.runtime.readHostTextFile}
           writeHostTextFile={list.runtime.writeHostTextFile}
           readManagedImagePreviewDataUrl={list.runtime.readManagedImagePreviewDataUrl}
+          readLocalImagePreviewDataUrl={list.runtime.readLocalImagePreviewDataUrl}
           plan={snapshot?.plan ?? { path: "", exists: false }}
           onStartImplementing={() => {
             composerDock.onComposerAgentModeChange("agent");

--- a/apps/desktop/src/components/workspace-files-tab.tsx
+++ b/apps/desktop/src/components/workspace-files-tab.tsx
@@ -10,6 +10,10 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
+import {
+  WorkspaceImagePreviewPane,
+  type WorkspaceImagePreviewState,
+} from "@/components/workspace-image-preview-pane";
 import { WorkspaceFilesPanel } from "@/components/workspace-files-panel";
 import { WorkspaceFilesSearchPanel } from "@/components/workspace-files-search-panel";
 import {
@@ -33,8 +37,10 @@ import {
 import { useWorkspaceToolsShellHorizontalDivider } from "@/lib/use-workspace-tools-shell-horizontal-divider";
 import { useHostApi } from "@/hooks/useHostApi";
 import { FILES_EXPLORER_TOOLBAR_SHELL_DIVIDER_ATTR } from "@/lib/workspace-tools-panel-edge";
+import type { ReadLocalImagePreview } from "@/components/tool-call/tool-call-types";
 import {
   isUnderWorkspaceEntryPath,
+  joinWorkspaceAbsolutePath,
   remapWorkspaceEntryPath,
   normalizeWorkspaceEntryRel,
 } from "@/lib/workspace-entry-path-sync";
@@ -67,6 +73,14 @@ type LoadedDoc =
   | { status: "loading"; readOnly: boolean; title: string; subtitle: string }
   | { status: "ready"; text: string; readOnly: boolean; title: string; subtitle: string }
   | { status: "binary"; readOnly: boolean; title: string; subtitle: string }
+  | {
+      status: "image";
+      readOnly: boolean;
+      title: string;
+      subtitle: string;
+      absolutePath: string;
+      mimeType: string;
+    }
   | { status: "error"; message: string; readOnly: boolean; title: string; subtitle: string }
   | { status: "empty"; message: string; readOnly: boolean; title: string; subtitle: string };
 
@@ -265,6 +279,7 @@ export type WorkspaceFilesTabProps = {
   readHostTextFile: (absolutePath: string) => Promise<WorkspaceReadTextFileResult>;
   writeHostTextFile: (request: WriteHostTextFileRequest) => Promise<void>;
   readManagedImagePreviewDataUrl?: (reference: string) => Promise<string | null>;
+  readLocalImagePreviewDataUrl?: ReadLocalImagePreview;
   onStartImplementing?: () => void;
   startImplementingDisabled?: boolean;
   autoRevealPlanNonce?: number;
@@ -315,6 +330,7 @@ export function WorkspaceFilesTab({
   readHostTextFile,
   writeHostTextFile,
   readManagedImagePreviewDataUrl,
+  readLocalImagePreviewDataUrl,
   onStartImplementing,
   startImplementingDisabled = false,
   autoRevealPlanNonce = 0,
@@ -345,6 +361,8 @@ export function WorkspaceFilesTab({
   type MonacoEditor = Monaco.editor.IStandaloneCodeEditor;
   const [selectedEntry, setSelectedEntry] = useState<SelectedEntry>(null);
   const [doc, setDoc] = useState<LoadedDoc | null>(null);
+  const [imagePreviewDataUrl, setImagePreviewDataUrl] = useState<string | null>(null);
+  const [imagePreviewState, setImagePreviewState] = useState<WorkspaceImagePreviewState>("loading");
   const [saveError, setSaveError] = useState("");
   const [draftText, setDraftText] = useState("");
   const [savedText, setSavedText] = useState("");
@@ -629,6 +647,23 @@ export function WorkspaceFilesTab({
     void readFile(filePath)
       .then((r) => {
         if (!cancelled) {
+          if (r.image) {
+            const absolutePath =
+              selectedEntry.kind === "external"
+                ? selectedEntry.absolutePath
+                : joinWorkspaceAbsolutePath(workspaceRoot, selectedEntry.relativePath);
+            setDraftText("");
+            setSavedText("");
+            setDoc({
+              status: "image",
+              readOnly: true,
+              title: pathBasename(filePath),
+              subtitle: filePath,
+              absolutePath,
+              mimeType: r.image.mimeType,
+            });
+            return;
+          }
           if (r.binary) {
             setDraftText("");
             setSavedText("");
@@ -675,7 +710,42 @@ export function WorkspaceFilesTab({
     readWorkspaceTextFile,
     selectedEntry,
     selectedPath,
+    workspaceRoot,
   ]);
+
+  useEffect(() => {
+    if (doc?.status !== "image") {
+      setImagePreviewDataUrl(null);
+      setImagePreviewState("loading");
+      return;
+    }
+    if (!readLocalImagePreviewDataUrl) {
+      setImagePreviewDataUrl(null);
+      setImagePreviewState("unavailable");
+      return;
+    }
+
+    let cancelled = false;
+    setImagePreviewDataUrl(null);
+    setImagePreviewState("loading");
+    void readLocalImagePreviewDataUrl(doc.absolutePath)
+      .then((dataUrl) => {
+        if (cancelled) {
+          return;
+        }
+        setImagePreviewDataUrl(dataUrl);
+        setImagePreviewState(dataUrl ? "ready" : "unavailable");
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setImagePreviewDataUrl(null);
+          setImagePreviewState("unavailable");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [doc, readLocalImagePreviewDataUrl]);
 
   const persistEditorText = useCallback(
     async (text: string) => {
@@ -1034,6 +1104,13 @@ export function WorkspaceFilesTab({
               <div className="flex h-full items-center justify-center p-4 text-center text-xs leading-relaxed text-muted-foreground">
                 {t("workspace.binaryFileNotSupported")}
               </div>
+            ) : doc?.status === "image" ? (
+              <WorkspaceImagePreviewPane
+                className={desktopMicaFileDetailSurfaceClass(useMicaBackdrop)}
+                previewState={imagePreviewState}
+                previewDataUrl={imagePreviewDataUrl}
+                fileLabel={doc.title}
+              />
             ) : doc?.status === "ready" ? (
               isPreviewVisible ? (
                 <>

--- a/apps/desktop/src/components/workspace-image-preview-pane.tsx
+++ b/apps/desktop/src/components/workspace-image-preview-pane.tsx
@@ -1,0 +1,227 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import { Spinner } from "@/components/ui/spinner";
+import { isModShortcutPressed } from "@/lib/desktop-shell";
+import { resolveUiLayoutZoomShortcutAction } from "@/lib/ui-layout-scale";
+import { cn } from "@/lib/utils";
+
+const DRAG_CLICK_THRESHOLD_PX = 4;
+const MIN_ZOOM = 0.25;
+const MAX_ZOOM = 4;
+const ZOOM_STEP = 0.1;
+/** 单击在当前预览区内相对放大 20%。 */
+const CLICK_ZOOM_FACTOR = 1.2;
+
+export type WorkspaceImagePreviewState = "loading" | "ready" | "unavailable";
+
+export function WorkspaceImagePreviewPane({
+  previewState,
+  previewDataUrl,
+  fileLabel,
+  className,
+}: {
+  previewState: WorkspaceImagePreviewState;
+  previewDataUrl: string | null;
+  fileLabel: string;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const panStartRef = useRef({ x: 0, y: 0 });
+  const movedDuringDragRef = useRef(false);
+
+  const canInteract = previewState === "ready" && Boolean(previewDataUrl);
+
+  const adjustZoom = useCallback((delta: number) => {
+    setZoom((current) => Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, current + delta)));
+  }, []);
+
+  const zoomInByClick = useCallback(() => {
+    setZoom((current) => Math.min(MAX_ZOOM, current * CLICK_ZOOM_FACTOR));
+  }, []);
+
+  const resetView = useCallback(() => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  }, []);
+
+  useEffect(() => {
+    resetView();
+  }, [previewDataUrl, resetView]);
+
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (!canInteract) {
+        return;
+      }
+      event.preventDefault();
+      adjustZoom(event.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP);
+    },
+    [adjustZoom, canInteract],
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    container.addEventListener("wheel", handleWheel, { passive: false });
+    return () => container.removeEventListener("wheel", handleWheel);
+  }, [handleWheel]);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!canInteract || event.button !== 0 || event.isPrimary === false) {
+        return;
+      }
+      movedDuringDragRef.current = false;
+      setIsDragging(true);
+      dragStartRef.current = { x: event.clientX, y: event.clientY };
+      panStartRef.current = pan;
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [canInteract, pan],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent) => {
+      if (!isDragging) {
+        return;
+      }
+      event.preventDefault();
+      const dx = event.clientX - dragStartRef.current.x;
+      const dy = event.clientY - dragStartRef.current.y;
+      if (
+        Math.abs(dx) > DRAG_CLICK_THRESHOLD_PX ||
+        Math.abs(dy) > DRAG_CLICK_THRESHOLD_PX
+      ) {
+        movedDuringDragRef.current = true;
+      }
+      setPan({
+        x: panStartRef.current.x + dx,
+        y: panStartRef.current.y + dy,
+      });
+    },
+    [isDragging],
+  );
+
+  const handlePointerEnd = useCallback(
+    (event: PointerEvent) => {
+      const wasDragging = isDragging;
+      setIsDragging(false);
+      const target = contentRef.current;
+      if (target instanceof HTMLElement) {
+        target.releasePointerCapture(event.pointerId);
+      }
+      if (wasDragging && canInteract && !movedDuringDragRef.current) {
+        zoomInByClick();
+      }
+    },
+    [canInteract, isDragging, zoomInByClick],
+  );
+
+  useEffect(() => {
+    const content = contentRef.current;
+    if (!content || !isDragging) {
+      return;
+    }
+    document.body.style.userSelect = "none";
+    content.addEventListener("pointermove", handlePointerMove, { passive: false });
+    content.addEventListener("pointerup", handlePointerEnd);
+    content.addEventListener("pointercancel", handlePointerEnd);
+    return () => {
+      document.body.style.userSelect = "";
+      content.removeEventListener("pointermove", handlePointerMove);
+      content.removeEventListener("pointerup", handlePointerEnd);
+      content.removeEventListener("pointercancel", handlePointerEnd);
+    };
+  }, [handlePointerEnd, handlePointerMove, isDragging]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!canInteract) {
+        return;
+      }
+      const action = resolveUiLayoutZoomShortcutAction({
+        defaultPrevented: event.defaultPrevented,
+        modPressed: isModShortcutPressed(event.nativeEvent),
+        altKey: event.altKey,
+        key: event.key,
+      });
+      if (!action) {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          zoomInByClick();
+        }
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      if (action === "in") {
+        adjustZoom(ZOOM_STEP);
+        return;
+      }
+      if (action === "out") {
+        adjustZoom(-ZOOM_STEP);
+        return;
+      }
+      resetView();
+    },
+    [adjustZoom, canInteract, resetView, zoomInByClick],
+  );
+
+  return (
+    <div
+        ref={containerRef}
+        data-spirit-surface="workspace-image-preview"
+        tabIndex={canInteract ? 0 : undefined}
+        role={canInteract ? "button" : undefined}
+        aria-label={canInteract ? fileLabel : undefined}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          "relative flex h-full min-h-0 w-full flex-col overflow-hidden outline-none",
+          canInteract && (isDragging ? "cursor-grabbing" : "cursor-zoom-in"),
+          className,
+        )}
+      >
+        {previewState === "loading" ? (
+          <div className="flex h-full items-center justify-center">
+            <Spinner className="size-5 text-muted-foreground" />
+          </div>
+        ) : previewState === "unavailable" || !previewDataUrl ? (
+          <div className="flex h-full items-center justify-center p-4 text-center text-xs leading-relaxed text-muted-foreground">
+            {t("workspace.imagePreviewUnavailable")}
+          </div>
+        ) : (
+          <div
+            ref={contentRef}
+            className="flex h-full min-h-0 w-full items-center justify-center overflow-hidden"
+            onPointerDown={handlePointerDown}
+          >
+            <img
+              src={previewDataUrl}
+              alt={fileLabel}
+              draggable={false}
+              className="max-h-full max-w-full select-none object-contain"
+              style={{
+                transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+                transformOrigin: "center center",
+              }}
+            />
+          </div>
+        )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/workspace-image-preview-pane.tsx
+++ b/apps/desktop/src/components/workspace-image-preview-pane.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -82,72 +83,54 @@ export function WorkspaceImagePreviewPane({
   }, [handleWheel]);
 
   const handlePointerDown = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
+    (event: ReactPointerEvent<HTMLDivElement>) => {
       if (!canInteract || event.button !== 0 || event.isPrimary === false) {
         return;
       }
       movedDuringDragRef.current = false;
-      setIsDragging(true);
       dragStartRef.current = { x: event.clientX, y: event.clientY };
       panStartRef.current = pan;
+      document.body.style.userSelect = "none";
       event.currentTarget.setPointerCapture(event.pointerId);
+      setIsDragging(true);
     },
     [canInteract, pan],
   );
 
-  const handlePointerMove = useCallback(
-    (event: PointerEvent) => {
-      if (!isDragging) {
-        return;
-      }
-      event.preventDefault();
-      const dx = event.clientX - dragStartRef.current.x;
-      const dy = event.clientY - dragStartRef.current.y;
-      if (
-        Math.abs(dx) > DRAG_CLICK_THRESHOLD_PX ||
-        Math.abs(dy) > DRAG_CLICK_THRESHOLD_PX
-      ) {
-        movedDuringDragRef.current = true;
-      }
-      setPan({
-        x: panStartRef.current.x + dx,
-        y: panStartRef.current.y + dy,
-      });
-    },
-    [isDragging],
-  );
+  const handlePointerMove = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture(event.pointerId)) {
+      return;
+    }
+    event.preventDefault();
+    const dx = event.clientX - dragStartRef.current.x;
+    const dy = event.clientY - dragStartRef.current.y;
+    if (
+      Math.abs(dx) > DRAG_CLICK_THRESHOLD_PX ||
+      Math.abs(dy) > DRAG_CLICK_THRESHOLD_PX
+    ) {
+      movedDuringDragRef.current = true;
+    }
+    setPan({
+      x: panStartRef.current.x + dx,
+      y: panStartRef.current.y + dy,
+    });
+  }, []);
 
   const handlePointerEnd = useCallback(
-    (event: PointerEvent) => {
-      const wasDragging = isDragging;
-      setIsDragging(false);
-      const target = contentRef.current;
-      if (target instanceof HTMLElement) {
-        target.releasePointerCapture(event.pointerId);
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.hasPointerCapture(event.pointerId)) {
+        return;
       }
-      if (wasDragging && canInteract && !movedDuringDragRef.current) {
+      const shouldZoomIn = canInteract && !movedDuringDragRef.current;
+      event.currentTarget.releasePointerCapture(event.pointerId);
+      document.body.style.userSelect = "";
+      setIsDragging(false);
+      if (shouldZoomIn) {
         zoomInByClick();
       }
     },
-    [canInteract, isDragging, zoomInByClick],
+    [canInteract, zoomInByClick],
   );
-
-  useEffect(() => {
-    const content = contentRef.current;
-    if (!content || !isDragging) {
-      return;
-    }
-    document.body.style.userSelect = "none";
-    content.addEventListener("pointermove", handlePointerMove, { passive: false });
-    content.addEventListener("pointerup", handlePointerEnd);
-    content.addEventListener("pointercancel", handlePointerEnd);
-    return () => {
-      document.body.style.userSelect = "";
-      content.removeEventListener("pointermove", handlePointerMove);
-      content.removeEventListener("pointerup", handlePointerEnd);
-      content.removeEventListener("pointercancel", handlePointerEnd);
-    };
-  }, [handlePointerEnd, handlePointerMove, isDragging]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>) => {
@@ -209,6 +192,9 @@ export function WorkspaceImagePreviewPane({
             ref={contentRef}
             className="flex h-full min-h-0 w-full items-center justify-center overflow-hidden"
             onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerEnd}
+            onPointerCancel={handlePointerEnd}
           >
             <img
               src={previewDataUrl}

--- a/apps/desktop/src/components/workspace-tools-panel.tsx
+++ b/apps/desktop/src/components/workspace-tools-panel.tsx
@@ -129,6 +129,7 @@ export type WorkspaceToolsDockProps = {
   readHostTextFile: (absolutePath: string) => Promise<WorkspaceReadTextFileResult>;
   writeHostTextFile: (request: WriteHostTextFileRequest) => Promise<void>;
   readManagedImagePreviewDataUrl?: (reference: string) => Promise<string | null>;
+  readLocalImagePreviewDataUrl?: (filePath: string) => Promise<string | null>;
   plan: PlanSnapshot;
   onStartImplementing?: () => void;
   startImplementingDisabled?: boolean;
@@ -460,6 +461,7 @@ const WorkspaceToolsDockContent = memo(function WorkspaceToolsDockContent({
   readHostTextFile,
   writeHostTextFile,
   readManagedImagePreviewDataUrl,
+  readLocalImagePreviewDataUrl,
   plan,
   onStartImplementing,
   startImplementingDisabled = false,
@@ -948,6 +950,7 @@ const WorkspaceToolsDockContent = memo(function WorkspaceToolsDockContent({
                         readHostTextFile={readHostTextFile}
                         writeHostTextFile={writeHostTextFile}
                         readManagedImagePreviewDataUrl={readManagedImagePreviewDataUrl}
+                        readLocalImagePreviewDataUrl={readLocalImagePreviewDataUrl}
                         onStartImplementing={onStartImplementing}
                         startImplementingDisabled={startImplementingDisabled}
                         autoRevealPlanNonce={planRevealEnabled ? autoRevealPlanNonce : 0}

--- a/apps/desktop/src/hooks/useDesktopKeyboardShortcuts.ts
+++ b/apps/desktop/src/hooks/useDesktopKeyboardShortcuts.ts
@@ -251,6 +251,15 @@ export function useDesktopKeyboardShortcuts({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        target instanceof Node &&
+        document
+          .querySelector('[data-spirit-surface="workspace-image-preview"]')
+          ?.contains(target)
+      ) {
+        return;
+      }
       const action = resolveUiLayoutZoomShortcutAction({
         defaultPrevented: event.defaultPrevented,
         modPressed: isModShortcutPressed(event),

--- a/apps/desktop/src/host/host-text-file.ts
+++ b/apps/desktop/src/host/host-text-file.ts
@@ -5,7 +5,12 @@ import path from 'node:path';
 import i18n from '../lib/i18n-host.js';
 import type { HostTextFileStatResult, WorkspaceReadTextFileResult } from '../types.js';
 
-import { WORKSPACE_TEXT_FILE_MAX_BYTES, workspaceTextFileResultFromBuffer } from './workspace-files.js';
+import {
+  WORKSPACE_IMAGE_FILE_MAX_BYTES,
+  WORKSPACE_TEXT_FILE_MAX_BYTES,
+  workspaceTextFileResultFromBuffer,
+} from './workspace-files.js';
+import { hasSupportedImageExtension } from '@spirit-agent/host-internal/image-file-support';
 
 export async function resolveHostTextFilePath(absolutePath: string): Promise<string> {
   const cleaned = absolutePath.replace(/\0/g, '').trim();
@@ -47,11 +52,11 @@ export async function readHostTextFile(absolutePath: string): Promise<WorkspaceR
   if (!fileStat.isFile()) {
     throw new Error(i18n.t('error.notAFile'));
   }
-  if (fileStat.size > WORKSPACE_TEXT_FILE_MAX_BYTES) {
+  if (fileStat.size > (hasSupportedImageExtension(filePath) ? WORKSPACE_IMAGE_FILE_MAX_BYTES : WORKSPACE_TEXT_FILE_MAX_BYTES)) {
     throw new Error(i18n.t('error.fileTooLarge'));
   }
   const buffer = await readFile(filePath);
-  return workspaceTextFileResultFromBuffer(buffer);
+  return workspaceTextFileResultFromBuffer(buffer, filePath);
 }
 
 export async function writeHostTextFile(absolutePath: string, text: string): Promise<void> {

--- a/apps/desktop/src/host/workspace-files.ts
+++ b/apps/desktop/src/host/workspace-files.ts
@@ -3,6 +3,10 @@ import { lstat, readFile, readdir, realpath, stat, writeFile } from 'node:fs/pro
 import path from 'node:path';
 
 import { resolveWorkspaceExplorerIgnoreFlags } from '@spirit-agent/host-internal';
+import {
+  detectSupportedImageFile,
+  hasSupportedImageExtension,
+} from '@spirit-agent/host-internal/image-file-support';
 
 import i18n from '../lib/i18n-host.js';
 import type {
@@ -25,7 +29,16 @@ function isENOENT(error: unknown): boolean {
 /** 单文件上限，避免大文件拖垮渲染进程。 */
 export const WORKSPACE_TEXT_FILE_MAX_BYTES = 2 * 1024 * 1024;
 
+/** 侧栏图片预览上限，与 electron read-local-image-preview 一致。 */
+export const WORKSPACE_IMAGE_FILE_MAX_BYTES = 8 * 1024 * 1024;
+
 const BINARY_SCAN_BYTES = 8192;
+
+function maxReadableFileBytes(filePath: string): number {
+  return hasSupportedImageExtension(filePath)
+    ? WORKSPACE_IMAGE_FILE_MAX_BYTES
+    : WORKSPACE_TEXT_FILE_MAX_BYTES;
+}
 
 /** 扫描缓冲区前缀：NUL 或非法 UTF-8 视为二进制。 */
 export function isBinaryTextFileBuffer(buffer: Buffer): boolean {
@@ -44,7 +57,17 @@ export function isBinaryTextFileBuffer(buffer: Buffer): boolean {
   }
 }
 
-export function workspaceTextFileResultFromBuffer(buffer: Buffer): WorkspaceReadTextFileResult {
+export function workspaceTextFileResultFromBuffer(
+  buffer: Buffer,
+  filePath: string,
+): WorkspaceReadTextFileResult {
+  const image = detectSupportedImageFile(filePath, buffer);
+  if (image) {
+    return { text: '', image: { mimeType: image.mimeType } };
+  }
+  if (hasSupportedImageExtension(filePath)) {
+    return { text: '', binary: true };
+  }
   if (isBinaryTextFileBuffer(buffer)) {
     return { text: '', binary: true };
   }
@@ -177,11 +200,11 @@ export async function readWorkspaceTextFile(
   if (!fileStat.isFile()) {
     throw new Error(i18n.t('error.notAFile'));
   }
-  if (fileStat.size > WORKSPACE_TEXT_FILE_MAX_BYTES) {
+  if (fileStat.size > maxReadableFileBytes(filePath)) {
     throw new Error(i18n.t('error.fileTooLarge'));
   }
   const buffer = await readFile(filePath);
-  return workspaceTextFileResultFromBuffer(buffer);
+  return workspaceTextFileResultFromBuffer(buffer, filePath);
 }
 
 export async function writeWorkspaceTextFile(

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -712,6 +712,7 @@
     "startImplementing": "Start Implementing",
     "emptyMarkdownDoc": "Current Markdown document is empty.",
     "binaryFileNotSupported": "Binary file not supported",
+    "imagePreviewUnavailable": "Unable to preview this image",
     "connectToShowFiles": "Connect to a workspace to show the file tree",
     "fileList": "File List",
     "fileExplorerToolbar": "File explorer toolbar",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -709,6 +709,7 @@
     "startImplementing": "开始实现",
     "emptyMarkdownDoc": "当前 Markdown 文档为空。",
     "binaryFileNotSupported": "二进制文件不受支持",
+    "imagePreviewUnavailable": "无法预览此图片",
     "connectToShowFiles": "连接工作区后显示文件树",
     "fileList": "文件列表",
     "fileExplorerToolbar": "文件浏览工具栏",

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -710,6 +710,8 @@ export interface WorkspaceReadTextFileResult {
   text: string;
   /** 二进制文件：不返回可编辑文本，由 UI 展示占位提示。 */
   binary?: true;
+  /** 经 magic bytes 校验的图片：由 UI 展示预览，不进入 Monaco。 */
+  image?: { mimeType: string };
 }
 
 /** readWorkspaceTextFile 选项；optional 时文件不存在返回空文本而不抛错。 */

--- a/apps/desktop/test/host/host-text-file.test.mjs
+++ b/apps/desktop/test/host/host-text-file.test.mjs
@@ -77,6 +77,22 @@ test('readHostTextFile returns binary for image extension with invalid signature
   }
 });
 
+test('readHostTextFile returns image metadata for validated ico files', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'spirit-host-binary-'));
+  const filePath = path.join(dir, 'favicon.ico');
+  const icoHeader = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]);
+  await writeFile(filePath, icoHeader);
+
+  try {
+    const read = await readHostTextFile(filePath);
+    assert.equal(read.image?.mimeType, 'image/x-icon');
+    assert.equal(read.binary, undefined);
+    assert.equal(read.text, '');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('statHostTextFile returns false for missing paths', async () => {
   const stat = await statHostTextFile(path.join(os.tmpdir(), 'spirit-missing-file.txt'));
   assert.equal(stat.exists, false);

--- a/apps/desktop/test/host/host-text-file.test.mjs
+++ b/apps/desktop/test/host/host-text-file.test.mjs
@@ -31,7 +31,7 @@ test('readHostTextFile reads an absolute path outside any workspace root', async
   }
 });
 
-test('readHostTextFile returns binary for non-text files', async () => {
+test('readHostTextFile returns image metadata for validated png files', async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'spirit-host-binary-'));
   const filePath = path.join(dir, 'icon.png');
   const pngHeader = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xff]);
@@ -39,7 +39,23 @@ test('readHostTextFile returns binary for non-text files', async () => {
 
   try {
     const read = await readHostTextFile(filePath);
+    assert.equal(read.image?.mimeType, 'image/png');
+    assert.equal(read.binary, undefined);
+    assert.equal(read.text, '');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('readHostTextFile returns binary for image extension with invalid signature', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'spirit-host-binary-'));
+  const filePath = path.join(dir, 'fake.png');
+  await writeFile(filePath, 'not a real png', 'utf8');
+
+  try {
+    const read = await readHostTextFile(filePath);
     assert.equal(read.binary, true);
+    assert.equal(read.image, undefined);
     assert.equal(read.text, '');
   } finally {
     await rm(dir, { recursive: true, force: true });

--- a/apps/desktop/test/host/host-text-file.test.mjs
+++ b/apps/desktop/test/host/host-text-file.test.mjs
@@ -31,6 +31,21 @@ test('readHostTextFile reads an absolute path outside any workspace root', async
   }
 });
 
+test('readHostTextFile returns image metadata for validated gif files', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'spirit-host-binary-'));
+  const filePath = path.join(dir, 'anim.gif');
+  const gifHeader = Buffer.from('GIF89a', 'ascii');
+  await writeFile(filePath, gifHeader);
+
+  try {
+    const read = await readHostTextFile(filePath);
+    assert.equal(read.image?.mimeType, 'image/gif');
+    assert.equal(read.binary, undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('readHostTextFile returns image metadata for validated png files', async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), 'spirit-host-binary-'));
   const filePath = path.join(dir, 'icon.png');

--- a/apps/desktop/test/host/workspace-files.test.mjs
+++ b/apps/desktop/test/host/workspace-files.test.mjs
@@ -43,6 +43,15 @@ test('workspaceTextFileResultFromBuffer does not treat svg as image', () => {
   assert.equal(result.text.includes('<svg'), true);
 });
 
+const ICO_HEADER = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]);
+
+test('workspaceTextFileResultFromBuffer returns image for validated ico', () => {
+  const result = workspaceTextFileResultFromBuffer(ICO_HEADER, 'favicon.ico');
+  assert.equal(result.image?.mimeType, 'image/x-icon');
+  assert.equal(result.binary, undefined);
+  assert.equal(result.text, '');
+});
+
 test('workspaceTextFileResultFromBuffer returns image for validated png', () => {
   const result = workspaceTextFileResultFromBuffer(PNG_HEADER, 'icon.png');
   assert.equal(result.image?.mimeType, 'image/png');

--- a/apps/desktop/test/host/workspace-files.test.mjs
+++ b/apps/desktop/test/host/workspace-files.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { workspaceTextFileResultFromBuffer } from '../../dist-electron/src/host/workspace-files.js';
+
+const PNG_HEADER = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xff,
+]);
+
+const GIF_HEADER = Buffer.from('GIF89a', 'ascii');
+
+const WEBP_HEADER = Buffer.from([
+  ...Buffer.from('RIFF', 'ascii'),
+  0x00,
+  0x00,
+  0x00,
+  0x00,
+  ...Buffer.from('WEBP', 'ascii'),
+]);
+
+test('workspaceTextFileResultFromBuffer returns image for validated gif and webp', () => {
+  const gif = workspaceTextFileResultFromBuffer(GIF_HEADER, 'anim.gif');
+  assert.equal(gif.image?.mimeType, 'image/gif');
+  assert.equal(gif.binary, undefined);
+
+  const webp = workspaceTextFileResultFromBuffer(WEBP_HEADER, 'photo.webp');
+  assert.equal(webp.image?.mimeType, 'image/webp');
+  assert.equal(webp.binary, undefined);
+});
+
+test('workspaceTextFileResultFromBuffer returns binary when image extension mismatches signature', () => {
+  const result = workspaceTextFileResultFromBuffer(Buffer.from('not a png', 'utf8'), 'icon.png');
+  assert.equal(result.binary, true);
+  assert.equal(result.image, undefined);
+  assert.equal(result.text, '');
+});
+
+test('workspaceTextFileResultFromBuffer does not treat svg as image', () => {
+  const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"></svg>', 'utf8');
+  const result = workspaceTextFileResultFromBuffer(svg, 'vector.svg');
+  assert.equal(result.image, undefined);
+  assert.equal(result.binary, undefined);
+  assert.equal(result.text.includes('<svg'), true);
+});
+
+test('workspaceTextFileResultFromBuffer returns image for validated png', () => {
+  const result = workspaceTextFileResultFromBuffer(PNG_HEADER, 'icon.png');
+  assert.equal(result.image?.mimeType, 'image/png');
+  assert.equal(result.binary, undefined);
+  assert.equal(result.text, '');
+});

--- a/packages/agent-core/src/anthropic/ai-sdk-transport.ts
+++ b/packages/agent-core/src/anthropic/ai-sdk-transport.ts
@@ -1345,6 +1345,8 @@ function guessImageMimeFromPath(path: string): string {
       return 'image/webp';
     case '.gif':
       return 'image/gif';
+    case '.ico':
+      return 'image/x-icon';
     case '.bmp':
       return 'image/bmp';
     default:

--- a/packages/agent-core/src/bedrock/ai-sdk-transport.ts
+++ b/packages/agent-core/src/bedrock/ai-sdk-transport.ts
@@ -1239,6 +1239,8 @@ function guessImageMimeFromPath(path: string): string {
       return 'image/webp';
     case '.gif':
       return 'image/gif';
+    case '.ico':
+      return 'image/x-icon';
     case '.bmp':
       return 'image/bmp';
     default:

--- a/packages/agent-core/src/openai/openai-multimodal-messages.ts
+++ b/packages/agent-core/src/openai/openai-multimodal-messages.ts
@@ -184,6 +184,8 @@ function guessImageMimeFromPath(path: string): string {
       return 'image/webp';
     case '.gif':
       return 'image/gif';
+    case '.ico':
+      return 'image/x-icon';
     case '.bmp':
       return 'image/bmp';
     default:

--- a/packages/agent-core/src/runtime/helpers.ts
+++ b/packages/agent-core/src/runtime/helpers.ts
@@ -616,7 +616,8 @@ function hasPendingWorkspaceImageExtension(filePath: string): boolean {
     extension.endsWith('.jpg') ||
     extension.endsWith('.jpeg') ||
     extension.endsWith('.gif') ||
-    extension.endsWith('.webp')
+    extension.endsWith('.webp') ||
+    extension.endsWith('.ico')
   );
 }
 
@@ -684,6 +685,9 @@ function detectPendingWorkspaceImageFile(filePath: string, bytes: Uint8Array): b
   }
   if (lower.endsWith('.webp')) {
     return hasAsciiBytePrefix(bytes, 'RIFF') && hasAsciiBytePrefix(bytes.slice(8), 'WEBP');
+  }
+  if (lower.endsWith('.ico')) {
+    return hasBytePrefix(bytes, [0x00, 0x00, 0x01, 0x00]);
   }
 
   return false;

--- a/packages/host-internal/package.json
+++ b/packages/host-internal/package.json
@@ -83,6 +83,10 @@
       "types": "./dist/tool-output-archive-path.d.ts",
       "default": "./dist/tool-output-archive-path.js"
     },
+    "./image-file-support": {
+      "types": "./dist/image-file-support.d.ts",
+      "default": "./dist/image-file-support.js"
+    },
     "./tools": {
       "types": "./dist/tools.d.ts",
       "default": "./dist/tools.js"

--- a/packages/host-internal/src/image-file-support.test.ts
+++ b/packages/host-internal/src/image-file-support.test.ts
@@ -23,6 +23,7 @@ const WEBP_HEADER = Uint8Array.from([
 test('hasSupportedImageExtension recognizes read_file image extensions', () => {
   assert.equal(hasSupportedImageExtension('assets/icon.png'), true);
   assert.equal(hasSupportedImageExtension('photo.JPG'), true);
+  assert.equal(hasSupportedImageExtension('public/favicon.ico'), true);
   assert.equal(hasSupportedImageExtension('notes.txt'), false);
   assert.equal(hasSupportedImageExtension('vector.svg'), false);
 });
@@ -42,6 +43,14 @@ test('detectSupportedImageFile validates gif and webp signatures', () => {
   assert.deepEqual(detectSupportedImageFile('photo.webp', WEBP_HEADER), {
     extension: '.webp',
     mimeType: 'image/webp',
+  });
+});
+
+test('detectSupportedImageFile validates ico signature', () => {
+  const icoHeader = Uint8Array.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]);
+  assert.deepEqual(detectSupportedImageFile('favicon.ico', icoHeader), {
+    extension: '.ico',
+    mimeType: 'image/x-icon',
   });
 });
 

--- a/packages/host-internal/src/image-file-support.test.ts
+++ b/packages/host-internal/src/image-file-support.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  detectSupportedImageFile,
+  hasSupportedImageExtension,
+} from './image-file-support.js';
+
+const PNG_HEADER = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+const GIF_HEADER = Uint8Array.from(
+  Array.from('GIF89a', (char) => char.charCodeAt(0)),
+);
+
+const WEBP_HEADER = Uint8Array.from([
+  ...Array.from('RIFF', (char) => char.charCodeAt(0)),
+  0x00, 0x00, 0x00, 0x00,
+  ...Array.from('WEBP', (char) => char.charCodeAt(0)),
+]);
+
+test('hasSupportedImageExtension recognizes read_file image extensions', () => {
+  assert.equal(hasSupportedImageExtension('assets/icon.png'), true);
+  assert.equal(hasSupportedImageExtension('photo.JPG'), true);
+  assert.equal(hasSupportedImageExtension('notes.txt'), false);
+  assert.equal(hasSupportedImageExtension('vector.svg'), false);
+});
+
+test('detectSupportedImageFile validates png signature', () => {
+  assert.deepEqual(detectSupportedImageFile('icon.png', PNG_HEADER), {
+    extension: '.png',
+    mimeType: 'image/png',
+  });
+});
+
+test('detectSupportedImageFile validates gif and webp signatures', () => {
+  assert.deepEqual(detectSupportedImageFile('anim.gif', GIF_HEADER), {
+    extension: '.gif',
+    mimeType: 'image/gif',
+  });
+  assert.deepEqual(detectSupportedImageFile('photo.webp', WEBP_HEADER), {
+    extension: '.webp',
+    mimeType: 'image/webp',
+  });
+});
+
+test('detectSupportedImageFile rejects mismatched extension and signature', () => {
+  assert.equal(detectSupportedImageFile('icon.png', Uint8Array.from([0, 1, 2, 3])), undefined);
+  assert.equal(detectSupportedImageFile('notes.txt', PNG_HEADER), undefined);
+});

--- a/packages/host-internal/src/image-file-support.ts
+++ b/packages/host-internal/src/image-file-support.ts
@@ -1,4 +1,4 @@
-type SupportedImageExtension = '.bmp' | '.gif' | '.jpeg' | '.jpg' | '.png' | '.webp';
+type SupportedImageExtension = '.bmp' | '.gif' | '.ico' | '.jpeg' | '.jpg' | '.png' | '.webp';
 
 export interface SupportedImageFile {
   extension: SupportedImageExtension;
@@ -8,6 +8,7 @@ export interface SupportedImageFile {
 const SUPPORTED_IMAGE_MIME_TYPES: Record<SupportedImageExtension, string> = {
   '.bmp': 'image/bmp',
   '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
   '.jpeg': 'image/jpeg',
   '.jpg': 'image/jpeg',
   '.png': 'image/png',
@@ -52,6 +53,7 @@ function supportedImageExtension(filePath: string): SupportedImageExtension | un
   switch (extension) {
     case '.bmp':
     case '.gif':
+    case '.ico':
     case '.jpeg':
     case '.jpg':
     case '.png':
@@ -73,6 +75,8 @@ function matchesImageSignature(extension: SupportedImageExtension, bytes: Uint8A
       return hasPrefix(bytes, [0xff, 0xd8, 0xff]);
     case '.gif':
       return hasAsciiPrefix(bytes, 'GIF87a') || hasAsciiPrefix(bytes, 'GIF89a');
+    case '.ico':
+      return hasPrefix(bytes, [0x00, 0x00, 0x01, 0x00]);
     case '.webp':
       return hasAsciiPrefix(bytes, 'RIFF') && hasAsciiPrefix(bytes.slice(8), 'WEBP');
   }

--- a/packages/host-internal/src/image-file-support.ts
+++ b/packages/host-internal/src/image-file-support.ts
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 type SupportedImageExtension = '.bmp' | '.gif' | '.jpeg' | '.jpg' | '.png' | '.webp';
 
 export interface SupportedImageFile {
@@ -15,6 +13,16 @@ const SUPPORTED_IMAGE_MIME_TYPES: Record<SupportedImageExtension, string> = {
   '.png': 'image/png',
   '.webp': 'image/webp',
 };
+
+function fileExtensionFromPath(filePath: string): string {
+  const normalized = filePath.replace(/\\/g, '/');
+  const basename = normalized.slice(normalized.lastIndexOf('/') + 1);
+  const dot = basename.lastIndexOf('.');
+  if (dot < 0) {
+    return '';
+  }
+  return basename.slice(dot).toLowerCase();
+}
 
 export function hasSupportedImageExtension(filePath: string): boolean {
   return supportedImageExtension(filePath) !== undefined;
@@ -40,7 +48,7 @@ export function detectSupportedImageFile(
 }
 
 function supportedImageExtension(filePath: string): SupportedImageExtension | undefined {
-  const extension = path.extname(filePath).toLowerCase();
+  const extension = fileExtensionFromPath(filePath);
   switch (extension) {
     case '.bmp':
     case '.gif':

--- a/packages/host-internal/src/tools.test.ts
+++ b/packages/host-internal/src/tools.test.ts
@@ -161,6 +161,40 @@ test('read_file still returns image part when model explicitly supports image in
   }
 });
 
+const ICO_HEADER = Buffer.from([0x00, 0x00, 0x01, 0x00, 0x01, 0x00]);
+
+test('read_file returns image part for validated ico files', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-host-tools-image-ico-'));
+  const spiritDataDir = join(workspaceRoot, '.spirit-data');
+  const imagePath = join(workspaceRoot, 'favicon.ico');
+
+  try {
+    await mkdir(spiritDataDir, { recursive: true });
+    await writeFile(imagePath, ICO_HEADER);
+
+    const service = new NodeHostToolService(
+      { workspaceRoot, spiritDataDir },
+      {
+        getModelCompatibilityProfile: () => ({
+          hasExplicitCapabilities: true,
+          capabilities: { imageInput: true },
+        }),
+      },
+    );
+
+    const output = await service.execute({
+      name: 'read_file',
+      path: imagePath,
+    });
+    assertHostToolExecutionOutput(output);
+    assert.match(output.summaryText, /^\[read image\]/u);
+    assert.match(output.summaryText, /mime_type: image\/x-icon/u);
+    assert.equal(output.content.some((part) => part.type === 'image'), true);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
 test('web_fetch executes in background like shell', () => {
   const service = new NodeHostToolService(
     { workspaceRoot: '/tmp', spiritDataDir: '/tmp/.spirit-data' },

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -2401,6 +2401,9 @@ function inferSupportedImageExtensionFromWebResponse(
       return '.bmp';
     case 'image/gif':
       return '.gif';
+    case 'image/x-icon':
+    case 'image/vnd.microsoft.icon':
+      return '.ico';
     case 'image/jpeg':
       return '.jpg';
     case 'image/png':
@@ -2566,7 +2569,7 @@ function detectGeneratedImageType(mediaType: string, bytes: Uint8Array): { exten
     };
   }
 
-  for (const extension of ['.png', '.jpg', '.webp', '.gif', '.bmp'] as const) {
+  for (const extension of ['.png', '.jpg', '.webp', '.gif', '.bmp', '.ico'] as const) {
     const detected = detectSupportedImageFile(`generated${extension}`, bytes);
     if (detected) {
       return {
@@ -2589,6 +2592,9 @@ function imageExtensionForMediaType(mediaType: string): string | undefined {
       return '.bmp';
     case 'image/gif':
       return '.gif';
+    case 'image/x-icon':
+    case 'image/vnd.microsoft.icon':
+      return '.ico';
     case 'image/jpeg':
       return '.jpg';
     case 'image/png':
@@ -2606,12 +2612,16 @@ function mimeTypeForImageExtension(extension: string): string | undefined {
       return 'image/bmp';
     case '.gif':
       return 'image/gif';
+    case '.ico':
+      return 'image/x-icon';
     case '.jpg':
       return 'image/jpeg';
     case '.png':
       return 'image/png';
     case '.webp':
       return 'image/webp';
+    case '.ico':
+      return 'image/x-icon';
     default:
       return undefined;
   }

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -2620,8 +2620,6 @@ function mimeTypeForImageExtension(extension: string): string | undefined {
       return 'image/png';
     case '.webp':
       return 'image/webp';
-    case '.ico':
-      return 'image/x-icon';
     default:
       return undefined;
   }


### PR DESCRIPTION
## Summary

- 导出 renderer-safe `image-file-support` 子路径，侧栏读取与 `read_file` 共用扩展名 + magic bytes 图片检测（bmp/gif/jpg/png/webp/ico）
- 新增 `WorkspaceImagePreviewPane`：内联滚轮缩放、拖拽平移、单击相对放大 20%；预览区焦点时跳过全局 UI 缩放快捷键
- `read_file`、侧栏 IPC 预览与模型多模态传输补齐 `.ico`（`image/x-icon`）支持
- 补充 host-internal 与 desktop host 边界单测

## Test plan

- [x] `npx tsx --test packages/host-internal/src/image-file-support.test.ts src/tools.test.ts`
- [x] `node --test apps/desktop/test/host/host-text-file.test.mjs apps/desktop/test/host/workspace-files.test.mjs`
- [x] `npx tsc --noEmit`（apps/desktop）
- [x] 手动：侧栏打开 png/ico 内联预览；滚轮缩放、拖拽、单击放大；伪造图片扩展名仍显示 binary 占位