### PR TITLE
feat(host-internal): Agent shell 注入 bundled rg 到 PATH

### DIFF
--- a/packages/host-internal/src/bundled-ripgrep-env.test.ts
+++ b/packages/host-internal/src/bundled-ripgrep-env.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import test from 'node:test';
+
+import { rgPath } from '@vscode/ripgrep';
+
+import {
+  SPIRIT_RG_BIN_DIR_ENV,
+  SPIRIT_RG_PATH_ENV,
+  SPIRIT_SHELL_USE_BUNDLED_RG_ENV,
+  buildAgentShellEnvironment,
+  resolveBundledRipgrepPath,
+} from './bundled-ripgrep-env.js';
+import { runShell } from './shell-execution.js';
+
+function pathSeparator(): string {
+  return process.platform === 'win32' ? ';' : ':';
+}
+
+function resolvePathEnvKey(env: NodeJS.ProcessEnv): string {
+  if (process.platform !== 'win32') {
+    return 'PATH';
+  }
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'Path';
+}
+
+test('resolveBundledRipgrepPath returns bundled rg when available', () => {
+  const resolved = resolveBundledRipgrepPath({});
+  assert.equal(resolved, rgPath);
+});
+
+test('buildAgentShellEnvironment prepends bundled rg bin dir to PATH', () => {
+  const baseEnv = { PATH: '/usr/bin:/bin' };
+  const env = buildAgentShellEnvironment(baseEnv);
+  const pathKey = resolvePathEnvKey(env);
+  const binDir = env[SPIRIT_RG_BIN_DIR_ENV];
+  const rgExecutable = env[SPIRIT_RG_PATH_ENV];
+
+  assert.ok(binDir);
+  assert.ok(rgExecutable);
+  assert.equal(env[pathKey]?.startsWith(`${binDir}${pathSeparator()}`), true);
+});
+
+test('buildAgentShellEnvironment skips injection when SPIRIT_SHELL_USE_BUNDLED_RG=0', () => {
+  const baseEnv = {
+    PATH: '/usr/bin:/bin',
+    [SPIRIT_SHELL_USE_BUNDLED_RG_ENV]: '0',
+  };
+  const env = buildAgentShellEnvironment(baseEnv);
+  const pathKey = resolvePathEnvKey(env);
+
+  assert.equal(env[pathKey], '/usr/bin:/bin');
+  assert.equal(env[SPIRIT_RG_PATH_ENV], undefined);
+  assert.equal(env[SPIRIT_RG_BIN_DIR_ENV], undefined);
+});
+
+test('buildAgentShellEnvironment respects external SPIRIT_RG_PATH override', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'spirit-rg-override-'));
+  const fakeRg = join(tempDir, process.platform === 'win32' ? 'rg.exe' : 'rg');
+
+  try {
+    await writeFile(fakeRg, '#!/bin/sh\n', 'utf8');
+    const baseEnv = {
+      PATH: '/usr/bin',
+      [SPIRIT_RG_PATH_ENV]: fakeRg,
+    };
+    const env = buildAgentShellEnvironment(baseEnv);
+
+    assert.equal(env[SPIRIT_RG_PATH_ENV], fakeRg);
+    assert.equal(env[SPIRIT_RG_BIN_DIR_ENV], tempDir);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('buildAgentShellEnvironment does not duplicate bin dir when already first in PATH', () => {
+  const binDir = dirname(rgPath);
+  const baseEnv = { PATH: `${binDir}${pathSeparator()}/usr/bin` };
+  const env = buildAgentShellEnvironment(baseEnv);
+  const pathKey = resolvePathEnvKey(env);
+
+  assert.equal(env[pathKey], baseEnv.PATH);
+  assert.equal(env[SPIRIT_RG_PATH_ENV], rgPath);
+  assert.equal(env[SPIRIT_RG_BIN_DIR_ENV], binDir);
+});
+
+test('runShell resolves rg from bundled PATH', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'spirit-shell-rg-'));
+  const locateCommand =
+    process.platform === 'win32' ? 'where rg' : 'command -v rg';
+
+  try {
+    const { result: versionResult } = runShell({
+      workspaceRoot,
+      command: 'rg --version',
+    });
+    const version = await versionResult;
+
+    assert.equal(version.exitCode, 0);
+    assert.match(version.stdout, /ripgrep/i);
+
+    const { result: locateResult } = runShell({
+      workspaceRoot,
+      command: locateCommand,
+    });
+    const located = await locateResult;
+
+    assert.equal(located.exitCode, 0);
+    const resolvedPath = located.stdout.trim().split(/\r?\n/)[0]?.trim();
+    assert.equal(resolvedPath, rgPath);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/packages/host-internal/src/bundled-ripgrep-env.ts
+++ b/packages/host-internal/src/bundled-ripgrep-env.ts
@@ -1,0 +1,82 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { rgPath } from '@vscode/ripgrep';
+
+export const SPIRIT_RG_PATH_ENV = 'SPIRIT_RG_PATH';
+export const SPIRIT_RG_BIN_DIR_ENV = 'SPIRIT_RG_BIN_DIR';
+export const SPIRIT_SHELL_USE_BUNDLED_RG_ENV = 'SPIRIT_SHELL_USE_BUNDLED_RG';
+
+function isBundledRipgrepInjectionDisabled(env: NodeJS.ProcessEnv): boolean {
+  const raw = env[SPIRIT_SHELL_USE_BUNDLED_RG_ENV]?.trim().toLowerCase();
+  return raw === '0' || raw === 'false' || raw === 'no' || raw === 'off';
+}
+
+function resolvePathEnvKey(env: NodeJS.ProcessEnv): string {
+  if (process.platform !== 'win32') {
+    return 'PATH';
+  }
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'Path';
+}
+
+function pathEntries(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  const separator = process.platform === 'win32' ? ';' : ':';
+  return value.split(separator).map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+}
+
+function pathsEqual(left: string, right: string): boolean {
+  try {
+    return path.resolve(left) === path.resolve(right);
+  } catch {
+    return left === right;
+  }
+}
+
+export function resolveBundledRipgrepPath(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  const override = env[SPIRIT_RG_PATH_ENV]?.trim();
+  if (override && existsSync(override)) {
+    return override;
+  }
+
+  try {
+    if (existsSync(rgPath)) {
+      return rgPath;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+export function buildAgentShellEnvironment(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+
+  if (isBundledRipgrepInjectionDisabled(env)) {
+    return env;
+  }
+
+  const rgExecutable = resolveBundledRipgrepPath(env);
+  if (!rgExecutable) {
+    return env;
+  }
+
+  const binDir = path.dirname(rgExecutable);
+  env[SPIRIT_RG_PATH_ENV] = rgExecutable;
+  env[SPIRIT_RG_BIN_DIR_ENV] = binDir;
+
+  const pathKey = resolvePathEnvKey(env);
+  const existingEntries = pathEntries(env[pathKey]);
+  if (existingEntries.length > 0 && pathsEqual(existingEntries[0]!, binDir)) {
+    return env;
+  }
+
+  const separator = process.platform === 'win32' ? ';' : ':';
+  const existingPath = env[pathKey] ?? '';
+  env[pathKey] = existingPath.length > 0 ? `${binDir}${separator}${existingPath}` : binDir;
+
+  return env;
+}

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -38,6 +38,7 @@ export * from './tools.js';
 export * from './workspace-file-reference-query.js';
 export * from './workspace-file-references.js';
 export * from './workspace-ignore.js';
+export * from './bundled-ripgrep-env.js';
 export * from './ripgrep-search.js';
 export * from './worktree-naming.js';
 export * from './generate-worktree-names.js';

--- a/packages/host-internal/src/ripgrep-search.ts
+++ b/packages/host-internal/src/ripgrep-search.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
-import { rgPath } from '@vscode/ripgrep';
+
+import { resolveBundledRipgrepPath } from './bundled-ripgrep-env.js';
 
 const MAX_SEARCH_FILE_SIZE = '1M';
 
@@ -214,8 +215,13 @@ function consumeRipgrepStdoutLines(params: {
 }
 
 export async function runRipgrepSearch(options: RipgrepSearchOptions): Promise<RipgrepSearchResult> {
+  const rgExecutable = resolveBundledRipgrepPath();
+  if (!rgExecutable) {
+    throw new Error('Could not resolve bundled ripgrep executable');
+  }
+
   const args = buildRipgrepArgs(options);
-  const child = spawn(rgPath, args, {
+  const child = spawn(rgExecutable, args, {
     cwd: options.workspaceRoot,
     windowsHide: true,
   });

--- a/packages/host-internal/src/shell-execution.ts
+++ b/packages/host-internal/src/shell-execution.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import path from 'node:path';
 
+import { buildAgentShellEnvironment } from './bundled-ripgrep-env.js';
 import {
   decodeShellHostOutput,
   defaultShellForPty,
@@ -149,7 +150,7 @@ export function runShell(options: RunShellOptions): RunShellHandle {
       cwd: options.workspaceRoot,
       windowsHide: true,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: process.env,
+      env: buildAgentShellEnvironment(process.env),
     });
 
     child.stdout?.on('data', (chunk: Buffer) => {


### PR DESCRIPTION
## Summary

- Agent `shell` 工具 spawn 时将 `@vscode/ripgrep` bundled `rg` 目录 prepend 到 PATH，并注入 `SPIRIT_RG_PATH` / `SPIRIT_RG_BIN_DIR`
- `grep` 工具与 shell 共用 `resolveBundledRipgrepPath` 解析逻辑
- `SPIRIT_SHELL_USE_BUNDLED_RG=0` 可关闭注入

## Test plan

- [x] `npm run build` in `packages/host-internal` 编译通过
- [x] `node --test dist/bundled-ripgrep-env.test.js` 单测通过（PATH prepend、override、禁用、去重）
- [x] `node --test dist/shell-execution.test.js` 既有 shell 测试通过
- [x] 集成冒烟：`runShell({ command: 'rg --version' })` 输出含 ripgrep 版本
- [x] 集成冒烟：`command -v rg` / `where rg` 解析路径与 bundled `rgPath` 一致