### PR TITLE
refactor: npm 包 scope 迁移至 @spiritagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Agent Core owns how the model sees project context:
 - **Smoke suites** — contract, runtime, and live provider checks under `packages/agent-core/src/smoke`.
 - **Eval harness** — scenario comparison and judging for prompt or tool-definition changes (`npm run eval:compare` from the repo root).
 
-`@spirit-agent/core` is published to npm; [`packages/host-internal`](packages/host-internal) holds shared host-side discovery, extensions, marketplace, workspace helpers, and LSP orchestration used by Desktop.
+`@spiritagent/agent-core` is published to npm; [`packages/host-internal`](packages/host-internal) holds shared host-side discovery, extensions, marketplace, workspace helpers, and LSP orchestration used by Desktop.
 
 ## Desktop
 

--- a/apps/desktop/NOTICE.md
+++ b/apps/desktop/NOTICE.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-This file was generated for `@spirit-agent/desktop` (`dependencies` + `devDependencies`; direct dependencies only by default).
+This file was generated for `@spiritagent/desktop` (`dependencies` + `devDependencies`; direct dependencies only by default).
 Regenerate: `npm run notice` — `-- --production` limits output to production dependencies, `-- --recursive` includes transitive dependencies.
 Scope constraint: exclude workspace-local/internal dependencies resolved via `workspace:` or `file:`; keep output sorted deterministically by package name and license section.
 

--- a/apps/desktop/electron/github-oauth-flow.ts
+++ b/apps/desktop/electron/github-oauth-flow.ts
@@ -5,7 +5,7 @@ import {
   pollGitHubDeviceToken,
   requestGitHubDeviceCode,
   type GitHubDeviceAuthChallenge,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import { saveGitHubOAuthCredentials } from '../src/host/github-auth-storage.js';
 

--- a/apps/desktop/electron/http-host.ts
+++ b/apps/desktop/electron/http-host.ts
@@ -8,7 +8,7 @@ import {
 } from 'node:http';
 import path from 'node:path';
 
-import { parseModelProviderId, parsePresetModelProviderId } from '@spirit-agent/host-internal/model-provider-presets';
+import { parseModelProviderId, parsePresetModelProviderId } from '@spiritagent/host-internal/model-provider-presets';
 
 import type { HostCommandName } from '../src/host/contracts.js';
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -20,7 +20,7 @@ import {
   type WebContents,
 } from 'electron';
 
-import { detectSupportedImageFile } from '@spirit-agent/host-internal/image-file-support';
+import { detectSupportedImageFile } from '@spiritagent/host-internal/image-file-support';
 
 import {
   registerDesktopNotifications,

--- a/apps/desktop/electron/open-system-terminal.ts
+++ b/apps/desktop/electron/open-system-terminal.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { shell } from 'electron';
 
-import { defaultShellForPty } from '@spirit-agent/host-internal/default-terminal-shell';
+import { defaultShellForPty } from '@spiritagent/host-internal/default-terminal-shell';
 
 function assertDirectory(cwd: string): string {
   const resolved = path.resolve(cwd);

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -277,7 +277,7 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   },
   setPaneWorkLocation(request: {
     sessionPath: string;
-    workLocation: import('@spirit-agent/host-internal').WorkLocationKind;
+    workLocation: import('@spiritagent/host-internal').WorkLocationKind;
   }) {
     return ipcRenderer.invoke('desktop:invoke', 'setPaneWorkLocation', { request });
   },

--- a/apps/desktop/electron/workspace-pty.ts
+++ b/apps/desktop/electron/workspace-pty.ts
@@ -5,9 +5,9 @@ import path from 'node:path';
 
 import type { WebContents } from 'electron';
 
-import { defaultShellForPty, shellDisplayNameForResolvedShell } from '@spirit-agent/host-internal/default-terminal-shell';
+import { defaultShellForPty, shellDisplayNameForResolvedShell } from '@spiritagent/host-internal/default-terminal-shell';
 
-export { defaultShellForPty, shellDisplayNameForResolvedShell } from '@spirit-agent/host-internal/default-terminal-shell';
+export { defaultShellForPty, shellDisplayNameForResolvedShell } from '@spiritagent/host-internal/default-terminal-shell';
 
 const require = createRequire(import.meta.url);
 

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@spirit-agent/desktop",
+  "name": "@spiritagent/desktop",
   "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@spirit-agent/desktop",
+      "name": "@spiritagent/desktop",
       "version": "0.2.6",
       "hasInstallScript": true,
       "dependencies": {
@@ -14,8 +14,8 @@
         "@radix-ui/react-scroll-area": "^1.2.10",
         "@shikijs/monaco": "^3.23.0",
         "@shikijs/themes": "^3.23.0",
-        "@spirit-agent/core": "file:../../packages/agent-core",
-        "@spirit-agent/host-internal": "file:../../packages/host-internal",
+        "@spiritagent/agent-core": "file:../../packages/agent-core",
+        "@spiritagent/host-internal": "file:../../packages/host-internal",
         "@streamdown/code": "^1.1.1",
         "@streamdown/math": "^1.0.2",
         "@streamdown/mermaid": "^1.0.2",
@@ -48,6 +48,7 @@
         "rehype-sanitize": "^6.0.0",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
+        "seti-icons": "^0.0.4",
         "shadcn": "^4.4.0",
         "shiki": "^3.23.0",
         "sonner": "^2.0.7",
@@ -81,7 +82,7 @@
       }
     },
     "../..": {
-      "name": "@spirit-agent/dev-root",
+      "name": "@spiritagent/dev-root",
       "workspaces": [
         "packages/*"
       ],
@@ -90,7 +91,7 @@
       }
     },
     "../../packages/agent-core": {
-      "name": "@spirit-agent/core",
+      "name": "@spiritagent/agent-core",
       "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
@@ -122,24 +123,30 @@
       }
     },
     "../../packages/host-internal": {
-      "name": "@spirit-agent/host-internal",
+      "name": "@spiritagent/host-internal",
       "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock": "^3.1068.0",
-        "@spirit-agent/core": "0.2.6",
+        "@mozilla/readability": "^0.6.0",
+        "@spiritagent/agent-core": "0.2.6",
         "@vscode/ripgrep": "^1.18.0",
         "fast-glob": "^3.3.3",
         "fflate": "^0.8.2",
         "glob": "^13.0.6",
         "google-auth-library": "^10.6.1",
         "ignore": "^5.3.2",
+        "jsdom": "^29.1.1",
         "tar": "^7.5.13",
+        "turndown": "^7.2.4",
+        "turndown-plugin-gfm": "^1.0.2",
         "vscode-jsonrpc": "^8.2.1",
         "vscode-languageserver-protocol": "^3.17.5"
       },
       "devDependencies": {
+        "@types/jsdom": "^28.0.3",
         "@types/node": "^25.6.0",
+        "@types/turndown": "^5.0.6",
         "license-checker-rseidelsohn": "^4.4.2",
         "typescript": "^5.6.3"
       },
@@ -4870,11 +4877,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@spirit-agent/core": {
+    "node_modules/@spiritagent/agent-core": {
       "resolved": "../../packages/agent-core",
       "link": true
     },
-    "node_modules/@spirit-agent/host-internal": {
+    "node_modules/@spiritagent/host-internal": {
       "resolved": "../../packages/host-internal",
       "link": true
     },
@@ -5706,6 +5713,12 @@
         "xmlbuilder": ">=11.0.1"
       }
     },
+    "node_modules/@types/q": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
+      "integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -5749,6 +5762,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/svgo": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/svgo/-/svgo-1.3.6.tgz",
+      "integrity": "sha512-AZU7vQcy/4WFEuwnwsNsJnFwupIpbllH1++LXScN6uxT1Z4zPzdrWG97w4/I7eFKFTvfy/bHFStWjdBAg2Vjug==",
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -6524,6 +6543,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -6532,6 +6567,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz",
+      "integrity": "sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/assert-plus": {
@@ -6585,6 +6663,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6600,6 +6687,21 @@
       "license": "ISC",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/axios": {
@@ -6713,7 +6815,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/boolean": {
@@ -7107,6 +7208,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -7520,6 +7639,91 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/coa": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+      "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/coa/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/coa/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/coa/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/coa/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/coa/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coa/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/coa/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -7792,6 +7996,25 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-select-base-adapter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -7816,6 +8039,37 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csso": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -8360,6 +8614,57 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.21",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
@@ -8503,9 +8808,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -8534,9 +8837,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -8833,7 +9134,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9339,6 +9639,98 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -9358,9 +9750,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -9373,7 +9765,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9383,6 +9774,26 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-toolkit": {
@@ -9870,6 +10281,21 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -10036,11 +10462,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fuzzysort": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
       "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
       "license": "MIT"
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -10144,6 +10611,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gitdiff-parser": {
@@ -10255,9 +10739,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -10328,6 +10810,18 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -10342,11 +10836,24 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -10368,7 +10875,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -10381,9 +10887,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -11136,6 +11642,20 @@
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -11187,11 +11707,90 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -11201,6 +11800,39 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -11234,6 +11866,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -11243,6 +11890,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -11250,6 +11912,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -11323,6 +12004,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-node-process": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
@@ -11336,6 +12041,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-obj": {
@@ -11368,6 +12089,24 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-regexp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
@@ -11378,6 +12117,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -11392,6 +12158,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -11402,6 +12216,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-wsl": {
@@ -12579,6 +13436,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -14142,9 +15005,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -14156,6 +15017,65 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.9.tgz",
+      "integrity": "sha512-mt8YM6XwsTTovI+kdZdHSxoyF2DI59up034orlC9NfweclcWOt7CVascNNLp6U+bjFVCVCIh9PwS76tDM/rH8g==",
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.reduce": "^1.0.8",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "gopd": "^1.2.0",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/on-finished": {
@@ -14271,6 +15191,23 @@
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "license": "MIT"
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -14601,6 +15538,15 @@
         "points-on-curve": "0.2.0"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
@@ -14849,6 +15795,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
     "node_modules/qs": {
@@ -15225,6 +16182,28 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/refractor": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
@@ -15355,6 +16334,26 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/rehype-harden": {
       "version": "1.1.8",
@@ -15873,6 +16872,31 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -15893,6 +16917,45 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -16010,6 +17073,62 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
       "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/seti-icons": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/seti-icons/-/seti-icons-0.0.4.tgz",
+      "integrity": "sha512-DXP6OzUzPtfSHQHKQ++U4mFByATGlN/fs5e43W3EAUtWf1FKauA3Li6Z2SQDB70l1m1Kr0mYzCtP6TsvRYT4Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/svgo": "^1.3.2",
+        "svgo": "^1.3.2"
+      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -16573,6 +17692,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -16602,6 +17728,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/streamdown": {
@@ -16721,6 +17860,63 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/stringify-entities": {
@@ -16865,6 +18061,219 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+      "deprecated": "This SVGO version is no longer supported. Upgrade to v2.x.x.",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/svgo/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/svgo/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/svgo/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/svgo/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/svgo/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/svgo/node_modules/css-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+      "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^3.2.1",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
+      }
+    },
+    "node_modules/svgo/node_modules/css-what": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.2.tgz",
+      "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/svgo/node_modules/dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/svgo/node_modules/domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/svgo/node_modules/domutils/node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/svgo/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/svgo/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/svgo/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/svgo/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/svgo/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/svgo/node_modules/nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "node_modules/svgo/node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "license": "ISC"
+    },
+    "node_modules/svgo/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/svgo/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tagged-tag": {
@@ -17344,6 +18753,80 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -17364,6 +18847,24 @@
       "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/undici": {
       "version": "6.26.0",
@@ -17553,6 +19054,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==",
+      "license": "MIT"
+    },
     "node_modules/until-async": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
@@ -17718,6 +19225,21 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/util.promisify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.1.tgz",
+      "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/uuid": {
       "version": "14.0.0",
@@ -17977,6 +19499,97 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrap-ansi": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spirit-agent/desktop",
+  "name": "@spiritagent/desktop",
   "private": true,
   "version": "0.2.6",
   "description": "Desktop application for Spirit Agent",
@@ -45,8 +45,8 @@
     "@radix-ui/react-scroll-area": "^1.2.10",
     "@shikijs/monaco": "^3.23.0",
     "@shikijs/themes": "^3.23.0",
-    "@spirit-agent/core": "file:../../packages/agent-core",
-    "@spirit-agent/host-internal": "file:../../packages/host-internal",
+    "@spiritagent/agent-core": "file:../../packages/agent-core",
+    "@spiritagent/host-internal": "file:../../packages/host-internal",
     "@streamdown/code": "^1.1.1",
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",

--- a/apps/desktop/scripts/check-renderer-agent-core-imports.mjs
+++ b/apps/desktop/scripts/check-renderer-agent-core-imports.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Desktop renderer 仅允许从 agent-core 的 renderer-safe 子路径做 value import。
- * 主入口 @spirit-agent/core 的 value import 会拉入 AI SDK / Node 依赖链。
+ * 主入口 @spiritagent/agent-core 的 value import 会拉入 AI SDK / Node 依赖链。
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
@@ -22,7 +22,7 @@ const RENDERER_SAFE_AGENT_CORE_SUBPATHS = new Set([
 const RENDERER_SCAN_ROOTS = ['components', 'hooks', 'lib', 'App.tsx'];
 
 const IMPORT_RE =
-  /import\s+(?:type\s+)?(?:[\w*{}\s,]+\s+from\s+)?['"]@spirit-agent\/core(?:\/([^'"]+))?['"]/gu;
+  /import\s+(?:type\s+)?(?:[\w*{}\s,]+\s+from\s+)?['"]@spiritagent\/agent-core(?:\/([^'"]+))?['"]/gu;
 
 function collectSourceFiles(entryPath) {
   const stat = statSync(entryPath);
@@ -50,7 +50,7 @@ function scanFile(filePath) {
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (!line.includes('@spirit-agent/core')) {
+    if (!line.includes('@spiritagent/agent-core')) {
       continue;
     }
     if (isTypeOnlyImport(line)) {
@@ -63,7 +63,7 @@ function scanFile(filePath) {
         violations.push({
           file: relative(repoRoot, filePath),
           line: index + 1,
-          reason: '禁止从 @spirit-agent/core 主入口做 value import',
+          reason: '禁止从 @spiritagent/agent-core 主入口做 value import',
         });
         continue;
       }

--- a/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
+++ b/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Desktop renderer 仅允许从 host-internal 的 renderer-safe 子路径做 value import。
- * 主入口 @spirit-agent/host-internal 的 value import 会拉入 node:fs 依赖链。
+ * 主入口 @spiritagent/host-internal 的 value import 会拉入 node:fs 依赖链。
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
@@ -30,7 +30,7 @@ const RENDERER_SAFE_HOST_INTERNAL_SUBPATHS = new Set([
 const RENDERER_SCAN_ROOTS = ['components', 'hooks', 'lib', 'App.tsx'];
 
 const IMPORT_RE =
-  /import\s+(?:type\s+)?(?:[\w*{}\s,]+\s+from\s+)?['"]@spirit-agent\/host-internal(?:\/([^'"]+))?['"]/gu;
+  /import\s+(?:type\s+)?(?:[\w*{}\s,]+\s+from\s+)?['"]@spiritagent\/host-internal(?:\/([^'"]+))?['"]/gu;
 
 function collectSourceFiles(entryPath) {
   const stat = statSync(entryPath);
@@ -58,7 +58,7 @@ function scanFile(filePath) {
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (!line.includes('@spirit-agent/host-internal')) {
+    if (!line.includes('@spiritagent/host-internal')) {
       continue;
     }
     if (isTypeOnlyImport(line)) {
@@ -71,7 +71,7 @@ function scanFile(filePath) {
         violations.push({
           file: relative(repoRoot, filePath),
           line: index + 1,
-          reason: '禁止从 @spirit-agent/host-internal 主入口做 value import',
+          reason: '禁止从 @spiritagent/host-internal 主入口做 value import',
         });
         continue;
       }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -50,7 +50,7 @@ import {
   resolveUseMicaBackdrop,
 } from "@/lib/desktop-shell";
 import { isMarkdownPath } from "@/lib/file-picker-path";
-import { isWorkspaceReferenceDirectoryPath, normalizeWorkspaceReferenceDirectoryPath } from "@spirit-agent/host-internal/workspace-file-reference-query";
+import { isWorkspaceReferenceDirectoryPath, normalizeWorkspaceReferenceDirectoryPath } from "@spiritagent/host-internal/workspace-file-reference-query";
 import { tryHandleDesktopWorkspaceLink } from "@/lib/workspace-navigation-link";
 import {
   applyUiLayoutScaleToDocument,

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -223,13 +223,13 @@ export function createWebHostApi(): HostApi {
     setLoopEnabled(enabled: boolean) {
       return post<DesktopSnapshot>(baseUrl, '/api/loop', { enabled });
     },
-    setApprovalLevel(approvalLevel: import('@spirit-agent/host-internal').ApprovalLevel) {
+    setApprovalLevel(approvalLevel: import('@spiritagent/host-internal').ApprovalLevel) {
       return post<DesktopSnapshot>(baseUrl, '/api/approval', { approvalLevel });
     },
     setPendingGitBranch(branch: string) {
       return post<DesktopSnapshot>(baseUrl, '/api/git/pending-branch', { branch });
     },
-    setWorkLocation(workLocation: import('@spirit-agent/host-internal').WorkLocationKind) {
+    setWorkLocation(workLocation: import('@spiritagent/host-internal').WorkLocationKind) {
       return post<DesktopSnapshot>(baseUrl, '/api/git/work-location', { workLocation });
     },
     checkoutGitBranch(request: import('../types.js').CheckoutGitBranchRequest) {
@@ -512,7 +512,7 @@ export function createWebHostApi(): HostApi {
       return post<HostTextFileStatResult>(baseUrl, '/api/host/file/stat', { absolutePath });
     },
     classifyLocalFileComposerRoute(absolutePath: string) {
-      return post<import('@spirit-agent/host-internal').LocalFileComposerRoute>(
+      return post<import('@spiritagent/host-internal').LocalFileComposerRoute>(
         baseUrl,
         '/api/host/file/classify-composer-route',
         { absolutePath },

--- a/apps/desktop/src/components/approval-level-menu.tsx
+++ b/apps/desktop/src/components/approval-level-menu.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ApprovalLevel } from "@spirit-agent/host-internal";
+import type { ApprovalLevel } from "@spiritagent/host-internal";
 import { Brain, ChevronDown, ShieldBan, ShieldCheck, type LucideIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 

--- a/apps/desktop/src/components/file-tool-lsp-diagnostics-badge.tsx
+++ b/apps/desktop/src/components/file-tool-lsp-diagnostics-badge.tsx
@@ -5,7 +5,7 @@ import {
   toolCardSecondaryTextClass,
 } from "@/lib/file-tool-lsp-diagnostics-display";
 import { cn } from "@/lib/utils";
-import type { LspWriteDiagnosticsUi } from "@spirit-agent/core";
+import type { LspWriteDiagnosticsUi } from "@spiritagent/agent-core";
 
 export function FileToolLspDiagnosticsBadge({
   diagnostics,

--- a/apps/desktop/src/components/file-tool-lsp-diagnostics-hover.tsx
+++ b/apps/desktop/src/components/file-tool-lsp-diagnostics-hover.tsx
@@ -5,7 +5,7 @@ import {
   type ReactNode,
 } from "react";
 
-import type { LspWriteDiagnosticsUi } from "@spirit-agent/core";
+import type { LspWriteDiagnosticsUi } from "@spiritagent/agent-core";
 
 import {
   Tooltip,

--- a/apps/desktop/src/components/model-picker-inspector-panel.tsx
+++ b/apps/desktop/src/components/model-picker-inspector-panel.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next';
 import {
   modelReasoningEffortLabel,
   modelReasoningEffortOptions,
-} from '@spirit-agent/core/reasoning-effort';
+} from '@spiritagent/agent-core/reasoning-effort';
 import {
   modelEffortControlLabelKind,
   modelShowsReasoningEffortControl,
   modelSupportsThinkingSwitch,
   resolveModelThinkingEnabled,
-} from '@spirit-agent/core/model-thinking-controls';
+} from '@spiritagent/agent-core/model-thinking-controls';
 
 import { ModelCatalogDetailPanel } from '@/components/model-catalog-detail-panel';
 import { modelCatalogHasDetailBody } from '@/lib/model-catalog-detail';

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -34,11 +34,11 @@ import {
   modelDisplayTitleFromMap,
 } from "@/lib/model-catalog-detail";
 import { toolCardSecondaryTextClass } from "@/lib/file-tool-lsp-diagnostics-display";
-import { modelReasoningEffortLabel } from "@spirit-agent/core/reasoning-effort";
+import { modelReasoningEffortLabel } from "@spiritagent/agent-core/reasoning-effort";
 import {
   modelSupportsThinkingSwitch,
   resolveModelThinkingEnabled,
-} from "@spirit-agent/core/model-thinking-controls";
+} from "@spiritagent/agent-core/model-thinking-controls";
 import { groupModelsForPicker } from "@/lib/model-picker-groups";
 import type { DesktopModelReasoningEffort, DesktopSnapshot, ModelProfileSnapshot, PreviewModelCatalogEntry } from "@/types";
 import { cn } from "@/lib/utils";

--- a/apps/desktop/src/components/settings/models/models-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/models/models-settings-panel.tsx
@@ -88,13 +88,13 @@ import type {
   PreviewModelsRequest,
   PreviewModelsResponse,
 } from "@/types";
-import { bedrockApiBaseFromRegion } from "@spirit-agent/host-internal/bedrock-region";
+import { bedrockApiBaseFromRegion } from "@spiritagent/host-internal/bedrock-region";
 import {
   bedrockMantleApiBaseFromRegion,
   isBedrockMantleOpenAiModel,
-} from "@spirit-agent/host-internal/bedrock-mantle";
-import { azureApiBaseFromResourceName, isValidAzureResourceName } from "@spirit-agent/host-internal/azure-resource";
-import { vertexApiBaseFromProjectAndLocation } from "@spirit-agent/host-internal/google-vertex-endpoints";
+} from "@spiritagent/host-internal/bedrock-mantle";
+import { azureApiBaseFromResourceName, isValidAzureResourceName } from "@spiritagent/host-internal/azure-resource";
+import { vertexApiBaseFromProjectAndLocation } from "@spiritagent/host-internal/google-vertex-endpoints";
 
 export function ModelsSettingsPanel({
   settings,

--- a/apps/desktop/src/components/work-location-menu.tsx
+++ b/apps/desktop/src/components/work-location-menu.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { WorkLocationKind } from "@spirit-agent/host-internal";
+import type { WorkLocationKind } from "@spiritagent/host-internal";
 import type { LucideIcon } from "lucide-react";
 import { ChevronDown, GitFork, Monitor } from "lucide-react";
 import { useTranslation } from "react-i18next";

--- a/apps/desktop/src/components/workspace-file-picker-row.tsx
+++ b/apps/desktop/src/components/workspace-file-picker-row.tsx
@@ -1,7 +1,7 @@
 import {
   isWorkspaceReferenceDirectoryPath,
   normalizeWorkspaceReferenceDirectoryPath,
-} from '@spirit-agent/host-internal/workspace-file-reference-query'
+} from '@spiritagent/host-internal/workspace-file-reference-query'
 import {
   DESKTOP_OVERLAY_LIST_ITEM_PRIMARY,
   DESKTOP_OVERLAY_LIST_ITEM_SECONDARY,

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -9,7 +9,7 @@ import {
   ListTodo,
 } from "lucide-react";
 
-import { WORKSPACE_REFERENCE_DIRECTORY_SUFFIX } from "@spirit-agent/host-internal/workspace-file-reference-query";
+import { WORKSPACE_REFERENCE_DIRECTORY_SUFFIX } from "@spiritagent/host-internal/workspace-file-reference-query";
 
 import {
   WorkspaceFileContextMenuContent,

--- a/apps/desktop/src/components/workspace-pr-tab.tsx
+++ b/apps/desktop/src/components/workspace-pr-tab.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronLeft } from "lucide-react";
-import { appendPullRequestChecksPages } from "@spirit-agent/host-internal/github-pull-request-checks-pages";
-import { appendPullRequestConversationPages } from "@spirit-agent/host-internal/github-pull-request-conversation-pages";
+import { appendPullRequestChecksPages } from "@spiritagent/host-internal/github-pull-request-checks-pages";
+import { appendPullRequestConversationPages } from "@spiritagent/host-internal/github-pull-request-conversation-pages";
 
 import { Button } from "@/components/ui/button";
 import { GitHubSignInPrompt } from "@/components/github-sign-in-prompt";

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -92,9 +92,9 @@ declare global {
     compactHistory(): Promise<DesktopSnapshot>;
     submitUserTurn(request: SubmitUserTurnRequest): Promise<DesktopSnapshot>;
     setLoopEnabled(enabled: boolean): Promise<DesktopSnapshot>;
-    setApprovalLevel(approvalLevel: import('@spirit-agent/host-internal').ApprovalLevel): Promise<DesktopSnapshot>;
+    setApprovalLevel(approvalLevel: import('@spiritagent/host-internal').ApprovalLevel): Promise<DesktopSnapshot>;
     setPendingGitBranch(branch: string): Promise<DesktopSnapshot>;
-    setWorkLocation(workLocation: import('@spirit-agent/host-internal').WorkLocationKind): Promise<DesktopSnapshot>;
+    setWorkLocation(workLocation: import('@spiritagent/host-internal').WorkLocationKind): Promise<DesktopSnapshot>;
     checkoutGitBranch(request: import('./types.js').CheckoutGitBranchRequest): Promise<DesktopSnapshot>;
     mergeWorktreeToMain(): Promise<DesktopSnapshot>;
     pushGitBranch(): Promise<DesktopSnapshot>;
@@ -241,7 +241,7 @@ declare global {
     statHostTextFile(absolutePath: string): Promise<HostTextFileStatResult>;
     classifyLocalFileComposerRoute(
       absolutePath: string,
-    ): Promise<import('@spirit-agent/host-internal').LocalFileComposerRoute>;
+    ): Promise<import('@spiritagent/host-internal').LocalFileComposerRoute>;
     pickWorkspaceDirectory(): Promise<string | null>;
     pickLocalFile(): Promise<string | null>;
     getPathForDroppedFile(file: File): string;

--- a/apps/desktop/src/hooks/use-monaco-code-completion.ts
+++ b/apps/desktop/src/hooks/use-monaco-code-completion.ts
@@ -3,11 +3,11 @@ import { useEffect, useRef } from "react";
 import {
   codeCompletionOperationToInlineItemAtCursor,
   type CodeCompletionOperation,
-} from "@spirit-agent/core/code-completion-to-monaco";
+} from "@spiritagent/agent-core/code-completion-to-monaco";
 import {
   codeCompletionOperationToDeleteDiffPreviewAtCursor,
   type InlineDeleteDiffPreviewSpec,
-} from "@spirit-agent/core/code-completion-delete-diff";
+} from "@spiritagent/agent-core/code-completion-delete-diff";
 import * as monaco from "monaco-editor";
 
 import { useHostApi } from "@/hooks/useHostApi";

--- a/apps/desktop/src/hooks/use-workspace-file-index.ts
+++ b/apps/desktop/src/hooks/use-workspace-file-index.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import { computeWorkspaceFileReferenceSuggestions } from '@spirit-agent/host-internal/workspace-file-reference-query'
+import { computeWorkspaceFileReferenceSuggestions } from '@spiritagent/host-internal/workspace-file-reference-query'
 
 import type { WorkspaceFileReferenceIndexSnapshot } from '@/types'
 

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -12,7 +12,7 @@ import type { TFunction } from "i18next";
 
 import {
   codeUnitIndexToCharCount,
-} from "@spirit-agent/host-internal/workspace-file-reference-query";
+} from "@spiritagent/host-internal/workspace-file-reference-query";
 
 import type { ComposerRichInputHandle } from "@/components/composer-rich-input";
 import { segmentsToMessageText } from "@/components/composer-rich-input";

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1011,7 +1011,7 @@ export function useDesktopRuntime() {
   );
 
   const setPaneWorkLocation = useCallback(
-    async (sessionPath: string, workLocation: import('@spirit-agent/host-internal').WorkLocationKind): Promise<boolean> => {
+    async (sessionPath: string, workLocation: import('@spiritagent/host-internal').WorkLocationKind): Promise<boolean> => {
       if (!api?.setPaneWorkLocation) {
         return false;
       }
@@ -1107,7 +1107,7 @@ export function useDesktopRuntime() {
   }, [api]);
 
   const classifyLocalFileComposerRoute = useCallback(
-    async (absolutePath: string): Promise<import('@spirit-agent/host-internal').LocalFileComposerRoute> => {
+    async (absolutePath: string): Promise<import('@spiritagent/host-internal').LocalFileComposerRoute> => {
       if (!api) {
         return 'reference';
       }
@@ -2534,7 +2534,7 @@ export function useDesktopRuntime() {
     }
   }, [api, applySnapshot]);
 
-  const setApprovalLevel = useCallback(async (approvalLevel: import('@spirit-agent/host-internal').ApprovalLevel): Promise<boolean> => {
+  const setApprovalLevel = useCallback(async (approvalLevel: import('@spiritagent/host-internal').ApprovalLevel): Promise<boolean> => {
     if (!api) {
       return false;
     }
@@ -2568,7 +2568,7 @@ export function useDesktopRuntime() {
   }, [api, applySnapshot]);
 
   const setWorkLocation = useCallback(async (
-    workLocation: import('@spirit-agent/host-internal').WorkLocationKind,
+    workLocation: import('@spiritagent/host-internal').WorkLocationKind,
   ): Promise<boolean> => {
     if (!api) {
       return false;

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -142,9 +142,9 @@ export interface HostApi {
   compactHistory(): Promise<DesktopSnapshot>;
   submitUserTurn(request: SubmitUserTurnRequest): Promise<DesktopSnapshot>;
   setLoopEnabled(enabled: boolean): Promise<DesktopSnapshot>;
-  setApprovalLevel(approvalLevel: import('@spirit-agent/host-internal').ApprovalLevel): Promise<DesktopSnapshot>;
+  setApprovalLevel(approvalLevel: import('@spiritagent/host-internal').ApprovalLevel): Promise<DesktopSnapshot>;
   setPendingGitBranch(branch: string): Promise<DesktopSnapshot>;
-  setWorkLocation(workLocation: import('@spirit-agent/host-internal').WorkLocationKind): Promise<DesktopSnapshot>;
+  setWorkLocation(workLocation: import('@spiritagent/host-internal').WorkLocationKind): Promise<DesktopSnapshot>;
   checkoutGitBranch(request: CheckoutGitBranchRequest): Promise<DesktopSnapshot>;
   mergeWorktreeToMain(): Promise<DesktopSnapshot>;
   pushGitBranch(): Promise<DesktopSnapshot>;
@@ -264,7 +264,7 @@ export interface HostApi {
   readHostTextFile(absolutePath: string): Promise<WorkspaceReadTextFileResult>;
   writeHostTextFile(request: WriteHostTextFileRequest): Promise<void>;
   statHostTextFile(absolutePath: string): Promise<HostTextFileStatResult>;
-  classifyLocalFileComposerRoute(absolutePath: string): Promise<import('@spirit-agent/host-internal').LocalFileComposerRoute>;
+  classifyLocalFileComposerRoute(absolutePath: string): Promise<import('@spiritagent/host-internal').LocalFileComposerRoute>;
   pickWorkspaceDirectory?(): Promise<string | null>;
   pickLocalFile?(): Promise<string | null>;
   getPathForDroppedFile?(file: File): string;

--- a/apps/desktop/src/host/auto-approval-review.ts
+++ b/apps/desktop/src/host/auto-approval-review.ts
@@ -4,7 +4,7 @@ import {
   runAutoApprovalReview,
   type ToolAutoReviewInput,
   type ToolAutoReviewResult,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import { resolveLightweightChatModelProfile } from './lightweight-chat-model.js';
 import { buildPrimaryTransportConfig } from './model-config.js';

--- a/apps/desktop/src/host/automation-conversation-projection.ts
+++ b/apps/desktop/src/host/automation-conversation-projection.ts
@@ -1,6 +1,6 @@
 import { setImmediate as waitForImmediate } from 'node:timers/promises';
 
-import type { RuntimeEvent, RuntimeTurnResult } from '@spirit-agent/core';
+import type { RuntimeEvent, RuntimeTurnResult } from '@spiritagent/agent-core';
 
 import type { ConversationMessageSnapshot } from '../types.js';
 import { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';

--- a/apps/desktop/src/host/automation-runner.ts
+++ b/apps/desktop/src/host/automation-runner.ts
@@ -5,7 +5,7 @@ import {
   createLlmTransport,
   type LlmPlanMetadata,
   type LlmTransportConfig,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   buildAutomationTriggerMessage,
   createHostAutomationStore,
@@ -15,7 +15,7 @@ import {
   type AutomationRunTriggerContext,
   type HostAutomationDefinition,
   type HostAutomationRun,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 import {
   AutomationConversationProjection,
   runAutomationStreamingTurn,

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -13,7 +13,7 @@ import {
   type GitHubAutomationPollMatch,
   type HostAutomationDefinition,
   type HostAutomationRun,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import { cloneDesktopConfig } from './service-utils.js';
 import { loadGitHubAccessToken } from './github-auth-storage.js';

--- a/apps/desktop/src/host/built-in-skills.ts
+++ b/apps/desktop/src/host/built-in-skills.ts
@@ -7,7 +7,7 @@ import {
   SKILL_FILE_NAME,
   SKILLS_DIR_NAME,
   ensureBuiltinAuthoringSkills,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 export const BUILTIN_GIT_SKILL_NAMES = ['git-commit', 'git-push', 'git-merge'] as const;
 

--- a/apps/desktop/src/host/code-completion-commands.ts
+++ b/apps/desktop/src/host/code-completion-commands.ts
@@ -1,6 +1,6 @@
-import { createJsonSchemaTransport } from '@spirit-agent/core';
-import { CodeCompletionService } from '@spirit-agent/host-internal';
-import type { CodeCompletionResult } from '@spirit-agent/core';
+import { createJsonSchemaTransport } from '@spiritagent/agent-core';
+import { CodeCompletionService } from '@spiritagent/host-internal';
+import type { CodeCompletionResult } from '@spiritagent/agent-core';
 
 import { resolveDesktopAgentMode } from '../lib/agent-mode.js';
 import { resolveLightweightChatModelProfile } from './lightweight-chat-model.js';

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -1,5 +1,5 @@
-import type { ChatArchive } from '@spirit-agent/core';
-import type { HostToolRequest, ApprovalLevel } from '@spirit-agent/host-internal';
+import type { ChatArchive } from '@spiritagent/agent-core';
+import type { HostToolRequest, ApprovalLevel } from '@spiritagent/host-internal';
 import type { PersistedDesktopTimelineTurnSnapshot } from './chat-schema.js';
 import type { StoredDesktopRewindMetadata } from './rewind.js';
 

--- a/apps/desktop/src/host/conversation-continuation.ts
+++ b/apps/desktop/src/host/conversation-continuation.ts
@@ -1,4 +1,4 @@
-import type { ChatArchive, PendingAssistantAux } from '@spirit-agent/core';
+import type { ChatArchive, PendingAssistantAux } from '@spiritagent/agent-core';
 
 import type { ConversationMessageSnapshot } from '../types.js';
 import type { SessionBundle } from './session-bundle.js';

--- a/apps/desktop/src/host/delete-file-line-delta.ts
+++ b/apps/desktop/src/host/delete-file-line-delta.ts
@@ -1,7 +1,7 @@
 import { existsSync, lstatSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { resolveInstructionPaths, type InstructionDiscoveryContext } from '@spirit-agent/host-internal';
+import { resolveInstructionPaths, type InstructionDiscoveryContext } from '@spiritagent/host-internal';
 
 import {
   deleteFileLineDeltaFromContent,

--- a/apps/desktop/src/host/direct-media-turn.ts
+++ b/apps/desktop/src/host/direct-media-turn.ts
@@ -10,7 +10,7 @@ import {
   type RuntimeToolExecution,
   type StoredLlmMessageArchiveEntry,
   type ToolExecutionOutput,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import i18n from '../lib/i18n-host.js';
 import {

--- a/apps/desktop/src/host/dream-collector-service.ts
+++ b/apps/desktop/src/host/dream-collector-service.ts
@@ -2,7 +2,7 @@ import {
   buildDreamCollectorSystemMessage,
   type LlmPlanMetadata,
   type LlmTransportConfig,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import i18n from '../lib/i18n-host.js';
 import type {

--- a/apps/desktop/src/host/dreams.ts
+++ b/apps/desktop/src/host/dreams.ts
@@ -8,18 +8,18 @@ import type {
   LlmPlanMetadata,
   LlmToolAgentState,
   LlmTransportConfig,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   llmMessageTextContent,
   normalizeStoredLlmMessage,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   createHostDreamStore,
   DREAM_RETENTION_MS as HOST_DREAM_RETENTION_MS,
   dreamLogsDirPath,
   type HostDreamRecord,
   type HostDreamSessionProgress,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   ConversationMessageSnapshot,

--- a/apps/desktop/src/host/ephemeral-llm-tasks.ts
+++ b/apps/desktop/src/host/ephemeral-llm-tasks.ts
@@ -3,8 +3,8 @@ import {
   type LlmExtensionSystemPrompt,
   type LlmToolAgentBasicInfo,
   type LlmTransportConfig,
-} from '@spirit-agent/core';
-import { generateWorktreeNamesFromTask } from '@spirit-agent/host-internal';
+} from '@spiritagent/agent-core';
+import { generateWorktreeNamesFromTask } from '@spiritagent/host-internal';
 
 import i18n from '../lib/i18n-host.js';
 import { resolveDesktopAgentMode } from '../lib/agent-mode.js';

--- a/apps/desktop/src/host/extension-warmup.ts
+++ b/apps/desktop/src/host/extension-warmup.ts
@@ -1,5 +1,5 @@
-import type { LlmExtensionSystemPrompt } from '@spirit-agent/core';
-import type { HostExtensionEvent } from '@spirit-agent/host-internal';
+import type { LlmExtensionSystemPrompt } from '@spiritagent/agent-core';
+import type { HostExtensionEvent } from '@spiritagent/host-internal';
 
 export type ExtensionWarmupTrigger =
   | { type: 'startup'; workspaceRoot: string }

--- a/apps/desktop/src/host/extensions.ts
+++ b/apps/desktop/src/host/extensions.ts
@@ -6,12 +6,12 @@ import {
   type JsonObject,
   type JsonValue,
   type OpenAiExtensionSystemPrompt,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   collectHostExtensionContributedTools,
   type HostExtensionManager,
   type HostInstalledExtension,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   DesktopExtensionCssLayer,

--- a/apps/desktop/src/host/finish-task-notice-rehydrate.ts
+++ b/apps/desktop/src/host/finish-task-notice-rehydrate.ts
@@ -3,7 +3,7 @@ import {
   normalizeStoredLlmMessage,
   type ChatArchive,
   type LlmMessage,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import type { ConversationMessageSnapshot } from '../types.js';
 import {

--- a/apps/desktop/src/host/fork-session.ts
+++ b/apps/desktop/src/host/fork-session.ts
@@ -1,4 +1,4 @@
-import type { ChatArchive, LlmMessage } from '@spirit-agent/core';
+import type { ChatArchive, LlmMessage } from '@spiritagent/agent-core';
 
 import type { ConversationMessageSnapshot } from '../types.js';
 import {

--- a/apps/desktop/src/host/git.ts
+++ b/apps/desktop/src/host/git.ts
@@ -20,7 +20,7 @@ import {
   resolveDefaultBranch,
   resolvePrimaryRepoRoot,
   type GitCheckoutOptions,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   DesktopGitSnapshot,

--- a/apps/desktop/src/host/github-oauth-bridge.ts
+++ b/apps/desktop/src/host/github-oauth-bridge.ts
@@ -1,4 +1,4 @@
-import type { GitHubDeviceAuthChallenge } from '@spirit-agent/host-internal';
+import type { GitHubDeviceAuthChallenge } from '@spiritagent/host-internal';
 
 export type BeginGitHubDeviceLoginRunner = () => Promise<GitHubDeviceAuthChallenge>;
 export type CompleteGitHubDeviceLoginRunner = () => Promise<{ login: string }>;

--- a/apps/desktop/src/host/hook-runtime.ts
+++ b/apps/desktop/src/host/hook-runtime.ts
@@ -5,8 +5,8 @@ import {
   type HookSessionContext,
   type SessionEndHookInput,
   type SessionStartHookInput,
-} from '@spirit-agent/core';
-import { createHookRunner } from '@spirit-agent/host-internal';
+} from '@spiritagent/agent-core';
+import { createHookRunner } from '@spiritagent/host-internal';
 
 import type { SessionBundle } from './session-bundle.js';
 import type { DesktopRuntime } from './runtime.js';

--- a/apps/desktop/src/host/hooks.ts
+++ b/apps/desktop/src/host/hooks.ts
@@ -7,8 +7,8 @@ import {
   type DeleteHookEntryRequest as HostDeleteHookEntryRequest,
   type HookListItem,
   type SaveHookEntryRequest as HostSaveHookEntryRequest,
-} from '@spirit-agent/host-internal';
-import { hooksUserConfigPath, hooksWorkspaceConfigPath } from '@spirit-agent/core';
+} from '@spiritagent/host-internal';
+import { hooksUserConfigPath, hooksWorkspaceConfigPath } from '@spiritagent/agent-core';
 
 import type {
   DeleteHookEntryRequest,

--- a/apps/desktop/src/host/host-automation-commands.ts
+++ b/apps/desktop/src/host/host-automation-commands.ts
@@ -5,7 +5,7 @@ import {
   type HostAutomationDefinition,
   type HostAutomationRun,
   type HostAutomationUpdateInput,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type { DesktopAutomationDetail, DesktopAutomationListItem } from '../types.js';
 import { spiritAgentDataDir } from './storage.js';

--- a/apps/desktop/src/host/host-command-payloads.ts
+++ b/apps/desktop/src/host/host-command-payloads.ts
@@ -1,7 +1,7 @@
 import type {
   ApprovalLevel,
   WorkLocationKind,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   AddMcpServerRequest,

--- a/apps/desktop/src/host/host-extension-commands.ts
+++ b/apps/desktop/src/host/host-extension-commands.ts
@@ -23,7 +23,7 @@ import {
   toDesktopMarketplaceDetail,
   toDesktopMarketplacePreparedInstall,
 } from './extensions.js';
-import { invalidateSharedUserMcpToolingCache } from '@spirit-agent/core';
+import { invalidateSharedUserMcpToolingCache } from '@spiritagent/agent-core';
 import i18n from '../lib/i18n-host.js';
 import type {
   AddMcpServerRequest,
@@ -51,8 +51,8 @@ import type {
 import type {
   HostExtensionEvent,
   HostExtensionMarketplaceManager,
-} from '@spirit-agent/host-internal';
-import type { LlmActiveSkill } from '@spirit-agent/core';
+} from '@spiritagent/host-internal';
+import type { LlmActiveSkill } from '@spiritagent/agent-core';
 import type { DesktopExtensionHostAdapter } from './extension-host-adapter.js';
 import type { DesktopConfigFile, DesktopWorkspaceBinding, HostMetadataSummary } from './storage.js';
 import type { DesktopGitSnapshot } from '../types.js';

--- a/apps/desktop/src/host/host-github-commands.ts
+++ b/apps/desktop/src/host/host-github-commands.ts
@@ -29,7 +29,7 @@ import {
   type GitHubPullRequestMergeResult,
   type GitHubPullRequestTabCounts,
   type GitHubRepositoryRef,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   DesktopGitSnapshot,

--- a/apps/desktop/src/host/host-model-commands.ts
+++ b/apps/desktop/src/host/host-model-commands.ts
@@ -2,13 +2,13 @@ import {
   parseModelProviderId,
   parsePresetModelProviderId,
   partitionModelsByProvider,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 import {
   defaultModelReasoningEffort,
   resolveModelReasoningEffortForContext,
   type ModelReasoningEffort,
-} from '@spirit-agent/core/reasoning-effort';
-import { shouldPinReasoningEffortToDefault } from '@spirit-agent/core/model-thinking-controls';
+} from '@spiritagent/agent-core/reasoning-effort';
+import { shouldPinReasoningEffortToDefault } from '@spiritagent/agent-core/model-thinking-controls';
 
 import { resolveDesktopAgentMode } from '../lib/agent-mode.js';
 import { parseModelContextLength } from '../lib/context-usage.js';
@@ -47,12 +47,12 @@ import {
   azureApiBaseFromResourceName,
   isValidAzureResourceName,
   vertexApiBaseFromProjectAndLocation,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 import {
   providerConnectSiteRequiresWorkspaceId,
   providerSupportsSiteSelection,
 } from './provider-presets.js';
-import { bedrockMantleApiBaseFromRegion, isBedrockMantleOpenAiModel } from '@spirit-agent/host-internal/bedrock-mantle';
+import { bedrockMantleApiBaseFromRegion, isBedrockMantleOpenAiModel } from '@spiritagent/host-internal/bedrock-mantle';
 import { modelSupportsChat } from './lightweight-chat-model.js';
 import {
   modelExistsInProviderScope,

--- a/apps/desktop/src/host/host-pane-workspace.ts
+++ b/apps/desktop/src/host/host-pane-workspace.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { normalizeWorkLocationKind } from '@spirit-agent/host-internal';
+import { normalizeWorkLocationKind } from '@spiritagent/host-internal';
 
 import i18n from '../lib/i18n-host.js';
 import type {

--- a/apps/desktop/src/host/host-text-file.ts
+++ b/apps/desktop/src/host/host-text-file.ts
@@ -10,7 +10,7 @@ import {
   WORKSPACE_TEXT_FILE_MAX_BYTES,
   workspaceTextFileResultFromBuffer,
 } from './workspace-files.js';
-import { hasSupportedImageExtension } from '@spirit-agent/host-internal/image-file-support';
+import { hasSupportedImageExtension } from '@spiritagent/host-internal/image-file-support';
 
 export async function resolveHostTextFilePath(absolutePath: string): Promise<string> {
   const cleaned = absolutePath.replace(/\0/g, '').trim();

--- a/apps/desktop/src/host/host-workspace-git-commands.ts
+++ b/apps/desktop/src/host/host-workspace-git-commands.ts
@@ -9,7 +9,7 @@ import {
   WORKSPACE_CONTENT_SEARCH_MAX_MATCHES,
   type WorkLocationKind,
   type WorkspaceFileReferenceIndexSnapshot,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import i18n from '../lib/i18n-host.js';
 import { clearCodeCompletionStateForWorkspace } from './code-completion-commands.js';

--- a/apps/desktop/src/host/lsp-commands.ts
+++ b/apps/desktop/src/host/lsp-commands.ts
@@ -1,4 +1,4 @@
-import { findLspProvider, installLspProvider } from '@spirit-agent/host-internal/lsp';
+import { findLspProvider, installLspProvider } from '@spiritagent/host-internal/lsp';
 
 import type { DesktopSnapshot, InstallLspProviderRequest } from '../types.js';
 import { buildDesktopLspSnapshot } from './lsp-snapshot.js';

--- a/apps/desktop/src/host/lsp-snapshot.ts
+++ b/apps/desktop/src/host/lsp-snapshot.ts
@@ -3,7 +3,7 @@ import {
   discoverAllLspProviders,
   type LspProviderDescriptor,
   type LspProviderId,
-} from '@spirit-agent/host-internal/lsp';
+} from '@spiritagent/host-internal/lsp';
 
 import type { DesktopLspProviderSnapshot, DesktopLspSnapshot } from '../types.js';
 import { normalizeAgentsConfig, type DesktopConfigFile } from './storage.js';

--- a/apps/desktop/src/host/mcp-config.ts
+++ b/apps/desktop/src/host/mcp-config.ts
@@ -13,7 +13,7 @@ import {
   summarizeTransport,
   type McpConfigFile,
   type McpServerConfig,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import type {
   AddMcpServerRequest,

--- a/apps/desktop/src/host/message-ordering.ts
+++ b/apps/desktop/src/host/message-ordering.ts
@@ -1,11 +1,11 @@
-import { formatTriggerLabel, normalizeAutomationTrigger } from '@spirit-agent/host-internal';
+import { formatTriggerLabel, normalizeAutomationTrigger } from '@spiritagent/host-internal';
 
 import i18n from '../lib/i18n-host.js';
 import type {
   LlmMessageContent,
   RuntimePendingApproval,
   RuntimePendingQuestions,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   finishTaskNoticeFromSummary,
   isGenericProviderWebSearchQuery,
@@ -13,13 +13,13 @@ import {
   previewRequestFromStreamingArguments,
   RESPONSES_BUILT_IN_SPIRIT_UI_KEY,
   tryExtractPartialWebSearchQuery,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import {
   hasAssistantToolLaterInTurn,
   isStandaloneThinkingMessage,
 } from '../lib/conversation-thinking-ui.js';
-import { listDirectoryToolDisplayPath } from '@spirit-agent/host-internal/skill-paths';
+import { listDirectoryToolDisplayPath } from '@spiritagent/host-internal/skill-paths';
 
 import {
   isSkillMarkdownPath,
@@ -939,7 +939,7 @@ export {
   finishTaskNoticeFromSummary,
   finishTaskNoticePreviewFromArguments,
   finishTaskSummaryFromStreamingArguments,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 export function finishTaskSummaryFromExecution(input: {
   request: unknown;

--- a/apps/desktop/src/host/message-queue.ts
+++ b/apps/desktop/src/host/message-queue.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 
-import type { PendingWorkspaceFile, LlmActiveSkill } from '@spirit-agent/core';
+import type { PendingWorkspaceFile, LlmActiveSkill } from '@spiritagent/agent-core';
 
 import i18n from '../lib/i18n-host.js';
 import type { ConversationMessageSnapshot, DesktopSnapshot } from '../types.js';

--- a/apps/desktop/src/host/model-catalog-cache.ts
+++ b/apps/desktop/src/host/model-catalog-cache.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { normalizeOpenAiApiBase } from '@spirit-agent/host-internal';
+import { normalizeOpenAiApiBase } from '@spiritagent/host-internal';
 
 import type {
   DesktopModelCapability,

--- a/apps/desktop/src/host/model-catalog-metadata.ts
+++ b/apps/desktop/src/host/model-catalog-metadata.ts
@@ -1,9 +1,9 @@
-import { formatModelDisplayNameFromId } from '@spirit-agent/host-internal/model-display-name';
+import { formatModelDisplayNameFromId } from '@spiritagent/host-internal/model-display-name';
 import {
   gatewayGoogleGeminiSupportedEfforts,
   routedAnthropicClaudeSupportedEfforts,
-} from '@spirit-agent/core';
-import type { ProviderListedModelEntry } from '@spirit-agent/host-internal';
+} from '@spiritagent/agent-core';
+import type { ProviderListedModelEntry } from '@spiritagent/host-internal';
 
 import type {
   DesktopModelCapability,

--- a/apps/desktop/src/host/model-catalog-startup-refresh.ts
+++ b/apps/desktop/src/host/model-catalog-startup-refresh.ts
@@ -1,5 +1,5 @@
-import { defaultModelReasoningEffort, type ModelReasoningEffort } from '@spirit-agent/core/reasoning-effort';
-import { normalizeOpenAiApiBase } from '@spirit-agent/host-internal/openai-api-base';
+import { defaultModelReasoningEffort, type ModelReasoningEffort } from '@spiritagent/agent-core/reasoning-effort';
+import { normalizeOpenAiApiBase } from '@spiritagent/host-internal/openai-api-base';
 
 import type {
   DesktopModelCapability,

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -5,19 +5,19 @@ import {
   type LlmModelCapabilities,
   type LlmTransportConfig,
   type OpenResponsesSdkProvider,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   isXiaomiResponsesReasoningEffortContext,
   resolveAnthropicTransportReasoningEffortForContext,
   resolveOpenAiTransportReasoningEffortForContext,
   type ModelReasoningEffortContext,
-} from '@spirit-agent/core/reasoning-effort';
+} from '@spiritagent/agent-core/reasoning-effort';
 import {
   modelSupportsThinkingSwitch,
   resolveAnthropicExplicitThinkingConfig,
   resolveVendorExtendedThinking,
   shouldPinReasoningEffortToDefault,
-} from '@spirit-agent/core/model-thinking-controls';
+} from '@spiritagent/agent-core/model-thinking-controls';
 import {
   listProviderModels,
   listProviderConnectSiteOptions,
@@ -29,7 +29,7 @@ import {
   azureApiBaseFromResourceName,
   vertexApiBaseFromProjectAndLocation,
   type ProviderListedModelEntry,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   AddProviderModelsRequest,

--- a/apps/desktop/src/host/pane-snapshot.ts
+++ b/apps/desktop/src/host/pane-snapshot.ts
@@ -31,7 +31,7 @@ export function buildPaneSessionSlice(input: {
     subagentSessionId?: string;
     autoReviewBlockReason?: string;
   };
-  pendingQuestions?: import('@spirit-agent/core').RuntimePendingQuestions<DesktopToolRequest>;
+  pendingQuestions?: import('@spiritagent/agent-core').RuntimePendingQuestions<DesktopToolRequest>;
   pendingImagePaths?: string[];
   pendingMcpResources?: import('../types.js').PendingMcpResource[];
   pendingUserTurn?: string;

--- a/apps/desktop/src/host/provider-presets.ts
+++ b/apps/desktop/src/host/provider-presets.ts
@@ -1,4 +1,4 @@
-/** 薄封装：预设提供商数据来自 `@spirit-agent/host-internal`，避免 Desktop 与 CLI 分叉。 */
+/** 薄封装：预设提供商数据来自 `@spiritagent/host-internal`，避免 Desktop 与 CLI 分叉。 */
 export {
   DEFAULT_CUSTOM_API_BASE,
   MODEL_PROVIDER_PICKER_ORDER,
@@ -11,10 +11,10 @@ export {
   providerConnectSiteRequiresWorkspaceId,
   resolveConnectApiBase,
   resolveProviderConnectApiBase,
-} from '@spirit-agent/host-internal/model-provider-presets';
+} from '@spiritagent/host-internal/model-provider-presets';
 export type {
   ModelProviderId,
   ProviderConnectSiteId,
   ProviderModelTransportKind,
   ResolveProviderConnectApiBaseOptions,
-} from '@spirit-agent/host-internal/model-provider-presets';
+} from '@spiritagent/host-internal/model-provider-presets';

--- a/apps/desktop/src/host/resolve-session-workspace-root.ts
+++ b/apps/desktop/src/host/resolve-session-workspace-root.ts
@@ -6,7 +6,7 @@ import {
   listGitWorktrees,
   readWorktreeContext,
   resolvePrimaryRepoRoot,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 export async function resolveStoredSessionWorkspaceRoot(input: {
   workspaceRoot: string;

--- a/apps/desktop/src/host/rewind-host.ts
+++ b/apps/desktop/src/host/rewind-host.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
-import type { ChatArchive, RuntimeToolExecution } from '@spirit-agent/core';
-import type { HostRecordedFileChange } from '@spirit-agent/host-internal';
+import type { ChatArchive, RuntimeToolExecution } from '@spiritagent/agent-core';
+import type { HostRecordedFileChange } from '@spiritagent/host-internal';
 
 import { resolveDesktopAgentMode } from '../lib/agent-mode.js';
 import type { ConversationMessageSnapshot, DesktopGitSnapshot, PlanSnapshot } from '../types.js';

--- a/apps/desktop/src/host/rewind.ts
+++ b/apps/desktop/src/host/rewind.ts
@@ -3,8 +3,8 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { ChatArchive } from '@spirit-agent/core';
-import type { HostRecordedFileChange, HostTodoRecord } from '@spirit-agent/host-internal';
+import type { ChatArchive } from '@spiritagent/agent-core';
+import type { HostRecordedFileChange, HostTodoRecord } from '@spiritagent/host-internal';
 
 import type { PersistedDesktopTimelineTurnSnapshot } from './chat-schema.js';
 import type { ConversationMessageSnapshot } from '../types.js';

--- a/apps/desktop/src/host/rules.ts
+++ b/apps/desktop/src/host/rules.ts
@@ -6,7 +6,7 @@ import {
   discoverRuleEntries,
   resolveInstructionPaths,
   type InstructionDiscoveryContext,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import i18n from '../lib/i18n-host.js';
 import type {

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -8,9 +8,9 @@ import {
   type RuntimeEvent,
   type RuntimeToolExecution,
   type RuntimeTurnResult,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import { toolCallPhaseShowsShimmer } from '../lib/tool-call-shimmer.js';
-import type { HostExtensionEvent } from '@spirit-agent/host-internal';
+import type { HostExtensionEvent } from '@spiritagent/host-internal';
 
 import {
   attachEditFileLineDelta,

--- a/apps/desktop/src/host/runtime.ts
+++ b/apps/desktop/src/host/runtime.ts
@@ -31,12 +31,12 @@ import {
   type SubagentWorkspaceBootstrap,
   type ToolAutoReviewer,
   type SessionApprovalLevel,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   persistPreCompactionHistoryArchive,
   persistToolOutputArchive,
   removePreCompactionHistoryArchive,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type { DesktopToolRequest } from './contracts.js';
 import { spiritAgentDataDir } from './storage.js';

--- a/apps/desktop/src/host/service-mcp.ts
+++ b/apps/desktop/src/host/service-mcp.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { McpService } from '@spirit-agent/core';
+import { McpService } from '@spiritagent/agent-core';
 
 import i18n from '../lib/i18n-host.js';
 import type {

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -2,11 +2,11 @@ import type {
   AskQuestionsResult as RuntimeAskQuestionsResult,
   ChatArchive,
   RuntimePendingQuestions,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   cloneLlmMessageContent,
   cloneLlmProviderState,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import i18n from '../lib/i18n-host.js';
 import type {
@@ -20,7 +20,7 @@ import {
   normalizeGeneratedWorktreeNames as normalizeGeneratedWorktreeNamesInternal,
   parseGeneratedWorktreeNamingResponse as parseGeneratedWorktreeNamingResponseInternal,
   resolveWorkspaceGroupingRoot,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 import type { GeneratedWorktreeNames } from './worktree-naming.js';
 import {
   type DesktopConfigFile,

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -33,7 +33,7 @@ import {
   type RuntimeToolExecution,
   type SpiritLlmTransport,
   type LlmActiveSkill,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   buildStartImplementingUserTurn,
   extractActivePlanPathFromLlmHistory,
@@ -56,7 +56,7 @@ import {
   gitBranchLabelForBasicInfo,
   setGitHubFetchImplementation,
   type WorkLocationKind,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   ActiveSessionSnapshot,
@@ -475,7 +475,7 @@ import {
   runDesktopSessionEndHook,
   runDesktopSessionStartHook,
 } from './hook-runtime.js';
-import type { HookRunner, SessionEndHookInput, SessionStartHookInput } from '@spirit-agent/core';
+import type { HookRunner, SessionEndHookInput, SessionStartHookInput } from '@spiritagent/agent-core';
 import {
   sharedMcpServiceForWorkspace,
 } from './service-mcp.js';
@@ -485,7 +485,7 @@ import {
   ensureLspServiceReady,
   lspUserConfigFromEnabled,
   sharedLspServiceForWorkspace,
-} from '@spirit-agent/host-internal/lsp';
+} from '@spiritagent/host-internal/lsp';
 import { buildDesktopLspSnapshot, defaultDesktopLspSnapshot } from './lsp-snapshot.js';
 import { installLspProviderCommand } from './lsp-commands.js';
 import {
@@ -642,7 +642,7 @@ class DesktopHostService {
   private lastToolSnapshotLogSignature: string | undefined;
   /** One MCP catalog per workspace — survives per-session DesktopToolExecutor rebuilds. */
   private readonly mcpServiceByWorkspaceRoot = new Map<string, McpService>();
-  private readonly lspServiceByWorkspaceRoot = new Map<string, import('@spirit-agent/host-internal/lsp').LspService>();
+  private readonly lspServiceByWorkspaceRoot = new Map<string, import('@spiritagent/host-internal/lsp').LspService>();
   private lspSnapshot = defaultDesktopLspSnapshot();
   private visiblePaneSessionPaths: string[] = [];
   private readonly paneSessionSliceCache = new Map<string, { signature: string; slice: PaneSessionSlice }>();

--- a/apps/desktop/src/host/session-activation.ts
+++ b/apps/desktop/src/host/session-activation.ts
@@ -5,7 +5,7 @@ import {
   resolveEffectivePaneActiveModel,
 } from './active-model-sync.js';
 
-import type { SessionEndHookInput, SessionStartHookInput } from '@spirit-agent/core';
+import type { SessionEndHookInput, SessionStartHookInput } from '@spiritagent/agent-core';
 
 import { resolveDesktopAgentMode } from '../lib/agent-mode.js';
 import i18n from '../lib/i18n-host.js';
@@ -26,7 +26,7 @@ import {
 } from './sessions.js';
 import type { DesktopTimelineTurnSnapshot, DesktopMessageTimeline } from './message-timeline.js';
 import { currentApiBase, sameWorkspaceRoot } from './service-utils.js';
-import type { HostExtensionEvent } from '@spirit-agent/host-internal';
+import type { HostExtensionEvent } from '@spiritagent/host-internal';
 import { cancelPendingWorktreeBootstrapOnBundle } from './worktree-bootstrap-orchestrator.js';
 import { resolveStoredSessionWorkspaceRoot } from './resolve-session-workspace-root.js';
 

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -3,9 +3,9 @@ import type {
   LlmActiveSkill,
   RuntimeEvent,
   SpiritLlmTransport,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import type { DesktopToolRequest, SessionTitleSource } from './contracts.js';
-import type { ApprovalLevel, WorkLocationKind } from '@spirit-agent/host-internal';
+import type { ApprovalLevel, WorkLocationKind } from '@spiritagent/host-internal';
 
 import type { DesktopRuntime } from './runtime.js';
 import type { DesktopToolExecutor } from './tool-executor.js';

--- a/apps/desktop/src/host/session-persistence.ts
+++ b/apps/desktop/src/host/session-persistence.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import type { ChatArchive } from '@spirit-agent/core';
+import type { ChatArchive } from '@spiritagent/agent-core';
 
 import {
   buildArchiveAssistantAuxFromConversation,

--- a/apps/desktop/src/host/session-title-generation.ts
+++ b/apps/desktop/src/host/session-title-generation.ts
@@ -1,10 +1,10 @@
 // Desktop 首批消费方：首条用户消息后异步生成会话标题；CLI 待产品定义后再接入。
-import { buildSpiritAgentCoreHostPrompt, createJsonSchemaTransport } from '@spirit-agent/core';
+import { buildSpiritAgentCoreHostPrompt, createJsonSchemaTransport } from '@spiritagent/agent-core';
 import {
   buildSessionTitlePrompt,
   normalizeGeneratedSessionTitle,
   SESSION_TITLE_JSON_SCHEMA,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import { resolveLightweightChatModelProfile } from './lightweight-chat-model.js';
 import { buildPrimaryTransportConfig } from './model-config.js';

--- a/apps/desktop/src/host/session-todos-host.ts
+++ b/apps/desktop/src/host/session-todos-host.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import type { HostTodoRecord } from '@spirit-agent/host-internal';
+import type { HostTodoRecord } from '@spiritagent/host-internal';
 
 import type { ConversationTodoSnapshot } from '../types.js';
 import type { SessionBundle } from './session-bundle.js';

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -5,7 +5,7 @@ import type {
   PendingWorkspaceFile,
   RuntimeApprovalDecision,
   RuntimeEvent,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import { cloneActiveSkills } from './runtime.js';
 
 import i18n from '../lib/i18n-host.js';
@@ -122,7 +122,7 @@ export interface SessionTurnOrchestratorContext {
   latestContinuableAssistantMessage(): ConversationMessageSnapshot | undefined;
   insertUserApprovalReplyMessage(content: string, pendingToolCallId?: string): void;
   normalizeApprovalDecision(decision: DesktopApprovalDecision | undefined): RuntimeApprovalDecision;
-  runSessionEndForActive?(reason: import('@spirit-agent/core').SessionEndHookInput['reason']): Promise<void>;
+  runSessionEndForActive?(reason: import('@spiritagent/agent-core').SessionEndHookInput['reason']): Promise<void>;
   worktreeBootstrapHost?: WorktreeBootstrapHostContext;
 }
 

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import type { ChatArchive } from '@spirit-agent/core';
+import type { ChatArchive } from '@spiritagent/agent-core';
 import {
   CHAT_SCHEMA_VERSION,
   hydrateTimelineSnapshotFromPersistence,
@@ -18,8 +18,8 @@ import type {
   ConversationMessageSnapshot,
   SessionListItem,
 } from '../types.js';
-import { extractActivePlanPathFromLlmHistory, normalizeApprovalLevel } from '@spirit-agent/host-internal';
-import type { ApprovalLevel } from '@spirit-agent/host-internal';
+import { extractActivePlanPathFromLlmHistory, normalizeApprovalLevel } from '@spiritagent/host-internal';
+import type { ApprovalLevel } from '@spiritagent/host-internal';
 import type { QueuedUserTurn } from './message-queue.js';
 import type { SessionTitleSource } from './contracts.js';
 import type { DesktopTimelineTurnSnapshot } from './message-timeline.js';

--- a/apps/desktop/src/host/skills.ts
+++ b/apps/desktop/src/host/skills.ts
@@ -6,12 +6,12 @@ import i18n from '../lib/i18n-host.js';
 import type {
   OpenAiActiveSkill,
   OpenAiActiveSkillResourceEntry,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   resolveInstructionPaths,
   SKILL_FILE_NAME,
   validateSkillName,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   CreateSkillRequest,

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -24,11 +24,11 @@ import {
   configureLlmHttpVersion,
   normalizeLlmHttpVersion,
   type LlmHttpVersion,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   normalizeModelReasoningEffort,
   resolveModelReasoningEffortForContext,
-} from '@spirit-agent/core/reasoning-effort';
+} from '@spiritagent/agent-core/reasoning-effort';
 import {
   createFileExtensionStateStore,
   type ExtensionManagementContext,
@@ -39,7 +39,7 @@ import {
   type HostInstructionMetadataSummary,
   type HostRuleDiscoveryResult,
   type HostSkillDiscoveryResult,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import { resolveDesktopAgentMode, type DesktopAgentMode } from '../lib/agent-mode.js';
 import { normalizeContextUsageSnapshot } from '../lib/context-usage.js';

--- a/apps/desktop/src/host/subagent-conversation-projection.ts
+++ b/apps/desktop/src/host/subagent-conversation-projection.ts
@@ -1,5 +1,5 @@
-import type { RuntimeEvent, SubagentSessionArchiveEntry, SubagentSessionStatus } from '@spirit-agent/core';
-import { llmMessageTextContent } from '@spirit-agent/core';
+import type { RuntimeEvent, SubagentSessionArchiveEntry, SubagentSessionStatus } from '@spiritagent/agent-core';
+import { llmMessageTextContent } from '@spiritagent/agent-core';
 
 import type { ConversationMessageSnapshot } from '../types.js';
 import { DesktopAssistantMessageStateMachine } from './assistant-message-state.js';

--- a/apps/desktop/src/host/subagent-viewer.ts
+++ b/apps/desktop/src/host/subagent-viewer.ts
@@ -1,9 +1,9 @@
-import type { SubagentSessionArchiveEntry } from '@spirit-agent/core';
+import type { SubagentSessionArchiveEntry } from '@spiritagent/agent-core';
 import {
   buildSubagentConversationSnapshots,
   resolveSubagentPromptFromTaskFields,
   type SubagentViewerMessage,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type {
   ConversationMessageSnapshot,

--- a/apps/desktop/src/host/subagent-worktree-bootstrap.ts
+++ b/apps/desktop/src/host/subagent-worktree-bootstrap.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import type { SubagentWorkspaceBootstrap } from '@spirit-agent/core';
+import type { SubagentWorkspaceBootstrap } from '@spiritagent/agent-core';
 
 import type { DesktopToolRequest } from './contracts.js';
 import type { DesktopToolExecutor } from './tool-executor.js';

--- a/apps/desktop/src/host/todos.ts
+++ b/apps/desktop/src/host/todos.ts
@@ -5,7 +5,7 @@ import {
   createHostTodoStore,
   type HostTodoRecord,
   type HostTodoScope,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type { DesktopTodoItem } from '../types.js';
 import { isProvisionalSessionPath, spiritAgentDataDir } from './storage.js';

--- a/apps/desktop/src/host/tool-executor.ts
+++ b/apps/desktop/src/host/tool-executor.ts
@@ -43,11 +43,11 @@ import {
   isLspDiagnosticsToolRequest,
   requestFromGetDiagnosticsFunctionCall,
   executeGetDiagnostics,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   LspService,
   appendLspDiagnosticsAfterWriteIfNeeded,
-} from '@spirit-agent/host-internal/lsp';
+} from '@spiritagent/host-internal/lsp';
 import {
   CREATE_AUTOMATION_CONTRIBUTED_TOOL,
   type HostAutomationCreateDefaults,
@@ -67,7 +67,7 @@ import {
   NodeHostToolService,
   normalizeApprovalLevel,
   createNoopMcpAdapter,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type { AskQuestionsQuestionSpec } from '../types.js';
 import { spiritAgentDataDir } from './storage.js';

--- a/apps/desktop/src/host/workspace-files.ts
+++ b/apps/desktop/src/host/workspace-files.ts
@@ -2,11 +2,11 @@ import { Buffer } from 'node:buffer';
 import { lstat, readFile, readdir, realpath, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { resolveWorkspaceExplorerIgnoreFlags } from '@spirit-agent/host-internal';
+import { resolveWorkspaceExplorerIgnoreFlags } from '@spiritagent/host-internal';
 import {
   detectSupportedImageFile,
   hasSupportedImageExtension,
-} from '@spirit-agent/host-internal/image-file-support';
+} from '@spiritagent/host-internal/image-file-support';
 
 import i18n from '../lib/i18n-host.js';
 import type {

--- a/apps/desktop/src/host/worktree-bootstrap-card.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-card.ts
@@ -1,5 +1,5 @@
-import type { PendingWorkspaceFile } from '@spirit-agent/core';
-import type { SubagentSessionStatus } from '@spirit-agent/core';
+import type { PendingWorkspaceFile } from '@spiritagent/agent-core';
+import type { SubagentSessionStatus } from '@spiritagent/agent-core';
 
 import i18n from '../lib/i18n-host.js';
 import { phaseToVerbContext } from '../lib/tool-verb-context.js';

--- a/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
+++ b/apps/desktop/src/host/worktree-bootstrap-orchestrator.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 /**
  * 主会话首条 Worktree 消息的非阻塞 bootstrap：先入 timeline，再在 poll tick 中完成 git/LLM 命名并 gate LLM turn。
  */
-import type { PendingWorkspaceFile } from '@spirit-agent/core';
+import type { PendingWorkspaceFile } from '@spiritagent/agent-core';
 import { cloneActiveSkills } from './runtime.js';
 
 import i18n from '../lib/i18n-host.js';

--- a/apps/desktop/src/host/worktree-naming.ts
+++ b/apps/desktop/src/host/worktree-naming.ts
@@ -1,4 +1,4 @@
 export {
   buildWorktreeNamingPrompt,
   type GeneratedWorktreeNames,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';

--- a/apps/desktop/src/lib/composer-file-reference-query.ts
+++ b/apps/desktop/src/lib/composer-file-reference-query.ts
@@ -1,5 +1,5 @@
-import { currentWorkspaceFileReferenceQuery } from "@spirit-agent/host-internal/workspace-file-reference-query";
-import type { ActiveWorkspaceFileReferenceQuery } from "@spirit-agent/host-internal/workspace-file-reference-query";
+import { currentWorkspaceFileReferenceQuery } from "@spiritagent/host-internal/workspace-file-reference-query";
+import type { ActiveWorkspaceFileReferenceQuery } from "@spiritagent/host-internal/workspace-file-reference-query";
 
 import {
   mergeAdjacentTextSegments,

--- a/apps/desktop/src/lib/context-usage.ts
+++ b/apps/desktop/src/lib/context-usage.ts
@@ -1,4 +1,4 @@
-import { normalizeOpenAiApiBase } from '@spirit-agent/host-internal/openai-api-base';
+import { normalizeOpenAiApiBase } from '@spiritagent/host-internal/openai-api-base';
 
 import { parseModelContextLength } from './model-context-length.js';
 import { DEFAULT_API_BASE } from '../host/storage.js';

--- a/apps/desktop/src/lib/file-tool-lsp-diagnostics-display.ts
+++ b/apps/desktop/src/lib/file-tool-lsp-diagnostics-display.ts
@@ -1,4 +1,4 @@
-import type { LspWriteDiagnosticsUi } from '@spirit-agent/core';
+import type { LspWriteDiagnosticsUi } from '@spiritagent/agent-core';
 
 import type { ToolBlockSnapshot } from '@/types';
 

--- a/apps/desktop/src/lib/github-markdown-link.ts
+++ b/apps/desktop/src/lib/github-markdown-link.ts
@@ -1,8 +1,8 @@
-import { parseGitHubPullRequestUrl } from "@spirit-agent/host-internal/github-pull-request-url";
+import { parseGitHubPullRequestUrl } from "@spiritagent/host-internal/github-pull-request-url";
 
 import type { GitHubPullRequestRevealRequest } from "@/lib/workspace-pr-navigation";
 
-export type { GitHubPullRequestUrlRef } from "@spirit-agent/host-internal/github-pull-request-url";
+export type { GitHubPullRequestUrlRef } from "@spiritagent/host-internal/github-pull-request-url";
 
 export type OpenPullRequestInPrTab = (request: GitHubPullRequestRevealRequest) => void;
 

--- a/apps/desktop/src/lib/model-catalog-detail.ts
+++ b/apps/desktop/src/lib/model-catalog-detail.ts
@@ -1,5 +1,5 @@
-import { resolveModelDisplayTitle } from '@spirit-agent/host-internal/model-display-name';
-import { normalizeOpenAiApiBase } from '@spirit-agent/host-internal/openai-api-base';
+import { resolveModelDisplayTitle } from '@spiritagent/host-internal/model-display-name';
+import { normalizeOpenAiApiBase } from '@spiritagent/host-internal/openai-api-base';
 
 import { formatCompactTokenCount } from '@/lib/format-compact-token-count';
 import { parseModelContextLength } from '@/lib/model-context-length';

--- a/apps/desktop/src/lib/model-picker-groups.ts
+++ b/apps/desktop/src/lib/model-picker-groups.ts
@@ -1,8 +1,8 @@
 import {
   MODEL_PROVIDER_PICKER_ORDER,
   PROVIDER_PICKER_ROWS,
-} from "@spirit-agent/host-internal/model-provider-presets";
-import { normalizeOpenAiApiBase } from "@spirit-agent/host-internal/openai-api-base";
+} from "@spiritagent/host-internal/model-provider-presets";
+import { normalizeOpenAiApiBase } from "@spiritagent/host-internal/openai-api-base";
 import type {
   DesktopModelCatalogHint,
   DesktopModelProvider,

--- a/apps/desktop/src/lib/monaco-code-completion-delete-preview.ts
+++ b/apps/desktop/src/lib/monaco-code-completion-delete-preview.ts
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor";
 
-import type { InlineDeleteDiffPreviewSpec } from "@spirit-agent/core/code-completion-delete-diff";
+import type { InlineDeleteDiffPreviewSpec } from "@spiritagent/agent-core/code-completion-delete-diff";
 
 const WIDGET_ID = "spirit.codeCompletion.deletePreview";
 

--- a/apps/desktop/src/lib/read-file-skill-display.ts
+++ b/apps/desktop/src/lib/read-file-skill-display.ts
@@ -1,11 +1,11 @@
 import {
   isSkillMarkdownPath,
   readFileToolDisplayBase,
-} from '@spirit-agent/host-internal/skill-paths';
+} from '@spiritagent/host-internal/skill-paths';
 
 import type { ToolBlockSnapshot } from '../types.js';
 
-export { isSkillMarkdownPath } from '@spirit-agent/host-internal/skill-paths';
+export { isSkillMarkdownPath } from '@spiritagent/host-internal/skill-paths';
 
 export const LEGACY_READ_FILE_HEADLINE =
   /^(?:查看|使用|View(?:ing|ed)?|Read(?:ing|ed)?|Us(?:ing|ed)?)\u002e?\s+(.+)$/u;

--- a/apps/desktop/src/lib/shell-tool-display.ts
+++ b/apps/desktop/src/lib/shell-tool-display.ts
@@ -1,7 +1,7 @@
 import {
   parseShellToolResult as parseShellToolResultPayload,
   type ShellToolResult,
-} from "@spirit-agent/core/shell-tool-result";
+} from "@spiritagent/agent-core/shell-tool-result";
 
 import i18n from "@/lib/i18n";
 import type { ToolBlockSnapshot } from "@/types";

--- a/apps/desktop/src/lib/skill-slash.ts
+++ b/apps/desktop/src/lib/skill-slash.ts
@@ -1,7 +1,7 @@
 import {
   charCountToCodeUnitIndex,
   codeUnitIndexToCharCount,
-} from '@spirit-agent/host-internal/workspace-file-reference-query'
+} from '@spiritagent/host-internal/workspace-file-reference-query'
 
 import type { RichSegment } from '@/lib/composer-segment-model'
 import { isComposerPlainEmpty } from '@/lib/composer-segment-model'

--- a/apps/desktop/src/lib/tool-output-archive-display.ts
+++ b/apps/desktop/src/lib/tool-output-archive-display.ts
@@ -1,4 +1,4 @@
-import { isToolOutputArchivePath } from '@spirit-agent/host-internal/tool-output-archive-path';
+import { isToolOutputArchivePath } from '@spiritagent/host-internal/tool-output-archive-path';
 
 export { isToolOutputArchivePath };
 

--- a/apps/desktop/src/lib/workspace-file-chip-styles.ts
+++ b/apps/desktop/src/lib/workspace-file-chip-styles.ts
@@ -1,7 +1,7 @@
 import {
   isWorkspaceReferenceDirectoryPath,
   normalizeWorkspaceReferenceDirectoryPath,
-} from '@spirit-agent/host-internal/workspace-file-reference-query';
+} from '@spiritagent/host-internal/workspace-file-reference-query';
 import { workspaceFileBasename } from '@/lib/file-picker-path';
 import {
   COMPOSER_INLINE_CHIP_CLASS,

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1,12 +1,12 @@
-import type { ModelProviderId, ProviderConnectSiteId } from '@spirit-agent/host-internal/model-provider-presets';
-import type { ModelReasoningEffort } from '@spirit-agent/core/reasoning-effort';
-import type { LspWriteDiagnosticsUi } from '@spirit-agent/core';
+import type { ModelProviderId, ProviderConnectSiteId } from '@spiritagent/host-internal/model-provider-presets';
+import type { ModelReasoningEffort } from '@spiritagent/agent-core/reasoning-effort';
+import type { LspWriteDiagnosticsUi } from '@spiritagent/agent-core';
 
 import type { DesktopAgentMode } from './lib/agent-mode.js';
 import type { DesktopAutomationTrigger } from './lib/automation-trigger.js';
 
 export type { DesktopAgentMode };
-import type { WorkspaceFileReferenceSuggestionsResult as HostWorkspaceFileReferenceSuggestionsResult, ApprovalLevel, GitHubPullRequestCommit } from '@spirit-agent/host-internal';
+import type { WorkspaceFileReferenceSuggestionsResult as HostWorkspaceFileReferenceSuggestionsResult, ApprovalLevel, GitHubPullRequestCommit } from '@spiritagent/host-internal';
 
 export type { ApprovalLevel };
 
@@ -697,7 +697,7 @@ export interface SetPanePendingGitBranchRequest {
 
 export interface SetPaneWorkLocationRequest {
   sessionPath: string;
-  workLocation: import('@spirit-agent/host-internal').WorkLocationKind;
+  workLocation: import('@spiritagent/host-internal').WorkLocationKind;
 }
 
 export interface CheckoutPaneGitBranchRequest {
@@ -1121,7 +1121,7 @@ export interface DesktopGitSnapshot {
   /** User-selected branch for the next send; defaults to `branch` when unset. */
   selectedBranch?: string;
   /** Session work-location preference; populated on client snapshots. */
-  workLocation?: import('@spirit-agent/host-internal').WorkLocationKind;
+  workLocation?: import('@spiritagent/host-internal').WorkLocationKind;
   /** True when the active workspace path is a linked Git worktree. */
   isWorktreeSession?: boolean;
   /** Primary repository root for the active worktree session. */
@@ -1221,7 +1221,7 @@ export type {
   GitHubPullRequestTabCounts,
   GitHubPullRequestTaskListProgress,
   GitHubRepositoryRef,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 export interface ListGitHubPullRequestsRequest {
   owner: string;
@@ -1252,13 +1252,13 @@ export interface GetGitHubPullRequestDetailRequest {
 }
 
 export interface MergeGitHubPullRequestRequest extends GetGitHubPullRequestDetailRequest {
-  mergeMethod: import('@spirit-agent/host-internal').GitHubPullRequestMergeMethod;
+  mergeMethod: import('@spiritagent/host-internal').GitHubPullRequestMergeMethod;
 }
 
 export type {
   GitHubPullRequestMergeMethod,
   GitHubPullRequestMergeResult,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 export interface ModelProfileSnapshot {
   name: string;

--- a/apps/desktop/test/host/dreams.test.mjs
+++ b/apps/desktop/test/host/dreams.test.mjs
@@ -6,8 +6,8 @@ import { test } from 'node:test';
 
 import {
   startOpenAiToolAgentState,
-} from '@spirit-agent/core';
-import { createHostDreamStore } from '@spirit-agent/host-internal';
+} from '@spiritagent/agent-core';
+import { createHostDreamStore } from '@spiritagent/host-internal';
 
 import {
   buildDreamCollectorPlanMetadata,

--- a/apps/desktop/test/host/image-generation-transport.test.mjs
+++ b/apps/desktop/test/host/image-generation-transport.test.mjs
@@ -5,7 +5,7 @@ import {
   AiSdkOpenResponsesTransport,
   createLlmTransport,
   isOpenAiCompatibleTransportConfig,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 test('deepseek primary transport without transportKind must still count as openai-compatible', () => {
   const runtimeTransportConfig = {

--- a/apps/desktop/test/host/lsp-snapshot.test.mjs
+++ b/apps/desktop/test/host/lsp-snapshot.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { LspService } from '@spirit-agent/host-internal/lsp';
+import { LspService } from '@spiritagent/host-internal/lsp';
 
 import { buildDesktopLspSnapshot } from '../../dist-electron/src/host/lsp-snapshot.js';
 import { DesktopToolExecutor } from '../../dist-electron/src/host/tool-executor.js';

--- a/apps/desktop/test/host/resolve-session-workspace-root.test.mjs
+++ b/apps/desktop/test/host/resolve-session-workspace-root.test.mjs
@@ -9,7 +9,7 @@ import test from 'node:test';
 import {
   addGitWorktree,
   buildWorktreeRootPath,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import { resolveStoredSessionWorkspaceRoot } from '../../dist-electron/src/host/resolve-session-workspace-root.js';
 

--- a/apps/desktop/test/host/rules.test.mjs
+++ b/apps/desktop/test/host/rules.test.mjs
@@ -96,7 +96,7 @@ test('deleteRuleFile removes managed rule file', async () => {
     const instructionPaths = desktopInstructionPaths(workspaceRoot);
     const targetPath = resolveRuleFilePath(instructionPaths, 'workspaceSpirit');
     await writeFile(targetPath, '# Rules\n', 'utf8');
-    const entries = await import('@spirit-agent/host-internal').then((mod) =>
+    const entries = await import('@spiritagent/host-internal').then((mod) =>
       mod.discoverRuleEntries({
         workspaceRoot,
         spiritDataDir,

--- a/apps/desktop/test/host/session-title.test.mjs
+++ b/apps/desktop/test/host/session-title.test.mjs
@@ -5,7 +5,7 @@ import {
   buildSessionTitlePrompt,
   normalizeGeneratedSessionTitle,
   SESSION_TITLE_MAX_LENGTH,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 import { DesktopMessageTimeline } from '../../dist-electron/src/host/message-timeline.js';
 import {
   countUserMessages,

--- a/apps/desktop/test/host/subagent-viewer.test.mjs
+++ b/apps/desktop/test/host/subagent-viewer.test.mjs
@@ -4,7 +4,7 @@ import { test } from 'node:test';
 import {
   buildSubagentConversationSnapshots,
   resolveSubagentPromptFromTaskFields,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 test('buildSubagentConversationSnapshots maps user, assistant text, and tool results', () => {
   const messages = buildSubagentConversationSnapshots(

--- a/apps/desktop/test/host/todos.test.mjs
+++ b/apps/desktop/test/host/todos.test.mjs
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { test } from 'node:test';
 
-import { createHostTodoStore } from '@spirit-agent/host-internal';
+import { createHostTodoStore } from '@spiritagent/host-internal';
 
 import {
   createTodoSessionScopeKey,

--- a/apps/desktop/test/skill-slash.test.mjs
+++ b/apps/desktop/test/skill-slash.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { currentWorkspaceFileReferenceQuery } from "@spirit-agent/host-internal/workspace-file-reference-query";
+import { currentWorkspaceFileReferenceQuery } from "@spiritagent/host-internal/workspace-file-reference-query";
 
 import {
   buildSkillSlashSuggestions,

--- a/docs/README_zh-CN.md
+++ b/docs/README_zh-CN.md
@@ -90,7 +90,7 @@ Agent Core 决定模型如何「看见」项目上下文：
 - **Smoke 套件** — 位于 `packages/agent-core/src/smoke` 的契约、运行时与线上提供商检查。
 - **Eval 框架** — 针对提示词或工具定义变更的场景对比与评判（在仓库根目录执行 `npm run eval:compare`）。
 
-`@spirit-agent/core` 发布至 npm；[`packages/host-internal`](../packages/host-internal) 承载 Desktop 共用的宿主侧发现、扩展、市场、工作区辅助与 LSP 编排。
+`@spiritagent/agent-core` 发布至 npm；[`packages/host-internal`](../packages/host-internal) 承载 Desktop 共用的宿主侧发现、扩展、市场、工作区辅助与 LSP 编排。
 
 ## Desktop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "@spirit-agent/dev-root",
+  "name": "@spiritagent/dev-root",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@spirit-agent/dev-root",
+      "name": "@spiritagent/dev-root",
       "workspaces": [
         "packages/*"
       ],
@@ -13,7 +13,7 @@
       }
     },
     "apps/desktop": {
-      "name": "@spirit-agent/desktop",
+      "name": "@spiritagent/desktop",
       "version": "0.2.6",
       "extraneous": true,
       "hasInstallScript": true,
@@ -21,9 +21,9 @@
         "@fontsource-variable/geist": "^5.2.8",
         "@napi-rs/keyring": "^1.2.0",
         "@radix-ui/react-scroll-area": "^1.2.10",
-        "@spirit-agent/core": "file:../../packages/agent-core",
-        "@spirit-agent/dev-root": "file:../..",
-        "@spirit-agent/host-internal": "file:../../packages/host-internal",
+        "@spiritagent/agent-core": "file:../../packages/agent-core",
+        "@spiritagent/dev-root": "file:../..",
+        "@spiritagent/host-internal": "file:../../packages/host-internal",
         "@streamdown/code": "^1.1.1",
         "@streamdown/math": "^1.0.2",
         "@streamdown/mermaid": "^1.0.2",
@@ -1826,15 +1826,15 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@spirit-agent/acp-server": {
+    "node_modules/@spiritagent/acp-server": {
       "resolved": "packages/acp-server",
       "link": true
     },
-    "node_modules/@spirit-agent/core": {
+    "node_modules/@spiritagent/agent-core": {
       "resolved": "packages/agent-core",
       "link": true
     },
-    "node_modules/@spirit-agent/host-internal": {
+    "node_modules/@spiritagent/host-internal": {
       "resolved": "packages/host-internal",
       "link": true
     },
@@ -3994,15 +3994,15 @@
       }
     },
     "packages/acp-server": {
-      "name": "@spirit-agent/acp-server",
+      "name": "@spiritagent/acp-server",
       "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.25.1",
         "@inquirer/prompts": "^7.5.0",
         "@napi-rs/keyring": "^1.2.0",
-        "@spirit-agent/core": "0.2.6",
-        "@spirit-agent/host-internal": "0.2.6"
+        "@spiritagent/agent-core": "0.2.6",
+        "@spiritagent/host-internal": "0.2.6"
       },
       "bin": {
         "spirit-agent-acp": "dist/src/stdio-entry.js"
@@ -4017,7 +4017,7 @@
       }
     },
     "packages/agent-core": {
-      "name": "@spirit-agent/core",
+      "name": "@spiritagent/agent-core",
       "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
@@ -5031,13 +5031,13 @@
       }
     },
     "packages/host-internal": {
-      "name": "@spirit-agent/host-internal",
+      "name": "@spiritagent/host-internal",
       "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-bedrock": "^3.1068.0",
         "@mozilla/readability": "^0.6.0",
-        "@spirit-agent/core": "0.2.6",
+        "@spiritagent/agent-core": "0.2.6",
         "@vscode/ripgrep": "^1.18.0",
         "fast-glob": "^3.3.3",
         "fflate": "^0.8.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spirit-agent/dev-root",
+  "name": "@spiritagent/dev-root",
   "private": true,
   "description": "Spirit Agent — root scripts for TS build + Rust CLI",
   "workspaces": [

--- a/packages/acp-server/NOTICE.md
+++ b/packages/acp-server/NOTICE.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-This file was generated for `@spirit-agent/acp-server` (`dependencies` + `devDependencies`; direct dependencies only by default).
+This file was generated for `@spiritagent/acp-server` (`dependencies` + `devDependencies`; direct dependencies only by default).
 Regenerate: `npm run notice` — `-- --production` limits output to production dependencies, `-- --recursive` includes transitive dependencies.
 Scope constraint: exclude workspace-local/internal dependencies resolved via `workspace:` or `file:`; keep output sorted deterministically by package name and license section.
 

--- a/packages/acp-server/README.md
+++ b/packages/acp-server/README.md
@@ -1,4 +1,4 @@
-# @spirit-agent/acp-server
+# @spiritagent/acp-server
 
 ACP ([Agent Client Protocol](https://agentclientprotocol.com)) server adapter for [Spirit Agent](https://github.com/SpiritAgents/SpiritAgent). Exposes the same agent runtime as Desktop and CLI over **stdio / ndJSON**, so ACP-compatible editors (for example **Zed** or **JetBrains Junie**) can use Spirit Agent without bespoke integration.
 
@@ -14,7 +14,7 @@ ACP ([Agent Client Protocol](https://agentclientprotocol.com)) server adapter fo
 ## Quick start
 
 ```bash
-npx @spirit-agent/acp-server --setup
+npx @spiritagent/acp-server --setup
 ```
 
 Setup writes to the shared Spirit data directory (`config.json` + OS keyring — same store as Desktop/CLI). After setup, your ACP client calls `authenticate`, then `session/new`.
@@ -30,8 +30,8 @@ Setup writes to the shared Spirit data directory (`config.json` + OS keyring —
 
 ## Related packages
 
-- [`@spirit-agent/core`](https://www.npmjs.com/package/@spirit-agent/core) — agent runtime and tool contracts.
-- [`@spirit-agent/host-internal`](https://www.npmjs.com/package/@spirit-agent/host-internal) — local tool execution and discovery.
+- [`@spiritagent/agent-core`](https://www.npmjs.com/package/@spiritagent/agent-core) — agent runtime and tool contracts.
+- [`@spiritagent/host-internal`](https://www.npmjs.com/package/@spiritagent/host-internal) — local tool execution and discovery.
 
 ## License
 

--- a/packages/acp-server/package.json
+++ b/packages/acp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spirit-agent/acp-server",
+  "name": "@spiritagent/acp-server",
   "version": "0.2.6",
   "description": "ACP (Agent Client Protocol) server adapter for Spirit Agent",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "@agentclientprotocol/sdk": "^0.25.1",
     "@inquirer/prompts": "^7.5.0",
     "@napi-rs/keyring": "^1.2.0",
-    "@spirit-agent/core": "0.2.6",
-    "@spirit-agent/host-internal": "0.2.6"
+    "@spiritagent/agent-core": "0.2.6",
+    "@spiritagent/host-internal": "0.2.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",

--- a/packages/acp-server/src/acp-agent.ts
+++ b/packages/acp-server/src/acp-agent.ts
@@ -1,7 +1,7 @@
 import type * as acp from '@agentclientprotocol/sdk';
 import type * as schema from '@agentclientprotocol/sdk';
 import { RequestError } from '@agentclientprotocol/sdk';
-import type { JsonValue, LlmActiveSkill, RuntimeEvent } from '@spirit-agent/core';
+import type { JsonValue, LlmActiveSkill, RuntimeEvent } from '@spiritagent/agent-core';
 import type { AuthState } from './auth/auth-state.js';
 import { buildAuthMethods } from './auth/build-auth-methods.js';
 import { TERMINAL_AUTH_METHOD_ID } from './auth/constants.js';

--- a/packages/acp-server/src/credentials/credentials.ts
+++ b/packages/acp-server/src/credentials/credentials.ts
@@ -1,4 +1,4 @@
-import type { ModelProviderId } from '@spirit-agent/host-internal';
+import type { ModelProviderId } from '@spiritagent/host-internal';
 
 import { keyringStore } from './keyring-store.js';
 import {

--- a/packages/acp-server/src/credentials/provider-accounts.ts
+++ b/packages/acp-server/src/credentials/provider-accounts.ts
@@ -1,4 +1,4 @@
-import type { ModelProviderId } from '@spirit-agent/host-internal';
+import type { ModelProviderId } from '@spiritagent/host-internal';
 
 export const KEYRING_SERVICE = 'SpiritAgent';
 export const KEYRING_GLOBAL_ACCOUNT = 'openai_api_key';

--- a/packages/acp-server/src/credentials/types.ts
+++ b/packages/acp-server/src/credentials/types.ts
@@ -1,4 +1,4 @@
-import type { ModelProviderId, ProviderModelTransportKind } from '@spirit-agent/host-internal';
+import type { ModelProviderId, ProviderModelTransportKind } from '@spiritagent/host-internal';
 
 export type SpiritModelCapability = 'chat' | 'image' | 'video' | 'imageGeneration' | 'videoGeneration';
 

--- a/packages/acp-server/src/event-mapper.ts
+++ b/packages/acp-server/src/event-mapper.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, RuntimeEvent } from '@spirit-agent/core';
+import type { JsonValue, RuntimeEvent } from '@spiritagent/agent-core';
 import type * as schema from '@agentclientprotocol/sdk';
 import { mapToolNameToKind, buildToolCallTitle, extractToolCallLocations } from './tool-call-mapper.js';
 
@@ -153,7 +153,7 @@ export function mapRuntimeEventToUpdate(
  * Formats tool execution output into ACP ToolCallContent array.
  */
 function formatToolExecutionOutput(
-  output: string | import('@spirit-agent/core').ToolExecutionOutput,
+  output: string | import('@spiritagent/agent-core').ToolExecutionOutput,
 ): schema.ToolCallContent[] | undefined {
   if (typeof output === 'string') {
     if (output.length === 0) return undefined;

--- a/packages/acp-server/src/noop-peer.ts
+++ b/packages/acp-server/src/noop-peer.ts
@@ -1,4 +1,4 @@
-import { JsonRpcPeer } from '@spirit-agent/core/host-bridge';
+import { JsonRpcPeer } from '@spiritagent/agent-core/host-bridge';
 import { PassThrough } from 'node:stream';
 
 /**

--- a/packages/acp-server/src/permission-bridge.ts
+++ b/packages/acp-server/src/permission-bridge.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, RuntimeApprovalDecision, RuntimePendingApproval } from '@spirit-agent/core';
+import type { JsonValue, RuntimeApprovalDecision, RuntimePendingApproval } from '@spiritagent/agent-core';
 import type { AgentSideConnection } from '@agentclientprotocol/sdk';
 import type * as schema from '@agentclientprotocol/sdk';
 import { mapToolNameToKind, buildToolCallTitle } from './tool-call-mapper.js';

--- a/packages/acp-server/src/runtime-factory.ts
+++ b/packages/acp-server/src/runtime-factory.ts
@@ -9,7 +9,7 @@ import {
   type JsonValue,
   type RuntimeEvent,
   type GeneratedImageSaveRequest,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   startLlmToolAgentState,
   continueLlmToolAgentState,
@@ -28,12 +28,12 @@ import {
   type LlmEnabledRule,
   type LlmEnabledSkillCatalogEntry,
   type LlmPlanMetadata,
-} from '@spirit-agent/core';
-import { buildApplyPatchFileToolsPromptSection } from '@spirit-agent/core';
-import { buildProviderWebSearchPromptSection } from '@spirit-agent/core';
-import type { SpiritAgentMode } from '@spirit-agent/core';
-import type { LocalHostToolService } from '@spirit-agent/core/host-bridge';
-import { HostToolExecutorProxy } from '@spirit-agent/core/host-bridge';
+} from '@spiritagent/agent-core';
+import { buildApplyPatchFileToolsPromptSection } from '@spiritagent/agent-core';
+import { buildProviderWebSearchPromptSection } from '@spiritagent/agent-core';
+import type { SpiritAgentMode } from '@spiritagent/agent-core';
+import type { LocalHostToolService } from '@spiritagent/agent-core/host-bridge';
+import { HostToolExecutorProxy } from '@spiritagent/agent-core/host-bridge';
 
 import {
   NodeHostToolService,
@@ -44,7 +44,7 @@ import {
   persistToolOutputArchive,
   readGitBranchLabelForBasicInfo,
   removePreCompactionHistoryArchive,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import { createNoopPeer } from './noop-peer.js';
 import { resolveTransportConfig } from './transport/resolve-transport.js';

--- a/packages/acp-server/src/session-manager.ts
+++ b/packages/acp-server/src/session-manager.ts
@@ -1,5 +1,5 @@
-import type { JsonValue, RuntimeEvent, SpiritAgentMode } from '@spirit-agent/core';
-import type { HostToolExecutorProxy } from '@spirit-agent/core/host-bridge';
+import type { JsonValue, RuntimeEvent, SpiritAgentMode } from '@spiritagent/agent-core';
+import type { HostToolExecutorProxy } from '@spiritagent/agent-core/host-bridge';
 import type { AcpServerConfig, AcpSessionState } from './types.js';
 import { AVAILABLE_MODES, normalizeModeId } from './types.js';
 import { createAcpRuntime, type AcpHostRuntime, type AcpRuntimeResult } from './runtime-factory.js';
@@ -22,7 +22,7 @@ export class SessionManager {
     workspaceRoot: string,
     onEvent: (sessionId: string, event: RuntimeEvent<JsonValue>) => void,
     initialMode: SpiritAgentMode = 'agent',
-  ): Promise<{ sessionId: string; modes: typeof AVAILABLE_MODES; enabledSkillCatalog: import('@spirit-agent/core').LlmEnabledSkillCatalogEntry[] }> {
+  ): Promise<{ sessionId: string; modes: typeof AVAILABLE_MODES; enabledSkillCatalog: import('@spiritagent/agent-core').LlmEnabledSkillCatalogEntry[] }> {
     const sessionId = generateSessionId();
 
     const sessionConfig: AcpServerConfig = {

--- a/packages/acp-server/src/setup/provider-wizard.ts
+++ b/packages/acp-server/src/setup/provider-wizard.ts
@@ -1,10 +1,10 @@
-import type { ModelProviderId, ProviderModelTransportKind } from '@spirit-agent/host-internal';
+import type { ModelProviderId, ProviderModelTransportKind } from '@spiritagent/host-internal';
 import {
   listProviderConnectSiteOptions,
   providerConnectSiteRequiresWorkspaceId,
   providerSupportsSiteSelection,
   resolveProviderConnectApiBase,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type { SpiritModelProfile } from '../credentials/types.js';
 

--- a/packages/acp-server/src/setup/run-interactive-setup.ts
+++ b/packages/acp-server/src/setup/run-interactive-setup.ts
@@ -5,7 +5,7 @@ import {
   PROVIDER_PICKER_ROWS,
   listProviderModels,
   type ModelProviderId,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import type { ProviderSetupResult } from '../credentials/types.js';
 import {

--- a/packages/acp-server/src/skill-bridge.ts
+++ b/packages/acp-server/src/skill-bridge.ts
@@ -6,7 +6,7 @@ import type {
   LlmActiveSkill,
   LlmActiveSkillResourceEntry,
   LlmEnabledSkillCatalogEntry,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import type * as schema from '@agentclientprotocol/sdk';
 
 // --- Constants (aligned with Desktop) ---

--- a/packages/acp-server/src/transport/resolve-transport.ts
+++ b/packages/acp-server/src/transport/resolve-transport.ts
@@ -4,16 +4,16 @@ import {
   type LlmModelCapabilities,
   type LlmTransportConfig,
   type OpenResponsesSdkProvider,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   resolveAnthropicTransportReasoningEffortForContext,
   resolveOpenAiTransportReasoningEffortForContext,
-} from '@spirit-agent/core/reasoning-effort';
+} from '@spiritagent/agent-core/reasoning-effort';
 import {
   bedrockMantleApiBaseFromRegion,
   isBedrockMantleOpenAiModel,
   type ModelProviderId,
-} from '@spirit-agent/host-internal';
+} from '@spiritagent/host-internal';
 
 import {
   loadActiveModelProfile,

--- a/packages/acp-server/src/types.ts
+++ b/packages/acp-server/src/types.ts
@@ -1,6 +1,6 @@
-import type { AgentRuntime, LlmActiveSkill, LlmEnabledSkillCatalogEntry, LlmTransportConfig, SpiritAgentMode } from '@spirit-agent/core';
-import type { HostToolExecutorProxy } from '@spirit-agent/core/host-bridge';
-import type { JsonValue } from '@spirit-agent/core';
+import type { AgentRuntime, LlmActiveSkill, LlmEnabledSkillCatalogEntry, LlmTransportConfig, SpiritAgentMode } from '@spiritagent/agent-core';
+import type { HostToolExecutorProxy } from '@spiritagent/agent-core/host-bridge';
+import type { JsonValue } from '@spiritagent/agent-core';
 
 /**
  * ACP Server runtime paths. LLM transport is resolved from shared Spirit config + keyring.

--- a/packages/acp-server/test/event-mapper.test.ts
+++ b/packages/acp-server/test/event-mapper.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { mapRuntimeEventToUpdate, createEventMapperState } from '../src/event-mapper.js';
-import type { RuntimeEvent, JsonValue } from '@spirit-agent/core';
+import type { RuntimeEvent, JsonValue } from '@spiritagent/agent-core';
 
 const SESSION_ID = 'sess_test123';
 

--- a/packages/agent-core/NOTICE.md
+++ b/packages/agent-core/NOTICE.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-This file was generated for `@spirit-agent/core` (`dependencies` + `devDependencies`; direct dependencies only by default).
+This file was generated for `@spiritagent/agent-core` (`dependencies` + `devDependencies`; direct dependencies only by default).
 Regenerate: `npm run notice` — `-- --production` limits output to production dependencies, `-- --recursive` includes transitive dependencies.
 Scope constraint: exclude workspace-local/internal dependencies resolved via `workspace:` or `file:`; keep output sorted deterministically by package name and license section.
 

--- a/packages/agent-core/README.md
+++ b/packages/agent-core/README.md
@@ -1,4 +1,4 @@
-# @spirit-agent/core
+# @spiritagent/agent-core
 
 TypeScript core runtime for [Spirit Agent](https://github.com/SpiritAgents/SpiritAgent) — the **single source of agent semantics** in the project. Desktop, CLI, and ACP hosts consume this package; they supply platform-specific execution and UI.
 
@@ -17,8 +17,8 @@ TypeScript core runtime for [Spirit Agent](https://github.com/SpiritAgents/Spiri
 
 ## Related packages
 
-- [`@spirit-agent/host-internal`](https://www.npmjs.com/package/@spirit-agent/host-internal) — shared host discovery, tools, extensions, and LSP helpers.
-- [`@spirit-agent/acp-server`](https://www.npmjs.com/package/@spirit-agent/acp-server) — ACP server adapter for editor integration.
+- [`@spiritagent/host-internal`](https://www.npmjs.com/package/@spiritagent/host-internal) — shared host discovery, tools, extensions, and LSP helpers.
+- [`@spiritagent/acp-server`](https://www.npmjs.com/package/@spiritagent/acp-server) — ACP server adapter for editor integration.
 
 ## License
 

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spirit-agent/core",
+  "name": "@spiritagent/agent-core",
   "version": "0.2.6",
   "description": "TypeScript core runtime for Spirit Agent",
   "license": "MIT",

--- a/packages/agent-core/src/hooks/config.test.ts
+++ b/packages/agent-core/src/hooks/config.test.ts
@@ -11,7 +11,7 @@ import {
   parseHooksConfigFile,
   resolveHookCommandPath,
   resolveMergedHookDefinitions,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 test('parseHooksConfigFile accepts valid config', () => {
   const parsed = parseHooksConfigFile({

--- a/packages/agent-core/src/mcp/config.ts
+++ b/packages/agent-core/src/mcp/config.ts
@@ -24,7 +24,7 @@ export const SPIRIT_DIR_NAME = '.spirit';
 export type McpConfigScope = 'user' | 'workspace';
 
 export const DEFAULT_MCP_CLIENT_INFO: McpClientInfo = {
-  name: '@spirit-agent/core',
+  name: '@spiritagent/agent-core',
   version: '0.2.6',
 };
 

--- a/packages/host-internal/NOTICE.md
+++ b/packages/host-internal/NOTICE.md
@@ -1,6 +1,6 @@
 # Third-party notices
 
-This file was generated for `@spirit-agent/host-internal` (`dependencies` + `devDependencies`; direct dependencies only by default).
+This file was generated for `@spiritagent/host-internal` (`dependencies` + `devDependencies`; direct dependencies only by default).
 Regenerate: `npm run notice` — `-- --production` limits output to production dependencies, `-- --recursive` includes transitive dependencies.
 Scope constraint: exclude workspace-local/internal dependencies resolved via `workspace:` or `file:`; keep output sorted deterministically by package name and license section.
 

--- a/packages/host-internal/README.md
+++ b/packages/host-internal/README.md
@@ -1,6 +1,6 @@
-# @spirit-agent/host-internal
+# @spiritagent/host-internal
 
-Shared **host-side implementation** for [Spirit Agent](https://github.com/SpiritAgents/SpiritAgent). It sits between platform hosts (Desktop, CLI, ACP server) and [`@spirit-agent/core`](https://www.npmjs.com/package/@spirit-agent/core), providing discovery, workspace helpers, and local execution plumbing.
+Shared **host-side implementation** for [Spirit Agent](https://github.com/SpiritAgents/SpiritAgent). It sits between platform hosts (Desktop, CLI, ACP server) and [`@spiritagent/agent-core`](https://www.npmjs.com/package/@spiritagent/agent-core), providing discovery, workspace helpers, and local execution plumbing.
 
 ## What it provides
 
@@ -13,12 +13,12 @@ Shared **host-side implementation** for [Spirit Agent](https://github.com/Spirit
 ## Requirements
 
 - Node.js 22+
-- [`@spirit-agent/core`](https://www.npmjs.com/package/@spirit-agent/core) at a matching version
+- [`@spiritagent/agent-core`](https://www.npmjs.com/package/@spiritagent/agent-core) at a matching version
 
 ## Related packages
 
-- [`@spirit-agent/core`](https://www.npmjs.com/package/@spirit-agent/core) — agent runtime, prompts, tool definitions, and transports.
-- [`@spirit-agent/acp-server`](https://www.npmjs.com/package/@spirit-agent/acp-server) — ACP server adapter that depends on this package for local tool execution.
+- [`@spiritagent/agent-core`](https://www.npmjs.com/package/@spiritagent/agent-core) — agent runtime, prompts, tool definitions, and transports.
+- [`@spiritagent/acp-server`](https://www.npmjs.com/package/@spiritagent/acp-server) — ACP server adapter that depends on this package for local tool execution.
 
 ## License
 

--- a/packages/host-internal/package.json
+++ b/packages/host-internal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spirit-agent/host-internal",
+  "name": "@spiritagent/host-internal",
   "version": "0.2.6",
   "description": "Internal TypeScript host implementation boundaries for Spirit Agent",
   "license": "MIT",
@@ -150,7 +150,7 @@
   "dependencies": {
     "@aws-sdk/client-bedrock": "^3.1068.0",
     "@mozilla/readability": "^0.6.0",
-    "@spirit-agent/core": "0.2.6",
+    "@spiritagent/agent-core": "0.2.6",
     "@vscode/ripgrep": "^1.18.0",
     "fast-glob": "^3.3.3",
     "fflate": "^0.8.2",

--- a/packages/host-internal/src/automation-host-tool.ts
+++ b/packages/host-internal/src/automation-host-tool.ts
@@ -3,7 +3,7 @@ import {
   type ContributedHostToolDefinition,
   type JsonObject,
   type JsonValue,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import type { HostAutomationTrigger } from './automations.js';
 import { normalizeAutomationTrigger } from './automations.js';

--- a/packages/host-internal/src/azure-resource.ts
+++ b/packages/host-internal/src/azure-resource.ts
@@ -6,4 +6,4 @@ export {
   isValidAzureResourceName,
   normalizeAzureResourceName,
   validateAzureResourceName,
-} from '@spirit-agent/core/azure-resource';
+} from '@spiritagent/agent-core/azure-resource';

--- a/packages/host-internal/src/code-completion/llm-source.ts
+++ b/packages/host-internal/src/code-completion/llm-source.ts
@@ -5,7 +5,7 @@ import {
   type JsonSchemaTransport,
   type LlmTransportConfig,
   validateCodeCompletionOutput,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import type { FormattedRecentEdits } from './edit-journal.js';
 import { buildCodeCompletionSystemSections, buildCodeCompletionUserPrompt } from './prompts.js';

--- a/packages/host-internal/src/code-completion/prompts.ts
+++ b/packages/host-internal/src/code-completion/prompts.ts
@@ -1,4 +1,4 @@
-import { buildCodeCompletionIdentityPrompt } from '@spirit-agent/core';
+import { buildCodeCompletionIdentityPrompt } from '@spiritagent/agent-core';
 
 import { buildCodeCompletionContextSlices } from './context.js';
 import type { CodeCompletionRequestContext } from './types.js';

--- a/packages/host-internal/src/code-completion/service.ts
+++ b/packages/host-internal/src/code-completion/service.ts
@@ -1,4 +1,4 @@
-import type { CodeCompletionResult } from '@spirit-agent/core';
+import type { CodeCompletionResult } from '@spiritagent/agent-core';
 
 import { CodeCompletionEditJournal } from './edit-journal.js';
 import type { LlmCodeCompletionDependencies } from './llm-source.js';

--- a/packages/host-internal/src/code-completion/types.ts
+++ b/packages/host-internal/src/code-completion/types.ts
@@ -1,4 +1,4 @@
-import type { CodeCompletionResult } from '@spirit-agent/core';
+import type { CodeCompletionResult } from '@spiritagent/agent-core';
 
 import type { FormattedRecentEdits } from './edit-journal.js';
 

--- a/packages/host-internal/src/compaction-archive.ts
+++ b/packages/host-internal/src/compaction-archive.ts
@@ -1,7 +1,7 @@
 import { mkdir, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import type { PreCompactionHistoryArchive } from '@spirit-agent/core';
+import type { PreCompactionHistoryArchive } from '@spiritagent/agent-core';
 
 import { sanitizeSessionIdForFilename } from './spirit-filename-sanitize.js';
 

--- a/packages/host-internal/src/discovery.ts
+++ b/packages/host-internal/src/discovery.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 
-import { normalizeSpiritAgentMode, type SpiritAgentMode } from '@spirit-agent/core';
+import { normalizeSpiritAgentMode, type SpiritAgentMode } from '@spiritagent/agent-core';
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 

--- a/packages/host-internal/src/generate-worktree-names.ts
+++ b/packages/host-internal/src/generate-worktree-names.ts
@@ -11,7 +11,7 @@ import {
   type LlmToolAgentBasicInfo,
   type LlmTransportConfig,
   type ToolExecutor,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import {
   buildWorktreeNamingPrompt,

--- a/packages/host-internal/src/hooks/command-runner.ts
+++ b/packages/host-internal/src/hooks/command-runner.ts
@@ -7,7 +7,7 @@ import {
   type HookCommandOutput,
   type HookExecutionRecord,
   type ResolvedHookDefinition,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 export interface RunCommandHookOptions {
   definition: ResolvedHookDefinition;

--- a/packages/host-internal/src/hooks/config-crud.ts
+++ b/packages/host-internal/src/hooks/config-crud.ts
@@ -8,7 +8,7 @@ import {
   type HookDefinition,
   type HookEventName,
   type HooksConfigFile,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import { loadHooksConfigFileAt, loadHooksConfigFileForMutation } from './loader.js';
 

--- a/packages/host-internal/src/hooks/loader.test.ts
+++ b/packages/host-internal/src/hooks/loader.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { hooksUserConfigPath } from '@spirit-agent/core';
+import { hooksUserConfigPath } from '@spiritagent/agent-core';
 
 import { loadHooksConfigFileAt, loadHooksConfigFileForMutation, validateHooksConfig } from './loader.js';
 

--- a/packages/host-internal/src/hooks/loader.ts
+++ b/packages/host-internal/src/hooks/loader.ts
@@ -13,7 +13,7 @@ import {
   type HookInput,
   type HooksConfigFile,
   hookMatcherTarget,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 export interface LoadHooksConfigOptions {
   spiritDataDir: string;

--- a/packages/host-internal/src/hooks/service.test.ts
+++ b/packages/host-internal/src/hooks/service.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { mergePreEventHookPermission } from '@spirit-agent/core';
+import { mergePreEventHookPermission } from '@spiritagent/agent-core';
 
 import { createHookRunner } from './service.js';
 

--- a/packages/host-internal/src/hooks/service.ts
+++ b/packages/host-internal/src/hooks/service.ts
@@ -10,7 +10,7 @@ import {
   type HookRunner,
   type HookRunnerContext,
   isPreHookEvent,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import { runCommandHook } from './command-runner.js';
 import { listHookDefinitionsForInput, loadHooksConfig, type LoadedHooksConfig } from './loader.js';

--- a/packages/host-internal/src/lsp/connection.ts
+++ b/packages/host-internal/src/lsp/connection.ts
@@ -2,7 +2,7 @@ import { spawn, type SpawnOptions } from 'node:child_process';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import type { LspDiagnostic } from '@spirit-agent/core';
+import type { LspDiagnostic } from '@spiritagent/agent-core';
 
 import { isWindowsPlatform } from './windows-path.js';
 import { normalizeLspFileUri } from './paths.js';

--- a/packages/host-internal/src/lsp/orchestrator.ts
+++ b/packages/host-internal/src/lsp/orchestrator.ts
@@ -2,8 +2,8 @@ import path from 'node:path';
 
 import { DEFAULT_LSP_TIMING, type LspTimingConfig } from './config.js';
 import { LspDisabledError, LspPathError } from './errors.js';
-import { formatDiagnosticsForLlm } from '@spirit-agent/core';
-import type { LspDiagnostic, LspFileChangeNotification } from '@spirit-agent/core';
+import { formatDiagnosticsForLlm } from '@spiritagent/agent-core';
+import type { LspDiagnostic, LspFileChangeNotification } from '@spiritagent/agent-core';
 import {
   isLspSupportedPath,
   parseLspFileChangeNotification,

--- a/packages/host-internal/src/lsp/paths.ts
+++ b/packages/host-internal/src/lsp/paths.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { isLspSupportedExtension, TYPESCRIPT_JS_EXTENSIONS } from '@spirit-agent/core';
-import type { LspFileChangeNotification, LspFileSnapshot } from '@spirit-agent/core';
+import { isLspSupportedExtension, TYPESCRIPT_JS_EXTENSIONS } from '@spiritagent/agent-core';
+import type { LspFileChangeNotification, LspFileSnapshot } from '@spiritagent/agent-core';
 import { LspPathError } from './errors.js';
 import { routeLspProviderForPath } from './providers.js';
 

--- a/packages/host-internal/src/lsp/provider-session.ts
+++ b/packages/host-internal/src/lsp/provider-session.ts
@@ -4,7 +4,7 @@ import { DEFAULT_LSP_TIMING, type LspTimingConfig } from './config.js';
 import { LspConnection } from './connection.js';
 import { LspDocumentStore } from './document-store.js';
 import { LspDisabledError, LspTimeoutError } from './errors.js';
-import type { LspDiagnostic, LspFileChangeNotification } from '@spirit-agent/core';
+import type { LspDiagnostic, LspFileChangeNotification } from '@spiritagent/agent-core';
 import {
   fileUriForResolvedPath,
   normalizeLspFileUri,

--- a/packages/host-internal/src/lsp/ready-providers.ts
+++ b/packages/host-internal/src/lsp/ready-providers.ts
@@ -1,11 +1,11 @@
-import type { LspReadyProviderSummary } from '@spirit-agent/core';
+import type { LspReadyProviderSummary } from '@spiritagent/agent-core';
 
 import type { LspOrchestrator } from './orchestrator.js';
 import { LSP_PROVIDERS } from './providers.js';
 
 export function readyProvidersForToolDefinitions(
   orchestrator: LspOrchestrator,
-): import('@spirit-agent/core').LspReadyProviderSummary[] {
+): import('@spiritagent/agent-core').LspReadyProviderSummary[] {
   const summaries: LspReadyProviderSummary[] = [];
   for (const provider of LSP_PROVIDERS) {
     const session = orchestrator.getSession(provider.id);

--- a/packages/host-internal/src/lsp/resolve-server.ts
+++ b/packages/host-internal/src/lsp/resolve-server.ts
@@ -3,7 +3,7 @@ import { access } from 'node:fs/promises';
 import { constants } from 'node:fs';
 import { promisify } from 'node:util';
 
-import { TYPESCRIPT_LANGUAGE_SERVER_COMMAND } from '@spirit-agent/core';
+import { TYPESCRIPT_LANGUAGE_SERVER_COMMAND } from '@spiritagent/agent-core';
 
 import {
   buildWindowsCommandCandidates,

--- a/packages/host-internal/src/lsp/service.ts
+++ b/packages/host-internal/src/lsp/service.ts
@@ -1,4 +1,4 @@
-import type { JsonValue, LspDiagnostic, LspReadyProviderSummary } from '@spirit-agent/core';
+import type { JsonValue, LspDiagnostic, LspReadyProviderSummary } from '@spiritagent/agent-core';
 
 import { DEFAULT_LSP_TIMING, type LspTimingConfig } from './config.js';
 import { LspOrchestrator } from './orchestrator.js';

--- a/packages/host-internal/src/lsp/write-append.test.ts
+++ b/packages/host-internal/src/lsp/write-append.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createToolExecutionTextOutput } from '@spirit-agent/core';
+import { createToolExecutionTextOutput } from '@spiritagent/agent-core';
 import { DEFAULT_LSP_TIMING } from './config.js';
 import { LspDisabledError, LspTimeoutError } from './errors.js';
 import { appendLspDiagnosticsAfterWriteIfNeeded } from './write-append.js';

--- a/packages/host-internal/src/lsp/write-append.ts
+++ b/packages/host-internal/src/lsp/write-append.ts
@@ -1,9 +1,9 @@
-import type { JsonValue, ToolExecutionOutput } from '@spirit-agent/core';
-import { APPEND_DIAGNOSTICS_AFTER_WRITES, HOST_WRITE_TOOL_NAMES } from '@spirit-agent/core';
+import type { JsonValue, ToolExecutionOutput } from '@spiritagent/agent-core';
+import { APPEND_DIAGNOSTICS_AFTER_WRITES, HOST_WRITE_TOOL_NAMES } from '@spiritagent/agent-core';
 import {
   buildLspWriteDiagnosticsUi,
   formatDiagnosticsSummaryBlock,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import { DEFAULT_LSP_TIMING } from './config.js';
 import { LspTimeoutError } from './errors.js';

--- a/packages/host-internal/src/openai-models.ts
+++ b/packages/host-internal/src/openai-models.ts
@@ -6,7 +6,7 @@ import {
   gatewayAnthropicClaudeSupportedEfforts,
   gatewayGoogleGeminiSupportedEfforts,
   routedAnthropicClaudeSupportedEfforts,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import type { ModelProviderId, ProviderModelTransportKind } from './model-provider-presets.js';
 import { resolveProviderConnectApiBase } from './model-provider-presets.js';

--- a/packages/host-internal/src/reasoning-effort.ts
+++ b/packages/host-internal/src/reasoning-effort.ts
@@ -17,7 +17,7 @@ export {
   resolveModelReasoningEffort,
   resolveModelReasoningEffortForContext,
   resolveOpenAiTransportReasoningEffortForContext,
-} from '@spirit-agent/core/reasoning-effort';
+} from '@spiritagent/agent-core/reasoning-effort';
 
 export type {
   AnthropicReasoningEffort,
@@ -30,4 +30,4 @@ export type {
   ModelReasoningProvider,
   ModelReasoningTransportKind,
   OpenAiCompatibleReasoningEffort,
-} from '@spirit-agent/core/reasoning-effort';
+} from '@spiritagent/agent-core/reasoning-effort';

--- a/packages/host-internal/src/session-title.ts
+++ b/packages/host-internal/src/session-title.ts
@@ -1,4 +1,4 @@
-import type { JsonObject } from '@spirit-agent/core';
+import type { JsonObject } from '@spiritagent/agent-core';
 
 export const SESSION_TITLE_MAX_LENGTH = 40;
 

--- a/packages/host-internal/src/shell-execution.test.ts
+++ b/packages/host-internal/src/shell-execution.test.ts
@@ -8,7 +8,7 @@ import {
   buildShellToolResult,
   combineShellToolOutput,
   serializeShellToolResult,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import { runShell } from './shell-execution.js';
 

--- a/packages/host-internal/src/subagent-viewer.ts
+++ b/packages/host-internal/src/subagent-viewer.ts
@@ -1,5 +1,5 @@
-import type { LlmMessageContent, LlmToolCall, StoredLlmMessageArchiveEntry } from '@spirit-agent/core';
-import { llmMessageTextContent } from '@spirit-agent/core';
+import type { LlmMessageContent, LlmToolCall, StoredLlmMessageArchiveEntry } from '@spiritagent/agent-core';
+import { llmMessageTextContent } from '@spiritagent/agent-core';
 
 export type SubagentViewerSessionStatus = 'bootstrapping' | 'running' | 'completed' | 'failed' | 'blocked';
 

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -19,7 +19,7 @@ import {
   throwUnknownToolError,
   toolNamesFromDefinitions,
   type JsonValue,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 
 import { applyDiff } from './apply-diff.js';
 import {
@@ -90,7 +90,7 @@ import { filterWorkspaceFilePathsByIgnore } from './workspace-ignore.js';
 import {
   buildShellToolResult,
   serializeShellToolResult,
-} from '@spirit-agent/core';
+} from '@spiritagent/agent-core';
 import {
   convertFetchedPageToToolText,
   WEB_FETCH_ACCEPT_HEADER,


### PR DESCRIPTION
## Summary

- 将 monorepo 内 npm 包从 `@spirit-agent/*` 迁移至 `@spiritagent/*`；原 `@spirit-agent/core` 更名为 `@spiritagent/agent-core` 以区分目录名
- 同步更新全仓库 import、package.json 依赖、README/NOTICE 与 lockfile；`dev-root` 与 `desktop` 保持 private，不在本次发布范围
- 已在 npm 注册 `@spiritagent` 组织；合并后计划以 `0.2.7` 发布 `@spiritagent/agent-core`、`@spiritagent/host-internal`、`@spiritagent/acp-server`
- 旧 `@spirit-agent` 组织保留，后续可 deprecate，不删除

## Test plan

- [x] `npm run build:agent-core`
- [x] `npm run build:host-internal`
- [x] `npm run build:acp-server`
- [x] 全仓库无 `@spirit-agent` 残留引用