### PR TITLE
feat(desktop): Desktop 会话标题手动重命名

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,34 @@ feat(desktop): macOS 侧栏切换按钮钉在红绿灯右侧
 
 ❌ 错位：`新增 useDarwinWindowFullscreen 读取 html class，不重复订阅 Electron IPC`——父提交里并无重复订阅，这是会话内对刚写代码的后续改写叙事，与本次 diff 无关
 
+### 命令行传递（多行 subject / body）
+
+- **PowerShell**：用字面量 here-string `@' … '@` 传给 `git commit -m`
+- **bash**：用 `git commit -m "$(cat <<'EOF' … EOF)"`
+
+PowerShell 示例：
+
+```powershell
+git commit -m @'
+feat(desktop): 示例 subject
+
+- 第一条 body
+- 第二条 body
+'@
+```
+
+bash 示例：
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(desktop): 示例 subject
+
+- 第一条 body
+- 第二条 body
+EOF
+)"
+```
+
 ## 通用约定
 
 - 优先保持跨平台兼容（含 Windows 分支与条件编译）。

--- a/apps/desktop/electron/http-host.ts
+++ b/apps/desktop/electron/http-host.ts
@@ -1178,6 +1178,19 @@ async function handleApiRequest({
     return;
   }
 
+  if (request.method === 'POST' && pathname === '/api/sessions/rename') {
+    writeJson(
+      request,
+      response,
+      200,
+      await runHostCommand('renameSession', {
+        path: typeof jsonBody?.path === 'string' ? jsonBody.path : '',
+        displayName: typeof jsonBody?.displayName === 'string' ? jsonBody.displayName : '',
+      }),
+    );
+    return;
+  }
+
   if (request.method === 'POST' && pathname === '/api/workspace/explorer') {
     writeJson(
       request,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -291,6 +291,9 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   deleteSession(path: string) {
     return ipcRenderer.invoke('desktop:invoke', 'deleteSession', { path });
   },
+  renameSession(path: string, displayName: string) {
+    return ipcRenderer.invoke('desktop:invoke', 'renameSession', { path, displayName });
+  },
   listWorkspaceFileReferenceSuggestions(request: unknown) {
     return ipcRenderer.invoke('desktop:invoke', 'listWorkspaceFileReferenceSuggestions', {
       request,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -341,6 +341,8 @@ export default function App() {
             sessionNavigationBusy={sessionNavigationBusy}
             deleteSessionBusy={sessionNavigationBusy}
             onDeleteSession={(path) => runtime.deleteSession(path)}
+            renameSessionBusy={sessionNavigationBusy}
+            onRenameSession={(path, displayName) => runtime.renameSession(path, displayName)}
             deleteWorkspaceBusy={sessionNavigationBusy}
             onDeleteWorkspace={(workspacePath) => runtime.deleteWorkspace(workspacePath)}
             unseenCompletedSessionPaths={runtime.unseenCompletedSessionPaths}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -566,6 +566,8 @@ export default function App() {
                 onNewSession={surfaceNav.handleNewSession}
                 deleteSessionBusy={sessionNavigationBusy}
                 onDeleteSession={(path) => runtime.deleteSession(path)}
+                renameSessionBusy={sessionNavigationBusy}
+                onRenameSession={(path, displayName) => runtime.renameSession(path, displayName)}
                 workspaceTools={workspaceTools}
                 onOpenIntegrationsSettings={openIntegrationsSettings}
                 onCompactionDemoStop={compactionDemo.stop}

--- a/apps/desktop/src/adapters/electron.ts
+++ b/apps/desktop/src/adapters/electron.ts
@@ -249,6 +249,9 @@ export async function createElectronHostApi(): Promise<HostApi> {
     deleteSession(path) {
       return bridge.deleteSession(path);
     },
+    renameSession(path, displayName) {
+      return bridge.renameSession(path, displayName);
+    },
     listWorkspaceFileReferenceSuggestions(request) {
       return bridge.listWorkspaceFileReferenceSuggestions(request);
     },

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -360,6 +360,9 @@ export function createWebHostApi(): HostApi {
     deleteSession(path: string) {
       return post<DesktopSnapshot>(baseUrl, '/api/sessions/delete', { path });
     },
+    renameSession(path: string, displayName: string) {
+      return post<DesktopSnapshot>(baseUrl, '/api/sessions/rename', { path, displayName });
+    },
     listWorkspaceFileReferenceSuggestions(request: QueryWorkspaceFileReferenceSuggestionsRequest) {
       return post<WorkspaceFileReferenceSuggestionsResponse>(
         baseUrl,

--- a/apps/desktop/src/components/conversation/conversation-pane-drop-indicator.tsx
+++ b/apps/desktop/src/components/conversation/conversation-pane-drop-indicator.tsx
@@ -9,7 +9,7 @@ import {
 import { paneDropIndicatorRect, visiblePaneDropZonesForDrag } from "@/lib/conversation-pane-drop-preview";
 
 const OVERLAY_MOTION_TRANSITION =
-  "left 200ms ease-out, top 200ms ease-out, width 200ms ease-out, height 200ms ease-out, opacity 150ms ease-out";
+  "left 120ms ease-out, top 120ms ease-out, width 120ms ease-out, height 120ms ease-out, opacity 150ms ease-out";
 
 /** Single viewport-fixed ring that glides between pane drop quadrants (matches browser element picker). */
 export function ConversationPaneDropIndicator() {

--- a/apps/desktop/src/components/conversation/conversation-pane-host.tsx
+++ b/apps/desktop/src/components/conversation/conversation-pane-host.tsx
@@ -42,6 +42,8 @@ export type ConversationPaneHostProps = {
   onNewSession?: () => void;
   deleteSessionBusy?: boolean;
   onDeleteSession?: (path: string) => void | Promise<void>;
+  renameSessionBusy?: boolean;
+  onRenameSession?: (path: string, displayName: string) => void | Promise<void>;
   workspaceTools: WorkspaceTools;
   onOpenIntegrationsSettings: () => void;
   onCompactionDemoStop: () => void;
@@ -121,6 +123,15 @@ export function ConversationPaneHost({
     }
   }, [paneId, split, splitPaneCount]);
 
+  const handleRenameSession = useCallback(
+    async (path: string, displayName: string) => {
+      if (controllerInput.onRenameSession) {
+        await controllerInput.onRenameSession(path, displayName);
+      }
+    },
+    [controllerInput.onRenameSession],
+  );
+
   return (
     <ConversationView
       useMicaBackdrop={useMicaBackdrop}
@@ -155,6 +166,13 @@ export function ConversationPaneHost({
       conversationBusy={pane.paneSnapshot?.conversation.isBusy === true}
       onDeleteSession={handleDeleteSession}
       onDeleteSessionOverlayClosed={handleDeleteSessionOverlayClosed}
+      showRenameSession={
+        !pane.paneIsEmptySession && Boolean(controllerInput.onRenameSession)
+      }
+      renameSessionPath={sessionPath}
+      renameSessionDisplayName={pane.paneSnapshot?.activeSession?.displayName ?? null}
+      renameSessionBusy={controllerInput.renameSessionBusy}
+      onRenameSession={handleRenameSession}
       compactionDemoActive={pane.compactionDemoActive}
       onCompactionDemoStop={controllerInput.onCompactionDemoStop}
       rewindDraft={pane.rewindDraft}

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -13,6 +13,7 @@ import { ComposerDock } from "@/components/conversation/composer-dock";
 import { BranchCheckoutDialog } from "@/components/branch-checkout-dialog";
 import { ConversationList } from "@/components/conversation/conversation-list";
 import { DesktopLayoutChromeBar } from "@/components/layout/desktop-layout-chrome-bar";
+import { sessionGitTooltipItemFromChromeSession } from "@/components/session-list-git-tooltip";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import type { ComposerRichInputHandle } from "@/components/composer-rich-input";
@@ -254,7 +255,14 @@ export function ConversationView({
   const conversationMessagesVisible =
     (!isEmptySession || subagentViewActive) && !hideStaleConversationMessages;
   const sessionTitleVisible = !isEmptySession && !hideStaleConversationMessages;
-
+  const sessionTooltip =
+    sessionTitleVisible && snapshot?.activeSession
+      ? sessionGitTooltipItemFromChromeSession({
+          path: snapshot.activeSession.filePath,
+          gitBranch: snapshot.git?.branch,
+          workspaceRoot: snapshot.workspaceRoot,
+        })
+      : null;
 
   useConversationSessionScrollTail({
     scrollAreaRef: conversationScrollAreaRef,
@@ -365,6 +373,7 @@ export function ConversationView({
               ? snapshot?.activeSession?.displayName
               : null
           }
+          sessionTooltip={sessionTooltip}
           subagentPromptText={
             subagentViewActive ? snapshot?.subagentViewer?.promptText : null
           }

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -187,6 +187,11 @@ export type ConversationViewProps = {
   conversationBusy?: boolean;
   onDeleteSession?: (path: string) => void | Promise<void>;
   onDeleteSessionOverlayClosed?: () => void | Promise<void>;
+  showRenameSession?: boolean;
+  renameSessionPath?: string | null;
+  renameSessionDisplayName?: string | null;
+  renameSessionBusy?: boolean;
+  onRenameSession?: (path: string, displayName: string) => void | Promise<void>;
   paneId?: string;
   onPaneFocus?: () => void;
   onPaneDragStart?: (paneId: string) => void;
@@ -229,6 +234,11 @@ export function ConversationView({
   conversationBusy = false,
   onDeleteSession,
   onDeleteSessionOverlayClosed,
+  showRenameSession = false,
+  renameSessionPath,
+  renameSessionDisplayName,
+  renameSessionBusy = false,
+  onRenameSession,
   paneId,
   onPaneFocus,
   onPaneDragStart,
@@ -368,6 +378,11 @@ export function ConversationView({
           conversationBusy={conversationBusy}
           onDeleteSession={onDeleteSession}
           onDeleteSessionOverlayClosed={onDeleteSessionOverlayClosed}
+          showRenameSession={showRenameSession}
+          renameSessionPath={renameSessionPath}
+          renameSessionDisplayName={renameSessionDisplayName}
+          renameSessionBusy={renameSessionBusy}
+          onRenameSession={onRenameSession}
         />
         {showDropTargets ? (() => {
           const visibleDropZones = resolveVisibleDropZones();

--- a/apps/desktop/src/components/layout/desktop-layout-chrome-bar.tsx
+++ b/apps/desktop/src/components/layout/desktop-layout-chrome-bar.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { LoaderCircle, PanelRightClose, PanelRightOpen, Plus, MoreHorizontal, SquareSplitHorizontal, SquareSplitVertical, Trash2, X } from "lucide-react";
+import { LoaderCircle, PanelRightClose, PanelRightOpen, Pencil, Plus, MoreHorizontal, SquareSplitHorizontal, SquareSplitVertical, Trash2, X } from "lucide-react";
 
 import {
   NewSessionShortcutKbd,
@@ -74,6 +74,11 @@ export function DesktopLayoutChromeBar({
   conversationBusy = false,
   onDeleteSession,
   onDeleteSessionOverlayClosed,
+  showRenameSession = false,
+  renameSessionPath,
+  renameSessionDisplayName,
+  renameSessionBusy = false,
+  onRenameSession,
 }: {
   useMicaBackdrop: boolean;
   showSessionSidebarToggle?: boolean;
@@ -100,6 +105,11 @@ export function DesktopLayoutChromeBar({
   conversationBusy?: boolean;
   onDeleteSession?: (path: string) => void | Promise<void>;
   onDeleteSessionOverlayClosed?: () => void | Promise<void>;
+  showRenameSession?: boolean;
+  renameSessionPath?: string | null;
+  renameSessionDisplayName?: string | null;
+  renameSessionBusy?: boolean;
+  onRenameSession?: (path: string, displayName: string) => void | Promise<void>;
 }) {
   const { t } = useTranslation();
   const { open: sessionSidebarOpen } = useSessionSidebarChrome();
@@ -111,8 +121,76 @@ export function DesktopLayoutChromeBar({
   const trimmedSessionTitle = sessionTitle?.trim() ?? "";
   const paneDragEnabled = Boolean(paneId && onPaneDragStart);
   const [deleteSessionDialogOpen, setDeleteSessionDialogOpen] = useState(false);
+  const [renamingTitle, setRenamingTitle] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const renameCommitInFlightRef = useRef(false);
+  const pendingRenameFocusRef = useRef(false);
   const trimmedDeleteSessionPath = deleteSessionPath?.trim() ?? "";
   const trimmedDeleteSessionDisplayName = deleteSessionDisplayName?.trim() ?? "";
+  const trimmedRenameSessionPath = renameSessionPath?.trim() ?? "";
+  const trimmedRenameSessionDisplayName = renameSessionDisplayName?.trim() ?? "";
+  const trimmedSubagentPromptText = subagentPromptText?.trim() ?? "";
+  const canRenameTitle =
+    showRenameSession
+    && Boolean(onRenameSession)
+    && Boolean(trimmedRenameSessionPath)
+    && !trimmedSubagentPromptText;
+
+  const handleRenameCancel = useCallback(() => {
+    setRenamingTitle(false);
+    setRenameValue("");
+  }, []);
+
+  const handleRenameStart = useCallback(() => {
+    if (renameSessionBusy || conversationBusy || !canRenameTitle) {
+      return;
+    }
+    setRenamingTitle(true);
+    setRenameValue(trimmedSessionTitle || trimmedRenameSessionDisplayName);
+  }, [
+    canRenameTitle,
+    conversationBusy,
+    renameSessionBusy,
+    trimmedRenameSessionDisplayName,
+    trimmedSessionTitle,
+  ]);
+
+  const handleRenameCommit = useCallback(async () => {
+    if (renameCommitInFlightRef.current) {
+      return;
+    }
+    if (!renamingTitle || !onRenameSession || !trimmedRenameSessionPath) {
+      handleRenameCancel();
+      return;
+    }
+    const trimmed = renameValue.trim();
+    const currentName = trimmedSessionTitle || trimmedRenameSessionDisplayName;
+    if (!trimmed || trimmed === currentName) {
+      handleRenameCancel();
+      return;
+    }
+    renameCommitInFlightRef.current = true;
+    try {
+      await onRenameSession(trimmedRenameSessionPath, trimmed);
+      handleRenameCancel();
+    } catch {
+      // Runtime error banner handles host failures.
+    } finally {
+      renameCommitInFlightRef.current = false;
+    }
+  }, [
+    handleRenameCancel,
+    onRenameSession,
+    renameValue,
+    renamingTitle,
+    trimmedRenameSessionDisplayName,
+    trimmedRenameSessionPath,
+    trimmedSessionTitle,
+  ]);
+
+  useEffect(() => {
+    handleRenameCancel();
+  }, [handleRenameCancel, trimmedRenameSessionPath]);
 
   const dismissDeleteSessionDialog = useCallback((afterClose?: () => void) => {
     setDeleteSessionDialogOpen(false);
@@ -206,11 +284,17 @@ export function DesktopLayoutChromeBar({
             </Tooltip>
           </div>
         ) : null}
-        {trimmedSessionTitle ? (
+        {trimmedSessionTitle || renamingTitle ? (
           <SessionChromeBreadcrumb
-            sessionTitle={trimmedSessionTitle}
+            sessionTitle={trimmedSessionTitle || trimmedRenameSessionDisplayName}
             subagentPromptText={subagentPromptText}
             onExitSubagentViewer={onExitSubagentViewer}
+            renaming={renamingTitle}
+            renameValue={renameValue}
+            onRenameValueChange={setRenameValue}
+            onRenameCommit={() => void handleRenameCommit()}
+            onRenameCancel={handleRenameCancel}
+            onRenameStart={canRenameTitle ? handleRenameStart : undefined}
           />
         ) : null}
       </div>
@@ -229,7 +313,17 @@ export function DesktopLayoutChromeBar({
                   <MoreHorizontal className="size-3.5 text-muted-foreground" aria-hidden />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "p-0")}>
+              <DropdownMenuContent
+                align="end"
+                className={cn(DESKTOP_OVERLAY_SHORT_MENU_MIN_WIDTH, "p-0")}
+                onCloseAutoFocus={(event) => {
+                  if (!pendingRenameFocusRef.current) {
+                    return;
+                  }
+                  event.preventDefault();
+                  pendingRenameFocusRef.current = false;
+                }}
+              >
                 <div className={DESKTOP_OVERLAY_SHORT_LIST_PADDING}>
                   <DropdownMenuItem
                     className="gap-1.5"
@@ -255,6 +349,25 @@ export function DesktopLayoutChromeBar({
                     </DropdownMenuItem>
                   ) : null}
                 </div>
+                {canRenameTitle ? (
+                  <>
+                    <DropdownMenuSeparator />
+                    <div className={DESKTOP_OVERLAY_SHORT_LIST_PADDING}>
+                      <DropdownMenuItem
+                        className="gap-1.5"
+                        disabled={renameSessionBusy || conversationBusy}
+                        title={conversationBusy ? t("sidebar.cannotRenameBusySession") : undefined}
+                        onSelect={() => {
+                          pendingRenameFocusRef.current = true;
+                          handleRenameStart();
+                        }}
+                      >
+                        <Pencil className="size-3.5 shrink-0 text-muted-foreground/80" aria-hidden />
+                        <span>{t("sidebar.renameSession")}</span>
+                      </DropdownMenuItem>
+                    </div>
+                  </>
+                ) : null}
                 {showDeleteSession && onDeleteSession && trimmedDeleteSessionPath ? (
                   <>
                     <DropdownMenuSeparator />

--- a/apps/desktop/src/components/layout/desktop-layout-chrome-bar.tsx
+++ b/apps/desktop/src/components/layout/desktop-layout-chrome-bar.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/layout/desktop-shortcut-kbds";
 import { SessionSidebarToggleButton } from "@/components/layout/session-sidebar-toggle-button";
 import { SessionChromeBreadcrumb } from "@/components/session-chrome-breadcrumb";
+import type { SessionGitTooltipItem } from "@/components/session-list-git-tooltip";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -55,6 +56,7 @@ export function DesktopLayoutChromeBar({
   showSplitMenu = false,
   showClosePane = false,
   sessionTitle,
+  sessionTooltip,
   subagentPromptText,
   onExitSubagentViewer,
   onNewSession,
@@ -86,6 +88,7 @@ export function DesktopLayoutChromeBar({
   showSplitMenu?: boolean;
   showClosePane?: boolean;
   sessionTitle?: string | null;
+  sessionTooltip?: SessionGitTooltipItem | null;
   subagentPromptText?: string | null;
   onExitSubagentViewer?: () => void;
   onNewSession?: () => void;
@@ -287,6 +290,7 @@ export function DesktopLayoutChromeBar({
         {trimmedSessionTitle || renamingTitle ? (
           <SessionChromeBreadcrumb
             sessionTitle={trimmedSessionTitle || trimmedRenameSessionDisplayName}
+            sessionTooltip={sessionTooltip}
             subagentPromptText={subagentPromptText}
             onExitSubagentViewer={onExitSubagentViewer}
             renaming={renamingTitle}

--- a/apps/desktop/src/components/session-chrome-breadcrumb.tsx
+++ b/apps/desktop/src/components/session-chrome-breadcrumb.tsx
@@ -110,7 +110,7 @@ export function SessionChromeBreadcrumb({
       input.select();
     });
     return () => cancelAnimationFrame(frameId);
-  }, [renaming, renameValue]);
+  }, [renaming]);
 
   if (!trimmedSessionTitle && !renaming) {
     return null;

--- a/apps/desktop/src/components/session-chrome-breadcrumb.tsx
+++ b/apps/desktop/src/components/session-chrome-breadcrumb.tsx
@@ -3,28 +3,33 @@ import {
   useRef,
   type KeyboardEvent,
   type MouseEvent,
+  type ReactNode,
 } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
   Breadcrumb,
   BreadcrumbItem,
-  BreadcrumbLink,
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { Tooltip, TooltipContent } from '@/components/ui/tooltip';
+import {
+  SessionListGitTooltipPanel,
+  type SessionGitTooltipItem,
+} from '@/components/session-list-git-tooltip';
 import {
   DESKTOP_CHROME_ACTIVE_TEXT,
   DESKTOP_CHROME_MUTED_TEXT,
+  DESKTOP_SESSION_TITLE_HOVER_CLASS,
+  SESSION_TITLE_RENAME_INPUT_CLASS,
 } from '@/lib/desktop-chrome';
 import { cn } from '@/lib/utils';
 
-const SESSION_RENAME_INPUT_CLASS =
-  "electron-no-drag min-w-0 flex-1 rounded border border-border/60 bg-background px-1 py-0 text-xs font-medium outline-none focus:border-ring";
-
 type SessionChromeBreadcrumbProps = {
   sessionTitle: string;
+  sessionTooltip?: SessionGitTooltipItem | null;
   subagentPromptText?: string | null;
   onExitSubagentViewer?: () => void;
   renaming?: boolean;
@@ -35,8 +40,47 @@ type SessionChromeBreadcrumbProps = {
   onRenameStart?: () => void;
 };
 
+const sessionTitleButtonClass = (interactive: boolean) =>
+  cn(
+    "electron-no-drag min-w-0 w-full truncate rounded-sm p-0 text-left text-xs font-medium",
+    DESKTOP_CHROME_MUTED_TEXT,
+    interactive && cn(DESKTOP_SESSION_TITLE_HOVER_CLASS, "cursor-pointer"),
+  );
+
+function SessionChromeTitleTooltip({
+  item,
+  children,
+}: {
+  item: SessionGitTooltipItem;
+  children: ReactNode;
+}) {
+  return (
+    <Tooltip<SessionGitTooltipItem>
+      getItemId={(tooltipItem) => tooltipItem.path}
+      delayDuration={300}
+      closeDelayMs={120}
+      anchorLingerMs={220}
+      disableHoverableContent
+    >
+      <Tooltip.Item item={item}>{children}</Tooltip.Item>
+      <TooltipContent
+        side="bottom"
+        sideOffset={6}
+        className="flex flex-col items-start gap-1 py-2"
+      >
+        {(activeItem) =>
+          activeItem ? (
+            <SessionListGitTooltipPanel item={activeItem as SessionGitTooltipItem} />
+          ) : null
+        }
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
 export function SessionChromeBreadcrumb({
   sessionTitle,
+  sessionTooltip,
   subagentPromptText,
   onExitSubagentViewer,
   renaming = false,
@@ -51,6 +95,7 @@ export function SessionChromeBreadcrumb({
   const skipBlurCommitRef = useRef(false);
   const trimmedSessionTitle = sessionTitle.trim();
   const trimmedSubagentPromptText = subagentPromptText?.trim() ?? '';
+  const titleInteractive = Boolean(onRenameStart);
 
   useLayoutEffect(() => {
     if (!renaming) {
@@ -84,11 +129,22 @@ export function SessionChromeBreadcrumb({
     }
   };
 
+  const wrapWithTooltip = (node: ReactNode) => {
+    if (!sessionTooltip) {
+      return node;
+    }
+    return (
+      <SessionChromeTitleTooltip item={sessionTooltip}>
+        {node}
+      </SessionChromeTitleTooltip>
+    );
+  };
+
   const sessionTitleNode = renaming ? (
     <input
       ref={renameInputRef}
       value={renameValue}
-      className={SESSION_RENAME_INPUT_CLASS}
+      className={cn(SESSION_TITLE_RENAME_INPUT_CLASS, "electron-no-drag w-full")}
       aria-label={t("sidebar.renameSession")}
       onChange={(event) => onRenameValueChange?.(event.target.value)}
       onKeyDown={handleRenameKeyDown}
@@ -100,25 +156,20 @@ export function SessionChromeBreadcrumb({
       }}
     />
   ) : trimmedSubagentPromptText ? (
-    <BreadcrumbLink asChild>
+    wrapWithTooltip(
       <button
         type="button"
-        className={cn(
-          "electron-no-drag min-w-0 truncate",
-          DESKTOP_CHROME_MUTED_TEXT,
-          "hover:text-sidebar-foreground focus-visible:text-sidebar-foreground",
-        )}
-        title={trimmedSessionTitle}
+        className={sessionTitleButtonClass(true)}
         onClick={onExitSubagentViewer}
       >
         {trimmedSessionTitle}
-      </button>
-    </BreadcrumbLink>
-  ) : (
-    <BreadcrumbPage
-      className={cn("min-w-0 truncate font-medium", DESKTOP_CHROME_MUTED_TEXT)}
-      title={trimmedSessionTitle}
-      onDoubleClick={(event: MouseEvent<HTMLElement>) => {
+      </button>,
+    )
+  ) : wrapWithTooltip(
+    <button
+      type="button"
+      className={sessionTitleButtonClass(titleInteractive)}
+      onDoubleClick={(event: MouseEvent<HTMLButtonElement>) => {
         if (!onRenameStart) {
           return;
         }
@@ -128,19 +179,20 @@ export function SessionChromeBreadcrumb({
       }}
     >
       {trimmedSessionTitle}
-    </BreadcrumbPage>
+    </button>,
   );
 
   return (
-    <Breadcrumb className="min-w-0">
+    <Breadcrumb className={cn("min-w-0", renaming && !trimmedSubagentPromptText && "flex-1")}>
       <BreadcrumbList className="flex-nowrap gap-1.5 text-xs font-medium sm:gap-2">
         <BreadcrumbItem
           className={cn(
             'min-w-0',
-            trimmedSubagentPromptText
-              ? 'max-w-[min(12rem,30vw)] shrink'
-              : 'max-w-[min(20rem,40vw)]',
-            renaming && 'max-w-[min(20rem,40vw)] flex-1',
+            renaming && !trimmedSubagentPromptText
+              ? 'max-w-full flex-1'
+              : trimmedSubagentPromptText
+                ? 'max-w-[min(12rem,30vw)] shrink'
+                : 'max-w-[min(20rem,40vw)]',
           )}
         >
           {sessionTitleNode}
@@ -151,7 +203,6 @@ export function SessionChromeBreadcrumb({
             <BreadcrumbItem className="min-w-0 max-w-[min(20rem,40vw)] flex-1">
               <BreadcrumbPage
                 className={cn("min-w-0 truncate font-medium", DESKTOP_CHROME_ACTIVE_TEXT)}
-                title={trimmedSubagentPromptText}
               >
                 {trimmedSubagentPromptText}
               </BreadcrumbPage>

--- a/apps/desktop/src/components/session-chrome-breadcrumb.tsx
+++ b/apps/desktop/src/components/session-chrome-breadcrumb.tsx
@@ -1,4 +1,12 @@
 import {
+  useLayoutEffect,
+  useRef,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbLink,
@@ -12,23 +20,116 @@ import {
 } from '@/lib/desktop-chrome';
 import { cn } from '@/lib/utils';
 
+const SESSION_RENAME_INPUT_CLASS =
+  "electron-no-drag min-w-0 flex-1 rounded border border-border/60 bg-background px-1 py-0 text-xs font-medium outline-none focus:border-ring";
+
 type SessionChromeBreadcrumbProps = {
   sessionTitle: string;
   subagentPromptText?: string | null;
   onExitSubagentViewer?: () => void;
+  renaming?: boolean;
+  renameValue?: string;
+  onRenameValueChange?: (value: string) => void;
+  onRenameCommit?: () => void;
+  onRenameCancel?: () => void;
+  onRenameStart?: () => void;
 };
 
 export function SessionChromeBreadcrumb({
   sessionTitle,
   subagentPromptText,
   onExitSubagentViewer,
+  renaming = false,
+  renameValue = "",
+  onRenameValueChange,
+  onRenameCommit,
+  onRenameCancel,
+  onRenameStart,
 }: SessionChromeBreadcrumbProps) {
+  const { t } = useTranslation();
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  const skipBlurCommitRef = useRef(false);
   const trimmedSessionTitle = sessionTitle.trim();
   const trimmedSubagentPromptText = subagentPromptText?.trim() ?? '';
 
-  if (!trimmedSessionTitle) {
+  useLayoutEffect(() => {
+    if (!renaming) {
+      return;
+    }
+    const input = renameInputRef.current;
+    if (!input) {
+      return;
+    }
+    const frameId = requestAnimationFrame(() => {
+      input.focus({ preventScroll: true });
+      input.select();
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, [renaming, renameValue]);
+
+  if (!trimmedSessionTitle && !renaming) {
     return null;
   }
+
+  const handleRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      skipBlurCommitRef.current = true;
+      onRenameCommit?.();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onRenameCancel?.();
+    }
+  };
+
+  const sessionTitleNode = renaming ? (
+    <input
+      ref={renameInputRef}
+      value={renameValue}
+      className={SESSION_RENAME_INPUT_CLASS}
+      aria-label={t("sidebar.renameSession")}
+      onChange={(event) => onRenameValueChange?.(event.target.value)}
+      onKeyDown={handleRenameKeyDown}
+      onBlur={() => {
+        if (!skipBlurCommitRef.current) {
+          onRenameCommit?.();
+        }
+        skipBlurCommitRef.current = false;
+      }}
+    />
+  ) : trimmedSubagentPromptText ? (
+    <BreadcrumbLink asChild>
+      <button
+        type="button"
+        className={cn(
+          "electron-no-drag min-w-0 truncate",
+          DESKTOP_CHROME_MUTED_TEXT,
+          "hover:text-sidebar-foreground focus-visible:text-sidebar-foreground",
+        )}
+        title={trimmedSessionTitle}
+        onClick={onExitSubagentViewer}
+      >
+        {trimmedSessionTitle}
+      </button>
+    </BreadcrumbLink>
+  ) : (
+    <BreadcrumbPage
+      className={cn("min-w-0 truncate font-medium", DESKTOP_CHROME_MUTED_TEXT)}
+      title={trimmedSessionTitle}
+      onDoubleClick={(event: MouseEvent<HTMLElement>) => {
+        if (!onRenameStart) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        onRenameStart();
+      }}
+    >
+      {trimmedSessionTitle}
+    </BreadcrumbPage>
+  );
 
   return (
     <Breadcrumb className="min-w-0">
@@ -39,31 +140,10 @@ export function SessionChromeBreadcrumb({
             trimmedSubagentPromptText
               ? 'max-w-[min(12rem,30vw)] shrink'
               : 'max-w-[min(20rem,40vw)]',
+            renaming && 'max-w-[min(20rem,40vw)] flex-1',
           )}
         >
-          {trimmedSubagentPromptText ? (
-            <BreadcrumbLink asChild>
-              <button
-                type="button"
-                className={cn(
-                  "electron-no-drag min-w-0 truncate",
-                  DESKTOP_CHROME_MUTED_TEXT,
-                  "hover:text-sidebar-foreground focus-visible:text-sidebar-foreground",
-                )}
-                title={trimmedSessionTitle}
-                onClick={onExitSubagentViewer}
-              >
-                {trimmedSessionTitle}
-              </button>
-            </BreadcrumbLink>
-          ) : (
-            <BreadcrumbPage
-              className={cn("min-w-0 truncate font-medium", DESKTOP_CHROME_MUTED_TEXT)}
-              title={trimmedSessionTitle}
-            >
-              {trimmedSessionTitle}
-            </BreadcrumbPage>
-          )}
+          {sessionTitleNode}
         </BreadcrumbItem>
         {trimmedSubagentPromptText ? (
           <>

--- a/apps/desktop/src/components/session-list-git-tooltip.tsx
+++ b/apps/desktop/src/components/session-list-git-tooltip.tsx
@@ -31,6 +31,22 @@ export function sessionGitTooltipItemFromSession(
   };
 }
 
+export function sessionGitTooltipItemFromChromeSession(input: {
+  path: string;
+  gitBranch?: string;
+  workspaceRoot: string;
+}): SessionGitTooltipItem | null {
+  const gitBranch = input.gitBranch?.trim();
+  if (!gitBranch) {
+    return null;
+  }
+  return {
+    path: input.path,
+    gitBranch,
+    workspaceRoot: input.workspaceRoot,
+  };
+}
+
 type SessionListGitTooltipProps = {
   children: ReactNode;
   delayDuration?: number;
@@ -99,6 +115,8 @@ function SessionListGitTooltipPanel({ item }: { item: SessionGitTooltipItem }) {
     </>
   );
 }
+
+export { SessionListGitTooltipPanel };
 
 export const SessionListGitTooltip = Object.assign(SessionListGitTooltipRoot, {
   Zone: Tooltip.Zone,

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -82,6 +82,7 @@ import { runAfterRadixOverlayClose } from "@/lib/overlay-motion";
 import { isViteDev } from "@/lib/vite-dev";
 import { cn } from "@/lib/utils";
 import { SettingsShortcutKbd } from "@/components/layout/desktop-shortcut-kbds";
+import { SESSION_TITLE_RENAME_INPUT_CLASS } from "@/lib/desktop-chrome";
 import { shortcutLabel, settingsShortcutLabel } from "@/lib/desktop-shell";
 import i18n from "@/lib/i18n";
 import { useHostApi } from "@/hooks/useHostApi";
@@ -95,9 +96,6 @@ import {
 /** 平台快捷键提示，模块加载时计算（平台不会运行时变化）。 */
 const newSessionShortcutLabel = shortcutLabel("N");
 const settingsShortcutLabelText = settingsShortcutLabel();
-
-const SESSION_RENAME_INPUT_CLASS =
-  "min-w-0 flex-1 rounded border border-border/60 bg-background px-1 py-0 text-xs outline-none focus:border-ring";
 
 function describeRenameError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -765,7 +763,7 @@ const SessionListRow = memo(function SessionListRow({
         <input
           ref={renameInputRef}
           value={renameValue}
-          className={SESSION_RENAME_INPUT_CLASS}
+          className={cn(SESSION_TITLE_RENAME_INPUT_CLASS, "flex-1 basis-0")}
           aria-label={t("sidebar.renameSession")}
           onChange={(event) => onRenameValueChange?.(event.target.value)}
           onKeyDown={handleRenameKeyDown}

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -2,9 +2,11 @@ import {
   memo,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type MouseEvent,
   type PointerEvent,
   type ReactNode,
@@ -28,6 +30,7 @@ import {
   Network,
   Package,
   Palette,
+  Pencil,
   Plug,
   Plus,
   SquarePen,
@@ -93,6 +96,13 @@ import {
 const newSessionShortcutLabel = shortcutLabel("N");
 const settingsShortcutLabelText = settingsShortcutLabel();
 
+const SESSION_RENAME_INPUT_CLASS =
+  "min-w-0 flex-1 rounded border border-border/60 bg-background px-1 py-0 text-xs outline-none focus:border-ring";
+
+function describeRenameError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 
 function samePath(a: string, b: string): boolean {
   return a.replace(/\\/g, "/").toLowerCase() === b.replace(/\\/g, "/").toLowerCase();
@@ -130,6 +140,8 @@ type SessionSidebarProps = {
   sessionNavigationBusy?: boolean;
   deleteSessionBusy?: boolean;
   onDeleteSession?: (path: string) => void | Promise<void>;
+  renameSessionBusy?: boolean;
+  onRenameSession?: (path: string, displayName: string) => void | Promise<void>;
   deleteWorkspaceBusy?: boolean;
   onDeleteWorkspace?: (workspacePath: string) => void | Promise<void>;
   disabled?: boolean;
@@ -276,6 +288,13 @@ type WorkspaceSessionGroupCollapsibleProps = {
   onLoadMore(): void;
   onNewSessionInWorkspace?: (workspaceRoot: string) => void;
   newSessionBusy?: boolean;
+  renamingSessionPath?: string | null;
+  renameValue?: string;
+  onRenameValueChange?: (value: string) => void;
+  onRenameCommit?: () => void;
+  onRenameCancel?: () => void;
+  onRenameStart?: (session: SessionListItem) => void;
+  canRenameSession?: boolean;
   groupNodeRef?(node: HTMLElement | null): void;
   headerPointerHandlers?: {
     onPointerDown(event: PointerEvent<HTMLElement>): void;
@@ -387,6 +406,13 @@ const WorkspaceSessionGroupCollapsible = memo(function WorkspaceSessionGroupColl
   onLoadMore,
   onNewSessionInWorkspace,
   newSessionBusy = false,
+  renamingSessionPath = null,
+  renameValue = "",
+  onRenameValueChange,
+  onRenameCommit,
+  onRenameCancel,
+  onRenameStart,
+  canRenameSession = false,
   groupNodeRef,
   headerPointerHandlers,
   onHeaderClickCapture,
@@ -557,6 +583,16 @@ const WorkspaceSessionGroupCollapsible = memo(function WorkspaceSessionGroupColl
                   disabled={disabled}
                   micaStyle={micaStyle}
                   onSelectPath={onSelectSession}
+                  renaming={renamingSessionPath === session.path}
+                  renameValue={renamingSessionPath === session.path ? renameValue : undefined}
+                  onRenameValueChange={onRenameValueChange}
+                  onRenameCommit={onRenameCommit}
+                  onRenameCancel={onRenameCancel}
+                  onRenameStart={
+                    canRenameSession && !session.isBusy
+                      ? () => onRenameStart?.(session)
+                      : undefined
+                  }
                 />
               </SessionListGitTooltip.Row>
             ))}
@@ -627,6 +663,12 @@ type SessionListRowProps = {
   disabled?: boolean;
   micaStyle?: boolean;
   onSelectPath(path: string): void;
+  renaming?: boolean;
+  renameValue?: string;
+  onRenameValueChange?: (value: string) => void;
+  onRenameCommit?: () => void;
+  onRenameCancel?: () => void;
+  onRenameStart?: () => void;
 };
 
 const SessionListRow = memo(function SessionListRow({
@@ -641,13 +683,102 @@ const SessionListRow = memo(function SessionListRow({
   disabled,
   micaStyle,
   onSelectPath,
+  renaming = false,
+  renameValue = "",
+  onRenameValueChange,
+  onRenameCommit,
+  onRenameCancel,
+  onRenameStart,
 }: SessionListRowProps) {
   const { t } = useTranslation();
   const gitTooltipContext = useOptionalSessionListGitTooltipContext();
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  const skipBlurCommitRef = useRef(false);
   const hasIndicator =
     (isBusy && !isBlocked) ||
     (!selected && (isBlocked || showCompletedUnseen));
   const showGitTooltip = Boolean(gitBranch?.trim()) && gitTooltipContext !== null;
+
+  useLayoutEffect(() => {
+    if (!renaming) {
+      return;
+    }
+    const input = renameInputRef.current;
+    if (!input) {
+      return;
+    }
+    const frameId = requestAnimationFrame(() => {
+      input.focus({ preventScroll: true });
+      input.select();
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, [renaming, renameValue]);
+
+  const rowClassName = cn(
+    "group flex w-full min-w-0 items-center overflow-hidden rounded-md text-left text-sm outline-none",
+    sidebarInteractionMotionClass,
+    "focus-visible:ring-2 focus-visible:ring-sidebar-ring/40",
+    nested
+      ? "py-2 pr-2.5 pl-2.5 gap-2"
+      : hasIndicator
+        ? "h-8 pr-2.5 pl-2.5 gap-2"
+        : "h-8 px-2.5",
+    !renaming && (
+      selected
+        ? sessionRowSelectedClass(micaStyle)
+        : cn(sidebarItemDefaultTextClass, sessionRowHoverClass(micaStyle))
+    ),
+  );
+
+  const leading = (nested || hasIndicator) ? (
+    <span className="flex w-3.5 shrink-0 items-center justify-center" aria-hidden>
+      {isBusy && !isBlocked ? (
+        <Spinner
+          className="size-3 shrink-0 text-primary"
+          aria-label={t('common.running')}
+        />
+      ) : !selected && isBlocked ? (
+        <SessionRowStatusDot tone="blocked" label={t("sidebar.sessionBlocked")} />
+      ) : !selected && showCompletedUnseen ? (
+        <SessionRowStatusDot tone="completed" label={t("sidebar.sessionCompleted")} />
+      ) : null}
+    </span>
+  ) : null;
+
+  const handleRenameKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      skipBlurCommitRef.current = true;
+      onRenameCommit?.();
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onRenameCancel?.();
+    }
+  };
+
+  if (renaming) {
+    return (
+      <div data-session-path={sessionPath} className={rowClassName}>
+        {leading}
+        <input
+          ref={renameInputRef}
+          value={renameValue}
+          className={SESSION_RENAME_INPUT_CLASS}
+          aria-label={t("sidebar.renameSession")}
+          onChange={(event) => onRenameValueChange?.(event.target.value)}
+          onKeyDown={handleRenameKeyDown}
+          onBlur={() => {
+            if (!skipBlurCommitRef.current) {
+              onRenameCommit?.();
+            }
+            skipBlurCommitRef.current = false;
+          }}
+        />
+      </div>
+    );
+  }
 
   return (
     <button
@@ -656,34 +787,17 @@ const SessionListRow = memo(function SessionListRow({
       disabled={disabled}
       aria-current={selected ? "true" : undefined}
       onClick={() => onSelectPath(sessionPath)}
-      className={cn(
-        "group flex w-full min-w-0 items-center overflow-hidden rounded-md text-left text-sm outline-none",
-        sidebarInteractionMotionClass,
-        "focus-visible:ring-2 focus-visible:ring-sidebar-ring/40",
-        nested
-          ? "py-2 pr-2.5 pl-2.5 gap-2"
-          : hasIndicator
-            ? "h-8 pr-2.5 pl-2.5 gap-2"
-            : "h-8 px-2.5",
-        selected
-          ? sessionRowSelectedClass(micaStyle)
-          : cn(sidebarItemDefaultTextClass, sessionRowHoverClass(micaStyle)),
-      )}
+      onDoubleClick={(event) => {
+        if (!onRenameStart || disabled || isBusy) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        onRenameStart();
+      }}
+      className={rowClassName}
     >
-      {(nested || hasIndicator) && (
-        <span className="flex w-3.5 shrink-0 items-center justify-center" aria-hidden>
-          {isBusy && !isBlocked ? (
-            <Spinner
-              className="size-3 shrink-0 text-primary"
-              aria-label={t('common.running')}
-            />
-          ) : !selected && isBlocked ? (
-            <SessionRowStatusDot tone="blocked" label={t("sidebar.sessionBlocked")} />
-          ) : !selected && showCompletedUnseen ? (
-            <SessionRowStatusDot tone="completed" label={t("sidebar.sessionCompleted")} />
-          ) : null}
-        </span>
-      )}
+      {leading}
       <span
         className="min-w-0 flex-1 basis-0 truncate text-xs font-medium"
         title={showGitTooltip ? undefined : displayName}
@@ -696,40 +810,49 @@ const SessionListRow = memo(function SessionListRow({
 
 type SessionListNavProps = {
   ariaLabel: string;
+  canRenameSession: boolean;
   canDeleteSession: boolean;
   contextMenuSession: SessionListItem | null;
   contextMenuSessionRef: RefObject<SessionListItem | null>;
+  renameSessionBusy?: boolean;
   deleteSessionBusy?: boolean;
   onSessionContextMenuCapture(event: MouseEvent<HTMLElement>): void;
   onContextMenuOpenChange(open: boolean): void;
+  onContextMenuCloseAutoFocus(event: Event): void;
+  onRequestRename(session: SessionListItem): void;
   onRequestDelete(session: SessionListItem): void;
   children: ReactNode;
 };
 
 function SessionListNav({
   ariaLabel,
+  canRenameSession,
   canDeleteSession,
   contextMenuSession,
   contextMenuSessionRef,
+  renameSessionBusy,
   deleteSessionBusy,
   onSessionContextMenuCapture,
   onContextMenuOpenChange,
+  onContextMenuCloseAutoFocus,
+  onRequestRename,
   onRequestDelete,
   children,
 }: SessionListNavProps) {
   const { t } = useTranslation();
+  const canSessionContextMenu = canRenameSession || canDeleteSession;
 
   const nav = (
     <nav
       className="flex min-w-0 flex-col gap-0.5"
       aria-label={ariaLabel}
-      onContextMenuCapture={canDeleteSession ? onSessionContextMenuCapture : undefined}
+      onContextMenuCapture={canSessionContextMenu ? onSessionContextMenuCapture : undefined}
     >
       {children}
     </nav>
   );
 
-  if (!canDeleteSession) {
+  if (!canSessionContextMenu) {
     return nav;
   }
 
@@ -738,21 +861,42 @@ function SessionListNav({
   return (
     <ContextMenu onOpenChange={onContextMenuOpenChange}>
       <ContextMenuTrigger asChild>{nav}</ContextMenuTrigger>
-      <ContextMenuContent aria-label={t("sidebar.sessionActions")}>
-        <ContextMenuItem
-          variant="destructive"
-          disabled={deleteSessionBusy || busy}
-          title={busy ? t("sidebar.cannotDeleteBusySession") : undefined}
-          onSelect={() => {
-            const session = contextMenuSessionRef.current ?? contextMenuSession;
-            if (session) {
-              onRequestDelete(session);
-            }
-          }}
-        >
-          <Trash2 aria-hidden />
-          {t("common.delete")}
-        </ContextMenuItem>
+      <ContextMenuContent
+        aria-label={t("sidebar.sessionActions")}
+        onCloseAutoFocus={onContextMenuCloseAutoFocus}
+      >
+        {canRenameSession ? (
+          <ContextMenuItem
+            disabled={renameSessionBusy || busy}
+            title={busy ? t("sidebar.cannotRenameBusySession") : undefined}
+            onSelect={() => {
+              const session = contextMenuSessionRef.current ?? contextMenuSession;
+              if (session) {
+                onRequestRename(session);
+              }
+            }}
+          >
+            <Pencil aria-hidden />
+            {t("sidebar.renameSession")}
+          </ContextMenuItem>
+        ) : null}
+        {canRenameSession && canDeleteSession ? <ContextMenuSeparator /> : null}
+        {canDeleteSession ? (
+          <ContextMenuItem
+            variant="destructive"
+            disabled={deleteSessionBusy || busy}
+            title={busy ? t("sidebar.cannotDeleteBusySession") : undefined}
+            onSelect={() => {
+              const session = contextMenuSessionRef.current ?? contextMenuSession;
+              if (session) {
+                onRequestDelete(session);
+              }
+            }}
+          >
+            <Trash2 aria-hidden />
+            {t("common.delete")}
+          </ContextMenuItem>
+        ) : null}
       </ContextMenuContent>
     </ContextMenu>
   );
@@ -760,30 +904,38 @@ function SessionListNav({
 
 type WorkspaceListNavProps = {
   canDeleteWorkspace: boolean;
+  canRenameSession: boolean;
   canDeleteSession: boolean;
   contextMenuWorkspaceGroup: SessionWorkspaceGroup | null;
   contextMenuWorkspaceGroupRef: RefObject<SessionWorkspaceGroup | null>;
   contextMenuSession: SessionListItem | null;
   contextMenuSessionRef: RefObject<SessionListItem | null>;
   deleteWorkspaceBusy?: boolean;
+  renameSessionBusy?: boolean;
   deleteSessionBusy?: boolean;
   onContextMenuCapture(event: MouseEvent<HTMLElement>): void;
+  onContextMenuCloseAutoFocus(event: Event): void;
   onRequestDeleteWorkspace(group: SessionWorkspaceGroup): void;
+  onRequestRenameSession(session: SessionListItem): void;
   onRequestDeleteSession(session: SessionListItem): void;
   children: ReactNode;
 };
 
 function WorkspaceListNav({
   canDeleteWorkspace,
+  canRenameSession,
   canDeleteSession,
   contextMenuWorkspaceGroup,
   contextMenuWorkspaceGroupRef,
   contextMenuSession,
   contextMenuSessionRef,
   deleteWorkspaceBusy,
+  renameSessionBusy,
   deleteSessionBusy,
   onContextMenuCapture,
+  onContextMenuCloseAutoFocus,
   onRequestDeleteWorkspace,
+  onRequestRenameSession,
   onRequestDeleteSession,
   children,
 }: WorkspaceListNavProps) {
@@ -791,7 +943,8 @@ function WorkspaceListNav({
   const { api, kind, ready: hostReady } = useHostApi();
   const canOpenWorkspaceDirectory = kind === "electron" && hostReady && api != null;
 
-  const canShowMenu = canDeleteWorkspace || canDeleteSession || canOpenWorkspaceDirectory;
+  const canShowMenu =
+    canDeleteWorkspace || canRenameSession || canDeleteSession || canOpenWorkspaceDirectory;
 
   const inner = (
     <div
@@ -819,7 +972,10 @@ function WorkspaceListNav({
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>{inner}</ContextMenuTrigger>
-      <ContextMenuContent aria-label={isWorkspaceTarget ? t("sidebar.workspaceActions") : t("sidebar.sessionActions")}>
+      <ContextMenuContent
+        aria-label={isWorkspaceTarget ? t("sidebar.workspaceActions") : t("sidebar.sessionActions")}
+        onCloseAutoFocus={onContextMenuCloseAutoFocus}
+      >
         {showOpenWorkspaceDirectory ? (
           <ContextMenuItem
             onSelect={() => {
@@ -849,6 +1005,24 @@ function WorkspaceListNav({
             <Trash2 aria-hidden />
             {t("common.delete")}
           </ContextMenuItem>
+        ) : null}
+        {!isWorkspaceTarget && canRenameSession ? (
+          <ContextMenuItem
+            disabled={renameSessionBusy || sessionBusy}
+            title={sessionBusy ? t("sidebar.cannotRenameBusySession") : undefined}
+            onSelect={() => {
+              const session = contextMenuSessionRef.current ?? contextMenuSession;
+              if (session) {
+                onRequestRenameSession(session);
+              }
+            }}
+          >
+            <Pencil aria-hidden />
+            {t("sidebar.renameSession")}
+          </ContextMenuItem>
+        ) : null}
+        {!isWorkspaceTarget && canRenameSession && canDeleteSession ? (
+          <ContextMenuSeparator />
         ) : null}
         {!isWorkspaceTarget && canDeleteSession ? (
           <ContextMenuItem
@@ -1063,6 +1237,8 @@ function SessionSidebarInner({
   sessionNavigationBusy = false,
   deleteSessionBusy = false,
   onDeleteSession,
+  renameSessionBusy = false,
+  onRenameSession,
   deleteWorkspaceBusy = false,
   onDeleteWorkspace,
   disabled,
@@ -1132,6 +1308,11 @@ function SessionSidebarInner({
   const contextMenuSessionRef = useRef<SessionListItem | null>(null);
   const [contextMenuWorkspaceGroup, setContextMenuWorkspaceGroup] = useState<SessionWorkspaceGroup | null>(null);
   const contextMenuWorkspaceGroupRef = useRef<SessionWorkspaceGroup | null>(null);
+  const [renamingSessionPath, setRenamingSessionPath] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [renameError, setRenameError] = useState("");
+  const renameCommitInFlightRef = useRef(false);
+  const pendingRenameFocusPathRef = useRef<string | null>(null);
   const scrollFadeRegionRef = useRef<HTMLDivElement>(null);
   const [scrollEdgeFades, setScrollEdgeFades] = useState<SidebarScrollEdgeFades>({
     top: false,
@@ -1145,6 +1326,7 @@ function SessionSidebarInner({
     return map;
   }, [sessions]);
   const canDeleteSession = Boolean(onDeleteSession) && !disabled;
+  const canRenameSession = Boolean(onRenameSession) && !disabled;
   const canDeleteWorkspace = Boolean(onDeleteWorkspace) && !disabled;
   const workspaceSectionSessionCount = useMemo(
     () => workspaceGroups.reduce((total, group) => total + group.sessions.length, 0),
@@ -1259,6 +1441,70 @@ function SessionSidebarInner({
     setContextMenuSession(null);
     setDeleteTarget(session);
     setDeleteSessionDialogOpen(true);
+  }, []);
+
+  const handleRenameCancel = useCallback(() => {
+    setRenamingSessionPath(null);
+    setRenameValue("");
+    setRenameError("");
+  }, []);
+
+  const handleRenameStart = useCallback((session: SessionListItem) => {
+    if (session.isBusy) {
+      return;
+    }
+    setRenamingSessionPath(session.path);
+    setRenameValue(session.displayName);
+    setRenameError("");
+  }, []);
+
+  const handleRenameCommit = useCallback(async () => {
+    if (renameCommitInFlightRef.current) {
+      return;
+    }
+    if (!renamingSessionPath || !onRenameSession) {
+      handleRenameCancel();
+      return;
+    }
+    const trimmed = renameValue.trim();
+    const session = sessionByPath.get(renamingSessionPath);
+    if (!trimmed || trimmed === session?.displayName) {
+      handleRenameCancel();
+      return;
+    }
+    renameCommitInFlightRef.current = true;
+    try {
+      await onRenameSession(renamingSessionPath, trimmed);
+      handleRenameCancel();
+    } catch (error) {
+      setRenameError(describeRenameError(error));
+    } finally {
+      renameCommitInFlightRef.current = false;
+    }
+  }, [
+    handleRenameCancel,
+    onRenameSession,
+    renameValue,
+    renamingSessionPath,
+    sessionByPath,
+  ]);
+
+  const handleRenameStartFromMenu = useCallback(
+    (session: SessionListItem) => {
+      pendingRenameFocusPathRef.current = session.path;
+      handleRenameStart(session);
+      contextMenuSessionRef.current = null;
+      setContextMenuSession(null);
+    },
+    [handleRenameStart],
+  );
+
+  const handleContextMenuCloseAutoFocus = useCallback((event: Event) => {
+    if (!pendingRenameFocusPathRef.current) {
+      return;
+    }
+    event.preventDefault();
+    pendingRenameFocusPathRef.current = null;
   }, []);
 
   const isSessionSelected = (sessionPath: string) =>
@@ -1633,15 +1879,19 @@ function SessionSidebarInner({
                 >
                   <WorkspaceListNav
                     canDeleteWorkspace={canDeleteWorkspace}
+                    canRenameSession={canRenameSession}
                     canDeleteSession={canDeleteSession}
                     contextMenuWorkspaceGroup={contextMenuWorkspaceGroup}
                     contextMenuWorkspaceGroupRef={contextMenuWorkspaceGroupRef}
                     contextMenuSession={contextMenuSession}
                     contextMenuSessionRef={contextMenuSessionRef}
                     deleteWorkspaceBusy={deleteWorkspaceBusy}
+                    renameSessionBusy={renameSessionBusy}
                     deleteSessionBusy={deleteSessionBusy}
                     onContextMenuCapture={handleWorkspaceContextMenuCapture}
+                    onContextMenuCloseAutoFocus={handleContextMenuCloseAutoFocus}
                     onRequestDeleteWorkspace={handleWorkspaceContextMenuDelete}
+                    onRequestRenameSession={handleRenameStartFromMenu}
                     onRequestDeleteSession={handleContextMenuDelete}
                   >
                     {workspaceGroups.map((group) => {
@@ -1671,6 +1921,13 @@ function SessionSidebarInner({
                           onLoadMore={() => loadMoreWorkspaceGroupSessions(group.id, group.sessions.length)}
                           onNewSessionInWorkspace={onNewSessionInWorkspace}
                           newSessionBusy={newSessionBusy}
+                          renamingSessionPath={renamingSessionPath}
+                          renameValue={renameValue}
+                          onRenameValueChange={setRenameValue}
+                          onRenameCommit={() => void handleRenameCommit()}
+                          onRenameCancel={handleRenameCancel}
+                          onRenameStart={handleRenameStart}
+                          canRenameSession={canRenameSession}
                           groupNodeRef={(node) => workspaceGroupReorder.registerGroupNode(group.id, node)}
                           headerPointerHandlers={workspaceGroupReorder.getHeaderPointerHandlers(group.id)}
                           onHeaderClickCapture={workspaceGroupReorder.handleHeaderClickCapture}
@@ -1688,12 +1945,16 @@ function SessionSidebarInner({
               ) : null}
               <SessionListNav
                 ariaLabel={t('sidebar.workspaceSessionsAria')}
+                canRenameSession={canRenameSession}
                 canDeleteSession={canDeleteSession}
                 contextMenuSession={contextMenuSession}
                 contextMenuSessionRef={contextMenuSessionRef}
+                renameSessionBusy={renameSessionBusy}
                 deleteSessionBusy={deleteSessionBusy}
                 onSessionContextMenuCapture={handleSessionContextMenuCapture}
                 onContextMenuOpenChange={handleContextMenuOpenChange}
+                onContextMenuCloseAutoFocus={handleContextMenuCloseAutoFocus}
+                onRequestRename={handleRenameStartFromMenu}
                 onRequestDelete={handleContextMenuDelete}
               >
                 {unboundSessions.length > 0 ? (
@@ -1735,6 +1996,16 @@ function SessionSidebarInner({
                               disabled={disabled}
                               micaStyle={micaStyle}
                               onSelectPath={onSelectSession}
+                              renaming={renamingSessionPath === session.path}
+                              renameValue={renamingSessionPath === session.path ? renameValue : undefined}
+                              onRenameValueChange={setRenameValue}
+                              onRenameCommit={() => void handleRenameCommit()}
+                              onRenameCancel={handleRenameCancel}
+                              onRenameStart={
+                                canRenameSession && !session.isBusy
+                                  ? () => handleRenameStart(session)
+                                  : undefined
+                              }
                             />
                           </SessionListGitTooltip.Row>
                         ))}

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -710,7 +710,7 @@ const SessionListRow = memo(function SessionListRow({
       input.select();
     });
     return () => cancelAnimationFrame(frameId);
-  }, [renaming, renameValue]);
+  }, [renaming]);
 
   const rowClassName = cn(
     "group flex w-full min-w-0 items-center overflow-hidden rounded-md text-left text-sm outline-none",

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -158,6 +158,7 @@ declare global {
       request: import('./types').CheckoutPaneGitBranchRequest,
     ): Promise<DesktopSnapshot>;
     deleteSession(path: string): Promise<DesktopSnapshot>;
+    renameSession(path: string, displayName: string): Promise<DesktopSnapshot>;
     listWorkspaceFileReferenceSuggestions(
       request: QueryWorkspaceFileReferenceSuggestionsRequest,
     ): Promise<WorkspaceFileReferenceSuggestionsResponse>;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -2974,6 +2974,27 @@ export function useDesktopRuntime() {
     [acknowledgeSessionAttention, api, applySnapshot, refreshSessions, restoreSessionUi],
   );
 
+  const renameSession = useCallback(
+    async (path: string, displayName: string) => {
+      if (!api) {
+        return;
+      }
+      setBusyAction("session");
+      try {
+        const next = await api.renameSession(path, displayName);
+        applySnapshot(next);
+        setRuntimeError("");
+        void refreshSessions();
+      } catch (error) {
+        setRuntimeError(describeError(error));
+        throw error;
+      } finally {
+        setBusyAction("");
+      }
+    },
+    [api, applySnapshot, refreshSessions],
+  );
+
   const deleteWorkspace = useCallback(
     async (workspacePath: string) => {
       if (!api?.forgetWorkspace) {
@@ -3503,6 +3524,7 @@ export function useDesktopRuntime() {
     focusPaneSession,
     closeSplitPaneSession,
     deleteSession,
+    renameSession,
     deleteWorkspace,
     listWorkspaceFileReferenceSuggestions,
     primeWorkspaceFileReferenceIndex,

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -229,6 +229,7 @@ export interface HostApi {
   setPaneWorkLocation(request: SetPaneWorkLocationRequest): Promise<DesktopSnapshot>;
   checkoutPaneGitBranch(request: CheckoutPaneGitBranchRequest): Promise<DesktopSnapshot>;
   deleteSession(path: string): Promise<DesktopSnapshot>;
+  renameSession(path: string, displayName: string): Promise<DesktopSnapshot>;
   listWorkspaceFileReferenceSuggestions(
     request: QueryWorkspaceFileReferenceSuggestionsRequest,
   ): Promise<WorkspaceFileReferenceSuggestionsResponse>;

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -102,6 +102,7 @@ export type HostCommandName =
   | 'setPaneWorkLocation'
   | 'checkoutPaneGitBranch'
   | 'deleteSession'
+  | 'renameSession'
   | 'listWorkspaceFileReferenceSuggestions'
   | 'requestCodeCompletion'
   | 'abortCodeCompletion'
@@ -133,7 +134,7 @@ export type HostCommandName =
 /** 与 `apps/cli/src/tool_runtime.rs` 中 `ToolRequest` 对齐的宿主工具请求。 */
 export type DesktopToolRequest = HostToolRequest<AskQuestionsQuestionSpec>;
 
-export type SessionTitleSource = 'seed' | 'llm';
+export type SessionTitleSource = 'seed' | 'llm' | 'manual';
 
 export interface StoredDesktopSession {
   chatSchemaVersion: 2;

--- a/apps/desktop/src/host/host-command-payloads.ts
+++ b/apps/desktop/src/host/host-command-payloads.ts
@@ -161,6 +161,7 @@ export type CommandPayloads = {
   setPaneWorkLocation: { request: SetPaneWorkLocationRequest };
   checkoutPaneGitBranch: { request: CheckoutPaneGitBranchRequest };
   deleteSession: { path: string };
+  renameSession: { path: string; displayName: string };
   listWorkspaceFileReferenceSuggestions: { request: QueryWorkspaceFileReferenceSuggestionsRequest };
   requestCodeCompletion: { request: RequestCodeCompletionRequest };
   abortCodeCompletion: undefined;

--- a/apps/desktop/src/host/host-invoke-dispatch.ts
+++ b/apps/desktop/src/host/host-invoke-dispatch.ts
@@ -96,6 +96,7 @@ export interface HostCommandDelegate {
     request: CommandPayloads['checkoutPaneGitBranch']['request'],
   ): Promise<unknown>;
   deleteSession(path: string): Promise<unknown>;
+  renameSession(path: string, displayName: string): Promise<unknown>;
   listWorkspaceFileReferenceSuggestions(
     request: CommandPayloads['listWorkspaceFileReferenceSuggestions']['request'],
   ): Promise<unknown>;
@@ -250,6 +251,7 @@ const hostCommandDispatch = {
   setPaneWorkLocation: (host, payload) => host.setPaneWorkLocation(payload.request),
   checkoutPaneGitBranch: (host, payload) => host.checkoutPaneGitBranch(payload.request),
   deleteSession: (host, payload) => host.deleteSession(payload.path),
+  renameSession: (host, payload) => host.renameSession(payload.path, payload.displayName),
   listWorkspaceFileReferenceSuggestions: (host, payload) =>
     host.listWorkspaceFileReferenceSuggestions(payload.request),
   requestCodeCompletion: (host, payload) => host.requestCodeCompletion(payload.request),

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -303,6 +303,7 @@ import {
   ensureVisiblePaneActiveModels,
 } from './active-model-sync.js';
 import { deleteSessionCommand, type SessionDeleteContext } from './session-delete.js';
+import { renameSessionCommand, type SessionRenameContext } from './session-rename.js';
 import {
   finishSessionActivationCommand,
   isBundleRuntimeFresh,
@@ -2424,6 +2425,22 @@ class DesktopHostService {
 
   async deleteSession(filePath: string): Promise<DesktopSnapshot> {
     return deleteSessionCommand(this.sessionDeleteContext(), filePath);
+  }
+
+  async renameSession(filePath: string, displayName: string): Promise<DesktopSnapshot> {
+    return renameSessionCommand(this.sessionRenameContext(), filePath, displayName);
+  }
+
+  private sessionRenameContext(): SessionRenameContext {
+    return {
+      ...this.sessionActivationContext(),
+      bundleRuntimeIsBusy: (sessionPath) => {
+        const bundle = this.sessionRegistry.findBySessionPath(sessionPath);
+        return isSessionBundleBusy(bundle);
+      },
+      notifySessionListUpdated: () => this.notifySessionListUpdated(),
+      emitLiveSnapshotUpdate: () => this.emitLiveSnapshotUpdate(),
+    };
   }
 
   private sessionDeleteContext(): SessionDeleteContext {

--- a/apps/desktop/src/host/session-rename.ts
+++ b/apps/desktop/src/host/session-rename.ts
@@ -1,0 +1,76 @@
+import path from 'node:path';
+
+import i18n from '../lib/i18n-host.js';
+import type { DesktopSnapshot } from '../types.js';
+import type { SessionActivationContext } from './session-activation.js';
+import { loadStoredSession, saveStoredSession } from './storage.js';
+
+function sameSessionPath(left: string, right: string): boolean {
+  return path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase();
+}
+
+export interface SessionRenameContext extends SessionActivationContext {
+  bundleRuntimeIsBusy(sessionPath: string): boolean;
+  notifySessionListUpdated(): void;
+  emitLiveSnapshotUpdate(): void;
+}
+
+export async function renameSessionCommand(
+  ctx: SessionRenameContext,
+  filePath: string,
+  displayName: string,
+): Promise<DesktopSnapshot> {
+  return ctx.runSerialized(async () => {
+    await ctx.ensureInitialized(undefined, { fastPath: true });
+
+    const trimmedPath = filePath.trim();
+    if (!trimmedPath) {
+      throw new Error(i18n.t('error.invalidSessionPath'));
+    }
+
+    const trimmedName = displayName.trim();
+    if (!trimmedName) {
+      throw new Error(i18n.t('error.emptySessionDisplayName'));
+    }
+
+    const resolvedPath = path.resolve(trimmedPath);
+    if (ctx.bundleRuntimeIsBusy(resolvedPath)) {
+      throw new Error(i18n.t('error.cannotDeleteBusySession'));
+    }
+
+    const registry = ctx.sessionRegistry();
+    const bundle = registry.findBySessionPath(resolvedPath);
+    const activeId = registry.activeSessionId();
+    const isActiveSession =
+      activeId !== undefined && sameSessionPath(activeId, resolvedPath);
+
+    if (
+      bundle?.activeSession
+      && path.resolve(bundle.activeSession.filePath) === resolvedPath
+    ) {
+      bundle.activeSession.displayName = trimmedName;
+      bundle.sessionTitleSource = 'manual';
+      await ctx.persistSessionBundle(bundle, {
+        fromRuntime: bundle.runtime,
+        bumpListSortAt: false,
+      });
+      if (isActiveSession) {
+        ctx.emitLiveSnapshotUpdate();
+      } else {
+        ctx.notifySessionListUpdated();
+      }
+      ctx.setLastRuntimeError('');
+      return ctx.buildSnapshot();
+    }
+
+    const stored = await loadStoredSession(resolvedPath);
+    await saveStoredSession(resolvedPath, {
+      ...stored,
+      sessionDisplayName: trimmedName,
+      sessionTitleSource: 'manual',
+    });
+    ctx.notifySessionListUpdated();
+    ctx.setLastRuntimeError('');
+    return ctx.buildSnapshot();
+  });
+}

--- a/apps/desktop/src/host/session-rename.ts
+++ b/apps/desktop/src/host/session-rename.ts
@@ -35,7 +35,7 @@ export async function renameSessionCommand(
 
     const resolvedPath = path.resolve(trimmedPath);
     if (ctx.bundleRuntimeIsBusy(resolvedPath)) {
-      throw new Error(i18n.t('error.cannotDeleteBusySession'));
+      throw new Error(i18n.t('error.cannotRenameBusySession'));
     }
 
     const registry = ctx.sessionRegistry();

--- a/apps/desktop/src/host/session-title-service.ts
+++ b/apps/desktop/src/host/session-title-service.ts
@@ -20,6 +20,9 @@ export async function applyGeneratedSessionTitle(input: {
       bundle?.activeSession
       && path.resolve(bundle.activeSession.filePath) === resolvedPath
     ) {
+      if (bundle.sessionTitleSource === 'manual') {
+        return;
+      }
       bundle.activeSession.displayName = input.title;
       bundle.sessionTitleSource = 'llm';
       await input.persistBundle(bundle);

--- a/apps/desktop/src/host/session-title-service.ts
+++ b/apps/desktop/src/host/session-title-service.ts
@@ -29,7 +29,7 @@ export async function applyGeneratedSessionTitle(input: {
     }
 
     const stored = await loadStoredSession(resolvedPath);
-    if (stored.sessionTitleSource === 'llm') {
+    if (stored.sessionTitleSource === 'llm' || stored.sessionTitleSource === 'manual') {
       return;
     }
     await saveStoredSession(resolvedPath, {

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -178,7 +178,9 @@ export function restoreStoredSessionState(input: {
       ? { activeModel: input.loaded.activeModel.trim() }
       : {}),
     ...(activePlanPath ? { activePlanPath } : {}),
-    ...(input.loaded.sessionTitleSource === 'seed' || input.loaded.sessionTitleSource === 'llm'
+    ...(input.loaded.sessionTitleSource === 'seed'
+      || input.loaded.sessionTitleSource === 'llm'
+      || input.loaded.sessionTitleSource === 'manual'
       ? { sessionTitleSource: input.loaded.sessionTitleSource }
       : {}),
     ...(input.loaded.contextUsage ? { contextUsage: { ...input.loaded.contextUsage } } : {}),

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -667,7 +667,9 @@ function normalizeStoredSession(parsed: Partial<StoredDesktopSession>): StoredDe
     ...(normalizeDisplayName(parsed.sessionDisplayName)
       ? { sessionDisplayName: normalizeDisplayName(parsed.sessionDisplayName) }
       : {}),
-    ...(parsed.sessionTitleSource === 'seed' || parsed.sessionTitleSource === 'llm'
+    ...(parsed.sessionTitleSource === 'seed'
+      || parsed.sessionTitleSource === 'llm'
+      || parsed.sessionTitleSource === 'manual'
       ? { sessionTitleSource: parsed.sessionTitleSource }
       : {}),
     ...(resolveStoredWorkspaceRoot(parsed.workspaceRoot)

--- a/apps/desktop/src/lib/browser-element-picker.ts
+++ b/apps/desktop/src/lib/browser-element-picker.ts
@@ -100,7 +100,7 @@ export function buildPickerInjectScript(): string {
   var marqueeDrag = false;
   var overlayMotionEnabled = false;
   var ELEMENT_OVERLAY_TRANSITION =
-    'left 200ms ease-out, top 200ms ease-out, width 200ms ease-out, height 200ms ease-out, opacity 150ms ease-out';
+    'left 120ms ease-out, top 120ms ease-out, width 120ms ease-out, height 120ms ease-out, opacity 150ms ease-out';
 
   var overlayEl = document.createElement('div');
   overlayEl.id = '__spiritPickerOverlay';

--- a/apps/desktop/src/lib/desktop-chrome.ts
+++ b/apps/desktop/src/lib/desktop-chrome.ts
@@ -29,6 +29,21 @@ export const DESKTOP_SHELL_LAYOUT_TRANSITION =
 /** 顶栏默认字色/图标色，与侧栏 `sidebarItemDefaultTextClass` 对齐 */
 export const DESKTOP_CHROME_MUTED_TEXT = "text-sidebar-action-foreground";
 
+/** 会话标题内联重命名 input：ghost、无边框，字色与侧栏/顶栏会话名一致 */
+export const SESSION_TITLE_RENAME_INPUT_CLASS = cn(
+  "min-w-0 rounded-none border-0 bg-transparent p-0 shadow-none outline-none ring-0 focus-visible:ring-0",
+  "text-xs font-medium",
+  DESKTOP_CHROME_MUTED_TEXT,
+);
+
+/** 顶栏/侧栏会话标题 hover：半透明铺底 + 字色变亮，与侧栏 `sidebarMenuHoverClass` 一致 */
+export const DESKTOP_SESSION_TITLE_HOVER_CLASS = cn(
+  "hover:!bg-foreground/[0.06] focus-visible:!bg-foreground/[0.06]",
+  "dark:hover:!bg-white/[0.06] dark:focus-visible:!bg-white/[0.06]",
+  "hover:!text-sidebar-foreground focus-visible:!text-sidebar-foreground",
+  instantHoverMotionClass,
+);
+
 /** 顶栏 hover/focus/当前项字色，与侧栏 `sidebarItemActiveTextClass` 对齐 */
 export const DESKTOP_CHROME_ACTIVE_TEXT = "text-sidebar-foreground";
 

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1034,6 +1034,7 @@
     "fileChangeSnapshotMissing": "File change snapshot missing; skipped this rewind item.",
     "ephemeralSessionExpired": "Temporary debug session does not exist or has expired.",
     "invalidSessionPath": "Invalid session path.",
+    "emptySessionDisplayName": "Session title cannot be empty.",
     "cannotDeleteBusySession": "Cannot delete a session while it is running.",
     "apiKeyNotConfigured": "API Key is not configured. Please fill it in Settings.",
     "mcpExecutorNotInitialized": "Desktop MCP tool executor has not been initialized.",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -1037,6 +1037,7 @@
     "ephemeralSessionExpired": "Temporary debug session does not exist or has expired.",
     "invalidSessionPath": "Invalid session path.",
     "emptySessionDisplayName": "Session title cannot be empty.",
+    "cannotRenameBusySession": "Cannot rename a session while it is running.",
     "cannotDeleteBusySession": "Cannot delete a session while it is running.",
     "apiKeyNotConfigured": "API Key is not configured. Please fill it in Settings.",
     "mcpExecutorNotInitialized": "Desktop MCP tool executor has not been initialized.",

--- a/apps/desktop/src/locales/en.json
+++ b/apps/desktop/src/locales/en.json
@@ -421,6 +421,8 @@
     "extensionSettings": "Extension Settings",
     "workspaceSessionsAria": "Workspace Sessions",
     "sessionActions": "Session actions",
+    "renameSession": "Rename",
+    "cannotRenameBusySession": "Cannot rename while the session is running.",
     "deleteSession": "Delete session",
     "deleteSessionConfirm": "Delete session \"{{name}}\"? This cannot be undone.",
     "cannotDeleteBusySession": "Cannot delete while the session is running.",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -421,6 +421,8 @@
     "extensionSettings": "扩展设置",
     "workspaceSessionsAria": "工作区会话",
     "sessionActions": "会话操作",
+    "renameSession": "重命名",
+    "cannotRenameBusySession": "会话运行中，无法重命名。",
     "deleteSession": "删除会话",
     "deleteSessionConfirm": "确定删除会话「{{name}}」？此操作无法撤销。",
     "cannotDeleteBusySession": "会话运行中，无法删除。",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -1031,6 +1031,7 @@
     "fileChangeSnapshotMissing": "文件变更快照缺失，已跳过该项回溯。",
     "ephemeralSessionExpired": "临时调试会话不存在或已过期。",
     "invalidSessionPath": "无效的会话路径。",
+    "emptySessionDisplayName": "会话标题不能为空。",
     "cannotDeleteBusySession": "运行中的会话无法删除。",
     "apiKeyNotConfigured": "未配置 API Key，请在设置中填写。",
     "mcpExecutorNotInitialized": "Desktop MCP tool executor 尚未初始化。",

--- a/apps/desktop/src/locales/zh-CN.json
+++ b/apps/desktop/src/locales/zh-CN.json
@@ -1034,6 +1034,7 @@
     "ephemeralSessionExpired": "临时调试会话不存在或已过期。",
     "invalidSessionPath": "无效的会话路径。",
     "emptySessionDisplayName": "会话标题不能为空。",
+    "cannotRenameBusySession": "运行中的会话无法重命名。",
     "cannotDeleteBusySession": "运行中的会话无法删除。",
     "apiKeyNotConfigured": "未配置 API Key，请在设置中填写。",
     "mcpExecutorNotInitialized": "Desktop MCP tool executor 尚未初始化。",


### PR DESCRIPTION
## Summary

- 新增 renameSession Host 命令与 sessionTitleSource: manual，手动标题持久化且 LLM 不再覆盖
- 侧栏与顶栏支持内联重命名，右键/三点菜单与双击入口，显示逻辑对齐删除项
- 顶栏会话标题接入与侧栏一致的 Git Tooltip（分支 + 工作区位置），ghost 样式与 hover 高亮

## Test plan

- [x] npm run build:electron 通过
- [x] 侧栏右键/双击重命名，Enter 提交、Escape 取消
- [x] 顶栏三点菜单/双击重命名，标题即时更新
- [x] 重启后会话 manual 标题保留，运行中会话入口 disabled
- [x] 顶栏 Git Tooltip 仅显示分支与工作区，无原生 title