### PR TITLE
perf(desktop): 流式输出改为主进程自驱泵与节流推送

### DIFF
--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { buildSingleTextQuestionNotificationReplyResult } from "@/lib/ask-questions-notification-reply";
 import { resolvePendingApprovalSessionPath, resolvePendingQuestionsSessionPath, resolvePendingQuestionsSnapshot } from "@/lib/pane-pending-turn-routing";
-import i18n from "@/lib/i18n";
+import i18n, { getStoredLanguage } from "@/lib/i18n";
 
 import type { SettingsFormState } from "@/components/settings/types";
 import { useHostApi } from "@/hooks/useHostApi";
@@ -372,7 +372,7 @@ export function useDesktopRuntime() {
     videoGenerationModel: "",
     lightweightChatModel: "",
     apiBase: "",
-    uiLocale: "",
+    uiLocale: getStoredLanguage(),
     apiKey: "",
     windowsMica: true,
     systemNotifications: true,
@@ -717,7 +717,7 @@ export function useDesktopRuntime() {
         videoGenerationModel: next.config.videoGenerationModel ?? "",
         lightweightChatModel: next.config.lightweightChatModel ?? "",
         apiBase: activeModelProfile?.apiBase ?? current.apiBase,
-        uiLocale: next.config.uiLocale ?? "",
+        uiLocale: next.config.uiLocale ?? getStoredLanguage(),
         apiKey: current.apiKey,
         windowsMica,
         systemNotifications: next.config.systemNotifications !== false,

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -125,6 +125,8 @@ type BusyAction =
 
 const DREAM_IDLE_POLL_INTERVAL_MS = 30_000;
 const GIT_STATE_POLL_INTERVAL_MS = 5_000;
+/** 远程 Web 客户端 busy 时的快照 poll 间隔；回合推进由宿主泵驱动，poll 只取快照。 */
+const WEB_BUSY_POLL_INTERVAL_MS = 150;
 const COMPOSER_DRAFT_PERSIST_DEBOUNCE_MS = 400;
 
 type SessionUiState = {
@@ -1306,14 +1308,12 @@ export function useDesktopRuntime() {
     });
   }, [pendingQuestions]);
 
-  const backgroundSessionsBusy = sessions.some((session) => session.isBusy === true);
-
-  /** Active or background session busy: poll until none are busy. */
+  /**
+   * 仅远程 Web 客户端：busy 时以固定间隔 poll 取快照（回合推进由宿主泵驱动，poll 不再驱动运行时）。
+   * Electron 下流式更新全部走宿主节流推送（subscribeDreamUpdates），无 poll 循环。
+   */
   useEffect(() => {
-    const shouldPoll = isRemoteWebHostClient(api?.kind)
-      ? snapshot?.conversation.isBusy === true
-      : snapshot?.conversation.isBusy === true || backgroundSessionsBusy;
-    if (!api || !shouldPoll) {
+    if (!api || !isRemoteWebHostClient(api.kind) || snapshot?.conversation.isBusy !== true) {
       return;
     }
 
@@ -1331,18 +1331,8 @@ export function useDesktopRuntime() {
           if (cancelled) {
             break;
           }
-          const localForegroundBusy = snapshotRef.current?.conversation.isBusy === true;
-          const localPath = snapshotRef.current?.activeSession?.filePath?.trim() ?? '';
-          const nextPath = next.activeSession?.filePath?.trim() ?? '';
-          const blockPollForegroundSwap =
-            api.kind === 'electron'
-            && !localForegroundBusy
-            && backgroundSessionsBusy
-            && localPath.length > 0
-            && nextPath.length > 0
-            && localPath !== nextPath
-            && busyActionRef.current !== 'session';
-          if (blockPollForegroundSwap) {
+          applySnapshot(next);
+          if (next.conversation.isBusy !== true) {
             const sessionItems = await api.listSessions();
             if (cancelled) {
               break;
@@ -1352,21 +1342,8 @@ export function useDesktopRuntime() {
             if (!stillBusy) {
               break;
             }
-            continue;
           }
-          applySnapshot(next);
-          if (next.conversation.isBusy === true) {
-            continue;
-          }
-          const sessionItems = await api.listSessions();
-          if (cancelled) {
-            break;
-          }
-          applySessionList(sessionItems);
-          const stillBusy = sessionItems.some((session) => session.isBusy === true);
-          if (!stillBusy) {
-            break;
-          }
+          await new Promise((resolve) => setTimeout(resolve, WEB_BUSY_POLL_INTERVAL_MS));
         }
       } catch (error) {
         if (!cancelled) {
@@ -1378,7 +1355,7 @@ export function useDesktopRuntime() {
     return () => {
       cancelled = true;
     };
-  }, [api, applySessionList, applySnapshot, backgroundSessionsBusy, snapshot?.conversation.isBusy]);
+  }, [api, applySessionList, applySnapshot, snapshot?.conversation.isBusy]);
 
   useEffect(() => {
     if (!api?.subscribeDreamUpdates) {

--- a/apps/desktop/src/host/direct-media-turn.ts
+++ b/apps/desktop/src/host/direct-media-turn.ts
@@ -261,6 +261,9 @@ async function finishDirectMediaTurn(
     orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
     await ctx.flushDeferredRuntimeRefreshIfIdle(input.bundle);
     await ctx.refreshTodoSnapshotForBundle(input.bundle);
+    input.bundle.conversationRevision += 1;
+    ctx.requestLiveSnapshotEmit();
+    ctx.notifySessionListUpdated();
   } finally {
     input.bundle.directMediaTurnInFlight = false;
     input.bundle.currentTurnSkills = [];

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -96,7 +96,6 @@ export interface DesktopRuntimeEventOrchestratorOptions {
   onTodoStoreMutated?: () => void;
   /** todo_write 工具卡增量文案：返回执行前的会话 TODO。 */
   todoItemsBeforeWrite?: () => ReadonlyArray<{ title: string; status: 'pending' | 'in_progress' | 'completed' }>;
-  requestLiveSnapshotUpdate?: () => void;
   /** delete_file：删除前按路径读取磁盘并统计行数 */
   lineDeltaForDeleteFile?: (inputPath: string) => EditFileLineDelta | undefined;
   /** delete_file：删除前按路径读取磁盘全文 baseline */
@@ -111,10 +110,6 @@ export interface DesktopRuntimeEventOrchestratorOptions {
   currentWorkspaceRoot?: () => string;
 }
 
-function isMcpLikeToolName(toolName: string): boolean {
-  return toolName === 'tool_call' || toolName === 'tool_describe' || toolName === 'fetch_mcp_resource';
-}
-
 export class DesktopRuntimeEventOrchestrator {
   private lastApplyEventBatchId = 0;
   private messageOrderDebugLastVerboseLogMs = 0;
@@ -125,7 +120,6 @@ export class DesktopRuntimeEventOrchestrator {
    * 同一个 AnimatedCollapse 实例上收起；本段 completed 时再拆成独立思考行。
    */
   private deferredAfterStreamThinking: string | undefined;
-  private shellOutputSnapshotTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(private readonly options: DesktopRuntimeEventOrchestratorOptions) {}
 
@@ -200,24 +194,6 @@ export class DesktopRuntimeEventOrchestrator {
     this.activeGenerateImageTools.clear();
     this.activeGenerateVideoTools.clear();
     this.deferredAfterStreamThinking = undefined;
-    if (this.shellOutputSnapshotTimer !== undefined) {
-      clearTimeout(this.shellOutputSnapshotTimer);
-      this.shellOutputSnapshotTimer = undefined;
-    }
-  }
-
-  private scheduleLiveSnapshotUpdateForShellOutput(): void {
-    this.scheduleThrottledLiveSnapshotUpdate();
-  }
-
-  private scheduleThrottledLiveSnapshotUpdate(): void {
-    if (this.shellOutputSnapshotTimer !== undefined) {
-      return;
-    }
-    this.shellOutputSnapshotTimer = setTimeout(() => {
-      this.shellOutputSnapshotTimer = undefined;
-      this.options.requestLiveSnapshotUpdate?.();
-    }, 150);
   }
 
   /** 无工具回合里暂挂的 after-stream 思考：在 completed / 空正文收尾时拆成独立思考行。 */
@@ -422,7 +398,6 @@ export class DesktopRuntimeEventOrchestrator {
         }
         this.options.assistantMessages.appendPendingAssistantChunk(event.text);
         this.options.messageTimeline?.()?.appendAssistantTextChunk(event.text);
-        this.scheduleThrottledLiveSnapshotUpdate();
         continue;
       }
       if (event.kind === 'replace-pending-assistant') {
@@ -536,9 +511,6 @@ export class DesktopRuntimeEventOrchestrator {
             request: event.request as JsonObject,
           },
         });
-        if (event.decisionKind === 'allow') {
-          this.options.requestLiveSnapshotUpdate?.();
-        }
         continue;
       }
       if (event.kind === 'tool-execution-output-chunk') {
@@ -555,7 +527,6 @@ export class DesktopRuntimeEventOrchestrator {
         };
         this.options.assistantMessages.upsertToolMessage(event.toolCallId, updated, batchId);
         this.options.messageTimeline?.()?.upsertToolMessage(event.toolCallId, updated);
-        this.scheduleLiveSnapshotUpdateForShellOutput();
         continue;
       }
       if (event.kind === 'tool-execution-finished') {
@@ -569,9 +540,6 @@ export class DesktopRuntimeEventOrchestrator {
           this.activeGenerateVideoTools.delete(event.execution.toolCallId);
         }
         this.integrateToolExecutions([event.execution], 'event');
-        if (isMcpLikeToolName(event.execution.toolName)) {
-          this.options.requestLiveSnapshotUpdate?.();
-        }
         this.options.dispatchExtensionEvent({
           type: 'onToolResult',
           detail: {
@@ -677,9 +645,6 @@ export class DesktopRuntimeEventOrchestrator {
         // Gateway resume 且轮次带工具前正文时不发 remove-pending-assistant（正文非空），
         // 占位行不能只挂在该事件上；内建工具终态落地即预置 after-tools Thinking 占位。
         this.options.messageTimeline?.()?.ensureAfterToolsThinkingPlaceholderRow();
-      }
-      if (isResponsesBuiltIn) {
-        this.options.requestLiveSnapshotUpdate?.();
       }
     }
     this.logMessageOrderApplyBatch(

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -245,6 +245,7 @@ import {
   applyDrainedRuntimeHostEvents,
   continueAssistantCompletionCommand,
   pollCommand,
+  pumpSessionsCommand,
   replyPendingApprovalCommand,
   replyPendingQuestionsCommand,
   sendQueuedUserTurnNowCommand,
@@ -253,6 +254,7 @@ import {
   type SessionTurnOrchestratorContext,
   type SubmitUserTurnAfterInitializedOptions,
 } from './session-turn-orchestrator.js';
+import { SessionPump, sessionBundleNeedsPumpTick } from './session-pump.js';
 import {
   startWorktreeBootstrapTurnCommand,
   type WorktreeBootstrapHostContext,
@@ -607,6 +609,14 @@ class DesktopHostService {
     }
   >();
   private serialized = Promise.resolve();
+  /** busy 会话的回合推进由主进程泵驱动，不依赖 renderer poll。 */
+  private readonly sessionPump = new SessionPump({
+    hasPumpWork: () => this.hasSessionPumpWork(),
+    runTick: () => pumpSessionsCommand(this.sessionTurnContext()),
+    onTickError: (error) => {
+      console.error('[desktop-host][pump] tick failed', error);
+    },
+  });
   private dreamCollectorStatus: DesktopDreamCollectorSnapshot = emptyDreamCollectorSnapshot('disabled');
   private dreamCollectorRunning = false;
   private dreamCollectorLastTickUnixMs = 0;
@@ -4281,7 +4291,19 @@ class DesktopHostService {
       return await work();
     } finally {
       release?.();
+      // 唯一 choke point：任何使会话变 busy 的命令（发消息、审批恢复、队列、automation…）
+      // 都经 runSerialized 收口，此处确保泵启动。
+      this.sessionPump.ensureRunning();
     }
+  }
+
+  private hasSessionPumpWork(): boolean {
+    for (const bundle of this.sessionRegistry.all()) {
+      if (sessionBundleNeedsPumpTick(bundle)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private requireEnabledSkillEntry(skillName: string): HostMetadataSummary['skills']['entries'][number] {

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -257,6 +257,7 @@ import {
 import {
   LIVE_SNAPSHOT_BUSY_HEARTBEAT_MS,
   LIVE_SNAPSHOT_EMIT_THROTTLE_MS,
+  SESSION_LIST_NOTIFY_INTERVAL_MS,
   SessionPump,
   pumpDebugEnabled,
   sessionBundleNeedsPumpTick,
@@ -627,6 +628,7 @@ class DesktopHostService {
   private lastLiveSnapshotEmitAtMs = 0;
   private debugLiveSnapshotEmitCount = 0;
   private debugLiveSnapshotEmitWindowStartedAtMs = 0;
+  private lastSessionListNotifyAtMs = 0;
   private dreamCollectorStatus: DesktopDreamCollectorSnapshot = emptyDreamCollectorSnapshot('disabled');
   private dreamCollectorRunning = false;
   private dreamCollectorLastTickUnixMs = 0;
@@ -4333,10 +4335,32 @@ class DesktopHostService {
       if (Date.now() - this.lastLiveSnapshotEmitAtMs >= LIVE_SNAPSHOT_BUSY_HEARTBEAT_MS) {
         this.requestThrottledLiveSnapshotEmit();
       }
+      this.maybeNotifySessionListDuringBackgroundActivity();
       return;
     }
     // busy → idle：推送终态快照并刷新会话列表（替代原 renderer poll 循环退出时的 listSessions）。
     this.requestThrottledLiveSnapshotEmit();
+    this.notifySessionListUpdated();
+  }
+
+  /** 前台空闲、其它 bundle busy 时，节流刷新侧边栏 isBusy 状态。 */
+  private maybeNotifySessionListDuringBackgroundActivity(): void {
+    const activeId = this.sessionRegistry.activeSessionId();
+    let backgroundBusy = false;
+    for (const bundle of this.sessionRegistry.all()) {
+      if (bundle.id !== activeId && isSessionBundleBusy(bundle)) {
+        backgroundBusy = true;
+        break;
+      }
+    }
+    if (!backgroundBusy) {
+      return;
+    }
+    const now = Date.now();
+    if (now - this.lastSessionListNotifyAtMs < SESSION_LIST_NOTIFY_INTERVAL_MS) {
+      return;
+    }
+    this.lastSessionListNotifyAtMs = now;
     this.notifySessionListUpdated();
   }
 

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -258,6 +258,7 @@ import {
   LIVE_SNAPSHOT_BUSY_HEARTBEAT_MS,
   LIVE_SNAPSHOT_EMIT_THROTTLE_MS,
   SessionPump,
+  pumpDebugEnabled,
   sessionBundleNeedsPumpTick,
 } from './session-pump.js';
 import {
@@ -624,6 +625,8 @@ class DesktopHostService {
   });
   private liveSnapshotEmitTimer: ReturnType<typeof setTimeout> | undefined;
   private lastLiveSnapshotEmitAtMs = 0;
+  private debugLiveSnapshotEmitCount = 0;
+  private debugLiveSnapshotEmitWindowStartedAtMs = 0;
   private dreamCollectorStatus: DesktopDreamCollectorSnapshot = emptyDreamCollectorSnapshot('disabled');
   private dreamCollectorRunning = false;
   private dreamCollectorLastTickUnixMs = 0;
@@ -3082,6 +3085,18 @@ class DesktopHostService {
     const snapshot = this.buildSnapshot();
     for (const listener of this.dreamUpdateListeners) {
       listener(snapshot);
+    }
+    if (pumpDebugEnabled()) {
+      this.debugLiveSnapshotEmitCount += 1;
+      const windowMs = Date.now() - this.debugLiveSnapshotEmitWindowStartedAtMs;
+      if (windowMs >= 5_000) {
+        const hz = (this.debugLiveSnapshotEmitCount / Math.max(1, windowMs)) * 1_000;
+        console.log(
+          `[desktop-host][pump] snapshot emits=${this.debugLiveSnapshotEmitCount} rate=${hz.toFixed(1)}/s`,
+        );
+        this.debugLiveSnapshotEmitCount = 0;
+        this.debugLiveSnapshotEmitWindowStartedAtMs = Date.now();
+      }
     }
   }
 

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -813,6 +813,7 @@ class DesktopHostService {
       activeSessionId: () => this.sessionRegistry.activeSessionId(),
       emitLiveSnapshotUpdate: () => this.emitLiveSnapshotUpdate(),
       requestLiveSnapshotEmit: () => this.requestThrottledLiveSnapshotEmit(),
+      notifySessionListUpdated: () => this.notifySessionListUpdated(),
       refreshRuntimeForBundle: (bundle) => this.refreshRuntimeForBundle(bundle),
       syncActiveRuntimePointer: () => this.syncActiveRuntimePointer(),
       clearAssistantContinuationMarkers: () => this.clearAssistantContinuationMarkers(),

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -254,7 +254,12 @@ import {
   type SessionTurnOrchestratorContext,
   type SubmitUserTurnAfterInitializedOptions,
 } from './session-turn-orchestrator.js';
-import { SessionPump, sessionBundleNeedsPumpTick } from './session-pump.js';
+import {
+  LIVE_SNAPSHOT_BUSY_HEARTBEAT_MS,
+  LIVE_SNAPSHOT_EMIT_THROTTLE_MS,
+  SessionPump,
+  sessionBundleNeedsPumpTick,
+} from './session-pump.js';
 import {
   startWorktreeBootstrapTurnCommand,
   type WorktreeBootstrapHostContext,
@@ -612,11 +617,13 @@ class DesktopHostService {
   /** busy 会话的回合推进由主进程泵驱动，不依赖 renderer poll。 */
   private readonly sessionPump = new SessionPump({
     hasPumpWork: () => this.hasSessionPumpWork(),
-    runTick: () => pumpSessionsCommand(this.sessionTurnContext()),
+    runTick: () => this.runSessionPumpTick(),
     onTickError: (error) => {
       console.error('[desktop-host][pump] tick failed', error);
     },
   });
+  private liveSnapshotEmitTimer: ReturnType<typeof setTimeout> | undefined;
+  private lastLiveSnapshotEmitAtMs = 0;
   private dreamCollectorStatus: DesktopDreamCollectorSnapshot = emptyDreamCollectorSnapshot('disabled');
   private dreamCollectorRunning = false;
   private dreamCollectorLastTickUnixMs = 0;
@@ -802,6 +809,7 @@ class DesktopHostService {
       getActiveBundle: () => this.sessionRegistry.getActive(),
       activeSessionId: () => this.sessionRegistry.activeSessionId(),
       emitLiveSnapshotUpdate: () => this.emitLiveSnapshotUpdate(),
+      requestLiveSnapshotEmit: () => this.requestThrottledLiveSnapshotEmit(),
       refreshRuntimeForBundle: (bundle) => this.refreshRuntimeForBundle(bundle),
       syncActiveRuntimePointer: () => this.syncActiveRuntimePointer(),
       clearAssistantContinuationMarkers: () => this.clearAssistantContinuationMarkers(),
@@ -1238,11 +1246,6 @@ class DesktopHostService {
       },
       todoItemsBeforeWrite: () =>
         bundle.cachedTodoSnapshot?.items.map(({ title, status }) => ({ title, status })) ?? [],
-      requestLiveSnapshotUpdate: () => {
-        if (bundle.id === this.sessionRegistry.activeSessionId()) {
-          this.emitLiveSnapshotUpdate();
-        }
-      },
       lineDeltaForDeleteFile: (inputPath) =>
         lineDeltaForDeleteFilePath(
           { workspaceRoot: bundle.workspaceRoot, spiritDataDir: spiritAgentDataDir() },
@@ -3072,6 +3075,7 @@ class DesktopHostService {
   }
 
   private emitLiveSnapshotUpdate(): void {
+    this.lastLiveSnapshotEmitAtMs = Date.now();
     if (!this.state || this.dreamUpdateListeners.size === 0) {
       return;
     }
@@ -4304,6 +4308,35 @@ class DesktopHostService {
       }
     }
     return false;
+  }
+
+  private async runSessionPumpTick(): Promise<void> {
+    await pumpSessionsCommand(this.sessionTurnContext());
+    if (this.hasSessionPumpWork()) {
+      // busy 但事件驱动的推送可能长时间不来（纯网络等待）；心跳保证 spinner 等宿主态动画刷新。
+      if (Date.now() - this.lastLiveSnapshotEmitAtMs >= LIVE_SNAPSHOT_BUSY_HEARTBEAT_MS) {
+        this.requestThrottledLiveSnapshotEmit();
+      }
+      return;
+    }
+    // busy → idle：推送终态快照并刷新会话列表（替代原 renderer poll 循环退出时的 listSessions）。
+    this.requestThrottledLiveSnapshotEmit();
+    this.notifySessionListUpdated();
+  }
+
+  /** 流式期间 live snapshot 的唯一推送出口：leading+trailing 节流。 */
+  private requestThrottledLiveSnapshotEmit(): void {
+    if (this.liveSnapshotEmitTimer !== undefined) {
+      return;
+    }
+    const elapsedMs = Date.now() - this.lastLiveSnapshotEmitAtMs;
+    const delayMs = Math.max(0, LIVE_SNAPSHOT_EMIT_THROTTLE_MS - elapsedMs);
+    const timer = setTimeout(() => {
+      this.liveSnapshotEmitTimer = undefined;
+      this.emitLiveSnapshotUpdate();
+    }, delayMs);
+    timer.unref?.();
+    this.liveSnapshotEmitTimer = timer;
   }
 
   private requireEnabledSkillEntry(skillName: string): HostMetadataSummary['skills']['entries'][number] {

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -71,6 +71,8 @@ export interface SessionBundle {
   cachedTodoSnapshot?: import('../types.js').ConversationTodoSnapshot;
   /** Bumped on rewind restore; exposed as `conversation.revision` in snapshots. */
   conversationRevision: number;
+  /** busy tick 落盘节流：上次 tick 落盘时间（内存态，不持久化）。 */
+  lastTickPersistAtMs?: number;
   /** Last successful create_plan absolute path for this session. */
   activePlanPath?: string;
   /** Tracks whether the sidebar title is seed-truncated or LLM-generated. */

--- a/apps/desktop/src/host/session-pump.ts
+++ b/apps/desktop/src/host/session-pump.ts
@@ -4,6 +4,12 @@ import { shouldAdvanceWorktreeBootstrap } from './worktree-bootstrap-orchestrato
 /** 泵 tick 间隔：决定流式事件消费与 UI 推送的最小节奏。 */
 export const SESSION_PUMP_INTERVAL_MS = 25;
 
+/** live snapshot 节流推送间隔（leading+trailing）。 */
+export const LIVE_SNAPSHOT_EMIT_THROTTLE_MS = 33;
+
+/** busy 但无变更时的心跳推送间隔（spinner / 计时等宿主态动画依赖推送刷新）。 */
+export const LIVE_SNAPSHOT_BUSY_HEARTBEAT_MS = 150;
+
 /** 与 pollCommand 的 tick 条件一致：runtime busy 或 worktree bootstrap 待推进。 */
 export function sessionBundleNeedsPumpTick(bundle: SessionBundle): boolean {
   return bundle.runtime?.isBusy() === true || shouldAdvanceWorktreeBootstrap(bundle);

--- a/apps/desktop/src/host/session-pump.ts
+++ b/apps/desktop/src/host/session-pump.ts
@@ -1,0 +1,119 @@
+import type { SessionBundle } from './session-bundle.js';
+import { shouldAdvanceWorktreeBootstrap } from './worktree-bootstrap-orchestrator.js';
+
+/** 泵 tick 间隔：决定流式事件消费与 UI 推送的最小节奏。 */
+export const SESSION_PUMP_INTERVAL_MS = 25;
+
+/** 与 pollCommand 的 tick 条件一致：runtime busy 或 worktree bootstrap 待推进。 */
+export function sessionBundleNeedsPumpTick(bundle: SessionBundle): boolean {
+  return bundle.runtime?.isBusy() === true || shouldAdvanceWorktreeBootstrap(bundle);
+}
+
+/** 环境变量 `SPIRIT_DESKTOP_PUMP_DEBUG`：设为 1/true/on 时输出泵的启停与 tick 频率统计。 */
+function pumpDebugEnabled(): boolean {
+  const raw = process.env.SPIRIT_DESKTOP_PUMP_DEBUG?.trim().toLowerCase() ?? '';
+  return raw === '1' || raw === 'true' || raw === 'on' || raw === 'yes';
+}
+
+const PUMP_DEBUG_STATS_INTERVAL_MS = 5_000;
+
+export interface SessionPumpOptions {
+  /** True while any session still needs pump ticks; pump stops when false. */
+  hasPumpWork(): boolean;
+  /** One serialized pump tick (advance runtimes, integrate events). */
+  runTick(): Promise<void>;
+  intervalMs?: number;
+  onTickError?(error: unknown): void;
+}
+
+/**
+ * 主进程自驱泵：busy 会话的回合推进不再依赖 renderer 的 poll 循环。
+ * 任一入口命令使会话变 busy 后调用 ensureRunning()，泵以固定间隔 tick 直到全部空闲。
+ */
+export class SessionPump {
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private running = false;
+  private debugTickCount = 0;
+  private debugTickDurationMs = 0;
+  private debugWindowStartedAtMs = 0;
+
+  constructor(private readonly options: SessionPumpOptions) {}
+
+  get intervalMs(): number {
+    return this.options.intervalMs ?? SESSION_PUMP_INTERVAL_MS;
+  }
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  ensureRunning(): void {
+    if (this.running) {
+      return;
+    }
+    if (!this.options.hasPumpWork()) {
+      return;
+    }
+    this.running = true;
+    if (pumpDebugEnabled()) {
+      console.log('[desktop-host][pump] start');
+      this.debugTickCount = 0;
+      this.debugTickDurationMs = 0;
+      this.debugWindowStartedAtMs = Date.now();
+    }
+    this.scheduleNext(0);
+  }
+
+  stop(): void {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    this.running = false;
+  }
+
+  private scheduleNext(delayMs: number): void {
+    const timer = setTimeout(() => {
+      this.timer = undefined;
+      void this.tick();
+    }, delayMs);
+    // 泵不应阻止主进程退出（Electron quit / 测试进程结束）。
+    timer.unref?.();
+    this.timer = timer;
+  }
+
+  private async tick(): Promise<void> {
+    const startedAtMs = Date.now();
+    try {
+      await this.options.runTick();
+    } catch (error) {
+      this.options.onTickError?.(error);
+    }
+    if (pumpDebugEnabled()) {
+      this.debugTickCount += 1;
+      this.debugTickDurationMs += Date.now() - startedAtMs;
+      const windowMs = Date.now() - this.debugWindowStartedAtMs;
+      if (windowMs >= PUMP_DEBUG_STATS_INTERVAL_MS) {
+        const hz = (this.debugTickCount / windowMs) * 1_000;
+        const avgMs = this.debugTickDurationMs / Math.max(1, this.debugTickCount);
+        console.log(
+          `[desktop-host][pump] ticks=${this.debugTickCount} rate=${hz.toFixed(1)}/s avgTick=${avgMs.toFixed(1)}ms`,
+        );
+        this.debugTickCount = 0;
+        this.debugTickDurationMs = 0;
+        this.debugWindowStartedAtMs = Date.now();
+      }
+    }
+    if (!this.running) {
+      return;
+    }
+    if (!this.options.hasPumpWork()) {
+      this.running = false;
+      if (pumpDebugEnabled()) {
+        console.log('[desktop-host][pump] idle, stop');
+      }
+      return;
+    }
+    this.scheduleNext(this.intervalMs);
+  }
+}

--- a/apps/desktop/src/host/session-pump.ts
+++ b/apps/desktop/src/host/session-pump.ts
@@ -15,8 +15,8 @@ export function sessionBundleNeedsPumpTick(bundle: SessionBundle): boolean {
   return bundle.runtime?.isBusy() === true || shouldAdvanceWorktreeBootstrap(bundle);
 }
 
-/** 环境变量 `SPIRIT_DESKTOP_PUMP_DEBUG`：设为 1/true/on 时输出泵的启停与 tick 频率统计。 */
-function pumpDebugEnabled(): boolean {
+/** 环境变量 `SPIRIT_DESKTOP_PUMP_DEBUG`：设为 1/true/on 时输出泵的启停、tick 频率与推送频率统计。 */
+export function pumpDebugEnabled(): boolean {
   const raw = process.env.SPIRIT_DESKTOP_PUMP_DEBUG?.trim().toLowerCase() ?? '';
   return raw === '1' || raw === 'true' || raw === 'on' || raw === 'yes';
 }

--- a/apps/desktop/src/host/session-pump.ts
+++ b/apps/desktop/src/host/session-pump.ts
@@ -10,6 +10,9 @@ export const LIVE_SNAPSHOT_EMIT_THROTTLE_MS = 33;
 /** busy 但无变更时的心跳推送间隔（spinner / 计时等宿主态动画依赖推送刷新）。 */
 export const LIVE_SNAPSHOT_BUSY_HEARTBEAT_MS = 150;
 
+/** 后台会话 busy 时侧边栏 listSessions 刷新间隔。 */
+export const SESSION_LIST_NOTIFY_INTERVAL_MS = 1_000;
+
 /** 与 pollCommand 的 tick 条件一致：runtime busy 或 worktree bootstrap 待推进。 */
 export function sessionBundleNeedsPumpTick(bundle: SessionBundle): boolean {
   return bundle.runtime?.isBusy() === true || shouldAdvanceWorktreeBootstrap(bundle);

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -20,10 +20,7 @@ import type { DesktopRuntime } from './runtime.js';
 import type { SessionBundle } from './session-bundle.js';
 import { toolMessageKey } from './message-ordering.js';
 import {
-  runtimeEventsIncludeAppliedFinishTaskPreview,
-  runtimeEventsIncludeAppliedHostToolStreamingUpdate,
   runtimeEventsIncludeAppliedResponsesBuiltInToolPreview,
-  runtimeEventsIncludeAppliedResponsesBuiltInToolStreamingUpdate,
   splitRuntimeEventsForIncrementalFinishTaskPreview,
   splitRuntimeEventsForIncrementalResponsesBuiltInToolPreview,
 } from './runtime-event-orchestrator.js';
@@ -91,6 +88,8 @@ export interface SessionTurnOrchestratorContext {
   getActiveBundle(): SessionBundle | undefined;
   activeSessionId(): string | undefined;
   emitLiveSnapshotUpdate(): void;
+  /** 节流版 live snapshot 推送（流式变更唯一出口；宿主侧 33ms leading+trailing）。 */
+  requestLiveSnapshotEmit(): void;
   refreshRuntimeForBundle(bundle: SessionBundle): Promise<void>;
   syncActiveRuntimePointer(): void;
   clearAssistantContinuationMarkers(): void;
@@ -352,21 +351,25 @@ export async function tickSessionCommand(
   }
 
   const orchestration = ctx.orchestrationFor(bundle);
+  let changed = false;
   if (bundle.runtime) {
     bundle.runtime.tickThinkingSpinner();
-    syncSubagentConversationProjections(bundle, bundle.runtime);
+    changed = syncSubagentConversationProjections(bundle, bundle.runtime) || changed;
     if (!options.light) {
       await bundle.runtime.poll();
-      syncSubagentConversationProjections(bundle, bundle.runtime);
-      applyDrainedRuntimeHostEvents(ctx, bundle, bundle.runtime.drainEvents());
+      changed = syncSubagentConversationProjections(bundle, bundle.runtime) || changed;
+      changed = applyDrainedRuntimeHostEvents(ctx, bundle, bundle.runtime.drainEvents()) || changed;
     } else {
       const drained = bundle.runtime.drainEvents();
       if (drained.length > 0 || bundle.deferredRuntimeHostEvents.length > 0) {
-        applyDrainedRuntimeHostEvents(ctx, bundle, drained);
+        changed = applyDrainedRuntimeHostEvents(ctx, bundle, drained) || changed;
       }
     }
   } else if (options.light && bundle.deferredRuntimeHostEvents.length > 0) {
-    applyDrainedRuntimeHostEvents(ctx, bundle, []);
+    changed = applyDrainedRuntimeHostEvents(ctx, bundle, []) || changed;
+  }
+  if (changed) {
+    ctx.requestLiveSnapshotEmit();
   }
   if (options.light) {
     await drainQueuedUserTurnIfIdle(ctx, bundle);
@@ -548,11 +551,12 @@ export async function replyPendingQuestionsCommand(
   });
 }
 
+/** @returns 是否应用了事件（供 tick 决定是否请求节流推送）。 */
 export function applyDrainedRuntimeHostEvents(
   ctx: SessionTurnOrchestratorContext,
   bundle: SessionBundle,
   drained: RuntimeEvent<DesktopToolRequest>[],
-): void {
+): boolean {
   const orchestration = ctx.orchestrationFor(bundle);
   const queued = [...bundle.deferredRuntimeHostEvents, ...drained];
   bundle.deferredRuntimeHostEvents = [];
@@ -572,18 +576,11 @@ export function applyDrainedRuntimeHostEvents(
     }
   }
   bundle.messages = bundle.messageTimeline.toMessages();
-  if (bundle.id !== ctx.activeSessionId()) {
-    return;
+  if (splitBuiltin.toApply.length === 0) {
+    return false;
   }
-  const shouldEmitLiveUpdate =
-    runtimeEventsIncludeAppliedFinishTaskPreview(splitBuiltin.toApply)
-    || runtimeEventsIncludeAppliedResponsesBuiltInToolStreamingUpdate(splitBuiltin.toApply)
-    || runtimeEventsIncludeAppliedHostToolStreamingUpdate(splitBuiltin.toApply)
-    || splitBuiltin.toApply.some((event) => event.kind === 'assistant-chunk');
-  if (shouldEmitLiveUpdate) {
-    bundle.conversationRevision += 1;
-    ctx.emitLiveSnapshotUpdate();
-  }
+  bundle.conversationRevision += 1;
+  return true;
 }
 
 function defaultDisplayTextForUserTurn(

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -341,6 +341,15 @@ export async function pollCommand(ctx: SessionTurnOrchestratorContext): Promise<
   }, 'poll');
 }
 
+/** busy 期间 tick 落盘的最小间隔；回合终态与进入阻塞时不受此限制。 */
+export const TICK_SESSION_PERSIST_INTERVAL_MS = 1_000;
+
+function isRuntimeBlocked(bundle: SessionBundle): boolean {
+  return Boolean(
+    bundle.runtime?.currentPendingApproval() || bundle.runtime?.currentPendingQuestions(),
+  );
+}
+
 export async function tickSessionCommand(
   ctx: SessionTurnOrchestratorContext,
   bundle: SessionBundle,
@@ -351,6 +360,8 @@ export async function tickSessionCommand(
   }
 
   const orchestration = ctx.orchestrationFor(bundle);
+  const wasBusy = bundle.runtime?.isBusy() === true;
+  const wasBlocked = isRuntimeBlocked(bundle);
   let changed = false;
   if (bundle.runtime) {
     bundle.runtime.tickThinkingSpinner();
@@ -379,10 +390,19 @@ export async function tickSessionCommand(
   orchestration.runtimeEvents.syncPendingToolStates();
   ctx.syncSubagentToolStreamingOutput(bundle);
   orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
-  await ctx.persistSessionBundle(bundle, {
-    fromRuntime: bundle.runtime,
-    bumpListSortAt: false,
-  });
+  // busy 期间按时间片落盘；回合终态（busy→idle）与进入审批/提问阻塞时强制落盘，持久化语义不变。
+  const busyAfterTick = bundle.runtime?.isBusy() === true;
+  const blockedAfterTick = isRuntimeBlocked(bundle);
+  const forcePersist = (wasBusy && !busyAfterTick) || (blockedAfterTick && !wasBlocked);
+  const persistDue =
+    Date.now() - (bundle.lastTickPersistAtMs ?? 0) >= TICK_SESSION_PERSIST_INTERVAL_MS;
+  if (forcePersist || persistDue) {
+    await ctx.persistSessionBundle(bundle, {
+      fromRuntime: bundle.runtime,
+      bumpListSortAt: false,
+    });
+    bundle.lastTickPersistAtMs = Date.now();
+  }
   await ctx.flushDeferredRuntimeRefreshIfIdle(bundle);
   await ctx.refreshTodoSnapshotForBundle(bundle);
   await drainQueuedUserTurnIfIdle(ctx, bundle);

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -314,20 +314,30 @@ export async function drainQueuedUserTurnIfIdle(
   }
 }
 
+/** 单次泵 tick 主体（调用方须已持有 runSerialized 锁）：推进所有 busy 会话并同步宿主状态。 */
+async function runSessionsPumpTick(ctx: SessionTurnOrchestratorContext): Promise<void> {
+  await ctx.ensureInitialized(undefined, { fastPath: true });
+  for (const bundle of ctx.allBundles()) {
+    if (bundle.runtime?.isBusy() || shouldAdvanceWorktreeBootstrap(bundle)) {
+      await tickSessionCommand(ctx, bundle);
+    }
+  }
+  const active = ctx.getActiveBundle();
+  if (active && !active.runtime?.isBusy()) {
+    await tickSessionCommand(ctx, active, { light: true });
+  }
+  ctx.syncActiveRuntimePointer();
+  ctx.startDreamCollectorIfNeeded();
+}
+
+/** SessionPump 每 tick 调用：与 pollCommand 同体，但不构建快照。 */
+export async function pumpSessionsCommand(ctx: SessionTurnOrchestratorContext): Promise<void> {
+  return ctx.runSerialized(() => runSessionsPumpTick(ctx), 'pump-tick');
+}
+
 export async function pollCommand(ctx: SessionTurnOrchestratorContext): Promise<DesktopSnapshot> {
   return ctx.runSerialized(async () => {
-    await ctx.ensureInitialized(undefined, { fastPath: true });
-    for (const bundle of ctx.allBundles()) {
-      if (bundle.runtime?.isBusy() || shouldAdvanceWorktreeBootstrap(bundle)) {
-        await tickSessionCommand(ctx, bundle);
-      }
-    }
-    const active = ctx.getActiveBundle();
-    if (active && !active.runtime?.isBusy()) {
-      await tickSessionCommand(ctx, active, { light: true });
-    }
-    ctx.syncActiveRuntimePointer();
-    ctx.startDreamCollectorIfNeeded();
+    await runSessionsPumpTick(ctx);
     return ctx.buildSnapshot();
   }, 'poll');
 }

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -90,6 +90,7 @@ export interface SessionTurnOrchestratorContext {
   emitLiveSnapshotUpdate(): void;
   /** 节流版 live snapshot 推送（流式变更唯一出口；宿主侧 33ms leading+trailing）。 */
   requestLiveSnapshotEmit(): void;
+  notifySessionListUpdated(): void;
   refreshRuntimeForBundle(bundle: SessionBundle): Promise<void>;
   syncActiveRuntimePointer(): void;
   clearAssistantContinuationMarkers(): void;

--- a/apps/desktop/src/host/subagent-conversation-projection.ts
+++ b/apps/desktop/src/host/subagent-conversation-projection.ts
@@ -183,19 +183,20 @@ export function ensureSubagentConversationProjection(
   return projection;
 }
 
+/** @returns 是否应用了子会话事件（供 tick 决定是否请求节流推送）。 */
 export function syncSubagentConversationProjections(
   bundle: SessionBundle,
   runtime: DesktopRuntime | undefined,
-): void {
+): boolean {
   if (!runtime) {
-    return;
+    return false;
   }
 
   syncSubagentWorktreeBootstrapCards(bundle, runtime);
 
   const childDrains = runtime.drainActiveChildSessionEvents();
   if (childDrains.length === 0) {
-    return;
+    return false;
   }
 
   for (const childDrain of childDrains) {
@@ -212,6 +213,7 @@ export function syncSubagentConversationProjections(
       syncedMessages,
     );
   }
+  return true;
 }
 
 function syncWorktreeBootstrapCardOnProjection(

--- a/apps/desktop/src/lib/clickable-pointer-cursor.ts
+++ b/apps/desktop/src/lib/clickable-pointer-cursor.ts
@@ -5,17 +5,20 @@ export const CLICKABLE_POINTER_CURSOR_CLASS = "spirit-clickable-pointer" as cons
 
 export function getStoredClickablePointerCursor(): boolean {
   if (typeof localStorage === "undefined") {
-    return false;
+    return true;
   }
-  return localStorage.getItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY) === "true";
+  return localStorage.getItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY) !== "false";
 }
 
 export function setStoredClickablePointerCursor(enabled: boolean): void {
-  if (enabled) {
-    localStorage.setItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY, "true");
+  if (typeof localStorage === "undefined") {
     return;
   }
-  localStorage.removeItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY);
+  if (enabled) {
+    localStorage.removeItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(CLICKABLE_POINTER_CURSOR_STORAGE_KEY, "false");
 }
 
 export function applyClickablePointerCursorToDocument(enabled: boolean): void {

--- a/apps/desktop/test/host/session-pump.test.mjs
+++ b/apps/desktop/test/host/session-pump.test.mjs
@@ -8,19 +8,23 @@ import {
 } from '../../dist-electron/src/host/session-pump.js';
 import { pumpSessionsCommand } from '../../dist-electron/src/host/session-turn-orchestrator.js';
 
-function createFakeRuntime({ pollsUntilIdle }) {
+function createFakeRuntime({ pollsUntilIdle, chunkPerPoll = false }) {
   const runtime = {
     pollCount: 0,
     busy: true,
+    pendingEvents: [],
     isBusy: () => runtime.busy,
     poll: async () => {
       runtime.pollCount += 1;
+      if (chunkPerPoll) {
+        runtime.pendingEvents.push({ kind: 'assistant-chunk', text: `chunk-${runtime.pollCount}` });
+      }
       if (runtime.pollCount >= pollsUntilIdle) {
         runtime.busy = false;
       }
     },
     tickThinkingSpinner: () => {},
-    drainEvents: () => [],
+    drainEvents: () => runtime.pendingEvents.splice(0, runtime.pendingEvents.length),
     drainActiveChildSessionEvents: () => [],
     childSessionArchives: () => [],
     currentPendingApproval: () => undefined,
@@ -38,6 +42,7 @@ function createFakeBundle(runtime) {
     messageTimeline: { toMessages: () => [] },
     deferredRuntimeHostEvents: [],
     responsesBuiltInPreviewSeenCallIds: new Set(),
+    conversationRevision: 0,
     queuedUserTurns: [],
     subagentDesktopMessagesBySessionId: new Map(),
     subagentConversationProjections: new Map(),
@@ -69,6 +74,9 @@ function createFakeOrchestratorContext(bundle, calls) {
     syncActiveRuntimePointer: () => {},
     startDreamCollectorIfNeeded: () => {},
     emitLiveSnapshotUpdate: () => {},
+    requestLiveSnapshotEmit: () => {
+      calls.push('request-emit');
+    },
     persistCurrentSessionIfNeeded: async () => {},
   };
 }
@@ -94,7 +102,7 @@ test('sessionBundleNeedsPumpTick tracks runtime busy state', () => {
 });
 
 test('pump drives a busy streaming round to completion without external poll', async () => {
-  const runtime = createFakeRuntime({ pollsUntilIdle: 3 });
+  const runtime = createFakeRuntime({ pollsUntilIdle: 3, chunkPerPoll: true });
   const bundle = createFakeBundle(runtime);
   const calls = [];
   const ctx = createFakeOrchestratorContext(bundle, calls);
@@ -114,6 +122,9 @@ test('pump drives a busy streaming round to completion without external poll', a
   assert.equal(runtime.busy, false);
   assert.equal(runtime.pollCount, 3);
   assert.ok(calls.filter((entry) => entry === 'persist').length >= 3);
+  // 每次 tick 应用了 assistant-chunk 事件 → 应请求节流推送，且 revision 递增。
+  assert.ok(calls.filter((entry) => entry === 'request-emit').length >= 3);
+  assert.equal(bundle.conversationRevision, 3);
 
   // 全部空闲后 ensureRunning 不应重启泵。
   pump.ensureRunning();

--- a/apps/desktop/test/host/session-pump.test.mjs
+++ b/apps/desktop/test/host/session-pump.test.mjs
@@ -183,6 +183,32 @@ test('entering pending approval forces persist', async () => {
   assert.equal(calls.filter((entry) => entry === 'persist').length, 1);
 });
 
+test('long streaming round: pump completes with bounded persist and steady emits', async () => {
+  const totalPolls = 500;
+  const runtime = createFakeRuntime({ pollsUntilIdle: totalPolls, chunkPerPoll: true });
+  const bundle = createFakeBundle(runtime);
+  bundle.lastTickPersistAtMs = Date.now();
+  const calls = [];
+  const ctx = createFakeOrchestratorContext(bundle, calls);
+
+  const pump = new SessionPump({
+    hasPumpWork: () => sessionBundleNeedsPumpTick(bundle),
+    runTick: () => pumpSessionsCommand(ctx),
+    intervalMs: 0,
+  });
+
+  pump.ensureRunning();
+  await waitUntil(() => !pump.isRunning(), { timeoutMs: 30_000 });
+
+  assert.equal(runtime.pollCount, totalPolls);
+  assert.equal(bundle.conversationRevision, totalPolls);
+  // 每 tick 均有事件 → 每 tick 请求一次节流推送（实际 IPC 推送频率由宿主节流器另行约束）。
+  assert.equal(calls.filter((entry) => entry === 'request-emit').length, totalPolls);
+  // 落盘按 1s 时间片 + 终态强制：远小于 tick 数。
+  const persistCount = calls.filter((entry) => entry === 'persist').length;
+  assert.ok(persistCount < 10, `persist ${persistCount} should be time-sliced`);
+});
+
 test('pump stop cancels pending tick', async () => {
   const runtime = createFakeRuntime({ pollsUntilIdle: 1_000 });
   const bundle = createFakeBundle(runtime);

--- a/apps/desktop/test/host/session-pump.test.mjs
+++ b/apps/desktop/test/host/session-pump.test.mjs
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
+
+import {
+  SessionPump,
+  sessionBundleNeedsPumpTick,
+} from '../../dist-electron/src/host/session-pump.js';
+import { pumpSessionsCommand } from '../../dist-electron/src/host/session-turn-orchestrator.js';
+
+function createFakeRuntime({ pollsUntilIdle }) {
+  const runtime = {
+    pollCount: 0,
+    busy: true,
+    isBusy: () => runtime.busy,
+    poll: async () => {
+      runtime.pollCount += 1;
+      if (runtime.pollCount >= pollsUntilIdle) {
+        runtime.busy = false;
+      }
+    },
+    tickThinkingSpinner: () => {},
+    drainEvents: () => [],
+    drainActiveChildSessionEvents: () => [],
+    childSessionArchives: () => [],
+    currentPendingApproval: () => undefined,
+    currentPendingQuestions: () => undefined,
+  };
+  return runtime;
+}
+
+function createFakeBundle(runtime) {
+  return {
+    id: 'session-pump-test',
+    workspaceRoot: '/tmp/workspace',
+    runtime,
+    messages: [],
+    messageTimeline: { toMessages: () => [] },
+    deferredRuntimeHostEvents: [],
+    responsesBuiltInPreviewSeenCallIds: new Set(),
+    queuedUserTurns: [],
+    subagentDesktopMessagesBySessionId: new Map(),
+    subagentConversationProjections: new Map(),
+  };
+}
+
+function createFakeOrchestratorContext(bundle, calls) {
+  const runtimeEvents = {
+    applyRuntimeHostEvents: () => {},
+    consumeCompletedTurnResult: () => {},
+    syncPendingToolStates: () => {},
+    syncAssistantPrefixFromHistoryBeforeToolRow: () => {},
+  };
+  return {
+    runSerialized: async (work) => work(),
+    ensureInitialized: async () => {
+      calls.push('ensureInitialized');
+    },
+    allBundles: () => [bundle],
+    getActiveBundle: () => bundle,
+    activeSessionId: () => 'other-session',
+    orchestrationFor: () => ({ runtimeEvents }),
+    syncSubagentToolStreamingOutput: () => {},
+    persistSessionBundle: async () => {
+      calls.push('persist');
+    },
+    flushDeferredRuntimeRefreshIfIdle: async () => {},
+    refreshTodoSnapshotForBundle: async () => {},
+    syncActiveRuntimePointer: () => {},
+    startDreamCollectorIfNeeded: () => {},
+    emitLiveSnapshotUpdate: () => {},
+    persistCurrentSessionIfNeeded: async () => {},
+  };
+}
+
+async function waitUntil(predicate, { timeoutMs = 2_000, stepMs = 10 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await delay(stepMs);
+  }
+  throw new Error('waitUntil timed out');
+}
+
+test('sessionBundleNeedsPumpTick tracks runtime busy state', () => {
+  const runtime = createFakeRuntime({ pollsUntilIdle: 1 });
+  const bundle = createFakeBundle(runtime);
+  assert.equal(sessionBundleNeedsPumpTick(bundle), true);
+  runtime.busy = false;
+  assert.equal(sessionBundleNeedsPumpTick(bundle), false);
+  assert.equal(sessionBundleNeedsPumpTick(createFakeBundle(undefined)), false);
+});
+
+test('pump drives a busy streaming round to completion without external poll', async () => {
+  const runtime = createFakeRuntime({ pollsUntilIdle: 3 });
+  const bundle = createFakeBundle(runtime);
+  const calls = [];
+  const ctx = createFakeOrchestratorContext(bundle, calls);
+
+  const pump = new SessionPump({
+    hasPumpWork: () => sessionBundleNeedsPumpTick(bundle),
+    runTick: () => pumpSessionsCommand(ctx),
+    intervalMs: 5,
+  });
+
+  pump.ensureRunning();
+  assert.equal(pump.isRunning(), true);
+  // 泵运行中重复 ensureRunning 应为幂等，不得叠加第二个循环。
+  pump.ensureRunning();
+
+  await waitUntil(() => !pump.isRunning());
+  assert.equal(runtime.busy, false);
+  assert.equal(runtime.pollCount, 3);
+  assert.ok(calls.filter((entry) => entry === 'persist').length >= 3);
+
+  // 全部空闲后 ensureRunning 不应重启泵。
+  pump.ensureRunning();
+  assert.equal(pump.isRunning(), false);
+  assert.equal(runtime.pollCount, 3);
+});
+
+test('pump stop cancels pending tick', async () => {
+  const runtime = createFakeRuntime({ pollsUntilIdle: 1_000 });
+  const bundle = createFakeBundle(runtime);
+  const ctx = createFakeOrchestratorContext(bundle, []);
+
+  const pump = new SessionPump({
+    hasPumpWork: () => sessionBundleNeedsPumpTick(bundle),
+    runTick: () => pumpSessionsCommand(ctx),
+    intervalMs: 5,
+  });
+
+  pump.ensureRunning();
+  await waitUntil(() => runtime.pollCount >= 1);
+  pump.stop();
+  const countAtStop = runtime.pollCount;
+  await delay(50);
+  // stop 后不允许出现新的 tick（容忍 stop 时刻已在途的一次）。
+  assert.ok(runtime.pollCount <= countAtStop + 1);
+  assert.equal(pump.isRunning(), false);
+});

--- a/apps/desktop/test/host/session-pump.test.mjs
+++ b/apps/desktop/test/host/session-pump.test.mjs
@@ -121,7 +121,8 @@ test('pump drives a busy streaming round to completion without external poll', a
   await waitUntil(() => !pump.isRunning());
   assert.equal(runtime.busy, false);
   assert.equal(runtime.pollCount, 3);
-  assert.ok(calls.filter((entry) => entry === 'persist').length >= 3);
+  // 落盘节流：首 tick（超时间片）+ 回合终态强制，共 2 次；中途 tick 不落盘。
+  assert.equal(calls.filter((entry) => entry === 'persist').length, 2);
   // 每次 tick 应用了 assistant-chunk 事件 → 应请求节流推送，且 revision 递增。
   assert.ok(calls.filter((entry) => entry === 'request-emit').length >= 3);
   assert.equal(bundle.conversationRevision, 3);
@@ -130,6 +131,56 @@ test('pump drives a busy streaming round to completion without external poll', a
   pump.ensureRunning();
   assert.equal(pump.isRunning(), false);
   assert.equal(runtime.pollCount, 3);
+});
+
+test('tick persist is throttled while busy and forced at turn end', async () => {
+  const runtime = createFakeRuntime({ pollsUntilIdle: 4 });
+  const bundle = createFakeBundle(runtime);
+  // 模拟回合开始前刚落过盘：1s 时间片内 busy tick 均不应再写盘。
+  bundle.lastTickPersistAtMs = Date.now();
+  const calls = [];
+  const ctx = createFakeOrchestratorContext(bundle, calls);
+
+  const pump = new SessionPump({
+    hasPumpWork: () => sessionBundleNeedsPumpTick(bundle),
+    runTick: () => pumpSessionsCommand(ctx),
+    intervalMs: 5,
+  });
+
+  pump.ensureRunning();
+  await waitUntil(() => !pump.isRunning());
+  assert.equal(runtime.pollCount, 4);
+  // 仅回合终态（busy→idle）那一 tick 强制落盘。
+  assert.equal(calls.filter((entry) => entry === 'persist').length, 1);
+});
+
+test('entering pending approval forces persist', async () => {
+  const runtime = createFakeRuntime({ pollsUntilIdle: 1_000 });
+  let approval;
+  runtime.currentPendingApproval = () => approval;
+  const basePoll = runtime.poll;
+  runtime.poll = async () => {
+    await basePoll();
+    if (runtime.pollCount === 2) {
+      approval = { toolName: 'shell' };
+    }
+  };
+  const bundle = createFakeBundle(runtime);
+  bundle.lastTickPersistAtMs = Date.now();
+  const calls = [];
+  const ctx = createFakeOrchestratorContext(bundle, calls);
+
+  const pump = new SessionPump({
+    hasPumpWork: () => sessionBundleNeedsPumpTick(bundle),
+    runTick: () => pumpSessionsCommand(ctx),
+    intervalMs: 5,
+  });
+
+  pump.ensureRunning();
+  await waitUntil(() => runtime.pollCount >= 4);
+  pump.stop();
+  // 进入 pending approval 的那一 tick 强制落盘；其后阻塞 tick 在时间片内不再写。
+  assert.equal(calls.filter((entry) => entry === 'persist').length, 1);
 });
 
 test('pump stop cancels pending tick', async () => {


### PR DESCRIPTION
## Summary

- 主进程新增 SessionPump（25ms tick），busy 会话回合推进不再依赖 renderer 无节流 poll 循环
- 流式 UI 更新统一为单一 33ms leading+trailing 节流推送，删除 assistant-chunk 即时 emit 与 shell 150ms timer 等旧多通道路径
- Electron renderer 摘除 busy while 循环，仅靠 subscribeDreamUpdates 推送；Web 客户端保留 poll 但固定 150ms 间隔
- busy 期间 persistSessionBundle 按约 1s 时间片节流，回合终态与进入审批/提问阻塞时强制落盘

## Test plan

- [x] npm run build:electron
- [x] npm run test:host（新增 session-pump 测试 6 项全过；与 main 基线失败集一致，无新增回归）
- [x] renderer lib 测试批次（561 项 pass）
- [x] vite build 冒烟
- [x] npm run dev 启动冒烟（SPIRIT_DESKTOP_PUMP_DEBUG=1 可见观测 log）
- [ ] 手动：超长流式输出（数万字）UI 不卡不崩、CPU/内存稳定