### PR TITLE
feat(desktop): 侧栏拖入 Split Pane 四向拆分

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -557,8 +557,10 @@ export default function App() {
                 onPaneDragStart={pane.onPaneDragStart}
                 onPaneDragLeave={pane.onPaneDragLeave}
                 onPaneDrop={pane.onPaneDrop}
+                onSidebarSessionDrop={pane.onSidebarSessionDrop}
                 paneDropOverlayActive={pane.paneDropOverlayActive}
                 paneDragSourcePaneId={pane.paneDragSourcePaneId}
+                sidebarSessionDragActive={pane.sidebarSessionDragActive}
                 useMicaBackdrop={useMicaBackdrop}
                 subagentViewActive={subagentViewActive}
                 subagentViewer={subagentViewer}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -297,6 +297,15 @@ export default function App() {
           />
         ) : null}
         <div data-spirit-surface="main-frame" className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
+        <ConversationSplitProvider
+          runtime={runtime}
+          snapshot={snapshot}
+          conversationAbortShortcutTargetRef={conversationAbortShortcutTargetRef}
+          onEnsureConversationSurface={() => {
+            surfaceNav.setLastNonSettingsSurface("conversation");
+            surfaceNav.setActiveSurface("conversation");
+          }}
+        >
         <SessionSidebarShell useMicaBackdrop={useMicaBackdrop}>
           <SessionSidebar
             narrow={false}
@@ -523,11 +532,6 @@ export default function App() {
             )}
             aria-hidden={surfaceNav.settingsMode}
           >
-          <ConversationSplitProvider
-            runtime={runtime}
-            snapshot={snapshot}
-            conversationAbortShortcutTargetRef={conversationAbortShortcutTargetRef}
-          >
           <div className="flex min-h-0 min-w-0 flex-1 flex-row overflow-hidden">
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
           <ConversationSplitRoot
@@ -587,9 +591,9 @@ export default function App() {
             onOpenIntegrationsSettings={openIntegrationsSettings}
           />
           </div>
-          </ConversationSplitProvider>
           </div>
         ) : null}
+        </ConversationSplitProvider>
         </div>
       </div>
 

--- a/apps/desktop/src/components/conversation/conversation-pane-drop-indicator.tsx
+++ b/apps/desktop/src/components/conversation/conversation-pane-drop-indicator.tsx
@@ -6,7 +6,7 @@ import {
   applyPickerOverlayGeometry,
   hidePickerOverlayBox,
 } from "@/lib/browser-element-picker";
-import { paneDropIndicatorRect, visiblePaneDropZonesForDrag } from "@/lib/conversation-pane-drop-preview";
+import { paneDropIndicatorRect, visiblePaneDropZonesForDrag, visiblePaneDropZonesForSidebarSessionDrag } from "@/lib/conversation-pane-drop-preview";
 
 const OVERLAY_MOTION_TRANSITION =
   "left 120ms ease-out, top 120ms ease-out, width 120ms ease-out, height 120ms ease-out, opacity 150ms ease-out";
@@ -54,16 +54,18 @@ export function ConversationPaneDropIndicator() {
     const sourceHost = paneDragSourcePaneId
       ? document.querySelector(`[data-pane-drop-host="${paneDragSourcePaneId}"]`)
       : null;
-    const visibleZones = visiblePaneDropZonesForDrag({
-      paneCount,
-      sourcePaneHost:
-        sidebarSessionDragActive || !paneDragSourcePaneId
-          ? null
-          : sourceHost instanceof HTMLElement
-            ? sourceHost
-            : null,
-      targetPaneHost: host,
-    });
+    const visibleZones = sidebarSessionDragActive
+      ? visiblePaneDropZonesForSidebarSessionDrag()
+      : visiblePaneDropZonesForDrag({
+          paneCount,
+          sourcePaneHost:
+            !paneDragSourcePaneId
+              ? null
+              : sourceHost instanceof HTMLElement
+                ? sourceHost
+                : null,
+          targetPaneHost: host,
+        });
     if (!visibleZones.includes(paneDropTarget.zone)) {
       el.style.transition = OVERLAY_MOTION_TRANSITION;
       hidePickerOverlayBox(el);

--- a/apps/desktop/src/components/conversation/conversation-pane-drop-indicator.tsx
+++ b/apps/desktop/src/components/conversation/conversation-pane-drop-indicator.tsx
@@ -13,8 +13,9 @@ const OVERLAY_MOTION_TRANSITION =
 
 /** Single viewport-fixed ring that glides between pane drop quadrants (matches browser element picker). */
 export function ConversationPaneDropIndicator() {
-  const { paneDragActive, paneDragSourcePaneId, paneDropTarget, paneCount } =
+  const { paneDragActive, sidebarSessionDragActive, paneDragSourcePaneId, paneDropTarget, paneCount } =
     useConversationSplit();
+  const dropDragActive = paneDragActive || sidebarSessionDragActive;
   const overlayRef = useRef<HTMLDivElement | null>(null);
   const motionEnabledRef = useRef(false);
 
@@ -25,9 +26,9 @@ export function ConversationPaneDropIndicator() {
     }
 
     const shouldHide =
-      !paneDragActive
+      !dropDragActive
       || !paneDropTarget
-      || paneDropTarget.paneId === paneDragSourcePaneId;
+      || (paneDragSourcePaneId !== null && paneDropTarget.paneId === paneDragSourcePaneId);
 
     if (shouldHide) {
       if (el.style.opacity === "1" || motionEnabledRef.current) {
@@ -55,7 +56,12 @@ export function ConversationPaneDropIndicator() {
       : null;
     const visibleZones = visiblePaneDropZonesForDrag({
       paneCount,
-      sourcePaneHost: sourceHost instanceof HTMLElement ? sourceHost : null,
+      sourcePaneHost:
+        sidebarSessionDragActive || !paneDragSourcePaneId
+          ? null
+          : sourceHost instanceof HTMLElement
+            ? sourceHost
+            : null,
       targetPaneHost: host,
     });
     if (!visibleZones.includes(paneDropTarget.zone)) {
@@ -84,13 +90,13 @@ export function ConversationPaneDropIndicator() {
 
     el.style.transition = OVERLAY_MOTION_TRANSITION;
     applyPickerOverlayBox(el, rect);
-  }, [paneCount, paneDragActive, paneDragSourcePaneId, paneDropTarget]);
+  }, [dropDragActive, paneCount, paneDragSourcePaneId, paneDropTarget, sidebarSessionDragActive]);
 
   useLayoutEffect(() => {
-    if (!paneDragActive) {
+    if (!dropDragActive) {
       motionEnabledRef.current = false;
     }
-  }, [paneDragActive]);
+  }, [dropDragActive]);
 
   return (
     <div

--- a/apps/desktop/src/components/conversation/conversation-pane-host.tsx
+++ b/apps/desktop/src/components/conversation/conversation-pane-host.tsx
@@ -51,8 +51,10 @@ export type ConversationPaneHostProps = {
   onPaneDragStart?: (paneId: string) => void;
   onPaneDragLeave?: () => void;
   onPaneDrop?: (targetPaneId: string, zone: PaneDropZone) => void;
+  onSidebarSessionDrop?: (targetPaneId: string, zone: import("@/lib/conversation-split-layout").PaneRepositionZone) => void;
   paneDropOverlayActive: boolean;
   paneDragSourcePaneId: string | null;
+  sidebarSessionDragActive: boolean;
   t: TFunction;
   language: string;
 };
@@ -75,8 +77,10 @@ export function ConversationPaneHost({
   onPaneDragStart,
   onPaneDragLeave,
   onPaneDrop,
+  onSidebarSessionDrop,
   paneDropOverlayActive,
   paneDragSourcePaneId,
+  sidebarSessionDragActive,
   ...controllerInput
 }: ConversationPaneHostProps) {
   const split = useConversationSplit();
@@ -151,8 +155,10 @@ export function ConversationPaneHost({
       onPaneDragStart={paneReorderEnabled ? onPaneDragStart : undefined}
       onPaneDragLeave={paneReorderEnabled ? onPaneDragLeave : undefined}
       onPaneDrop={paneReorderEnabled ? onPaneDrop : undefined}
+      onSidebarSessionDrop={onSidebarSessionDrop}
       paneDropOverlayActive={paneDropOverlayActive}
       paneDragSourcePaneId={paneDragSourcePaneId}
+      sidebarSessionDragActive={sidebarSessionDragActive}
       subagentViewActive={pane.subagentViewActive}
       onExitSubagentViewer={pane.onExitSubagentViewer}
       onNewSession={controllerInput.onNewSession}

--- a/apps/desktop/src/components/conversation/conversation-split-root.tsx
+++ b/apps/desktop/src/components/conversation/conversation-split-root.tsx
@@ -31,8 +31,10 @@ type ConversationSplitRootProps = {
     onPaneDragStart: (paneId: string) => void;
     onPaneDragLeave: () => void;
     onPaneDrop: (targetPaneId: string, zone: import("@/lib/conversation-split-layout").PaneDropZone) => void;
+    onSidebarSessionDrop: (targetPaneId: string, zone: import("@/lib/conversation-split-layout").PaneRepositionZone) => void;
     paneDropOverlayActive: boolean;
     paneDragSourcePaneId: string | null;
+    sidebarSessionDragActive: boolean;
   }) => ReactNode;
 };
 
@@ -295,8 +297,12 @@ function SplitLayoutRenderer({
           onPaneDragStart: split.startPaneDrag,
           onPaneDragLeave: split.clearPaneDrag,
           onPaneDrop: split.completePaneDrop,
-          paneDropOverlayActive: split.paneDragActive,
+          onSidebarSessionDrop: (targetPaneId, zone) => {
+            void split.completeSidebarSessionDrop(targetPaneId, zone);
+          },
+          paneDropOverlayActive: split.paneDragActive || split.sidebarSessionDragActive,
           paneDragSourcePaneId: split.paneDragSourcePaneId,
+          sidebarSessionDragActive: split.sidebarSessionDragActive,
         })}
       </>
     );

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -42,7 +42,7 @@ import type { ConversationRenderItem } from "@/lib/conversation-process-groups";
 import type { TurnContinuePresentation } from "@/lib/conversation-continue-ui";
 import type { PendingAssistantAux } from "@/types";
 import { useConversationSplit } from "@/contexts/conversation-split-context";
-import { PANE_DROP_ZONE_ORDER, effectiveRepositionZone, paneDropZoneGridCellClass, paneDropZoneGridLayoutClass, visiblePaneDropZonesForDrag } from "@/lib/conversation-pane-drop-preview";
+import { PANE_DROP_ZONE_ORDER, effectiveRepositionZone, paneDropZoneGridCellClass, paneDropZoneGridLayoutClass, visiblePaneDropZonesForDrag, visiblePaneDropZonesForSidebarSessionDrag } from "@/lib/conversation-pane-drop-preview";
 import type { PaneDropZone } from "@/lib/conversation-split-layout";
 
 type DesktopRuntime = ReturnType<typeof useDesktopRuntime>;
@@ -294,7 +294,7 @@ export function ConversationView({
 
   const resolveVisibleDropZones = useCallback(() => {
     if (sidebarSessionDragActive) {
-      return PANE_DROP_ZONE_ORDER;
+      return visiblePaneDropZonesForSidebarSessionDrag();
     }
     if (!paneId || !paneDragSourcePaneId) {
       return PANE_DROP_ZONE_ORDER;

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -199,8 +199,10 @@ export type ConversationViewProps = {
   onPaneDragEnter?: (paneId: string, zone: import("@/lib/conversation-split-layout").PaneRepositionZone) => void;
   onPaneDragLeave?: () => void;
   onPaneDrop?: (paneId: string, zone: PaneDropZone) => void;
+  onSidebarSessionDrop?: (paneId: string, zone: import("@/lib/conversation-split-layout").PaneRepositionZone) => void;
   paneDropOverlayActive?: boolean;
   paneDragSourcePaneId?: string | null;
+  sidebarSessionDragActive?: boolean;
 };
 
 export function ConversationView({
@@ -246,8 +248,10 @@ export function ConversationView({
   onPaneDragEnter,
   onPaneDragLeave,
   onPaneDrop,
+  onSidebarSessionDrop,
   paneDropOverlayActive = false,
   paneDragSourcePaneId = null,
+  sidebarSessionDragActive = false,
 }: ConversationViewProps) {
   const { t } = useTranslation();
   const split = useConversationSplit();
@@ -279,12 +283,19 @@ export function ConversationView({
     enabled: conversationMessagesVisible,
   });
 
-  const dropOverlayActive = Boolean(paneId && onPaneDrop && paneDropOverlayActive);
+  const dropOverlayActive = Boolean(
+    paneId
+    && paneDropOverlayActive
+    && (onPaneDrop || onSidebarSessionDrop),
+  );
   const isDragSourcePane = Boolean(paneId && paneDragSourcePaneId === paneId);
   const showDropTargets = dropOverlayActive && !isDragSourcePane;
   const dropHostRef = useRef<HTMLDivElement | null>(null);
 
   const resolveVisibleDropZones = useCallback(() => {
+    if (sidebarSessionDragActive) {
+      return PANE_DROP_ZONE_ORDER;
+    }
     if (!paneId || !paneDragSourcePaneId) {
       return PANE_DROP_ZONE_ORDER;
     }
@@ -296,7 +307,7 @@ export function ConversationView({
       sourcePaneHost: sourceHost instanceof HTMLElement ? sourceHost : null,
       targetPaneHost: dropHostRef.current,
     });
-  }, [paneDragSourcePaneId, paneId, split.paneCount]);
+  }, [paneDragSourcePaneId, paneId, sidebarSessionDragActive, split.paneCount]);
 
   const updateDropTarget = useCallback(
     (zone: PaneDropZone) => {
@@ -423,11 +434,16 @@ export function ConversationView({
                   if (!visibleDropZones.includes(zone)) {
                     return;
                   }
+                  const repositionZone = effectiveRepositionZone(zone, visibleDropZones);
+                  if (sidebarSessionDragActive && onSidebarSessionDrop) {
+                    void onSidebarSessionDrop(paneId!, repositionZone);
+                    return;
+                  }
                   if (zone === "swap") {
                     onPaneDrop?.(paneId!, zone);
                     return;
                   }
-                  onPaneDrop?.(paneId!, effectiveRepositionZone(zone, visibleDropZones));
+                  onPaneDrop?.(paneId!, repositionZone);
                 }}
               />
             ))}

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type DragEvent,
   type MouseEvent,
   type PointerEvent,
   type ReactNode,
@@ -83,6 +84,8 @@ import { isViteDev } from "@/lib/vite-dev";
 import { cn } from "@/lib/utils";
 import { SettingsShortcutKbd } from "@/components/layout/desktop-shortcut-kbds";
 import { SESSION_TITLE_RENAME_INPUT_CLASS } from "@/lib/desktop-chrome";
+import { useOptionalConversationSplit } from "@/contexts/conversation-split-context";
+import { isSidebarSessionDragBlockedTarget, setSidebarSessionDragData } from "@/lib/sidebar-session-drag";
 import { shortcutLabel, settingsShortcutLabel } from "@/lib/desktop-shell";
 import i18n from "@/lib/i18n";
 import { useHostApi } from "@/hooks/useHostApi";
@@ -419,7 +422,10 @@ const WorkspaceSessionGroupCollapsible = memo(function WorkspaceSessionGroupColl
   workspaceReorderActive = false,
 }: WorkspaceSessionGroupCollapsibleProps) {
   const { t } = useTranslation();
+  const split = useOptionalConversationSplit();
   const workspaceRoot = group.rootPath?.trim() ?? "";
+  const workspaceNewSessionDragEnabled =
+    Boolean(split) && Boolean(workspaceRoot) && !disabled && !newSessionBusy;
   const [workspaceRowHovered, setWorkspaceRowHovered] = useState(false);
   const [plusTooltipAnchorLocked, setPlusTooltipAnchorLocked] = useState(false);
   const showWorkspaceRowHoverChrome = workspaceRowHovered || isDragging || isPressing;
@@ -528,6 +534,7 @@ const WorkspaceSessionGroupCollapsible = memo(function WorkspaceSessionGroupColl
                 variant="ghost"
                 size="icon"
                 data-workspace-new-session=""
+                draggable={workspaceNewSessionDragEnabled}
                 className={cn(
                   "mr-0.5 size-6 shrink-0",
                   workspaceRowHovered || plusTooltipAnchorLocked
@@ -537,10 +544,24 @@ const WorkspaceSessionGroupCollapsible = memo(function WorkspaceSessionGroupColl
                   sidebarItemDefaultTextClass,
                   sidebarInteractionMotionClass,
                   sidebarItemHoverClass(micaStyle),
+                  workspaceNewSessionDragEnabled && "cursor-grab active:cursor-grabbing",
                 )}
                 disabled={disabled || newSessionBusy}
                 aria-label={t("sidebar.newSessionInWorkspace", { workspace: group.label })}
                 onClick={() => onNewSessionInWorkspace(workspaceRoot)}
+                onDragStart={(event) => {
+                  if (!split || !workspaceNewSessionDragEnabled) {
+                    event.preventDefault();
+                    return;
+                  }
+                  const payload = {
+                    kind: "new-in-workspace" as const,
+                    workspaceRoot,
+                  };
+                  setSidebarSessionDragData(event.dataTransfer, payload);
+                  split.startSidebarSessionDrag(payload);
+                }}
+                onDragEnd={() => split?.clearSidebarSessionDrag()}
               >
                 <Plus className="size-3.5" aria-hidden />
               </Button>
@@ -689,9 +710,11 @@ const SessionListRow = memo(function SessionListRow({
   onRenameStart,
 }: SessionListRowProps) {
   const { t } = useTranslation();
+  const split = useOptionalConversationSplit();
   const gitTooltipContext = useOptionalSessionListGitTooltipContext();
   const renameInputRef = useRef<HTMLInputElement>(null);
   const skipBlurCommitRef = useRef(false);
+  const sessionDragEnabled = Boolean(split) && !disabled && !isBusy && !renaming;
   const hasIndicator =
     (isBusy && !isBlocked) ||
     (!selected && (isBlocked || showCompletedUnseen));
@@ -756,6 +779,20 @@ const SessionListRow = memo(function SessionListRow({
     }
   };
 
+  const handleSessionDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    if (!split || !sessionDragEnabled || isSidebarSessionDragBlockedTarget(event.target)) {
+      event.preventDefault();
+      return;
+    }
+    const payload = { kind: "stored" as const, sessionPath };
+    setSidebarSessionDragData(event.dataTransfer, payload);
+    split.startSidebarSessionDrag(payload);
+  };
+
+  const handleSessionDragEnd = () => {
+    split?.clearSidebarSessionDrag();
+  };
+
   if (renaming) {
     return (
       <div data-session-path={sessionPath} className={rowClassName}>
@@ -783,8 +820,11 @@ const SessionListRow = memo(function SessionListRow({
       type="button"
       data-session-path={sessionPath}
       disabled={disabled}
+      draggable={sessionDragEnabled}
       aria-current={selected ? "true" : undefined}
       onClick={() => onSelectPath(sessionPath)}
+      onDragStart={handleSessionDragStart}
+      onDragEnd={handleSessionDragEnd}
       onDoubleClick={(event) => {
         if (!onRenameStart || disabled || isBusy) {
           return;
@@ -793,7 +833,10 @@ const SessionListRow = memo(function SessionListRow({
         event.stopPropagation();
         onRenameStart();
       }}
-      className={rowClassName}
+      className={cn(
+        rowClassName,
+        sessionDragEnabled && "cursor-grab active:cursor-grabbing",
+      )}
     >
       {leading}
       <span
@@ -1243,6 +1286,7 @@ function SessionSidebarInner({
   unseenCompletedSessionPaths,
 }: SessionSidebarProps) {
   const { t, i18n } = useTranslation();
+  const split = useOptionalConversationSplit();
   const settingsMode = mode === "settings";
 
   useEffect(() => {
@@ -1521,6 +1565,8 @@ function SessionSidebarInner({
     !automationsActive &&
     !sessionNavigationBusy &&
     (newSessionBusy || !isActiveSessionInSidebar);
+  const newSessionDragEnabled =
+    Boolean(split) && !disabled && !(newSessionBusy && !newSessionNavActive);
 
   useEffect(() => {
     if (!activeFilePath) {
@@ -1681,6 +1727,7 @@ function SessionSidebarInner({
             variant={sidebarNavButtonVariant(micaStyle, newSessionNavActive)}
             size={narrow ? "icon" : "sm"}
             aria-current={newSessionNavActive ? "page" : undefined}
+            draggable={newSessionDragEnabled}
             className={cn(
               "text-xs",
               sidebarItemDefaultTextClass,
@@ -1691,9 +1738,20 @@ function SessionSidebarInner({
               narrow
                 ? "size-8 shrink-0"
                 : "group h-8 w-full justify-start gap-2",
+              newSessionDragEnabled && "cursor-grab active:cursor-grabbing",
             )}
             disabled={disabled || (newSessionBusy && !newSessionNavActive)}
             onClick={onNewSession}
+            onDragStart={(event) => {
+              if (!split || !newSessionDragEnabled) {
+                event.preventDefault();
+                return;
+              }
+              const payload = { kind: "new" as const };
+              setSidebarSessionDragData(event.dataTransfer, payload);
+              split.startSidebarSessionDrag(payload);
+            }}
+            onDragEnd={() => split?.clearSidebarSessionDrag()}
           >
             <SquarePen className="size-3.5" aria-hidden />
             <span className={cn(narrow && "sr-only")}>{t('sidebar.newSession')}</span>

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -544,7 +544,6 @@ const WorkspaceSessionGroupCollapsible = memo(function WorkspaceSessionGroupColl
                   sidebarItemDefaultTextClass,
                   sidebarInteractionMotionClass,
                   sidebarItemHoverClass(micaStyle),
-                  workspaceNewSessionDragEnabled && "cursor-grab active:cursor-grabbing",
                 )}
                 disabled={disabled || newSessionBusy}
                 aria-label={t("sidebar.newSessionInWorkspace", { workspace: group.label })}
@@ -833,10 +832,7 @@ const SessionListRow = memo(function SessionListRow({
         event.stopPropagation();
         onRenameStart();
       }}
-      className={cn(
-        rowClassName,
-        sessionDragEnabled && "cursor-grab active:cursor-grabbing",
-      )}
+      className={rowClassName}
     >
       {leading}
       <span
@@ -1738,7 +1734,6 @@ function SessionSidebarInner({
               narrow
                 ? "size-8 shrink-0"
                 : "group h-8 w-full justify-start gap-2",
-              newSessionDragEnabled && "cursor-grab active:cursor-grabbing",
             )}
             disabled={disabled || (newSessionBusy && !newSessionNavActive)}
             onClick={onNewSession}

--- a/apps/desktop/src/contexts/conversation-split-context.tsx
+++ b/apps/desktop/src/contexts/conversation-split-context.tsx
@@ -667,6 +667,12 @@ export function ConversationSplitProvider({
 
     }
 
+    if (layoutNavigationLockRef.current) {
+
+      return;
+
+    }
+
     const generation = ++layoutResolveGenerationRef.current;
 
     const current = layoutRef.current;
@@ -1492,55 +1498,65 @@ export function ConversationSplitProvider({
     async (targetPaneId: string, zone: PaneRepositionZone) => {
       const payload = sidebarSessionDragPayload;
       clearSidebarSessionDrag();
-      if (!payload || !layout || !runtime.apiReady) {
+      const layoutBeforeDrop = layoutRef.current;
+      if (!payload || !layoutBeforeDrop || !runtime.apiReady) {
+        return;
+      }
+
+      if (!findLeafByPaneId(layoutBeforeDrop, targetPaneId)) {
         return;
       }
 
       onEnsureConversationSurface?.();
 
       if (payload.kind === "stored") {
-        const existingPaneId = findPaneIdBySessionPath(layout, payload.sessionPath);
+        const existingPaneId = findPaneIdBySessionPath(layoutBeforeDrop, payload.sessionPath);
         if (existingPaneId) {
           focusPane(existingPaneId, payload.sessionPath);
           return;
         }
       }
 
-      const newPaneId = createPaneId();
-      let newSessionPath: string;
+      layoutNavigationLockRef.current = true;
+      setLayoutNavigationPending(true);
 
-      if (payload.kind === "stored") {
-        newSessionPath = payload.sessionPath;
-      } else {
-        if (payload.kind === "new-in-workspace") {
-          const trimmed = payload.workspaceRoot.trim();
-          if (trimmed) {
-            const currentRoot = snapshot?.workspaceRoot?.trim() ?? "";
-            const needsSwitch =
-              snapshot?.workspaceBinding !== "project"
-              || !currentRoot
-              || !sameWorkspacePath(currentRoot, trimmed);
-            if (needsSwitch) {
-              const switched = await runtime.switchWorkspaceRoot(trimmed);
-              if (!switched) {
-                return;
+      try {
+        const newPaneId = createPaneId();
+        let newSessionPath: string;
+
+        if (payload.kind === "stored") {
+          newSessionPath = payload.sessionPath;
+        } else {
+          if (payload.kind === "new-in-workspace") {
+            const trimmed = payload.workspaceRoot.trim();
+            if (trimmed) {
+              const currentRoot = snapshot?.workspaceRoot?.trim() ?? "";
+              const needsSwitch =
+                snapshot?.workspaceBinding !== "project"
+                || !currentRoot
+                || !sameWorkspacePath(currentRoot, trimmed);
+              if (needsSwitch) {
+                const switched = await runtime.switchWorkspaceRoot(trimmed);
+                if (!switched) {
+                  return;
+                }
               }
             }
           }
+          const response = await runtime.beginSplitPaneSession(newPaneId, { deferSnapshot: true });
+          newSessionPath = response.sessionPath;
         }
-        const response = await runtime.beginSplitPaneSession(newPaneId, { deferSnapshot: true });
-        newSessionPath = response.sessionPath;
-      }
 
-      const newLeaf = createLeafNode(newPaneId, newSessionPath);
-      const nextLayout = splitPaneAtZone(layout, targetPaneId, zone, newLeaf);
-      const paths = collectPaneSessionPaths(nextLayout);
+        const layoutForSplit = layoutRef.current;
+        if (!layoutForSplit || !findLeafByPaneId(layoutForSplit, targetPaneId)) {
+          return;
+        }
 
-      layoutNavigationLockRef.current = true;
-      setLayoutNavigationPending(true);
-      visiblePathsSyncedRef.current = paths.join("\0");
+        const newLeaf = createLeafNode(newPaneId, newSessionPath);
+        const nextLayout = splitPaneAtZone(layoutForSplit, targetPaneId, zone, newLeaf);
+        const paths = collectPaneSessionPaths(nextLayout);
+        visiblePathsSyncedRef.current = paths.join("\0");
 
-      try {
         await runtime.syncSplitPaneSessions(paths, newSessionPath);
         setLayout(nextLayout);
         setFocusedPaneId(newPaneId);
@@ -1553,7 +1569,6 @@ export function ConversationSplitProvider({
     [
       clearSidebarSessionDrag,
       focusPane,
-      layout,
       onEnsureConversationSurface,
       runtime,
       sidebarSessionDragPayload,

--- a/apps/desktop/src/contexts/conversation-split-context.tsx
+++ b/apps/desktop/src/contexts/conversation-split-context.tsx
@@ -1534,12 +1534,21 @@ export function ConversationSplitProvider({
 
       const newLeaf = createLeafNode(newPaneId, newSessionPath);
       const nextLayout = splitPaneAtZone(layout, targetPaneId, zone, newLeaf);
-      setLayout(nextLayout);
-      setFocusedPaneId(newPaneId);
-      persistSessionSplitBinding(nextLayout);
       const paths = collectPaneSessionPaths(nextLayout);
+
+      layoutNavigationLockRef.current = true;
+      setLayoutNavigationPending(true);
       visiblePathsSyncedRef.current = paths.join("\0");
-      await runtime.syncSplitPaneSessions(paths, newSessionPath);
+
+      try {
+        await runtime.syncSplitPaneSessions(paths, newSessionPath);
+        setLayout(nextLayout);
+        setFocusedPaneId(newPaneId);
+        persistSessionSplitBinding(nextLayout);
+      } finally {
+        layoutNavigationLockRef.current = false;
+        setLayoutNavigationPending(false);
+      }
     },
     [
       clearSidebarSessionDrag,

--- a/apps/desktop/src/contexts/conversation-split-context.tsx
+++ b/apps/desktop/src/contexts/conversation-split-context.tsx
@@ -569,7 +569,7 @@ export function ConversationSplitProvider({
 
   // 指针不在有效 drop zone 上时同步清除 target（dragLeave 在快速滑过源面板时可能误判）
   useEffect(() => {
-    if (!paneDragActive) {
+    if (!paneDragActive && !sidebarSessionDragActive) {
       return;
     }
     const sourcePaneId = paneDragSourcePaneId;
@@ -583,7 +583,7 @@ export function ConversationSplitProvider({
       if (zoneEl instanceof HTMLElement) {
         const hostEl = zoneEl.closest("[data-pane-drop-host]");
         const hostPaneId = hostEl?.getAttribute("data-pane-drop-host");
-        if (hostPaneId && hostPaneId !== sourcePaneId) {
+        if (hostPaneId && (sidebarSessionDragActive || hostPaneId !== sourcePaneId)) {
           return;
         }
       }
@@ -591,7 +591,7 @@ export function ConversationSplitProvider({
     };
     document.addEventListener("dragover", handleDocumentDragOver);
     return () => document.removeEventListener("dragover", handleDocumentDragOver);
-  }, [paneDragActive, paneDragSourcePaneId, setPaneDropTarget]);
+  }, [paneDragActive, paneDragSourcePaneId, setPaneDropTarget, sidebarSessionDragActive]);
 
   const [layoutNavigationPending, setLayoutNavigationPending] = useState(false);
 

--- a/apps/desktop/src/contexts/conversation-split-context.tsx
+++ b/apps/desktop/src/contexts/conversation-split-context.tsx
@@ -54,6 +54,8 @@ import {
 
   splitPaneAt,
 
+  splitPaneAtZone,
+
   updateLeafSessionPath,
 
   updateSplitRatio,
@@ -99,7 +101,14 @@ import type { FocusedPaneComposerInsertHandlers } from "@/lib/focused-pane-compo
 import type { ConversationAbortShortcutTargetRef } from "@/lib/conversation-abort-shortcut";
 import type { DesktopSnapshot } from "@/types";
 
+import { sameWorkspacePath } from "@/lib/workspace-display-label";
+
 type DesktopRuntime = ReturnType<typeof useDesktopRuntime>;
+
+export type SidebarSessionDragPayload =
+  | { kind: "stored"; sessionPath: string }
+  | { kind: "new" }
+  | { kind: "new-in-workspace"; workspaceRoot: string };
 
 
 
@@ -155,6 +164,19 @@ type ConversationSplitContextValue = {
 
   setPaneDropTarget: (target: { paneId: string; zone: PaneDropZone } | null) => void;
 
+  sidebarSessionDragActive: boolean;
+
+  sidebarSessionDragPayload: SidebarSessionDragPayload | null;
+
+  startSidebarSessionDrag: (payload: SidebarSessionDragPayload) => void;
+
+  clearSidebarSessionDrag: () => void;
+
+  completeSidebarSessionDrop: (
+    targetPaneId: string,
+    zone: PaneRepositionZone,
+  ) => Promise<void>;
+
   layoutNavigationPending: boolean;
 
   focusedPaneComposerInsertRef: MutableRefObject<FocusedPaneComposerInsertHandlers | null>;
@@ -181,6 +203,19 @@ function layoutIncludesSessionPath(layout: SplitLayoutNode, sessionPath: string)
 
   );
 
+}
+
+function findPaneIdBySessionPath(
+  layout: SplitLayoutNode,
+  sessionPath: string,
+): string | null {
+  const target = normalizeSessionPathKey(sessionPath);
+  for (const leaf of collectSplitLayoutLeaves(layout)) {
+    if (normalizeSessionPathKey(leaf.sessionPath) === target) {
+      return leaf.paneId;
+    }
+  }
+  return null;
 }
 
 
@@ -470,6 +505,8 @@ export function ConversationSplitProvider({
 
   conversationAbortShortcutTargetRef = null,
 
+  onEnsureConversationSurface,
+
   children,
 
 }: {
@@ -479,6 +516,8 @@ export function ConversationSplitProvider({
   snapshot: DesktopSnapshot | null;
 
   conversationAbortShortcutTargetRef?: ConversationAbortShortcutTargetRef | null;
+
+  onEnsureConversationSurface?: () => void;
 
   children: ReactNode;
 
@@ -498,6 +537,11 @@ export function ConversationSplitProvider({
     paneId: string;
     zone: PaneDropZone;
   } | null>(null);
+
+  const [sidebarSessionDragPayload, setSidebarSessionDragPayload] =
+    useState<SidebarSessionDragPayload | null>(null);
+
+  const sidebarSessionDragActive = sidebarSessionDragPayload !== null;
 
   const focusedPaneComposerInsertRef = useRef<FocusedPaneComposerInsertHandlers | null>(null);
 
@@ -1435,7 +1479,79 @@ export function ConversationSplitProvider({
 
   );
 
+  const startSidebarSessionDrag = useCallback((payload: SidebarSessionDragPayload) => {
+    setSidebarSessionDragPayload(payload);
+  }, []);
 
+  const clearSidebarSessionDrag = useCallback(() => {
+    setSidebarSessionDragPayload(null);
+    setPaneDropTarget(null);
+  }, [setPaneDropTarget]);
+
+  const completeSidebarSessionDrop = useCallback(
+    async (targetPaneId: string, zone: PaneRepositionZone) => {
+      const payload = sidebarSessionDragPayload;
+      clearSidebarSessionDrag();
+      if (!payload || !layout || !runtime.apiReady) {
+        return;
+      }
+
+      onEnsureConversationSurface?.();
+
+      if (payload.kind === "stored") {
+        const existingPaneId = findPaneIdBySessionPath(layout, payload.sessionPath);
+        if (existingPaneId) {
+          focusPane(existingPaneId, payload.sessionPath);
+          return;
+        }
+      }
+
+      const newPaneId = createPaneId();
+      let newSessionPath: string;
+
+      if (payload.kind === "stored") {
+        newSessionPath = payload.sessionPath;
+      } else {
+        if (payload.kind === "new-in-workspace") {
+          const trimmed = payload.workspaceRoot.trim();
+          if (trimmed) {
+            const currentRoot = snapshot?.workspaceRoot?.trim() ?? "";
+            const needsSwitch =
+              snapshot?.workspaceBinding !== "project"
+              || !currentRoot
+              || !sameWorkspacePath(currentRoot, trimmed);
+            if (needsSwitch) {
+              const switched = await runtime.switchWorkspaceRoot(trimmed);
+              if (!switched) {
+                return;
+              }
+            }
+          }
+        }
+        const response = await runtime.beginSplitPaneSession(newPaneId, { deferSnapshot: true });
+        newSessionPath = response.sessionPath;
+      }
+
+      const newLeaf = createLeafNode(newPaneId, newSessionPath);
+      const nextLayout = splitPaneAtZone(layout, targetPaneId, zone, newLeaf);
+      setLayout(nextLayout);
+      setFocusedPaneId(newPaneId);
+      persistSessionSplitBinding(nextLayout);
+      const paths = collectPaneSessionPaths(nextLayout);
+      visiblePathsSyncedRef.current = paths.join("\0");
+      await runtime.syncSplitPaneSessions(paths, newSessionPath);
+    },
+    [
+      clearSidebarSessionDrag,
+      focusPane,
+      layout,
+      onEnsureConversationSurface,
+      runtime,
+      sidebarSessionDragPayload,
+      snapshot?.workspaceBinding,
+      snapshot?.workspaceRoot,
+    ],
+  );
 
   const value = useMemo<ConversationSplitContextValue>(
 
@@ -1483,6 +1599,16 @@ export function ConversationSplitProvider({
 
       setPaneDropTarget,
 
+      sidebarSessionDragActive,
+
+      sidebarSessionDragPayload,
+
+      startSidebarSessionDrag,
+
+      clearSidebarSessionDrag,
+
+      completeSidebarSessionDrop,
+
       layoutNavigationPending,
 
       focusedPaneComposerInsertRef,
@@ -1497,11 +1623,15 @@ export function ConversationSplitProvider({
 
       clearPaneDrag,
 
+      clearSidebarSessionDrag,
+
       closePaneById,
 
       collapsePaneLayoutById,
 
       completePaneDrop,
+
+      completeSidebarSessionDrop,
 
       focusPane,
 
@@ -1517,6 +1647,10 @@ export function ConversationSplitProvider({
 
       paneDropTarget,
 
+      sidebarSessionDragActive,
+
+      sidebarSessionDragPayload,
+
       repositionPaneById,
 
       setPaneDropTarget,
@@ -1524,6 +1658,8 @@ export function ConversationSplitProvider({
       splitPane,
 
       startPaneDrag,
+
+      startSidebarSessionDrag,
 
       updateRatio,
 

--- a/apps/desktop/src/lib/conversation-pane-drop-preview.ts
+++ b/apps/desktop/src/lib/conversation-pane-drop-preview.ts
@@ -1,7 +1,7 @@
 import type { MarqueeRect } from "@/lib/browser-element-picker";
 import type { PaneDropZone, PaneRepositionZone } from "@/lib/conversation-split-layout";
 
-/** 2×2 grid: TL above, TR after, BL before, BR below. */
+/** 2×2 grid: TL above, TR after, BL before, BR below. Used when pane reorder has no adjacent source. */
 export const PANE_DROP_ZONE_ORDER: readonly PaneRepositionZone[] = [
   "above",
   "after",
@@ -9,10 +9,32 @@ export const PANE_DROP_ZONE_ORDER: readonly PaneRepositionZone[] = [
   "below",
 ];
 
+/**
+ * Sidebar session drag: left/right edge columns (full height) + center column (above/below).
+ * Indicators tile the full left/right/top/bottom half — not quadrant corners.
+ */
+export const SIDEBAR_SESSION_DROP_ZONE_ORDER: readonly PaneRepositionZone[] = [
+  "before",
+  "above",
+  "after",
+  "below",
+];
+
+export function visiblePaneDropZonesForSidebarSessionDrag(): readonly PaneRepositionZone[] {
+  return SIDEBAR_SESSION_DROP_ZONE_ORDER;
+}
+
 export const PANE_DROP_ZONE_GRID_CLASS: Record<PaneRepositionZone, string> = {
   above: "col-start-1 row-start-1",
   after: "col-start-2 row-start-1",
   before: "col-start-1 row-start-2",
+  below: "col-start-2 row-start-2",
+};
+
+const PANE_DROP_ZONE_SIDEBAR_SPLIT_CLASS: Record<PaneRepositionZone, string> = {
+  before: "col-start-1 row-span-2 row-start-1",
+  above: "col-start-2 row-start-1",
+  after: "col-start-3 row-span-2 row-start-1",
   below: "col-start-2 row-start-2",
 };
 
@@ -113,11 +135,27 @@ type VisibleZoneLayout =
   | "top-bottom"
   | "left-right"
   | "triple-row"
-  | "triple-col";
+  | "triple-col"
+  | "sidebar-split";
+
+function isSidebarSplitZoneSet(visibleZones: readonly PaneDropZone[]): boolean {
+  const set = new Set(visibleZones);
+  return (
+    visibleZones.length === 4
+    && set.has("before")
+    && set.has("after")
+    && set.has("above")
+    && set.has("below")
+    && !set.has("swap")
+  );
+}
 
 function visibleZoneLayout(
   visibleZones: readonly PaneDropZone[],
 ): VisibleZoneLayout | null {
+  if (isSidebarSplitZoneSet(visibleZones)) {
+    return "sidebar-split";
+  }
   const set = new Set(visibleZones);
   if (set.has("swap") && set.has("above") && set.has("below")) {
     return "triple-row";
@@ -185,10 +223,100 @@ function tripleBandSizes(length: number): { edge: number; swap: number } {
   return { edge, swap };
 }
 
+function sidebarSplitColBandSizes(width: number): { edge: number; center: number } {
+  const center = width * (SWAP_BAND_FR / TRIPLE_BAND_TOTAL_FR);
+  const edge = (width - center) / 2;
+  return { edge, center };
+}
+
+function sidebarSplitHitRect(hostRect: DOMRect, zone: PaneRepositionZone): MarqueeRect {
+  const left = hostRect.left;
+  const top = hostRect.top;
+  const width = hostRect.width;
+  const height = hostRect.height;
+  const { edge: edgeW, center: centerW } = sidebarSplitColBandSizes(width);
+  const halfH = height / 2;
+  const centerLeft = left + edgeW;
+
+  switch (zone) {
+    case "before":
+      return {
+        x: Math.round(left),
+        y: Math.round(top),
+        width: Math.round(edgeW),
+        height: Math.round(height),
+      };
+    case "after":
+      return {
+        x: Math.round(left + edgeW + centerW),
+        y: Math.round(top),
+        width: Math.round(edgeW),
+        height: Math.round(height),
+      };
+    case "above":
+      return {
+        x: Math.round(centerLeft),
+        y: Math.round(top),
+        width: Math.round(centerW),
+        height: Math.round(halfH),
+      };
+    case "below":
+      return {
+        x: Math.round(centerLeft),
+        y: Math.round(top + halfH),
+        width: Math.round(centerW),
+        height: Math.round(halfH),
+      };
+  }
+}
+
+function sidebarSplitIndicatorRect(hostRect: DOMRect, zone: PaneRepositionZone): MarqueeRect {
+  const left = hostRect.left;
+  const top = hostRect.top;
+  const width = hostRect.width;
+  const height = hostRect.height;
+  const halfW = width / 2;
+  const halfH = height / 2;
+
+  switch (zone) {
+    case "before":
+      return {
+        x: Math.round(left),
+        y: Math.round(top),
+        width: Math.round(halfW),
+        height: Math.round(height),
+      };
+    case "after":
+      return {
+        x: Math.round(left + halfW),
+        y: Math.round(top),
+        width: Math.round(halfW),
+        height: Math.round(height),
+      };
+    case "above":
+      return {
+        x: Math.round(left),
+        y: Math.round(top),
+        width: Math.round(width),
+        height: Math.round(halfH),
+      };
+    case "below":
+      return {
+        x: Math.round(left),
+        y: Math.round(top + halfH),
+        width: Math.round(width),
+        height: Math.round(halfH),
+      };
+  }
+}
+
 export function paneDropZoneGridLayoutClass(
   visibleZones: readonly PaneDropZone[],
 ): string {
   const layout = visibleZoneLayout(visibleZones);
+  if (layout === "sidebar-split") {
+    return `grid-cols-[${TRIPLE_EDGE_FR}fr_${SWAP_BAND_FR}fr_${TRIPLE_EDGE_FR}fr] grid-rows-2`;
+  }
   if (layout === "triple-row" || layout === "top-bottom") {
     return `grid-cols-1 grid-rows-[${TRIPLE_EDGE_FR}fr_${SWAP_BAND_FR}fr_${TRIPLE_EDGE_FR}fr]`;
   }
@@ -203,6 +331,9 @@ export function paneDropZoneGridCellClass(
   visibleZones: readonly PaneDropZone[],
 ): string | undefined {
   const layout = visibleZoneLayout(visibleZones);
+  if (layout === "sidebar-split" && (zone === "before" || zone === "above" || zone === "after" || zone === "below")) {
+    return PANE_DROP_ZONE_SIDEBAR_SPLIT_CLASS[zone];
+  }
   if (layout === "triple-row" && (zone === "above" || zone === "swap" || zone === "below")) {
     return PANE_DROP_ZONE_TRIPLE_ROW_CLASS[zone];
   }
@@ -227,6 +358,10 @@ export function paneDropZoneRect(
   const halfW = width / 2;
   const halfH = height / 2;
   const layout = visibleZoneLayout(visibleZones);
+
+  if (layout === "sidebar-split" && zone !== "swap") {
+    return sidebarSplitHitRect(hostRect, zone);
+  }
 
   if (layout === "triple-row") {
     const { edge: edgeH, swap: swapH } = tripleBandSizes(height);
@@ -375,6 +510,9 @@ export function paneDropIndicatorRect(
       width: Math.round(hostRect.width),
       height: Math.round(hostRect.height),
     };
+  }
+  if (visibleZoneLayout(visibleZones) === "sidebar-split") {
+    return sidebarSplitIndicatorRect(hostRect, zone);
   }
   return paneDropZoneRect(hostRect, zone, visibleZones);
 }

--- a/apps/desktop/src/lib/conversation-split-layout.ts
+++ b/apps/desktop/src/lib/conversation-split-layout.ts
@@ -370,6 +370,21 @@ function replaceLeaf(
   };
 }
 
+/** Split a target pane by wrapping it with a new leaf at the given drop zone (sidebar session drag). */
+export function splitPaneAtZone(
+  node: SplitLayoutNode,
+  targetPaneId: string,
+  zone: PaneRepositionZone,
+  newLeaf: SplitLayoutLeafNode,
+): SplitLayoutNode {
+  const targetLeaf = findLeafByPaneId(node, targetPaneId);
+  if (!targetLeaf) {
+    return node;
+  }
+  const replacement = wrapWithSplit(targetLeaf, newLeaf, zone);
+  return replaceLeaf(node, targetPaneId, replacement);
+}
+
 export function repositionPane(
   node: SplitLayoutNode,
   sourcePaneId: string,

--- a/apps/desktop/src/lib/sidebar-session-drag.ts
+++ b/apps/desktop/src/lib/sidebar-session-drag.ts
@@ -1,0 +1,54 @@
+import type { SidebarSessionDragPayload } from "@/contexts/conversation-split-context";
+
+export const SIDEBAR_SESSION_DRAG_MIME = "application/x-spirit-sidebar-session";
+
+export function setSidebarSessionDragData(
+  dataTransfer: DataTransfer,
+  payload: SidebarSessionDragPayload,
+): void {
+  dataTransfer.setData(SIDEBAR_SESSION_DRAG_MIME, JSON.stringify(payload));
+  dataTransfer.effectAllowed = "copy";
+}
+
+export function parseSidebarSessionDragData(
+  dataTransfer: DataTransfer,
+): SidebarSessionDragPayload | null {
+  const raw = dataTransfer.getData(SIDEBAR_SESSION_DRAG_MIME);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as SidebarSessionDragPayload;
+    if (
+      parsed.kind === "stored"
+      && typeof parsed.sessionPath === "string"
+      && parsed.sessionPath.trim()
+    ) {
+      return { kind: "stored", sessionPath: parsed.sessionPath.trim() };
+    }
+    if (parsed.kind === "new") {
+      return { kind: "new" };
+    }
+    if (
+      parsed.kind === "new-in-workspace"
+      && typeof parsed.workspaceRoot === "string"
+      && parsed.workspaceRoot.trim()
+    ) {
+      return { kind: "new-in-workspace", workspaceRoot: parsed.workspaceRoot.trim() };
+    }
+  } catch {
+    // Invalid drag payload.
+  }
+  return null;
+}
+
+export function isSidebarSessionDragBlockedTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element
+    && Boolean(
+      target.closest(
+        'input, textarea, select, [role="menuitem"], [data-no-session-drag]',
+      ),
+    )
+  );
+}

--- a/apps/desktop/test/renderer/conversation-pane-drop-preview.test.mjs
+++ b/apps/desktop/test/renderer/conversation-pane-drop-preview.test.mjs
@@ -8,6 +8,7 @@ import {
   paneDropIndicatorRect,
   paneDropZoneRect,
   visiblePaneDropZonesForDrag,
+  visiblePaneDropZonesForSidebarSessionDrag,
 } from "../../src/lib/conversation-pane-drop-preview.ts";
 import {
   createLeafNode,
@@ -102,6 +103,36 @@ test("repositionPane converts vertical split to horizontal when dropping top ont
     return;
   }
   assert.equal(moved.direction, "horizontal");
+});
+
+test("visiblePaneDropZonesForSidebarSessionDrag uses edge columns and center above/below", () => {
+  const visible = visiblePaneDropZonesForSidebarSessionDrag();
+  assert.deepEqual(visible, ["before", "above", "after", "below"]);
+});
+
+test("paneDropIndicatorRect tiles full halves for sidebar session split", () => {
+  const host = rect(0, 0, 400, 400);
+  const visible = visiblePaneDropZonesForSidebarSessionDrag();
+  const above = paneDropIndicatorRect(host, "above", visible);
+  assert.deepEqual(above, { x: 0, y: 0, width: 400, height: 200 });
+  const before = paneDropIndicatorRect(host, "before", visible);
+  assert.deepEqual(before, { x: 0, y: 0, width: 200, height: 400 });
+  const after = paneDropIndicatorRect(host, "after", visible);
+  assert.deepEqual(after, { x: 200, y: 0, width: 200, height: 400 });
+  const below = paneDropIndicatorRect(host, "below", visible);
+  assert.deepEqual(below, { x: 0, y: 200, width: 400, height: 200 });
+});
+
+test("paneDropZoneRect keeps sidebar above/below hits in the center column band", () => {
+  const host = rect(0, 0, 400, 400);
+  const visible = visiblePaneDropZonesForSidebarSessionDrag();
+  const aboveHit = paneDropZoneRect(host, "above", visible);
+  assert.equal(aboveHit.width, 80);
+  assert.equal(aboveHit.x, 160);
+  assert.equal(aboveHit.height, 200);
+  const beforeHit = paneDropZoneRect(host, "before", visible);
+  assert.equal(beforeHit.width, 160);
+  assert.equal(beforeHit.height, 400);
 });
 
 test("visiblePaneDropZonesForDrag uses full quadrants when panes are not adjacent", () => {

--- a/apps/desktop/test/renderer/conversation-split-layout.test.mjs
+++ b/apps/desktop/test/renderer/conversation-split-layout.test.mjs
@@ -12,6 +12,7 @@ import {
   findSessionSidebarAnchorPaneId,
   repositionPane,
   splitPaneAt,
+  splitPaneAtZone,
   updateSplitRatio,
   updateSplitRatios,
   collectSplitJunctions,
@@ -84,6 +85,54 @@ test("updateSplitRatio updates the matching split node", () => {
     return;
   }
   assert.equal(updated.ratio, 0.7);
+});
+
+test("splitPaneAtZone places incoming before target horizontally", () => {
+  const root = createSinglePaneLayout("a", "/sessions/a.json");
+  const next = splitPaneAtZone(root, "a", "before", createLeafNode("b", "/sessions/b.json"));
+  assert.equal(next.kind, "split");
+  if (next.kind !== "split") {
+    return;
+  }
+  assert.equal(next.direction, "horizontal");
+  assert.equal(next.first.paneId, "b");
+  assert.equal(next.second.paneId, "a");
+});
+
+test("splitPaneAtZone places incoming after target horizontally", () => {
+  const root = createSinglePaneLayout("a", "/sessions/a.json");
+  const next = splitPaneAtZone(root, "a", "after", createLeafNode("b", "/sessions/b.json"));
+  assert.equal(next.kind, "split");
+  if (next.kind !== "split") {
+    return;
+  }
+  assert.equal(next.direction, "horizontal");
+  assert.equal(next.first.paneId, "a");
+  assert.equal(next.second.paneId, "b");
+});
+
+test("splitPaneAtZone places incoming above target vertically", () => {
+  const root = createSinglePaneLayout("a", "/sessions/a.json");
+  const next = splitPaneAtZone(root, "a", "above", createLeafNode("b", "/sessions/b.json"));
+  assert.equal(next.kind, "split");
+  if (next.kind !== "split") {
+    return;
+  }
+  assert.equal(next.direction, "vertical");
+  assert.equal(next.first.paneId, "b");
+  assert.equal(next.second.paneId, "a");
+});
+
+test("splitPaneAtZone places incoming below target vertically", () => {
+  const root = createSinglePaneLayout("a", "/sessions/a.json");
+  const next = splitPaneAtZone(root, "a", "below", createLeafNode("b", "/sessions/b.json"));
+  assert.equal(next.kind, "split");
+  if (next.kind !== "split") {
+    return;
+  }
+  assert.equal(next.direction, "vertical");
+  assert.equal(next.first.paneId, "a");
+  assert.equal(next.second.paneId, "b");
 });
 
 test("repositionPane moves a leaf below the target", () => {


### PR DESCRIPTION
## Summary

- 侧栏会话项、新建会话与工作区 + 按钮支持 HTML5 拖拽至右侧 Pane，触发四向 split
- 新增 splitPaneAtZone 与 completeSidebarSessionDrop，既有会话可直接开进新 pane（无需新 IPC）
- 侧栏拖入使用 sidebar-split 半屏指示器：左右边缘平铺半屏，上下仅在中间竖条识别
- ConversationSplitProvider 上提包裹 main-frame；已在 layout 中的会话 drop 时聚焦已有 pane

## Test plan

- [x] node --test apps/desktop/test/renderer/conversation-split-layout.test.mjs
- [x] node --test apps/desktop/test/renderer/conversation-pane-drop-preview.test.mjs
- [x] npm run build:electron -w @spirit-agent/desktop
- [x] Windows Desktop 手动：单 Pane 拖已有会话/新会话四向 split、多 Pane 目标 pane split、重复会话聚焦、侧栏手型光标