### PR TITLE
refactor(desktop): Desktop 字重降权与 Token 统一

### DIFF
--- a/apps/desktop/src/components/action-picker-row.tsx
+++ b/apps/desktop/src/components/action-picker-row.tsx
@@ -40,7 +40,7 @@ export function ActionPickerRow({ item }: ActionPickerRowProps) {
   return (
     <div className="flex min-w-0 items-center gap-2 overflow-hidden">
       <SlashCommandIcon kind={item.kind} />
-      <span className="shrink-0 whitespace-nowrap DESKTOP_LIST_ITEM_PRIMARY_CLASS leading-6">
+      <span className={cn("shrink-0 whitespace-nowrap leading-6", DESKTOP_LIST_ITEM_PRIMARY_CLASS)}>
         {item.name}
       </span>
       <span className="min-w-0 flex-1 truncate text-xs leading-6 text-muted-foreground">

--- a/apps/desktop/src/components/action-picker-row.tsx
+++ b/apps/desktop/src/components/action-picker-row.tsx
@@ -1,6 +1,8 @@
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography"
+import { cn } from "@/lib/utils"
 import { isNewSessionAction, type ActionPaletteItem } from '@/lib/action-palette'
 import { SLASH_SUGGESTION_ICONS } from '@/lib/slash-command-icons'
 import type { SkillSlashSuggestionKind } from '@/lib/skill-slash'
@@ -21,7 +23,7 @@ export function ActionPickerRow({ item }: ActionPickerRowProps) {
     return (
       <div className="flex min-w-0 items-center gap-2 overflow-hidden">
         <Plus className="size-3.5 shrink-0 opacity-70" aria-hidden />
-        <span className="shrink-0 whitespace-nowrap text-sm font-medium leading-6 text-popover-foreground">
+        <span className={cn("shrink-0 whitespace-nowrap leading-6", DESKTOP_LIST_ITEM_PRIMARY_CLASS)}>
           {t(item.labelKey)}
         </span>
         <span className="min-w-0 flex-1 truncate text-xs leading-6 text-muted-foreground">
@@ -38,7 +40,7 @@ export function ActionPickerRow({ item }: ActionPickerRowProps) {
   return (
     <div className="flex min-w-0 items-center gap-2 overflow-hidden">
       <SlashCommandIcon kind={item.kind} />
-      <span className="shrink-0 whitespace-nowrap text-sm font-medium leading-6 text-popover-foreground">
+      <span className="shrink-0 whitespace-nowrap DESKTOP_LIST_ITEM_PRIMARY_CLASS leading-6">
         {item.name}
       </span>
       <span className="min-w-0 flex-1 truncate text-xs leading-6 text-muted-foreground">

--- a/apps/desktop/src/components/action-picker-row.tsx
+++ b/apps/desktop/src/components/action-picker-row.tsx
@@ -16,6 +16,12 @@ function SlashCommandIcon({ kind }: { kind: SkillSlashSuggestionKind }) {
   return <Icon className="size-3.5 shrink-0 opacity-70" aria-hidden />
 }
 
+const actionPickerPrimaryTitleClass = cn(
+  "shrink-0 whitespace-nowrap leading-6",
+  DESKTOP_LIST_ITEM_PRIMARY_CLASS,
+  "text-popover-foreground",
+)
+
 export function ActionPickerRow({ item }: ActionPickerRowProps) {
   const { t } = useTranslation()
 
@@ -23,7 +29,7 @@ export function ActionPickerRow({ item }: ActionPickerRowProps) {
     return (
       <div className="flex min-w-0 items-center gap-2 overflow-hidden">
         <Plus className="size-3.5 shrink-0 opacity-70" aria-hidden />
-        <span className={cn("shrink-0 whitespace-nowrap leading-6", DESKTOP_LIST_ITEM_PRIMARY_CLASS)}>
+        <span className={actionPickerPrimaryTitleClass}>
           {t(item.labelKey)}
         </span>
         <span className="min-w-0 flex-1 truncate text-xs leading-6 text-muted-foreground">
@@ -40,7 +46,7 @@ export function ActionPickerRow({ item }: ActionPickerRowProps) {
   return (
     <div className="flex min-w-0 items-center gap-2 overflow-hidden">
       <SlashCommandIcon kind={item.kind} />
-      <span className={cn("shrink-0 whitespace-nowrap leading-6", DESKTOP_LIST_ITEM_PRIMARY_CLASS)}>
+      <span className={actionPickerPrimaryTitleClass}>
         {item.name}
       </span>
       <span className="min-w-0 flex-1 truncate text-xs leading-6 text-muted-foreground">

--- a/apps/desktop/src/components/approval-level-menu.tsx
+++ b/apps/desktop/src/components/approval-level-menu.tsx
@@ -15,6 +15,7 @@ import {
   COMPOSER_INLINE_CHIP_ICON_CLASS,
   COMPOSER_INLINE_CHIP_TEXT_CLASS,
 } from "@/lib/composer-inline-chip-styles";
+import { DESKTOP_MENU_TRIGGER_TEXT_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 type ApprovalLevelMenuProps = {
@@ -89,7 +90,8 @@ export function ApprovalLevelMenu({
               aria-label={t('composer.selectApprovalLevel')}
               disabled={disabled}
               className={cn(
-                "inline-flex h-7 max-w-full items-center gap-1.5 rounded-md border-0 bg-transparent px-1 text-left text-xs font-medium outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50",
+                "inline-flex h-7 max-w-full items-center gap-1.5 rounded-md border-0 bg-transparent px-1 text-left outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50",
+                    DESKTOP_MENU_TRIGGER_TEXT_CLASS,
                 approvalLevelTriggerTextClass(approvalLevel),
               )}
             >

--- a/apps/desktop/src/components/automation-detail-view.tsx
+++ b/apps/desktop/src/components/automation-detail-view.tsx
@@ -11,6 +11,7 @@ import type {
   GitHubAutomationRepositoriesSnapshot,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
+import { FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 type AutomationDetailViewProps = {
@@ -145,7 +146,7 @@ export function AutomationDetailView({
               {t("automations.detailBack")}
             </button>
             <ChevronRight className="size-3.5 text-muted-foreground/70" aria-hidden />
-            <span className="font-semibold text-foreground">
+            <span className={cn(FONT_WEIGHT_MEDIUM, "text-foreground")}>
               {definition?.title ?? listFallback?.title ?? automationId}
             </span>
           </nav>

--- a/apps/desktop/src/components/automation-detail-view.tsx
+++ b/apps/desktop/src/components/automation-detail-view.tsx
@@ -69,7 +69,7 @@ function AutomationDetailTabs({
             className={cn(
               "rounded-md px-3 py-2 text-sm",
               activeTab === id
-                ? "font-medium text-foreground underline decoration-foreground/80 underline-offset-[10px]"
+                ? "font-normal text-foreground underline decoration-foreground/80 underline-offset-[10px]"
                 : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
             )}
             onClick={() => onTabChange(id)}
@@ -141,7 +141,7 @@ export function AutomationDetailView({
             <button
               type="button"
               onClick={onBack}
-              className="font-medium text-muted-foreground transition-colors hover:text-foreground"
+              className="font-normal text-muted-foreground transition-colors hover:text-foreground"
             >
               {t("automations.detailBack")}
             </button>

--- a/apps/desktop/src/components/automation-schedule-menu.tsx
+++ b/apps/desktop/src/components/automation-schedule-menu.tsx
@@ -23,6 +23,7 @@ import {
   type DesktopAutomationSchedule,
   type DesktopAutomationWeekday,
 } from "@/lib/automation-schedule";
+import { DESKTOP_MENU_TRIGGER_TEXT_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 const WEEKDAY_OPTIONS: Array<{ value: DesktopAutomationWeekday; labelKey: string }> = [
@@ -123,7 +124,8 @@ export function AutomationScheduleMenu({
           type="button"
           disabled={disabled}
           className={cn(
-            "inline-flex h-7 max-w-full items-center gap-1 rounded-md border-0 bg-transparent px-1 text-xs font-medium text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
+            "inline-flex h-7 max-w-full items-center gap-1 rounded-md border-0 bg-transparent px-1 text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
+                    DESKTOP_MENU_TRIGGER_TEXT_CLASS,
           )}
         >
           <span className="min-w-0 truncate">{label}</span>

--- a/apps/desktop/src/components/automation-settings-panel.tsx
+++ b/apps/desktop/src/components/automation-settings-panel.tsx
@@ -13,6 +13,7 @@ import {
   isValidDesktopAutomationTrigger,
   type DesktopAutomationTrigger,
 } from "@/lib/automation-trigger";
+import { FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 import type {
   ApprovalLevel,
@@ -163,7 +164,7 @@ export function AutomationSettingsPanel({
           onChange={(event) => setTitle(event.target.value)}
           placeholder={t("automations.dialogTitlePlaceholder")}
           disabled={disabled}
-          className="w-full border-0 bg-transparent text-lg font-medium text-foreground outline-none placeholder:text-muted-foreground/70"
+          className={cn("w-full border-0 bg-transparent text-lg text-foreground outline-none placeholder:text-muted-foreground/70", FONT_WEIGHT_MEDIUM)}
         />
         <textarea
           value={overview}

--- a/apps/desktop/src/components/automation-trigger-menu.tsx
+++ b/apps/desktop/src/components/automation-trigger-menu.tsx
@@ -43,6 +43,7 @@ import type {
   GitHubAutomationRepositoriesSnapshot,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
+import { DESKTOP_MENU_TRIGGER_TEXT_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 type AutomationTriggerMenuProps = {
@@ -102,7 +103,8 @@ export function AutomationTriggerMenu({
           type="button"
           disabled={disabled}
           className={cn(
-            "inline-flex h-7 max-w-full items-center gap-1 rounded-md border-0 bg-transparent px-1 text-xs font-medium text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
+            "inline-flex h-7 max-w-full items-center gap-1 rounded-md border-0 bg-transparent px-1 text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:opacity-50",
+                    DESKTOP_MENU_TRIGGER_TEXT_CLASS,
           )}
         >
           <span className="min-w-0 truncate">{label}</span>

--- a/apps/desktop/src/components/automations-view.tsx
+++ b/apps/desktop/src/components/automations-view.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useRef, useState, type MouseEvent, type ReactNode
 import { LoaderCircle, Sparkles, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
-import { Button } from "@/components/ui/button";
+import { DESKTOP_PAGE_TITLE_CLASS, FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -100,7 +100,7 @@ export function AutomationsView({
         <div className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-3">
             <div className="min-w-0 flex-1 space-y-1">
-              <h1 className="text-xl font-semibold tracking-tight text-foreground">
+              <h1 className={DESKTOP_PAGE_TITLE_CLASS}>
                 {t("automations.title")}
               </h1>
               <p className="text-sm text-muted-foreground">{t("automations.subtitle")}</p>

--- a/apps/desktop/src/components/automations-view.tsx
+++ b/apps/desktop/src/components/automations-view.tsx
@@ -2,7 +2,8 @@ import { useCallback, useMemo, useRef, useState, type MouseEvent, type ReactNode
 import { LoaderCircle, Sparkles, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
-import { DESKTOP_PAGE_TITLE_CLASS, FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
+import { DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
+import { Button } from "@/components/ui/button";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -294,7 +295,7 @@ function AutomationListRow({
       )}
     >
       <div className="flex flex-wrap items-center gap-2">
-        <span className="text-sm font-medium text-foreground">{item.title}</span>
+        <span className="text-sm font-normal text-foreground">{item.title}</span>
         {!item.enabled ? (
           <span className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
             {t("automations.disabled")}

--- a/apps/desktop/src/components/branch-select-menu.tsx
+++ b/apps/desktop/src/components/branch-select-menu.tsx
@@ -95,6 +95,7 @@ export function BranchSelectMenu({
               disabled={triggerDisabled}
               className={cn(
                 "inline-flex h-7 min-w-0 max-w-[min(12rem,28vw)] items-center gap-1.5 rounded-md border-0 bg-transparent px-1 text-left outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+                DESKTOP_MENU_TRIGGER_TEXT_CLASS,
                 "text-muted-foreground",
               )}
             >

--- a/apps/desktop/src/components/branch-select-menu.tsx
+++ b/apps/desktop/src/components/branch-select-menu.tsx
@@ -18,6 +18,7 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTruncatedElement } from "@/hooks/use-truncated-element";
 import { DESKTOP_OVERLAY_LIST_WIDTH, DESKTOP_OVERLAY_SHORT_LIST_PADDING } from "@/lib/desktop-chrome";
+import { DESKTOP_MENU_TRIGGER_TEXT_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 type BranchSelectMenuProps = {
@@ -43,7 +44,8 @@ function BranchSelectMenuItem({
     <TooltipItem item={isTruncated ? branch : null}>
       <DropdownMenuItem
         onSelect={onSelect}
-        className={cn("min-w-0", activeBranch === branch && "bg-accent/40")}
+        className={cn("min-w-0",
+                    DESKTOP_MENU_TRIGGER_TEXT_CLASS, activeBranch === branch && "bg-accent/40")}
       >
         <span ref={labelRef} className="min-w-0 truncate">
           {branch}
@@ -92,7 +94,7 @@ export function BranchSelectMenu({
               aria-label={t('composer.selectBranch')}
               disabled={triggerDisabled}
               className={cn(
-                "inline-flex h-7 min-w-0 max-w-[min(12rem,28vw)] items-center gap-1.5 rounded-md border-0 bg-transparent px-1 text-left text-xs font-medium outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+                "inline-flex h-7 min-w-0 max-w-[min(12rem,28vw)] items-center gap-1.5 rounded-md border-0 bg-transparent px-1 text-left outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
                 "text-muted-foreground",
               )}
             >

--- a/apps/desktop/src/components/composer-changes-card.tsx
+++ b/apps/desktop/src/components/composer-changes-card.tsx
@@ -25,7 +25,7 @@ export function ComposerChangesCard({
       onClick={onOpenGitTab}
       aria-label={t("composer.changesAria")}
     >
-      <span className="font-sans text-xs font-medium leading-none text-muted-foreground">{t("composer.changes")}</span>
+      <span className="font-sans text-xs font-normal leading-none text-muted-foreground">{t("composer.changes")}</span>
       <EditFileLineDeltaBadge delta={delta} className="font-normal" />
     </button>
   );

--- a/apps/desktop/src/components/composer-insert-menu.tsx
+++ b/apps/desktop/src/components/composer-insert-menu.tsx
@@ -18,6 +18,7 @@ import {
   DESKTOP_OVERLAY_LIST_LIST_PADDING,
   instantHoverMotionClass,
 } from '@/lib/desktop-chrome'
+import { FONT_WEIGHT_MEDIUM } from '@/lib/desktop-typography'
 import { cn } from '@/lib/utils'
 
 type ComposerInsertMenuProps = {

--- a/apps/desktop/src/components/composer-insert-menu.tsx
+++ b/apps/desktop/src/components/composer-insert-menu.tsx
@@ -32,7 +32,7 @@ type PendingInsertAction = 'at' | 'slash' | 'local'
 
 function SlashBadge() {
   return (
-    <span className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-muted/65 text-[10px] font-semibold text-muted-foreground">
+    <span className={cn("inline-flex size-4 shrink-0 items-center justify-center rounded-sm bg-muted/65 text-[10px] text-muted-foreground", FONT_WEIGHT_MEDIUM)}>
       /
     </span>
   )

--- a/apps/desktop/src/components/composer-todo-card.tsx
+++ b/apps/desktop/src/components/composer-todo-card.tsx
@@ -91,7 +91,7 @@ export function ComposerTodoCard({ todos, sessionKey }: ComposerTodoCardProps) {
                 : "pending"
           }
         />
-        <span className="min-w-0 flex-1 truncate font-medium">{summaryTitle}</span>
+        <span className="min-w-0 flex-1 truncate font-normal">{summaryTitle}</span>
         {!expanded && todos.items.length > 1 ? (
           <span className="shrink-0 text-xs text-muted-foreground">
             {completedCount}/{todos.items.length}

--- a/apps/desktop/src/components/conversation/composer-dock.tsx
+++ b/apps/desktop/src/components/conversation/composer-dock.tsx
@@ -37,6 +37,7 @@ import { sameWorkspacePath } from "@/lib/workspace-display-label";
 import { normalizePaneSessionPathKey } from "@/lib/pane-desktop-snapshot";
 import { shouldShowComposerChangesCard } from "@/lib/composer-changes-card-visibility";
 import type { ComposerLocalFileAttachmentView } from "@/lib/local-file-attachments";
+import { FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 import { useComposerSuggestionAnchor } from "@/hooks/use-composer-suggestion-anchor";
 import type {
@@ -231,7 +232,7 @@ export const ComposerDock = forwardRef<HTMLDivElement, ComposerDockProps>(functi
         {isEmptySession ? (
           <div data-spirit-surface="conversation-empty">
             <p
-              className="mb-6 text-center text-2xl font-medium tracking-tight text-foreground sm:text-3xl"
+              className={cn("mb-6 text-center text-2xl tracking-tight text-foreground sm:text-3xl", FONT_WEIGHT_MEDIUM)}
               data-testid="empty-session-greeting"
             >
               {emptySessionGreeting}

--- a/apps/desktop/src/components/conversation/conversation-thinking-collapsibles.tsx
+++ b/apps/desktop/src/components/conversation/conversation-thinking-collapsibles.tsx
@@ -34,7 +34,7 @@ export function ReasoningLabelWithShimmer({
   return (
     <span
       className={cn(
-        "shrink-0 text-xs font-medium tracking-wide",
+        "shrink-0 text-xs font-normal tracking-wide",
         active ? "spirit-thinking-shimmer-text" : "text-muted-foreground",
       )}
     >

--- a/apps/desktop/src/components/conversation/conversation-view.tsx
+++ b/apps/desktop/src/components/conversation/conversation-view.tsx
@@ -494,7 +494,7 @@ export function ConversationView({
                 <p className="text-xs text-muted-foreground">
                   {longConversationListDemoActive ? (
                     <>
-                      <span className="font-medium text-foreground">
+                      <span className="font-normal text-foreground">
                         {t("app.longConversationListDemo")}
                       </span>
                       <span className="hidden sm:inline">
@@ -507,7 +507,7 @@ export function ConversationView({
                     </>
                   ) : (
                     <>
-                      <span className="font-medium text-foreground">{t('app.compactionDemo')}</span>
+                      <span className="font-normal text-foreground">{t('app.compactionDemo')}</span>
                       <span className="hidden sm:inline">
                         {" "}
                         · {t('app.compactionDemoDescription')}

--- a/apps/desktop/src/components/create-automation-dialog.tsx
+++ b/apps/desktop/src/components/create-automation-dialog.tsx
@@ -30,6 +30,7 @@ import type {
   GitHubAutomationRepositoriesSnapshot,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
+import { FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 type CreateAutomationDialogProps = {
@@ -123,7 +124,7 @@ export function CreateAutomationDialog({
             onChange={(event) => setTitle(event.target.value)}
             placeholder={t("automations.dialogTitlePlaceholder")}
             disabled={disabled}
-            className="w-full border-0 bg-transparent text-lg font-medium text-foreground outline-none placeholder:text-muted-foreground/70"
+            className={cn("w-full border-0 bg-transparent text-lg text-foreground outline-none placeholder:text-muted-foreground/70", FONT_WEIGHT_MEDIUM)}
           />
           <textarea
             value={overview}

--- a/apps/desktop/src/components/detail-page-tabs.tsx
+++ b/apps/desktop/src/components/detail-page-tabs.tsx
@@ -101,7 +101,7 @@ export function DetailPageTabs<T extends string>({
                 className={cn(
                   tabButtonClassBySize[size],
                   selected
-                    ? "font-medium text-foreground underline decoration-foreground/80"
+                    ? "font-normal text-foreground underline decoration-foreground/80"
                     : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
                 )}
                 onClick={() => onTabChange(id)}

--- a/apps/desktop/src/components/dream-graph-card.tsx
+++ b/apps/desktop/src/components/dream-graph-card.tsx
@@ -184,7 +184,7 @@ function DreamInfoNode({ data }: NodeProps<Node<DreamNodeData>>) {
             position={Position.Right}
             className="!h-2 !w-2 !border-0 !bg-transparent !opacity-0"
           />
-          <p className="line-clamp-2 text-[13px] font-medium leading-5 text-foreground/95">{data.label}</p>
+          <p className="line-clamp-2 text-[13px] font-normal leading-5 text-foreground/95">{data.label}</p>
           <p className="mt-1 text-[11px] leading-4 text-muted-foreground">{data.subtitle}</p>
         </div>
       </PopoverTrigger>
@@ -196,7 +196,7 @@ function DreamInfoNode({ data }: NodeProps<Node<DreamNodeData>>) {
           className="nodrag nopan flex h-[min(36rem,var(--radix-popover-content-available-height))] w-[22rem] flex-col overflow-hidden p-0"
         >
           <div className="border-b border-border/60 px-4 py-3">
-            <p className="line-clamp-2 text-sm font-medium text-foreground">{dream.title}</p>
+            <p className="line-clamp-2 text-sm font-normal text-foreground">{dream.title}</p>
             <p className="mt-1 text-[11px] text-muted-foreground">
               {formatDreamTimestamp(dream.updatedAtUnixMs)}
             </p>

--- a/apps/desktop/src/components/edit-file-line-delta-badge.tsx
+++ b/apps/desktop/src/components/edit-file-line-delta-badge.tsx
@@ -61,7 +61,7 @@ export function EditFileLineDeltaBadge({
   }
 
   return (
-    <span className={cn("inline-flex shrink-0 items-center gap-1 font-sans text-xs font-medium leading-none", className)}>
+    <span className={cn("inline-flex shrink-0 items-center gap-1 font-sans text-xs font-normal leading-none", className)}>
       {delta.added > 0 ? (
         <span className="inline-flex items-baseline leading-none text-emerald-600 dark:text-emerald-400">
           <span aria-hidden className="leading-none">+</span>

--- a/apps/desktop/src/components/file-tool-lsp-diagnostics-hover.tsx
+++ b/apps/desktop/src/components/file-tool-lsp-diagnostics-hover.tsx
@@ -18,7 +18,7 @@ import { cn } from "@/lib/utils";
 function LspDiagnosticsDetailPanel({ diagnostics }: { diagnostics: LspWriteDiagnosticsUi }) {
   return (
     <div className="space-y-2">
-      <p className="text-[10px] font-medium text-muted-foreground/70">
+      <p className="text-[10px] font-normal text-muted-foreground/70">
         {diagnostics.relativePath}
       </p>
       <ul className="max-h-64 space-y-1.5 overflow-y-auto text-xs leading-relaxed">

--- a/apps/desktop/src/components/git-changes-section.tsx
+++ b/apps/desktop/src/components/git-changes-section.tsx
@@ -91,7 +91,7 @@ function ChangeRow({
         </div>
         <span
           className={cn(
-            "ml-1 shrink-0 text-[10px] font-medium tabular-nums",
+            "ml-1 shrink-0 text-[10px] font-normal tabular-nums",
             statusCodeClass(change.code),
           )}
           title={change.code}
@@ -142,7 +142,7 @@ export function GitChangesSection({
         className="flex shrink-0 items-center justify-between gap-2 px-2 py-1.5"
       >
         <div className="flex min-w-0 items-center gap-1">
-          <h3 className="m-0 shrink-0 text-xs font-medium leading-none text-foreground">
+          <h3 className="m-0 shrink-0 text-xs font-normal leading-none text-foreground">
             {t("workspace.git.changes")}
           </h3>
           {branchLabel ? (

--- a/apps/desktop/src/components/git-commit-graph.tsx
+++ b/apps/desktop/src/components/git-commit-graph.tsx
@@ -461,9 +461,9 @@ function CommitGraphRowDetail({ row }: { row: GitCommitGraphRow }) {
 
   return (
     <div className="space-y-2">
-      <p className="text-sm font-medium leading-snug">{row.commit.subject}</p>
+      <p className="text-sm font-normal leading-snug">{row.commit.subject}</p>
       <p className="text-[11px]">
-        <span className="font-medium">{row.commit.author}</span>
+        <span className="font-normal">{row.commit.author}</span>
         {" "}
         <span className="text-muted-foreground">{row.commit.authoredAt}</span>
       </p>
@@ -531,7 +531,7 @@ function CommitGraphRowWithHover({
       data-commit-oid={row.commit.oid}
       onPointerEnter={onPointerEnter}
     >
-      <span className="min-w-0 flex-1 truncate text-xs font-medium leading-snug text-foreground/80">
+      <span className="min-w-0 flex-1 truncate text-xs font-normal leading-snug text-foreground/80">
         {row.commit.subject}
       </span>
     </button>

--- a/apps/desktop/src/components/github-device-login-dialog.tsx
+++ b/apps/desktop/src/components/github-device-login-dialog.tsx
@@ -11,6 +11,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { GitHubDeviceAuthChallenge } from "@/types";
+import { FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
+import { cn } from "@/lib/utils";
 
 export type GitHubDeviceLoginDialogProps = {
   open: boolean;
@@ -50,7 +52,7 @@ export function GitHubDeviceLoginDialog({
         <div className="flex min-h-[10rem] flex-col items-center justify-center py-2 text-center">
           {challenge ? (
             <div className="space-y-4">
-              <p className="text-3xl font-semibold tracking-widest text-foreground">
+              <p className={cn("text-3xl tracking-widest text-foreground", FONT_WEIGHT_MEDIUM)}>
                 {challenge.userCode}
               </p>
               <p className="text-xs text-muted-foreground">{t("settings.integrationsDeviceWaiting")}</p>

--- a/apps/desktop/src/components/marketplace-view.tsx
+++ b/apps/desktop/src/components/marketplace-view.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/desktop-chrome";
 import { desktopMicaTintClass, desktopMicaTintInnerClass } from "@/lib/desktop-mica-surface";
 import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
+import { FONT_WEIGHT_MEDIUM } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 import type {
   DesktopExtensionListItem,
@@ -435,7 +436,7 @@ export function MarketplaceView({
           >
             <div className="flex flex-col items-center gap-6">
               <div className="flex w-full flex-col items-center gap-2">
-                <p className="text-center text-lg font-medium tracking-tight text-foreground">{t('marketplace.title')}</p>
+                <p className={cn("text-center text-lg tracking-tight text-foreground", FONT_WEIGHT_MEDIUM)}>{t('marketplace.title')}</p>
                 <div className="flex w-full max-w-sm items-center gap-1.5">
                   <div
                     className={cn(

--- a/apps/desktop/src/components/marketplace-view.tsx
+++ b/apps/desktop/src/components/marketplace-view.tsx
@@ -505,7 +505,7 @@ export function MarketplaceView({
                         )}
                         <span className="min-w-0 flex-1 space-y-1">
                           <span className="flex flex-wrap items-center gap-1.5">
-                            <span className="truncate font-medium text-foreground">{item.displayName}</span>
+                            <span className="truncate font-normal text-foreground">{item.displayName}</span>
                             {item.featured ? (
                               <Badge variant="secondary" className="text-[10px] font-normal">
                                 {t('marketplace.featured')}
@@ -570,7 +570,7 @@ export function MarketplaceView({
                     )}
                     <div className="min-w-0 flex-1 space-y-1">
                       <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                        <h2 className="text-base font-medium leading-snug tracking-tight text-foreground">
+                        <h2 className="text-base font-normal leading-snug tracking-tight text-foreground">
                           {selectedCatalog.displayName}
                         </h2>
                         <Badge variant="outline" className="text-[10px] font-normal">
@@ -634,7 +634,7 @@ export function MarketplaceView({
                         className={cn(
                           "rounded-md px-3 py-2 text-sm",
                           activeTab === tabId
-                            ? "font-medium text-foreground underline decoration-foreground/80 underline-offset-[10px]"
+                            ? "font-normal text-foreground underline decoration-foreground/80 underline-offset-[10px]"
                             : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
                         )}
                         onClick={() => setActiveTab(tabId)}

--- a/apps/desktop/src/components/minimal-tool-call-card.tsx
+++ b/apps/desktop/src/components/minimal-tool-call-card.tsx
@@ -172,7 +172,7 @@ export function MinimalToolSummary({
   statusSuffixTone?: ToolSummaryStatusSuffixTone;
 }) {
   const shimmerClass = shimmerActive
-    ? "spirit-thinking-shimmer-text font-medium tracking-wide"
+    ? "spirit-thinking-shimmer-text font-normal tracking-wide"
     : summaryClass;
   const truncateSummary = detailTone === "shell-command";
 
@@ -224,13 +224,13 @@ function ResponsesBuiltInToolExpandedBody({
     <div className="space-y-3">
       {input ? (
         <div className="space-y-1">
-          <p className="text-[10px] font-medium tracking-wide text-muted-foreground/70">Input</p>
+          <p className="text-[10px] font-normal tracking-wide text-muted-foreground/70">Input</p>
           <ToolCallDetailScrollPre>{input}</ToolCallDetailScrollPre>
         </div>
       ) : null}
       {output ? (
         <div className="space-y-1">
-          <p className="text-[10px] font-medium tracking-wide text-muted-foreground/70">Output</p>
+          <p className="text-[10px] font-normal tracking-wide text-muted-foreground/70">Output</p>
           <ToolCallDetailScrollPre>{output}</ToolCallDetailScrollPre>
         </div>
       ) : shimmerActive ? (

--- a/apps/desktop/src/components/model-catalog-detail-panel.tsx
+++ b/apps/desktop/src/components/model-catalog-detail-panel.tsx
@@ -13,6 +13,7 @@ import {
   modelCatalogDisplayTitle,
 } from '@/lib/model-catalog-detail';
 import { parseModelContextLength } from '@/lib/model-context-length';
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 import { cn } from '@/lib/utils';
 import type { ModelProfileSnapshot, PreviewModelCatalogEntry } from '@/types';
 
@@ -87,7 +88,7 @@ export function ModelCatalogDetailPanel({
           className={cn(
             isList
               ? DESKTOP_OVERLAY_LIST_ITEM_PRIMARY
-              : 'text-sm font-medium leading-snug text-foreground',
+              : cn(DESKTOP_LIST_ITEM_PRIMARY_CLASS, "leading-snug"),
           )}
         >
           {title}

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -41,6 +41,7 @@ import {
 } from "@spiritagent/agent-core/model-thinking-controls";
 import { groupModelsForPicker } from "@/lib/model-picker-groups";
 import type { DesktopModelReasoningEffort, DesktopSnapshot, ModelProfileSnapshot, PreviewModelCatalogEntry } from "@/types";
+import { DESKTOP_MENU_TRIGGER_TEXT_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 type ModelPickerItem = DesktopSnapshot["config"]["models"][number];
@@ -269,7 +270,8 @@ export function ModelPickerMenu({
                   disabled={disabled}
                   onFocus={handleTriggerFocus}
                   className={cn(
-                    "inline-flex h-7 min-w-0 max-w-full items-center gap-0.5 rounded-md border-0 bg-transparent px-1 text-left text-xs font-medium text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50",
+                    "inline-flex h-7 min-w-0 max-w-full items-center gap-0.5 rounded-md border-0 bg-transparent px-1 text-left text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50",
+                    DESKTOP_MENU_TRIGGER_TEXT_CLASS,
                     instantHoverMotionClass,
                     triggerClassName,
                   )}

--- a/apps/desktop/src/components/pending-questions-card.tsx
+++ b/apps/desktop/src/components/pending-questions-card.tsx
@@ -182,7 +182,7 @@ export function PendingQuestionsCard({
                   <div className="min-w-0 flex-1 space-y-0.5">
                     <span
                       className={cn(
-                        "font-medium",
+                        "font-normal",
                         selected ? "text-foreground/90" : questionRowTextClass,
                       )}
                     >

--- a/apps/desktop/src/components/process-card-collapsible.tsx
+++ b/apps/desktop/src/components/process-card-collapsible.tsx
@@ -103,7 +103,7 @@ export function ProcessCardCollapsible({
           interactive ? "cursor-pointer focus-visible:ring-2 focus-visible:ring-ring/50" : "cursor-default",
         )}
       >
-        <span className="min-w-0 truncate text-xs font-medium tracking-wide text-muted-foreground">
+        <span className="min-w-0 truncate text-xs font-normal tracking-wide text-muted-foreground">
           {summary}
         </span>
         {interactive ? (

--- a/apps/desktop/src/components/process-group-blocks.tsx
+++ b/apps/desktop/src/components/process-group-blocks.tsx
@@ -26,7 +26,7 @@ function ReasoningLabel({ active, activeLabel, idleLabel }: {
   return (
     <span
       className={cn(
-        "shrink-0 text-xs font-medium tracking-wide",
+        "shrink-0 text-xs font-normal tracking-wide",
         active ? "spirit-thinking-shimmer-text" : "text-muted-foreground",
       )}
     >

--- a/apps/desktop/src/components/session-chrome-breadcrumb.tsx
+++ b/apps/desktop/src/components/session-chrome-breadcrumb.tsx
@@ -25,6 +25,7 @@ import {
   DESKTOP_SESSION_TITLE_HOVER_CLASS,
   SESSION_TITLE_RENAME_INPUT_CLASS,
 } from '@/lib/desktop-chrome';
+import { DESKTOP_SIDEBAR_TEXT_CLASS, FONT_WEIGHT_NORMAL } from '@/lib/desktop-typography';
 import { cn } from '@/lib/utils';
 
 type SessionChromeBreadcrumbProps = {
@@ -42,7 +43,8 @@ type SessionChromeBreadcrumbProps = {
 
 const sessionTitleButtonClass = (interactive: boolean) =>
   cn(
-    "electron-no-drag min-w-0 w-full truncate rounded-sm p-0 text-left text-xs font-medium",
+    "electron-no-drag min-w-0 w-full truncate rounded-sm p-0 text-left",
+    DESKTOP_SIDEBAR_TEXT_CLASS,
     DESKTOP_CHROME_MUTED_TEXT,
     interactive && cn(DESKTOP_SESSION_TITLE_HOVER_CLASS, "cursor-pointer"),
   );
@@ -184,7 +186,7 @@ export function SessionChromeBreadcrumb({
 
   return (
     <Breadcrumb className={cn("min-w-0", renaming && !trimmedSubagentPromptText && "flex-1")}>
-      <BreadcrumbList className="flex-nowrap gap-1.5 text-xs font-medium sm:gap-2">
+      <BreadcrumbList className={cn("flex-nowrap gap-1.5 sm:gap-2", DESKTOP_SIDEBAR_TEXT_CLASS)}>
         <BreadcrumbItem
           className={cn(
             'min-w-0',
@@ -202,7 +204,7 @@ export function SessionChromeBreadcrumb({
             <BreadcrumbSeparator />
             <BreadcrumbItem className="min-w-0 max-w-[min(20rem,40vw)] flex-1">
               <BreadcrumbPage
-                className={cn("min-w-0 truncate font-medium", DESKTOP_CHROME_ACTIVE_TEXT)}
+                className={cn("min-w-0 truncate", FONT_WEIGHT_NORMAL, DESKTOP_CHROME_ACTIVE_TEXT)}
               >
                 {trimmedSubagentPromptText}
               </BreadcrumbPage>

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -84,6 +84,7 @@ import { isViteDev } from "@/lib/vite-dev";
 import { cn } from "@/lib/utils";
 import { SettingsShortcutKbd } from "@/components/layout/desktop-shortcut-kbds";
 import { SESSION_TITLE_RENAME_INPUT_CLASS } from "@/lib/desktop-chrome";
+import { DESKTOP_SIDEBAR_TEXT_CLASS } from "@/lib/desktop-typography";
 import { useOptionalConversationSplit } from "@/contexts/conversation-split-context";
 import { isSidebarSessionDragBlockedTarget, setSidebarSessionDragData } from "@/lib/sidebar-session-drag";
 import { shortcutLabel, settingsShortcutLabel } from "@/lib/desktop-shell";
@@ -514,7 +515,7 @@ const WorkspaceSessionGroupCollapsible = memo(function WorkspaceSessionGroupColl
               aria-hidden
             />
           </span>
-          <span className="truncate text-xs font-medium">{group.label}</span>
+          <span className={cn("truncate", DESKTOP_SIDEBAR_TEXT_CLASS)}>{group.label}</span>
         </AnimatedCollapseTrigger>
         {onNewSessionInWorkspace && workspaceRoot ? (
           <Tooltip
@@ -836,7 +837,7 @@ const SessionListRow = memo(function SessionListRow({
     >
       {leading}
       <span
-        className="min-w-0 flex-1 basis-0 truncate text-xs font-medium"
+        className={cn("min-w-0 flex-1 basis-0 truncate", DESKTOP_SIDEBAR_TEXT_CLASS)}
         title={showGitTooltip ? undefined : displayName}
       >
         {displayName}

--- a/apps/desktop/src/components/settings/models/model-settings-row.tsx
+++ b/apps/desktop/src/components/settings/models/model-settings-row.tsx
@@ -6,6 +6,7 @@ import { modelSettingsRowAriaLabel } from "@/lib/model-catalog-detail";
 import { modelCapabilityLabel } from "@/lib/model-capability-label";
 import { cn } from "@/lib/utils";
 import type { SettingsModelProfile } from "./model-defaults";
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 
 export function ModelSettingsRowButton({
   model,
@@ -51,7 +52,7 @@ export function ModelSettingsRowButton({
     >
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-medium text-foreground">{displayTitle}</span>
+          <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{displayTitle}</span>
           {isActive ? (
             <Badge variant="secondary" className="text-muted-foreground">
               {t("settings.currentInference")}

--- a/apps/desktop/src/components/settings/models/models-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/models/models-settings-panel.tsx
@@ -95,6 +95,7 @@ import {
 } from "@spiritagent/host-internal/bedrock-mantle";
 import { azureApiBaseFromResourceName, isValidAzureResourceName } from "@spiritagent/host-internal/azure-resource";
 import { vertexApiBaseFromProjectAndLocation } from "@spiritagent/host-internal/google-vertex-endpoints";
+import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 
 export function ModelsSettingsPanel({
   settings,
@@ -841,7 +842,7 @@ export function ModelsSettingsPanel({
                 >
                   <div className="flex items-center justify-between gap-3 border-b border-border/35 px-4 py-3">
                     <div className="flex min-w-0 items-center gap-2">
-                      <span className="text-sm font-semibold text-foreground">
+                      <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>
                         {providerLabel(provider)}
                       </span>
                       <Badge variant="secondary" className="text-muted-foreground shrink-0">
@@ -1042,7 +1043,7 @@ export function ModelsSettingsPanel({
                     >
                       <div className="min-w-0 flex-1 space-y-1">
                         <div className="flex flex-wrap items-center gap-2">
-                          <span className="text-sm font-medium text-foreground">
+                          <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>
                             {displayTitle}
                           </span>
                           {isActive ? (
@@ -1141,7 +1142,7 @@ export function ModelsSettingsPanel({
                   }
                 />
                 <div className="grid gap-1.5">
-                  <Label htmlFor="model-default-active" className="text-sm font-medium text-foreground">
+                  <Label htmlFor="model-default-active" className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>
                     {t('settings.activeModelLabel')}
                   </Label>
                   <p className="text-xs leading-5 text-muted-foreground">
@@ -1171,7 +1172,7 @@ export function ModelsSettingsPanel({
                 <div className="grid gap-1.5">
                   <Label
                     htmlFor="model-default-image-generation"
-                    className="text-sm font-medium text-foreground"
+                    className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}
                   >
                     {t('settings.imageGenModelLabel')}
                   </Label>
@@ -1200,7 +1201,7 @@ export function ModelsSettingsPanel({
                 <div className="grid gap-1.5">
                   <Label
                     htmlFor="model-default-video-generation"
-                    className="text-sm font-medium text-foreground"
+                    className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}
                   >
                     {t('settings.videoGenModelLabel')}
                   </Label>
@@ -1229,7 +1230,7 @@ export function ModelsSettingsPanel({
                 <div className="grid gap-1.5">
                   <Label
                     htmlFor="model-default-lightweight-chat"
-                    className="text-sm font-medium text-foreground"
+                    className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}
                   >
                     {t('settings.lightweightChatModelLabel')}
                   </Label>
@@ -1580,7 +1581,7 @@ export function ModelsSettingsPanel({
                       role="tab"
                       aria-selected={customConnectMode === value}
                       className={cn(
-                        "rounded-md px-2.5 text-xs font-medium transition-colors",
+                        DESKTOP_EDITOR_TAB_CLASS,
                         customConnectMode === value
                           ? "bg-background text-foreground shadow-sm"
                           : "text-muted-foreground hover:text-foreground",
@@ -1671,7 +1672,7 @@ export function ModelsSettingsPanel({
                       role="tab"
                       aria-selected={bedrockConnectMode === value}
                       className={cn(
-                        "rounded-md px-2.5 text-xs font-medium transition-colors",
+                        DESKTOP_EDITOR_TAB_CLASS,
                         bedrockConnectMode === value
                           ? "bg-background text-foreground shadow-sm"
                           : "text-muted-foreground hover:text-foreground",
@@ -1822,7 +1823,7 @@ export function ModelsSettingsPanel({
                       role="tab"
                       aria-selected={vertexConnectMode === value}
                       className={cn(
-                        "rounded-md px-2.5 text-xs font-medium transition-colors",
+                        DESKTOP_EDITOR_TAB_CLASS,
                         vertexConnectMode === value
                           ? "bg-background text-foreground shadow-sm"
                           : "text-muted-foreground hover:text-foreground",

--- a/apps/desktop/src/components/settings/models/models-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/models/models-settings-panel.tsx
@@ -95,7 +95,7 @@ import {
 } from "@spiritagent/host-internal/bedrock-mantle";
 import { azureApiBaseFromResourceName, isValidAzureResourceName } from "@spiritagent/host-internal/azure-resource";
 import { vertexApiBaseFromProjectAndLocation } from "@spiritagent/host-internal/google-vertex-endpoints";
-import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
+import {DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 export function ModelsSettingsPanel({
   settings,
@@ -813,7 +813,7 @@ export function ModelsSettingsPanel({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('settings.modelsTitle')}</h1>
+        <h1 className={DESKTOP_PAGE_TITLE_CLASS}>{t('settings.modelsTitle')}</h1>
         <Button
           type="button"
           size="sm"

--- a/apps/desktop/src/components/settings/panels/agents-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/agents-settings-panel.tsx
@@ -19,7 +19,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import type { DesktopLspProviderSnapshot, DesktopSnapshot } from "@/types";
 import { isDesktopInstallableProvider } from "@/lib/lsp-provider-install";
-import { DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_SETTINGS_LABEL_CLASS } from "@/lib/desktop-typography";
+import {DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_SETTINGS_LABEL_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 /** Agents 面板专用行布局（grid）；与 appearance 等面板的 flex SettingsRow 不同。 */
 export function AgentsSettingsRow({
@@ -79,7 +79,7 @@ export function AgentsSettingsPanel({
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("settings.agents")}</h1>
+      <h1 className={DESKTOP_PAGE_TITLE_CLASS}>{t("settings.agents")}</h1>
 
       <div className="divide-y divide-border/35 rounded-lg border border-border/40 bg-background/80 px-4 sm:px-5">
         <AgentsSettingsRow

--- a/apps/desktop/src/components/settings/panels/agents-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/agents-settings-panel.tsx
@@ -19,6 +19,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import type { DesktopLspProviderSnapshot, DesktopSnapshot } from "@/types";
 import { isDesktopInstallableProvider } from "@/lib/lsp-provider-install";
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_SETTINGS_LABEL_CLASS } from "@/lib/desktop-typography";
 
 /** Agents 面板专用行布局（grid）；与 appearance 等面板的 flex SettingsRow 不同。 */
 export function AgentsSettingsRow({
@@ -35,7 +36,7 @@ export function AgentsSettingsRow({
   return (
     <div className="grid gap-3 py-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-6">
       <div className="min-w-0 space-y-1">
-        <label htmlFor={htmlFor} className="text-sm font-medium text-foreground">
+        <label htmlFor={htmlFor} className={DESKTOP_SETTINGS_LABEL_CLASS}>
           {label}
         </label>
         {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
@@ -106,7 +107,7 @@ export function AgentsSettingsPanel({
           >
             <div className="min-w-0 space-y-1">
               <div className="flex flex-wrap items-center gap-2">
-                <p className="text-sm font-medium text-foreground">{provider.displayName}</p>
+                <p className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{provider.displayName}</p>
                 {providerStatusBadge(provider, t)}
               </div>
               <p className="text-xs text-muted-foreground">{provider.languages.join(" · ")}</p>

--- a/apps/desktop/src/components/settings/panels/developer-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/developer-settings-panel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import type { SettingsViewProps } from "@/components/settings/types";
 import { Button } from "@/components/ui/button";
 import { LONG_CONVERSATION_LIST_DEMO_TURN_COUNT } from "@/lib/long-conversation-list-demo";
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 
 export function DeveloperSettingsPanel({
   onStartCompactionUiDemo,
@@ -13,7 +14,7 @@ export function DeveloperSettingsPanel({
     <div className="divide-y divide-border/35 rounded-lg border border-border/40 bg-background/80 px-4 sm:px-5">
       <div className="flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0 space-y-1">
-          <p className="text-sm font-medium text-foreground">{t("settings.compactionDemoTitle")}</p>
+          <p className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{t("settings.compactionDemoTitle")}</p>
           <p className="text-xs leading-5 text-muted-foreground">
             {t("settings.compactionDemoDescription")}
           </p>
@@ -31,7 +32,7 @@ export function DeveloperSettingsPanel({
       </div>
       <div className="flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0 space-y-1">
-          <p className="text-sm font-medium text-foreground">
+          <p className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>
             {t("settings.longConversationListDemoTitle")}
           </p>
           <p className="text-xs leading-5 text-muted-foreground">

--- a/apps/desktop/src/components/settings/panels/dream-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/dream-settings-panel.tsx
@@ -7,7 +7,9 @@ import { SettingsRow } from "@/components/settings/settings-row";
 import type { SettingsViewProps } from "@/components/settings/types";
 import { Checkbox } from "@/components/ui/checkbox";
 import i18n from "@/lib/i18n";
+import { cn } from "@/lib/utils";
 import type { DesktopDreamOverviewItem, DesktopSnapshot } from "@/types";
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS, FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 
 function dreamCollectorStateLabel(state: DesktopSnapshot["dreams"]["collector"]["state"]): string {
   switch (state) {
@@ -118,11 +120,11 @@ export function DreamSettingsPanel({
         </SettingsRow>
 
         <div className="py-4">
-          <p className="text-sm font-medium text-foreground">{t("settings.collectorStatus")}</p>
+          <p className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{t("settings.collectorStatus")}</p>
           <div className="mt-2 grid gap-1 text-sm text-muted-foreground sm:text-right">
             <p>
               {t("settings.status")}
-              <span className="font-medium text-foreground">
+              <span className={cn(FONT_WEIGHT_NORMAL, "text-foreground")}>
                 {dreamCollectorStateLabel(collector?.state ?? "disabled")}
               </span>
             </p>

--- a/apps/desktop/src/components/settings/panels/extension-configuration-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/extension-configuration-panel.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { DesktopExtensionListItem, UpdateExtensionSecretRequest, UpdateExtensionSettingsRequest } from "@/types";
+import { DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 export function ExtensionConfigurationPanel({
   item,
@@ -68,7 +69,7 @@ export function ExtensionConfigurationPanel({
   return (
     <div className="space-y-5">
       <div className="space-y-1">
-        <h1 className="text-xl font-semibold tracking-tight text-foreground">
+        <h1 className={DESKTOP_PAGE_TITLE_CLASS}>
           {item.desktopSettingsPage?.title ?? item.displayName}
         </h1>
         <p className="text-sm text-muted-foreground">

--- a/apps/desktop/src/components/settings/panels/extensions-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/extensions-settings-panel.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { DeleteExtensionRequest, DesktopExtensionListItem } from "@/types";
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_SECTION_LABEL_COMPACT_CLASS } from "@/lib/desktop-typography";
 
 export function ExtensionsSettingsPanel({
   snapshot,
@@ -93,7 +94,7 @@ export function ExtensionsSettingsPanel({
             >
               <div className="min-w-0 flex-1 space-y-1.5">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-medium text-foreground">{item.displayName}</span>
+                  <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{item.displayName}</span>
                   <Badge variant="secondary" className="text-muted-foreground">
                     {item.version}
                   </Badge>
@@ -120,7 +121,7 @@ export function ExtensionsSettingsPanel({
                 ) : null}
                 {item.desktopCss?.length ? (
                   <div className="space-y-1 pt-1">
-                    <p className="text-xs font-medium text-foreground">{t('settings.desktopCss')}</p>
+                    <p className={DESKTOP_SECTION_LABEL_COMPACT_CLASS}>{t('settings.desktopCss')}</p>
                     {item.desktopCss.map((entry) => (
                       <div
                         key={`${item.id}:desktop-css:${entry.path}`}
@@ -143,7 +144,7 @@ export function ExtensionsSettingsPanel({
                 ) : null}
                 {item.cliHooks?.length ? (
                   <div className="space-y-1 pt-1">
-                    <p className="text-xs font-medium text-foreground">{t('settings.cliHooks')}</p>
+                    <p className={DESKTOP_SECTION_LABEL_COMPACT_CLASS}>{t('settings.cliHooks')}</p>
                     {item.cliHooks.map((hook, index) => (
                       <div
                         key={`${item.id}:cli-hook:${hook.slot}:${index}`}

--- a/apps/desktop/src/components/settings/panels/extensions-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/extensions-settings-panel.tsx
@@ -16,7 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { DeleteExtensionRequest, DesktopExtensionListItem } from "@/types";
-import { DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_SECTION_LABEL_COMPACT_CLASS } from "@/lib/desktop-typography";
+import {DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_SECTION_LABEL_COMPACT_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 export function ExtensionsSettingsPanel({
   snapshot,
@@ -66,7 +66,7 @@ export function ExtensionsSettingsPanel({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex items-center gap-2">
-            <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('settings.extensionsTitle')}</h1>
+            <h1 className={DESKTOP_PAGE_TITLE_CLASS}>{t('settings.extensionsTitle')}</h1>
             {snapshot?.extensionsLoading ? (
               <LoaderCircle className="size-4 animate-spin text-muted-foreground" aria-label={t('common.loading')} />
             ) : null}

--- a/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import type {
-import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
+import {DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
   DeleteHookEntryRequest,
   DesktopHookEventName,
   DesktopHookListItem,
@@ -156,7 +156,7 @@ export function HooksSettingsPanel({
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0 flex-1 space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">
+          <h1 className={DESKTOP_PAGE_TITLE_CLASS}>
             {t("settings.hooks")}
           </h1>
           {workspaceBindingDisabled ? (

--- a/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import type {
+import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
   DeleteHookEntryRequest,
   DesktopHookEventName,
   DesktopHookListItem,
@@ -205,7 +206,7 @@ export function HooksSettingsPanel({
               >
                 <div className="min-w-0 flex-1 space-y-1.5">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium text-foreground">{item.event}</span>
+                    <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{item.event}</span>
                     <Badge variant="outline" className="text-muted-foreground">
                       {hookScopeLabel(item.scope, t)}
                     </Badge>
@@ -328,7 +329,7 @@ export function HooksSettingsPanel({
                     role="tab"
                     aria-selected={createScope === opt.scope}
                     className={cn(
-                      "rounded-md px-2.5 text-xs font-medium transition-colors",
+                      DESKTOP_EDITOR_TAB_CLASS,
                       createScope === opt.scope
                         ? "bg-background text-foreground shadow-sm"
                         : "text-muted-foreground hover:text-foreground",

--- a/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
@@ -24,8 +24,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import {
+  DESKTOP_EDITOR_TAB_CLASS,
+  DESKTOP_LIST_ITEM_PRIMARY_CLASS,
+  DESKTOP_PAGE_TITLE_CLASS,
+} from "@/lib/desktop-typography";
 import type {
-import {DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
   DeleteHookEntryRequest,
   DesktopHookEventName,
   DesktopHookListItem,

--- a/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
@@ -7,7 +7,11 @@ import { GitHubDeviceLoginDialog } from "@/components/github-device-login-dialog
 import { GitHubMarkIcon } from "@/components/github-mark-icon";
 import { Button } from "@/components/ui/button";
 import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
-import {import { DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
+import {
+  DESKTOP_LIST_ITEM_PRIMARY_CLASS,
+  DESKTOP_PAGE_TITLE_CLASS,
+} from "@/lib/desktop-typography";
+import {
   useGitHubDeviceLogin,
   type GitHubDeviceLoginRuntime,
 } from "@/hooks/use-github-device-login";

--- a/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
@@ -8,6 +8,7 @@ import { GitHubMarkIcon } from "@/components/github-mark-icon";
 import { Button } from "@/components/ui/button";
 import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
 import {
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
   useGitHubDeviceLogin,
   type GitHubDeviceLoginRuntime,
 } from "@/hooks/use-github-device-login";
@@ -87,7 +88,7 @@ export function IntegrationsSettingsPanel({
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex flex-wrap items-center gap-2">
               <GitHubMarkIcon className="size-4 shrink-0 text-foreground" />
-              <span className="text-sm font-medium text-foreground">
+              <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>
                 {t("settings.integrationsGitHub")}
               </span>
             </div>

--- a/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/integrations-settings-panel.tsx
@@ -7,8 +7,7 @@ import { GitHubDeviceLoginDialog } from "@/components/github-device-login-dialog
 import { GitHubMarkIcon } from "@/components/github-mark-icon";
 import { Button } from "@/components/ui/button";
 import { showDesktopErrorToast } from "@/lib/desktop-error-toast";
-import {
-import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
+import {import { DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
   useGitHubDeviceLogin,
   type GitHubDeviceLoginRuntime,
 } from "@/hooks/use-github-device-login";
@@ -75,7 +74,7 @@ export function IntegrationsSettingsPanel({
 
   return (
     <div className="space-y-4">
-      <h1 className="text-xl font-semibold tracking-tight text-foreground">
+      <h1 className={DESKTOP_PAGE_TITLE_CLASS}>
         {t("settings.integrations")}
       </h1>
 

--- a/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
@@ -26,6 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import i18n from "@/lib/i18n";
 import type {
+import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
   DeleteMcpServerRequest,
   DesktopMcpScope,
   DesktopMcpServerListItem,
@@ -277,7 +278,7 @@ export function McpsSettingsPanel({
             >
               <div className="min-w-0 flex-1 space-y-1.5">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-medium text-foreground">{item.displayName}</span>
+                  <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{item.displayName}</span>
                   <McpRuntimeBadge state={runtimeInfo[runtimeKey]?.state ?? (item.enabled ? "loading" : "disabled")} />
                   <Badge variant="outline" className="text-muted-foreground">
                     {item.scope === "user" ? t('settings.skillUserDirShort') : t('settings.mcpScopeWorkspace')}
@@ -400,7 +401,7 @@ export function McpsSettingsPanel({
                     role="tab"
                     aria-selected={createScope === opt.scope}
                     className={cn(
-                      "rounded-md px-2.5 text-xs font-medium transition-colors",
+                      DESKTOP_EDITOR_TAB_CLASS,
                       createScope === opt.scope
                         ? "bg-background text-foreground shadow-sm"
                         : "text-muted-foreground hover:text-foreground",
@@ -431,7 +432,7 @@ export function McpsSettingsPanel({
                     role="tab"
                     aria-selected={transportType === value}
                     className={cn(
-                      "rounded-md px-2.5 text-xs font-medium transition-colors",
+                      DESKTOP_EDITOR_TAB_CLASS,
                       transportType === value
                         ? "bg-background text-foreground shadow-sm"
                         : "text-muted-foreground hover:text-foreground",

--- a/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
@@ -26,7 +26,7 @@ import {
 import { cn } from "@/lib/utils";
 import i18n from "@/lib/i18n";
 import type {
-import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
+import {DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
   DeleteMcpServerRequest,
   DesktopMcpScope,
   DesktopMcpServerListItem,
@@ -246,7 +246,7 @@ export function McpsSettingsPanel({
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0 flex-1 space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">MCPs</h1>
+          <h1 className={DESKTOP_PAGE_TITLE_CLASS}>MCPs</h1>
           {workspaceBindingDisabled ? (
             <p className="text-xs text-muted-foreground">{t('app.noWorkspaceBindingHint')}</p>
           ) : null}

--- a/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
@@ -25,8 +25,12 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import i18n from "@/lib/i18n";
+import {
+  DESKTOP_EDITOR_TAB_CLASS,
+  DESKTOP_LIST_ITEM_PRIMARY_CLASS,
+  DESKTOP_PAGE_TITLE_CLASS,
+} from "@/lib/desktop-typography";
 import type {
-import {DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
   DeleteMcpServerRequest,
   DesktopMcpScope,
   DesktopMcpServerListItem,

--- a/apps/desktop/src/components/settings/panels/networks-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/networks-settings-panel.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { DesktopSnapshot } from "@/types";
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 
 function webHostStatusLabel(state: DesktopSnapshot["webHost"]["status"]["state"]): string {
   switch (state) {
@@ -149,7 +150,7 @@ export function NetworksSettingsPanel({
           </SettingsRow>
 
           <div className="py-4">
-            <p className="text-sm font-medium text-foreground">{t("settings.remoteStatus")}</p>
+            <p className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{t("settings.remoteStatus")}</p>
             <div className="mt-2 grid gap-1 text-sm text-muted-foreground sm:text-right">
               <p className="truncate">
                 <span className="text-foreground">

--- a/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
@@ -20,6 +20,7 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import i18n from "@/lib/i18n";
 import type { CreateRuleRequest, DesktopRuleListItem, DesktopSkillRootKind } from "@/types";
+import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 
 const ruleCreateRootOptions: Array<{
   kind: DesktopSkillRootKind;
@@ -145,7 +146,7 @@ export function RulesSettingsPanel({
             >
               <div className="min-w-0 flex-1 space-y-1">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-medium text-foreground">{ruleFileBaseName(item.shortLabel)}</span>
+                  <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{ruleFileBaseName(item.shortLabel)}</span>
                   <Badge variant="secondary" className="text-muted-foreground">
                     {ruleLocationLabel(item)}
                   </Badge>
@@ -267,7 +268,7 @@ export function RulesSettingsPanel({
                     role="tab"
                     aria-selected={createRootKind === opt.kind}
                     className={cn(
-                      "rounded-md px-2.5 text-xs font-medium transition-colors",
+                      DESKTOP_EDITOR_TAB_CLASS,
                       createRootKind === opt.kind
                         ? "bg-background text-foreground shadow-sm"
                         : "text-muted-foreground hover:text-foreground",

--- a/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
@@ -20,7 +20,7 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import i18n from "@/lib/i18n";
 import type { CreateRuleRequest, DesktopRuleListItem, DesktopSkillRootKind } from "@/types";
-import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
+import {DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 const ruleCreateRootOptions: Array<{
   kind: DesktopSkillRootKind;
@@ -100,7 +100,7 @@ export function RulesSettingsPanel({
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0 flex-1 space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">{t('settings.rules')}</h1>
+          <h1 className={DESKTOP_PAGE_TITLE_CLASS}>{t('settings.rules')}</h1>
           {workspaceBindingDisabled ? (
             <p className="text-xs text-muted-foreground">{t('app.noWorkspaceBindingHint')}</p>
           ) : null}

--- a/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
@@ -19,6 +19,7 @@ import { DesktopFormInput, DesktopFormTextarea } from "@/components/ui/desktop-f
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import type { CreateSkillRequest, DeleteSkillRequest, DesktopSkillListItem, DesktopSkillRootKind } from "@/types";
+import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 
 function skillLocationLabel(item: DesktopSkillListItem): string {
   return skillRootKindLabel(item.rootKind);
@@ -129,7 +130,7 @@ export function SkillsSettingsPanel({
             >
               <div className="min-w-0 flex-1 space-y-1">
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-medium text-foreground">{item.name}</span>
+                  <span className={DESKTOP_LIST_ITEM_PRIMARY_CLASS}>{item.name}</span>
                   <Badge variant="secondary" className="text-muted-foreground">
                     {skillLocationLabel(item)}
                   </Badge>
@@ -242,7 +243,7 @@ export function SkillsSettingsPanel({
                     role="tab"
                     aria-selected={createRootKind === opt.kind}
                     className={cn(
-                      "rounded-md px-2.5 text-xs font-medium transition-colors",
+                      DESKTOP_EDITOR_TAB_CLASS,
                       createRootKind === opt.kind
                         ? "bg-background text-foreground shadow-sm"
                         : "text-muted-foreground hover:text-foreground",

--- a/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
@@ -19,7 +19,7 @@ import { DesktopFormInput, DesktopFormTextarea } from "@/components/ui/desktop-f
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import type { CreateSkillRequest, DeleteSkillRequest, DesktopSkillListItem, DesktopSkillRootKind } from "@/types";
-import { DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
+import {DESKTOP_EDITOR_TAB_CLASS, DESKTOP_LIST_ITEM_PRIMARY_CLASS, DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 function skillLocationLabel(item: DesktopSkillListItem): string {
   return skillRootKindLabel(item.rootKind);
@@ -84,7 +84,7 @@ export function SkillsSettingsPanel({
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0 flex-1 space-y-1">
-          <h1 className="text-xl font-semibold tracking-tight text-foreground">Skills</h1>
+          <h1 className={DESKTOP_PAGE_TITLE_CLASS}>Skills</h1>
           {workspaceBindingDisabled ? (
             <p className="text-xs text-muted-foreground">{t('app.noWorkspaceBindingHint')}</p>
           ) : null}

--- a/apps/desktop/src/components/settings/panels/tab-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/tab-settings-panel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { AgentsSettingsRow } from "@/components/settings/panels/agents-settings-panel";
 import type { SettingsViewProps } from "@/components/settings/types";
 import { Checkbox } from "@/components/ui/checkbox";
+import { DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 export function TabSettingsPanel({
   settings,
@@ -12,7 +13,7 @@ export function TabSettingsPanel({
 
   return (
     <div className="space-y-6">
-      <h1 className="text-xl font-semibold tracking-tight text-foreground">{t("settings.tab")}</h1>
+      <h1 className={DESKTOP_PAGE_TITLE_CLASS}>{t("settings.tab")}</h1>
 
       <div className="divide-y divide-border/35 rounded-lg border border-border/40 bg-background/80 px-4 sm:px-5">
         <AgentsSettingsRow

--- a/apps/desktop/src/components/settings/settings-row.tsx
+++ b/apps/desktop/src/components/settings/settings-row.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Label } from "@/components/ui/label";
+import { DESKTOP_SETTINGS_LABEL_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 export function SettingsRow({
@@ -24,7 +25,7 @@ export function SettingsRow({
       )}
     >
       <div className="min-w-0 sm:max-w-[42%]">
-        <Label htmlFor={htmlFor} className="text-sm font-medium text-foreground">
+        <Label htmlFor={htmlFor} className={DESKTOP_SETTINGS_LABEL_CLASS}>
           {label}
         </Label>
         {description ? (

--- a/apps/desktop/src/components/settings/settings-view.tsx
+++ b/apps/desktop/src/components/settings/settings-view.tsx
@@ -23,6 +23,7 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { desktopMicaTintClass } from "@/lib/desktop-mica-surface";
 import { cn } from "@/lib/utils";
+import { DESKTOP_PAGE_TITLE_CLASS } from "@/lib/desktop-typography";
 
 export function SettingsView({
   tab,
@@ -107,7 +108,7 @@ export function SettingsView({
         <div className="flex min-h-full flex-col justify-center">
           <div className="mx-auto w-full max-w-2xl px-4 py-8 sm:px-6">
             {!extensionSettingsItem && tab !== "models" && tab !== "skills" && tab !== "rules" && tab !== "mcps" && tab !== "hooks" && tab !== "extensions" && tab !== "agents" && tab !== "tab" && tab !== "integrations" ? (
-              <h1 className="mb-6 flex items-center gap-2 text-xl font-semibold tracking-tight text-foreground">
+              <h1 className={cn("mb-6 flex items-center gap-2", DESKTOP_PAGE_TITLE_CLASS)}>
                 {t(settingsPageTitleKey[tab])}
                 {tab === "dreams" ? <Badge variant="outline">Beta</Badge> : null}
               </h1>

--- a/apps/desktop/src/components/tool-call/image-generation-tool-card.tsx
+++ b/apps/desktop/src/components/tool-call/image-generation-tool-card.tsx
@@ -111,7 +111,7 @@ export function ImageGenerationToolCard({
           <div className="flex size-full items-center justify-center px-4 text-center">
             <span
               className={cn(
-                "text-sm font-medium",
+                "text-sm font-normal",
                 loading ? "spirit-thinking-shimmer-text" : "text-muted-foreground",
               )}
             >

--- a/apps/desktop/src/components/tool-call/video-generation-tool-card.tsx
+++ b/apps/desktop/src/components/tool-call/video-generation-tool-card.tsx
@@ -78,7 +78,7 @@ export function VideoGenerationToolCard({
           <div className="flex size-full items-center justify-center px-4 text-center">
             <span
               className={cn(
-                "text-sm font-medium",
+                "text-sm font-normal",
                 loading ? "spirit-thinking-shimmer-text" : "text-muted-foreground",
               )}
             >

--- a/apps/desktop/src/components/ui/badge.tsx
+++ b/apps/desktop/src/components/ui/badge.tsx
@@ -2,10 +2,11 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 
 const badgeVariants = cva(
-  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  `group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs ${FONT_WEIGHT_NORMAL} whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!`,
   {
     variants: {
       variant: {

--- a/apps/desktop/src/components/ui/button-group.tsx
+++ b/apps/desktop/src/components/ui/button-group.tsx
@@ -1,6 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 import { Separator } from "@/components/ui/separator"
 
@@ -49,7 +50,7 @@ function ButtonGroupText({
   return (
     <Comp
       className={cn(
-        "flex items-center gap-2 rounded-lg border bg-muted px-2.5 text-sm font-medium [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        `flex items-center gap-2 rounded-lg border bg-muted px-2.5 text-sm ${FONT_WEIGHT_NORMAL} [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4`,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -2,10 +2,11 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  `group/button inline-flex shrink-0 cursor-pointer items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm ${FONT_WEIGHT_NORMAL} whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
   {
     variants: {
       variant: {

--- a/apps/desktop/src/components/ui/card.tsx
+++ b/apps/desktop/src/components/ui/card.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 
 function Card({
@@ -38,7 +39,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-title"
       className={cn(
-        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        `font-heading text-base leading-snug ${FONT_WEIGHT_NORMAL} group-data-[size=sm]/card:text-sm`,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/command.tsx
+++ b/apps/desktop/src/components/ui/command.tsx
@@ -123,7 +123,7 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
+        "overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-normal **:[[cmdk-group-heading]]:text-muted-foreground",
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/context-menu.tsx
+++ b/apps/desktop/src/components/ui/context-menu.tsx
@@ -4,6 +4,7 @@ import { ContextMenu as ContextMenuPrimitive } from "radix-ui"
 
 import { radixAnchoredOverlayMotion } from "@/lib/overlay-motion"
 import { getUiLayoutPortalContainer } from "@/lib/ui-layout-scale"
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 import { ChevronRightIcon, CheckIcon } from "lucide-react"
 
@@ -221,7 +222,8 @@ function ContextMenuLabel({
       data-slot="context-menu-label"
       data-inset={inset}
       className={cn(
-        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        "px-1.5 py-1 text-xs text-muted-foreground data-inset:pl-7",
+        FONT_WEIGHT_NORMAL,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Dialog as DialogPrimitive } from "radix-ui"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 import { getUiLayoutPortalContainer } from "@/lib/ui-layout-scale"
 import { Button } from "@/components/ui/button"
@@ -206,7 +207,7 @@ function DialogTitle({
     <DialogPrimitive.Title
       data-slot="dialog-title"
       className={cn(
-        "font-heading text-base leading-none font-medium",
+        `font-heading text-base leading-none ${FONT_WEIGHT_NORMAL}`,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/input-group.tsx
+++ b/apps/desktop/src/components/ui/input-group.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -23,7 +24,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const inputGroupAddonVariants = cva(
-  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  `flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm ${FONT_WEIGHT_NORMAL} text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4`,
   {
     variants: {
       align: {

--- a/apps/desktop/src/components/ui/input.tsx
+++ b/apps/desktop/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         type={type}
         data-slot="input"
         className={cn(
-          "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+          "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-normal file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
           className
         )}
         {...props}

--- a/apps/desktop/src/components/ui/kbd.tsx
+++ b/apps/desktop/src/components/ui/kbd.tsx
@@ -1,3 +1,4 @@
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 
 function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
@@ -5,7 +6,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
     <kbd
       data-slot="kbd"
       className={cn(
-        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-muted in-data-[slot=tooltip-content]:text-popover-foreground [&_svg:not([class*='size-'])]:size-3",
+        `pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs ${FONT_WEIGHT_NORMAL} text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-muted in-data-[slot=tooltip-content]:text-popover-foreground [&_svg:not([class*='size-'])]:size-3`,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/label.tsx
+++ b/apps/desktop/src/components/ui/label.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Label as LabelPrimitive } from "radix-ui"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 
 function Label({
@@ -11,7 +12,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "flex cursor-pointer items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        `flex cursor-pointer items-center gap-2 text-sm leading-none ${FONT_WEIGHT_NORMAL} select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50`,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/menubar.tsx
+++ b/apps/desktop/src/components/ui/menubar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Menubar as MenubarPrimitive } from "radix-ui"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 import { getUiLayoutPortalContainer } from "@/lib/ui-layout-scale"
 import { CheckIcon, ChevronRightIcon } from "lucide-react"
@@ -62,7 +63,8 @@ function MenubarTrigger({
     <MenubarPrimitive.Trigger
       data-slot="menubar-trigger"
       className={cn(
-        "flex cursor-pointer items-center rounded-sm px-1.5 py-[2px] text-sm font-medium outline-hidden select-none hover:bg-muted aria-expanded:bg-muted",
+        "flex cursor-pointer items-center rounded-sm px-1.5 py-[2px] text-sm outline-hidden select-none hover:bg-muted aria-expanded:bg-muted",
+        FONT_WEIGHT_NORMAL,
         className
       )}
       {...props}
@@ -186,7 +188,8 @@ function MenubarLabel({
       data-slot="menubar-label"
       data-inset={inset}
       className={cn(
-        "px-1.5 py-1 text-sm font-medium data-inset:pl-7",
+        "px-1.5 py-1 text-sm data-inset:pl-7",
+        FONT_WEIGHT_NORMAL,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/table.tsx
+++ b/apps/desktop/src/components/ui/table.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils"
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
@@ -42,7 +43,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        `border-t bg-muted/50 ${FONT_WEIGHT_NORMAL} [&>tr]:last:border-b-0`,
         className
       )}
       {...props}
@@ -68,7 +69,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        `h-10 px-2 text-left align-middle ${FONT_WEIGHT_NORMAL} whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0`,
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/toggle.tsx
+++ b/apps/desktop/src/components/ui/toggle.tsx
@@ -3,11 +3,12 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { Toggle as TogglePrimitive } from "radix-ui";
 
 import { instantHoverMotionClass } from "@/lib/desktop-chrome";
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
   cn(
-    "group/toggle inline-flex cursor-pointer items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap outline-none hover:bg-muted/50 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted/35 data-[state=on]:bg-muted/35 data-[state=on]:hover:bg-muted/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+    `group/toggle inline-flex cursor-pointer items-center justify-center gap-1 rounded-lg text-sm ${FONT_WEIGHT_NORMAL} whitespace-nowrap outline-none hover:bg-muted/50 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted/35 data-[state=on]:bg-muted/35 data-[state=on]:hover:bg-muted/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
     instantHoverMotionClass,
   ),
   {

--- a/apps/desktop/src/components/work-location-menu.tsx
+++ b/apps/desktop/src/components/work-location-menu.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { DESKTOP_OVERLAY_SHORT_LIST_PADDING } from "@/lib/desktop-chrome";
+import { DESKTOP_MENU_TRIGGER_TEXT_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 const WORK_LOCATION_OPTIONS: WorkLocationKind[] = ["local", "worktree"];
@@ -54,7 +55,8 @@ export function WorkLocationMenu({
               aria-label={t('composer.selectWorkLocation')}
               disabled={disabled}
               className={cn(
-                "inline-flex h-7 max-w-full items-center gap-1.5 rounded-md border-0 bg-transparent px-1 text-left text-xs font-medium outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+                "inline-flex h-7 max-w-full items-center gap-1.5 rounded-md border-0 bg-transparent px-1 text-left outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+                    DESKTOP_MENU_TRIGGER_TEXT_CLASS,
                 "text-muted-foreground",
               )}
             >

--- a/apps/desktop/src/components/workspace-browser-tab.tsx
+++ b/apps/desktop/src/components/workspace-browser-tab.tsx
@@ -162,7 +162,7 @@ function BrowserNewTabPage({
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-3">
       <div className="mb-3 flex items-center justify-between gap-2">
-        <h3 className="text-sm font-medium text-foreground">{t("workspace.browserNewTabTitle")}</h3>
+        <h3 className="text-sm font-normal text-foreground">{t("workspace.browserNewTabTitle")}</h3>
         <Button
           type="button"
           variant="secondary"
@@ -196,7 +196,7 @@ function BrowserNewTabPage({
                   )}
                   onClick={() => onNavigate(url)}
                 >
-                  <span className="block truncate font-medium text-foreground">{displayTitle}</span>
+                  <span className="block truncate font-normal text-foreground">{displayTitle}</span>
                   {displaySubtitle ? (
                     <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">
                       {displaySubtitle}

--- a/apps/desktop/src/components/workspace-file-picker-row.tsx
+++ b/apps/desktop/src/components/workspace-file-picker-row.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/desktop-chrome'
 import { workspaceFileBasename } from '@/lib/file-picker-path'
 import { WorkspaceFileIcon } from '@/components/workspace-file-icon'
+import { DESKTOP_LIST_ITEM_PRIMARY_CLASS } from "@/lib/desktop-typography";
 import { cn } from '@/lib/utils'
 
 type WorkspaceFilePickerRowProps = {
@@ -51,7 +52,7 @@ export function WorkspaceFilePickerRow({
       <WorkspaceFileIcon path={displayPath} kind={iconKind} />
       <span
         className={cn(
-          'shrink-0 whitespace-nowrap text-sm font-medium leading-6',
+          cn("shrink-0 whitespace-nowrap leading-6", DESKTOP_LIST_ITEM_PRIMARY_CLASS),
           tone === 'menu' ? 'text-foreground' : 'text-popover-foreground',
         )}
       >

--- a/apps/desktop/src/components/workspace-files-search-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-search-panel.tsx
@@ -354,7 +354,7 @@ export function WorkspaceFilesSearchPanel({
                       ) : (
                         <WorkspaceFileIcon name={headerName} className="opacity-80" />
                       )}
-                      <span className="min-w-0 flex-1 truncate font-medium">
+                      <span className="min-w-0 flex-1 truncate font-normal">
                         {pathBasename(row.relativePath)}
                       </span>
                       <span className="shrink-0 text-muted-foreground">{row.matchCount}</span>

--- a/apps/desktop/src/components/workspace-files-tab.tsx
+++ b/apps/desktop/src/components/workspace-files-tab.tsx
@@ -213,7 +213,7 @@ function WorkspaceFilesExplorerToolbar({
         </Tooltip>
         {fileOpen ? (
           <span
-            className="min-w-0 truncate text-xs font-medium text-foreground/95"
+            className="min-w-0 truncate text-xs font-normal text-foreground/95"
             title={headerSubtitle || undefined}
           >
             {headerTitle}

--- a/apps/desktop/src/components/workspace-git-tab.tsx
+++ b/apps/desktop/src/components/workspace-git-tab.tsx
@@ -414,7 +414,7 @@ export function WorkspaceGitTab({
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <div ref={historyHeaderRef} className="shrink-0 px-2 py-1.5">
-          <h3 className="text-xs font-medium text-foreground">{t("workspace.git.history")}</h3>
+          <h3 className="text-xs font-normal text-foreground">{t("workspace.git.history")}</h3>
         </div>
         <GitCommitGraph
           className="flex-1"

--- a/apps/desktop/src/components/workspace-pr-checks-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-checks-view.tsx
@@ -72,7 +72,7 @@ function PrCheckRow({
   const row = (
     <div className="flex min-w-0 items-center gap-2 px-3 py-3">
       <CheckStateIcon state={check.state} label={stateLabel} />
-      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground/80">
+      <span className="min-w-0 flex-1 truncate text-xs font-normal text-foreground/80">
         {check.name}
       </span>
       <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground/75 dark:text-muted-foreground/65">

--- a/apps/desktop/src/components/workspace-pr-commits-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-commits-view.tsx
@@ -51,7 +51,7 @@ function PrCommitRow({
           alt=""
           className="size-5 shrink-0 rounded-full bg-muted object-cover"
         />
-        <span className="truncate text-xs font-medium text-foreground/80">{commit.authorLogin}</span>
+        <span className="truncate text-xs font-normal text-foreground/80">{commit.authorLogin}</span>
         <time
           className="shrink-0 text-[11px] text-muted-foreground/75 dark:text-muted-foreground/65"
           dateTime={commit.createdAt}

--- a/apps/desktop/src/components/workspace-pr-conversation-timeline.tsx
+++ b/apps/desktop/src/components/workspace-pr-conversation-timeline.tsx
@@ -75,7 +75,7 @@ function PrConversationCommentHeader({
   return (
     <div className="flex min-w-0 items-center gap-2">
       <PrConversationTimelineAvatar login={login} avatarUrl={avatarUrl} />
-      <span className="truncate text-xs font-medium text-foreground/80">{login}</span>
+      <span className="truncate text-xs font-normal text-foreground/80">{login}</span>
       <time
         className="shrink-0 text-[11px] text-muted-foreground/75 dark:text-muted-foreground/65"
         dateTime={createdAt}
@@ -375,7 +375,7 @@ function MergeTimelineRow({ item }: { item: GitHubPullRequestConversationMerged 
     >
       <div className="flex min-w-0 items-center gap-2">
         <PrConversationTimelineAvatar login={item.authorLogin} avatarUrl={item.avatarUrl} />
-        <span className="truncate text-xs font-medium text-foreground/80">{item.authorLogin}</span>
+        <span className="truncate text-xs font-normal text-foreground/80">{item.authorLogin}</span>
         <span className="truncate text-xs leading-relaxed text-muted-foreground">
           {t("workspace.prMergedThisPullRequest")}
         </span>

--- a/apps/desktop/src/components/workspace-pr-detail-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-detail-view.tsx
@@ -289,7 +289,7 @@ export function WorkspacePrDetailView({
               <h2 className="m-0">
                 <a
                   href={detail.url}
-                  className="min-w-0 text-sm font-medium text-foreground focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
+                  className="min-w-0 text-sm font-normal text-foreground focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none"
                   aria-label={t("workspace.prOpenOnGitHub")}
                   onClick={(event) => {
                     event.preventDefault();

--- a/apps/desktop/src/components/workspace-pr-list-row.tsx
+++ b/apps/desktop/src/components/workspace-pr-list-row.tsx
@@ -60,7 +60,7 @@ export function WorkspacePrListRow({ item, onSelect }: WorkspacePrListRowProps) 
               alt=""
               className="size-3 shrink-0 rounded-full bg-muted object-cover"
             />
-            <span className="truncate text-xs font-medium text-foreground/80">{item.authorLogin}</span>
+            <span className="truncate text-xs font-normal text-foreground/80">{item.authorLogin}</span>
           </span>
           <span className="shrink-0 text-[11px] text-muted-foreground/75 dark:text-muted-foreground/65">
             #{item.number}

--- a/apps/desktop/src/components/workspace-selector-menu.tsx
+++ b/apps/desktop/src/components/workspace-selector-menu.tsx
@@ -158,6 +158,7 @@ export function WorkspaceSelectorMenu({
                 aria-label={t("app.selectWorkspace")}
                 className={cn(
                   "inline-flex h-7 max-w-full min-w-0 items-center gap-1 rounded-md border-0 bg-transparent px-1 text-left text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+                  DESKTOP_MENU_TRIGGER_TEXT_CLASS,
                   instantHoverMotionClass,
                   triggerClassName,
                 )}

--- a/apps/desktop/src/components/workspace-selector-menu.tsx
+++ b/apps/desktop/src/components/workspace-selector-menu.tsx
@@ -29,6 +29,7 @@ import {
   sameWorkspacePath,
 } from "@/lib/workspace-display-label";
 import type { DesktopSnapshot } from "@/types";
+import { DESKTOP_MENU_TRIGGER_TEXT_CLASS } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 export type WorkspaceSelectorMenuProps = {
@@ -73,7 +74,8 @@ function WorkspaceSelectorMenuItem({
     <TooltipItem item={tooltipItem}>
       <DropdownMenuItem
         onSelect={onSelect}
-        className={cn("items-start", DESKTOP_OVERLAY_LIST_ITEM, selected && "bg-accent/40")}
+        className={cn("items-start",
+                    DESKTOP_MENU_TRIGGER_TEXT_CLASS, DESKTOP_OVERLAY_LIST_ITEM, selected && "bg-accent/40")}
       >
         <div className="min-w-0 flex-1">
           <div ref={labelRef} className={cn(DESKTOP_OVERLAY_LIST_ITEM_PRIMARY, "truncate")}>
@@ -155,7 +157,7 @@ export function WorkspaceSelectorMenu({
                 disabled={disabled}
                 aria-label={t("app.selectWorkspace")}
                 className={cn(
-                  "inline-flex h-7 max-w-full min-w-0 items-center gap-1 rounded-md border-0 bg-transparent px-1 text-left text-xs font-medium text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+                  "inline-flex h-7 max-w-full min-w-0 items-center gap-1 rounded-md border-0 bg-transparent px-1 text-left text-muted-foreground outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
                   instantHoverMotionClass,
                   triggerClassName,
                 )}

--- a/apps/desktop/src/components/workspace-tools-panel.tsx
+++ b/apps/desktop/src/components/workspace-tools-panel.tsx
@@ -738,7 +738,7 @@ const WorkspaceToolsDockContent = memo(function WorkspaceToolsDockContent({
                     aria-controls={`workspace-tool-panel-${item.id}`}
                     tabIndex={selected ? 0 : -1}
                     aria-label={displayTitle ? undefined : label}
-                    className="flex min-w-0 flex-1 items-center gap-1 rounded-t-md bg-transparent py-2 pl-2 pr-2 text-xs font-medium outline-none"
+                    className="flex min-w-0 flex-1 items-center gap-1 rounded-t-md bg-transparent py-2 pl-2 pr-2 text-xs font-normal outline-none"
                     onClick={() => onActiveTabIdChange(item.id)}
                   >
                     {showFilesSetiIcon ? (

--- a/apps/desktop/src/lib/ask-chip-styles.ts
+++ b/apps/desktop/src/lib/ask-chip-styles.ts
@@ -1,6 +1,8 @@
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
+
 // 半透明底色：与 Composer 磨砂 surface 混叠，避免 opaque 色块与底色调不齐
 export const ASK_CHIP_CLASS =
-  "inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-1.5 py-0.5 text-xs font-medium leading-none text-emerald-900 select-none align-middle mx-0.5 dark:bg-emerald-500/15 dark:text-emerald-500";
+  `inline-flex items-center gap-1 rounded-md bg-emerald-500/10 px-1.5 py-0.5 text-xs ${FONT_WEIGHT_NORMAL} leading-none text-emerald-900 select-none align-middle mx-0.5 dark:bg-emerald-500/15 dark:text-emerald-500`;
 
 export function makeAskChipNode(doc: Document, label = "Ask"): HTMLElement {
   const span = doc.createElement("span");

--- a/apps/desktop/src/lib/composer-inline-chip-styles.ts
+++ b/apps/desktop/src/lib/composer-inline-chip-styles.ts
@@ -1,5 +1,7 @@
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
+
 const INLINE_CHIP_LAYOUT =
-  "inline-flex items-center gap-1 px-0.5 py-0.5 text-xs font-medium leading-none select-none align-middle mx-0.5";
+  `inline-flex items-center gap-1 px-0.5 py-0.5 text-xs ${FONT_WEIGHT_NORMAL} leading-none select-none align-middle mx-0.5`;
 
 export const COMPOSER_INLINE_CHIP_TEXT_CLASS =
   "text-blue-500 dark:text-blue-400";

--- a/apps/desktop/src/lib/debug-chip-styles.ts
+++ b/apps/desktop/src/lib/debug-chip-styles.ts
@@ -1,6 +1,8 @@
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
+
 // 半透明底色试点：与 Composer 磨砂 surface 混叠，避免 opaque 色块与底色调不齐
 export const DEBUG_CHIP_CLASS =
-  "inline-flex items-center gap-1 rounded-md bg-red-500/10 px-1.5 py-0.5 text-xs font-medium leading-none text-red-700 select-none align-middle mx-0.5 dark:bg-red-500/15 dark:text-red-400";
+  `inline-flex items-center gap-1 rounded-md bg-red-500/10 px-1.5 py-0.5 text-xs ${FONT_WEIGHT_NORMAL} leading-none text-red-700 select-none align-middle mx-0.5 dark:bg-red-500/15 dark:text-red-400`;
 
 export function makeDebugChipNode(doc: Document, label = "Debug"): HTMLElement {
   const span = doc.createElement("span");

--- a/apps/desktop/src/lib/desktop-chrome.ts
+++ b/apps/desktop/src/lib/desktop-chrome.ts
@@ -1,3 +1,9 @@
+import {
+  DESKTOP_OVERLAY_GROUP_LABEL_CLASS,
+  DESKTOP_OVERLAY_ITEM_PRIMARY_CLASS,
+  DESKTOP_SIDEBAR_TEXT_CLASS,
+  FONT_WEIGHT_NORMAL,
+} from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 /**
@@ -32,7 +38,7 @@ export const DESKTOP_CHROME_MUTED_TEXT = "text-sidebar-action-foreground";
 /** 会话标题内联重命名 input：ghost、无边框，字色与侧栏/顶栏会话名一致 */
 export const SESSION_TITLE_RENAME_INPUT_CLASS = cn(
   "min-w-0 rounded-none border-0 bg-transparent p-0 shadow-none outline-none ring-0 focus-visible:ring-0",
-  "text-xs font-medium",
+  DESKTOP_SIDEBAR_TEXT_CLASS,
   DESKTOP_CHROME_MUTED_TEXT,
 );
 
@@ -64,7 +70,8 @@ export const DESKTOP_FILES_EXPLORER_TOOLBAR_ICON_BTN = cn(
 );
 
 export const DESKTOP_CHROME_COMMIT_BTN = cn(
-  "h-7 rounded-md px-2 text-xs font-medium text-foreground/90 hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-foreground/10",
+  "h-7 rounded-md px-2 text-xs text-foreground/90 hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-foreground/10",
+  FONT_WEIGHT_NORMAL,
   instantHoverMotionClass,
 );
 
@@ -172,12 +179,13 @@ export const DESKTOP_OVERLAY_LIST_LIST_PADDING = "p-1 pr-1.5";
 
 export const DESKTOP_OVERLAY_LIST_LIST_GAP = "gap-0.5";
 
-export const DESKTOP_OVERLAY_LIST_GROUP_LABEL =
-  "px-2 py-1.5 text-[11px] font-medium tracking-wide text-muted-foreground";
+export const DESKTOP_OVERLAY_LIST_GROUP_LABEL = cn(
+  "px-2 py-1.5",
+  DESKTOP_OVERLAY_GROUP_LABEL_CLASS,
+);
 
 /** 详情 Popover 内嵌标签（无额外 padding，配合 DESKTOP_OVERLAY_LIST_DETAIL_* 使用） */
-export const DESKTOP_OVERLAY_LIST_DETAIL_LABEL =
-  "text-[11px] font-medium tracking-wide text-muted-foreground";
+export const DESKTOP_OVERLAY_LIST_DETAIL_LABEL = DESKTOP_OVERLAY_GROUP_LABEL_CLASS;
 
 export const DESKTOP_OVERLAY_LIST_ITEM = "px-2 py-1.5";
 
@@ -208,8 +216,7 @@ export const DESKTOP_SELECT_LABEL = DESKTOP_OVERLAY_LIST_GROUP_LABEL;
 export const DESKTOP_OVERLAY_LIST_ACTION_ITEM =
   "px-2 py-1.5 text-xs text-popover-foreground";
 
-export const DESKTOP_OVERLAY_LIST_ITEM_PRIMARY =
-  "truncate text-xs font-medium text-popover-foreground";
+export const DESKTOP_OVERLAY_LIST_ITEM_PRIMARY = DESKTOP_OVERLAY_ITEM_PRIMARY_CLASS;
 
 export const DESKTOP_OVERLAY_LIST_ITEM_SECONDARY =
   "truncate text-[11px] text-muted-foreground";

--- a/apps/desktop/src/lib/desktop-typography.ts
+++ b/apps/desktop/src/lib/desktop-typography.ts
@@ -1,0 +1,68 @@
+import { cn } from "@/lib/utils";
+
+/** Desktop 字重语义 token；数值与 Tailwind 默认一致（400 / 500 / 600） */
+export const FONT_WEIGHT_NORMAL = "font-normal";
+export const FONT_WEIGHT_MEDIUM = "font-medium";
+export const FONT_WEIGHT_SEMIBOLD = "font-semibold";
+
+/** 页面级主标题（设置、Automations 等） */
+export const DESKTOP_PAGE_TITLE_CLASS = cn(
+  "text-xl",
+  FONT_WEIGHT_MEDIUM,
+  "tracking-tight text-foreground",
+);
+
+/** 设置行 label */
+export const DESKTOP_SETTINGS_LABEL_CLASS = cn(
+  "text-sm",
+  FONT_WEIGHT_NORMAL,
+  "text-foreground",
+);
+
+/** 侧栏会话名、分组标签等 */
+export const DESKTOP_SIDEBAR_TEXT_CLASS = cn("text-xs", FONT_WEIGHT_NORMAL);
+
+/** 浮层列表主文本 */
+export const DESKTOP_OVERLAY_ITEM_PRIMARY_CLASS = cn(
+  "truncate text-xs",
+  FONT_WEIGHT_NORMAL,
+  "text-popover-foreground",
+);
+
+/** 浮层分组标签 */
+export const DESKTOP_OVERLAY_GROUP_LABEL_CLASS = cn(
+  "text-[11px]",
+  FONT_WEIGHT_NORMAL,
+  "tracking-wide text-muted-foreground",
+);
+
+/** 设置列表项 / 模型名等 */
+export const DESKTOP_LIST_ITEM_PRIMARY_CLASS = cn(
+  "text-sm",
+  FONT_WEIGHT_NORMAL,
+  "text-foreground",
+);
+
+/** 设置子节标题、编辑器 tab 切换 */
+export const DESKTOP_SECTION_LABEL_CLASS = cn(
+  "text-sm",
+  FONT_WEIGHT_NORMAL,
+  "text-foreground",
+);
+
+/** 紧凑型子节标题（Extensions 内嵌小节等） */
+export const DESKTOP_SECTION_LABEL_COMPACT_CLASS = cn(
+  "text-xs",
+  FONT_WEIGHT_NORMAL,
+  "text-foreground",
+);
+
+/** 菜单 / 工具栏触发器 */
+export const DESKTOP_MENU_TRIGGER_TEXT_CLASS = cn("text-xs", FONT_WEIGHT_NORMAL);
+
+/** 编辑器 tab 切换（xs） */
+export const DESKTOP_EDITOR_TAB_CLASS = cn(
+  "rounded-md px-2.5 text-xs",
+  FONT_WEIGHT_NORMAL,
+  "transition-colors",
+);

--- a/apps/desktop/src/lib/loop-chip-styles.ts
+++ b/apps/desktop/src/lib/loop-chip-styles.ts
@@ -1,6 +1,8 @@
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
+
 // 半透明底色：与 Composer 磨砂 surface 混叠，避免 opaque 色块与底色调不齐
 export const LOOP_CHIP_CLASS =
-  "inline-flex items-center gap-1 rounded-md bg-indigo-500/10 px-1.5 py-0.5 text-xs font-medium leading-none text-indigo-700 select-none align-middle mx-0.5 dark:bg-indigo-500/15 dark:text-indigo-400";
+  `inline-flex items-center gap-1 rounded-md bg-indigo-500/10 px-1.5 py-0.5 text-xs ${FONT_WEIGHT_NORMAL} leading-none text-indigo-700 select-none align-middle mx-0.5 dark:bg-indigo-500/15 dark:text-indigo-400`;
 
 export function makeLoopChipNode(doc: Document, label = "Loop"): HTMLElement {
   const span = doc.createElement("span");

--- a/apps/desktop/src/lib/markdown-message-components.tsx
+++ b/apps/desktop/src/lib/markdown-message-components.tsx
@@ -17,6 +17,7 @@ import {
   scrollMarkdownFragmentIntoView,
 } from "@/lib/markdown-fragment-link";
 import { slugifyMarkdownHeadingChildren } from "@/lib/markdown-heading-slug";
+import { FONT_WEIGHT_MEDIUM, FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
 
 export type MarkdownTone = "default" | "muted";
@@ -57,10 +58,10 @@ export function createMarkdownMessageComponents(
         id={slugifyMarkdownHeadingChildren(children)}
         className={cn(
           compact
-            ? "mt-2 mb-1.5 text-sm font-semibold tracking-tight first:mt-0"
+            ? cn("mt-2 mb-1.5 text-sm tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
             : muted
-              ? "mt-2 mb-1.5 text-sm font-semibold tracking-tight first:mt-0"
-              : "mt-3 mb-2 text-lg font-semibold tracking-tight first:mt-0",
+              ? cn("mt-2 mb-1.5 text-sm tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
+              : cn("mt-3 mb-2 text-lg tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM),
           headingText,
           className,
         )}
@@ -74,10 +75,10 @@ export function createMarkdownMessageComponents(
         id={slugifyMarkdownHeadingChildren(children)}
         className={cn(
           compact
-            ? "mt-2 mb-1 text-xs font-semibold tracking-tight first:mt-0"
+            ? cn("mt-2 mb-1 text-xs tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
             : muted
-              ? "mt-2 mb-1 text-sm font-semibold tracking-tight first:mt-0"
-              : "mt-3 mb-1.5 text-base font-semibold tracking-tight first:mt-0",
+              ? cn("mt-2 mb-1 text-sm tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
+              : cn("mt-3 mb-1.5 text-base tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM),
           headingText,
           className,
         )}
@@ -89,7 +90,7 @@ export function createMarkdownMessageComponents(
     h3: ({ className, children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
       <h3
         id={slugifyMarkdownHeadingChildren(children)}
-        className={cn("mt-2 mb-1 text-sm font-semibold first:mt-0", headingText, className)}
+        className={cn("mt-2 mb-1 text-sm first:mt-0", FONT_WEIGHT_MEDIUM, headingText, className)}
         {...props}
       >
         {children}
@@ -98,7 +99,7 @@ export function createMarkdownMessageComponents(
     h4: ({ className, children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
       <h4
         id={slugifyMarkdownHeadingChildren(children)}
-        className={cn("mt-2 mb-1 text-sm font-medium first:mt-0", headingText, className)}
+        className={cn("mt-2 mb-1 text-sm first:mt-0", FONT_WEIGHT_NORMAL, headingText, className)}
         {...props}
       >
         {children}
@@ -164,7 +165,7 @@ export function createMarkdownMessageComponents(
     },
     strong: ({ className, ...props }: HTMLAttributes<HTMLElement>) => (
       <strong
-        className={cn("font-semibold", muted ? "text-muted-foreground" : "text-foreground", className)}
+        className={cn(FONT_WEIGHT_MEDIUM, muted ? "text-muted-foreground" : "text-foreground", className)}
         {...props}
       />
     ),
@@ -225,7 +226,8 @@ export function createMarkdownMessageComponents(
     th: ({ className, ...props }: HTMLAttributes<HTMLTableCellElement>) => (
       <th
         className={cn(
-          "border border-border/50 px-2 py-1.5 text-left font-medium",
+          "border border-border/50 px-2 py-1.5 text-left",
+          FONT_WEIGHT_NORMAL,
           muted ? "text-muted-foreground" : "text-foreground",
           className,
         )}

--- a/apps/desktop/src/lib/plan-chip-styles.ts
+++ b/apps/desktop/src/lib/plan-chip-styles.ts
@@ -1,6 +1,8 @@
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
+
 // 半透明底色：与 Composer 磨砂 surface 混叠，避免 opaque 色块与底色调不齐
 export const PLAN_CHIP_CLASS =
-  "inline-flex items-center gap-1 rounded-md bg-orange-300/20 px-1.5 py-0.5 text-xs font-medium leading-none text-yellow-600 select-none align-middle mx-0.5 dark:bg-orange-300/15 dark:text-orange-300";
+  `inline-flex items-center gap-1 rounded-md bg-orange-300/20 px-1.5 py-0.5 text-xs ${FONT_WEIGHT_NORMAL} leading-none text-yellow-600 select-none align-middle mx-0.5 dark:bg-orange-300/15 dark:text-orange-300`;
 
 export function makePlanChipNode(doc: Document, label = "Plan"): HTMLElement {
   const span = doc.createElement("span");

--- a/apps/desktop/src/lib/skill-chip-styles.ts
+++ b/apps/desktop/src/lib/skill-chip-styles.ts
@@ -1,5 +1,7 @@
+import { FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
+
 export const SKILL_CHIP_CLASS =
-  "inline-flex items-center px-0.5 py-0.5 text-xs font-medium leading-none text-yellow-600 select-none align-middle mx-0.5 dark:text-amber-400";
+  `inline-flex items-center px-0.5 py-0.5 text-xs ${FONT_WEIGHT_NORMAL} leading-none text-yellow-600 select-none align-middle mx-0.5 dark:text-amber-400`;
 
 export function makeSkillChipNode(alias: string, doc: Document): HTMLElement {
   const span = doc.createElement("span");

--- a/apps/desktop/src/styles/tool-call-diff-view.css
+++ b/apps/desktop/src/styles/tool-call-diff-view.css
@@ -86,7 +86,7 @@
 
 .tool-call-diff .diff-line.review-diff-target-line .diff-gutter {
   color: var(--foreground);
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .tool-call-diff .diff-line.review-diff-target-line .diff-code {
@@ -198,5 +198,5 @@
 
 .tool-call-diff .diff-code .token.important {
   color: var(--diff-syntax-important);
-  font-weight: 600;
+  font-weight: 500;
 }


### PR DESCRIPTION
## Summary

- 新增 `desktop-typography.ts` 集中定义三档字重语义 token（normal / medium / semibold）及复合 class
- 将 Desktop 绝大部分 UI 从 font-medium(500) 降至 font-normal(400)，页面标题与 Markdown 强调从 font-semibold(600) 降至 font-medium(500)
- 共享 chrome（侧栏、设置、菜单/Select 浮层、shadcn 基元）统一改引 token，分 8 个 Phase 提交便于审计

## Test plan

- [x] 侧栏会话列表、分组标签字重明显变轻
- [x] 设置页正文、列表项、Models provider 分组头均为 normal
- [x] 设置页 h1、Automations/Marketplace 主标题为 medium（不再 semibold）
- [x] 模型选择器、字体下拉、审批/分支/工作区等菜单触发器与列表项为 normal
- [x] Button、Label、Badge 等 shadcn 基元默认 normal
- [x] 助手 Markdown h1–h3 / strong 为 medium，h4 / 表头为 normal
- [x] `rg font-semibold|font-medium` 字面量仅保留在 `desktop-typography.ts`
- [x] `npm run build`（apps/desktop renderer tsc + vite）通过