### PR TITLE
fix(desktop): 修复宿主会话删除崩溃、消息串会话与持久化风险

### DIFF
--- a/apps/desktop/src/host/conversation-continuation.ts
+++ b/apps/desktop/src/host/conversation-continuation.ts
@@ -294,10 +294,26 @@ export function refreshArchiveFromRuntime(
     return;
   }
 
-  const desktopMessages = bundle.messageTimeline.toMessages();
+  // busy 期间高频调用：timeline 未变时复用消息/aux 投影，只向 runtime 取最新 llmHistory/subagentSessions
+  const revision = bundle.messageTimeline.revision();
+  let projection = bundle.archiveProjectionCache;
+  if (
+    !projection
+    || projection.timeline !== bundle.messageTimeline
+    || projection.revision !== revision
+  ) {
+    const desktopMessages = bundle.messageTimeline.toMessages();
+    projection = {
+      timeline: bundle.messageTimeline,
+      revision,
+      archiveMessages: buildArchiveMessagesFromConversation(desktopMessages),
+      archiveAssistantAux: buildArchiveAssistantAuxFromConversation(desktopMessages),
+    };
+    bundle.archiveProjectionCache = projection;
+  }
   const archive = bundle.runtime.toArchive(
-    buildArchiveMessagesFromConversation(desktopMessages),
-    buildArchiveAssistantAuxFromConversation(desktopMessages),
+    projection.archiveMessages,
+    projection.archiveAssistantAux,
   ) satisfies ChatArchive;
   bundle.archiveHistory = archive.llmHistory;
   bundle.archiveSubagentSessions = archive.subagentSessions ?? [];

--- a/apps/desktop/src/host/host-extension-commands.ts
+++ b/apps/desktop/src/host/host-extension-commands.ts
@@ -116,6 +116,8 @@ export interface HostExtensionCommandContext {
   ): Promise<DesktopSnapshot>;
   appendInlineAssistantReply(displayText: string, assistantText: string): Promise<DesktopSnapshot>;
   setLastRuntimeError(error: string): void;
+  /** MCP / hooks 配置写盘后失效快照侧列表缓存。 */
+  invalidateConfigListCaches(): void;
   buildSnapshot(): DesktopSnapshot;
 }
 
@@ -220,6 +222,7 @@ export async function addMcpServerCommand(
       workspaceRoot: state.workspaceRoot,
       workspaceBinding: state.workspaceBinding,
     });
+    ctx.invalidateConfigListCaches();
     if (scope === 'user') {
       invalidateSharedUserMcpToolingCache();
     }
@@ -242,6 +245,7 @@ export async function deleteMcpServerCommand(
       request,
       workspaceRoot: state.workspaceRoot,
     });
+    ctx.invalidateConfigListCaches();
     if (scope === 'user') {
       invalidateSharedUserMcpToolingCache();
     }
@@ -527,6 +531,7 @@ export async function saveHookEntryCommand(
       workspaceRoot: state.workspaceRoot,
       workspaceBinding: state.workspaceBinding,
     });
+    ctx.invalidateConfigListCaches();
     return ctx.buildSnapshot();
   });
 }
@@ -543,6 +548,7 @@ export async function deleteHookEntryCommand(
       workspaceRoot: state.workspaceRoot,
       workspaceBinding: state.workspaceBinding,
     });
+    ctx.invalidateConfigListCaches();
     return ctx.buildSnapshot();
   });
 }

--- a/apps/desktop/src/host/message-timeline.ts
+++ b/apps/desktop/src/host/message-timeline.ts
@@ -109,6 +109,11 @@ export class DesktopMessageTimeline {
   private activeSegmentId: number | undefined;
   private lastSegmentRowsLogSignature: string | undefined;
   private pendingSegmentRowsLogMsByKey = new Map<string, number>();
+  /** 结构修订号：所有公开 mutator 起始处递增；toMessages 投影按修订号缓存。 */
+  private revisionCounter = 1;
+  private toMessagesCache:
+    | { revision: number; messages: ConversationMessageSnapshot[] }
+    | undefined;
 
   constructor(private readonly options: DesktopMessageTimelineOptions) {}
 
@@ -149,7 +154,21 @@ export class DesktopMessageTimeline {
     }));
   }
 
+  /** Current structural revision; bumped by every public mutator. */
+  revision(): number {
+    return this.revisionCounter;
+  }
+
+  /** 新增 mutator 时须在起始处调用，否则 toMessages 缓存会返回陈旧投影。 */
+  private markMutated(): void {
+    this.revisionCounter += 1;
+  }
+
   toMessages(): ConversationMessageSnapshot[] {
+    if (this.toMessagesCache?.revision === this.revisionCounter) {
+      // 返回浅拷贝：调用方对数组做 push/pop 不得污染缓存；消息对象仍共享
+      return [...this.toMessagesCache.messages];
+    }
     const messages: ConversationMessageSnapshot[] = [];
     for (const turn of this.orderedTurns()) {
       if (turn.userRow) {
@@ -161,7 +180,8 @@ export class DesktopMessageTimeline {
         }
       }
     }
-    return messages;
+    this.toMessagesCache = { revision: this.revisionCounter, messages };
+    return [...messages];
   }
 
   beginUserTurn(
@@ -172,6 +192,7 @@ export class DesktopMessageTimeline {
       localFileAttachments?: ConversationLocalFileAttachmentSnapshot[];
     } = {},
   ): ConversationMessageSnapshot {
+    this.markMutated();
     this.clearContinuationMarkers();
     const turn: DesktopTimelineTurn = {
       turnId: this.nextTurnId++,
@@ -196,6 +217,7 @@ export class DesktopMessageTimeline {
   }
 
   beginAssistantSegment(kind: DesktopTimelineSegmentKind = 'initial'): ConversationMessageSnapshot {
+    this.markMutated();
     const prior = this.activeSegment();
     if (prior?.status === 'streaming') {
       this.completeActiveAssistantSegment();
@@ -209,6 +231,7 @@ export class DesktopMessageTimeline {
   }
 
   setAssistantTextContent(messageId: number, content: string): boolean {
+    this.markMutated();
     for (const row of this.allRows()) {
       if (row.messageId !== messageId || row.kind !== 'assistant-text') {
         continue;
@@ -221,6 +244,7 @@ export class DesktopMessageTimeline {
   }
 
   clearSubagentStatusLeak(messageId: number): boolean {
+    this.markMutated();
     let cleared = false;
     for (const row of this.allRows()) {
       if (row.messageId !== messageId || row.kind !== 'assistant-text') {
@@ -246,6 +270,7 @@ export class DesktopMessageTimeline {
   }
 
   appendAssistantTextChunk(chunk: string): ConversationMessageSnapshot {
+    this.markMutated();
     const segment = this.ensureActiveSegment();
     const hasTools = segmentHasToolRows(segment);
     if (hasTools) {
@@ -270,6 +295,7 @@ export class DesktopMessageTimeline {
   }
 
   replaceAssistantText(text: string): ConversationMessageSnapshot {
+    this.markMutated();
     const segment = this.ensureActiveSegment();
     const row = segmentHasToolRows(segment)
       ? this.ensureStreamingAssistantTextRowAfterTools(segment)
@@ -280,6 +306,7 @@ export class DesktopMessageTimeline {
   }
 
   updatePendingAssistantAux(kind: 'thinking' | 'compressing', text: string): ConversationMessageSnapshot {
+    this.markMutated();
     const segment = this.ensureActiveSegment();
     const row = this.ensureActiveAssistantTextRow('aux');
     const normalized = text.trim();
@@ -311,6 +338,7 @@ export class DesktopMessageTimeline {
   }
 
   applyFinishTaskNoticeByMessageId(messageId: number, notice: string): boolean {
+    this.markMutated();
     const normalizedNotice = notice.trim();
     if (!normalizedNotice) {
       return false;
@@ -332,6 +360,7 @@ export class DesktopMessageTimeline {
   }
 
   updateFinishTaskNoticePreview(notice: string): ConversationMessageSnapshot | undefined {
+    this.markMutated();
     const normalizedNotice = notice.trim();
     if (!normalizedNotice) {
       return undefined;
@@ -357,6 +386,7 @@ export class DesktopMessageTimeline {
   }
 
   clearFinishTaskNoticePreview(): ConversationMessageSnapshot | undefined {
+    this.markMutated();
     const segment = this.activeSegment() ?? this.lastSegmentOfActiveTurn();
     if (!segment) {
       return undefined;
@@ -410,6 +440,7 @@ export class DesktopMessageTimeline {
     if (!text.trim()) {
       return undefined;
     }
+    this.markMutated();
     const segment = this.ensureActiveSegment();
     if (this.hasFinalizedAuxInActiveSegment('thinking', text)) {
       this.stripSegmentAuxKind(segment, 'thinking', text);
@@ -495,6 +526,7 @@ export class DesktopMessageTimeline {
     if (!text.trim()) {
       return undefined;
     }
+    this.markMutated();
     const segment = this.ensureActiveSegment();
     this.stripSegmentAuxKind(segment, 'compaction', text);
     const row = this.createRow({
@@ -511,6 +543,7 @@ export class DesktopMessageTimeline {
   }
 
   upsertToolMessage(toolCallId: string, tool: ToolBlockSnapshot): ConversationMessageSnapshot {
+    this.markMutated();
     const normalizedTool = cloneTool(tool);
     const existing = this.findToolRow(toolCallId);
     if (existing) {
@@ -558,6 +591,7 @@ export class DesktopMessageTimeline {
   }
 
   removeToolMessage(toolCallId: string): boolean {
+    this.markMutated();
     for (const segment of this.orderedTurns().flatMap((turn) => this.orderedSegments(turn))) {
       const index = segment.rows.findIndex(
         (row) => row.kind === 'tool' && row.tool?.toolCallId === toolCallId,
@@ -580,6 +614,7 @@ export class DesktopMessageTimeline {
     if (!trimmed) {
       return undefined;
     }
+    this.markMutated();
 
     let targetSegment: DesktopTimelineSegment | undefined;
     let insertAfterToolIndex = -1;
@@ -650,6 +685,7 @@ export class DesktopMessageTimeline {
     if (!content.trim()) {
       return undefined;
     }
+    this.markMutated();
     const segment = this.ensureActiveSegment();
     const existing = segment.rows.find(
       (row) =>
@@ -687,6 +723,7 @@ export class DesktopMessageTimeline {
     if (!content.trim() && !normalizeMessageAuxSnapshot(aux)) {
       return undefined;
     }
+    this.markMutated();
     const segment = this.ensureActiveSegment();
     let row = this.activeAssistantTextRow(segment);
     const normalizedContent = content.trim();
@@ -736,6 +773,7 @@ export class DesktopMessageTimeline {
       return undefined;
     }
 
+    this.markMutated();
     const segment = this.activeSegment() ?? this.lastSegmentOfActiveTurn();
     if (!segment) {
       return undefined;
@@ -772,6 +810,7 @@ export class DesktopMessageTimeline {
   }
 
   completeActiveAssistantSegment(): void {
+    this.markMutated();
     const segment = this.activeSegment();
     if (!segment) {
       return;
@@ -791,6 +830,7 @@ export class DesktopMessageTimeline {
   }
 
   abortActiveAssistantSegment(): void {
+    this.markMutated();
     const segment = this.activeSegment();
     if (!segment) {
       return;
@@ -804,6 +844,7 @@ export class DesktopMessageTimeline {
   }
 
   removePendingAssistantText(): void {
+    this.markMutated();
     const segment = this.activeSegment();
     if (!segment) {
       return;
@@ -825,6 +866,7 @@ export class DesktopMessageTimeline {
    * 预置 after-tools pending 行供 Thinking 占位 UI 挂载。
    */
   ensureAfterToolsThinkingPlaceholderRow(): ConversationMessageSnapshot | undefined {
+    this.markMutated();
     const segment = this.activeSegment();
     if (!segment || !segmentHasToolRows(segment) || !segmentAllToolsTerminal(segment)) {
       return undefined;
@@ -844,6 +886,7 @@ export class DesktopMessageTimeline {
   }
 
   clearContinuationMarkers(): void {
+    this.markMutated();
     for (const row of this.allRows()) {
       delete row.canContinue;
     }
@@ -876,6 +919,7 @@ export class DesktopMessageTimeline {
     input: { content?: string } = {},
   ): ConversationMessageSnapshot | undefined {
     this.clearContinuationMarkers();
+    // clearContinuationMarkers 已 markMutated；本方法仅追加 row.canContinue 标记
     const normalized = input.content?.trim() ?? '';
     const candidates = rows.filter((row) => {
       if (!isRenderableAssistantRow(row)) {

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -47,6 +47,7 @@ import {
   readModelCatalogCache,
   writeModelCatalogCache,
 } from './model-catalog-cache.js';
+import { invalidateModelCatalogHintsMemo } from './snapshot.js';
 import {
   previewCatalogMapForTransport,
   previewModelCatalogForTransport,
@@ -713,6 +714,8 @@ export async function loadPreviewModelsForTransport(input: {
     input.provider,
     input.transportKind,
   );
+  // 目录缓存文件已更新，失效快照侧的内存 memo，下次 buildSnapshot 重读新目录
+  invalidateModelCatalogHintsMemo();
   return {
     modelIds,
     ...(modelCatalog ? { modelCatalog } : {}),

--- a/apps/desktop/src/host/rewind-host.ts
+++ b/apps/desktop/src/host/rewind-host.ts
@@ -10,6 +10,7 @@ import type { SessionBundle } from './session-bundle.js';
 import {
   bindRewindFileChangesToToolMessage,
   createRewindCheckpointMetadata,
+  deleteRewindSidecarFiles,
   fileChangeMetadata,
   nextDesktopRewindSequence,
   pruneRewindMetadataAfterCheckpoint,
@@ -247,7 +248,13 @@ export function restoreBeforeRewindCheckpoint(
   ctx.activeBundle().archiveHistory = cloneArchiveHistory(archive.llmHistory);
   ctx.activeBundle().archiveSubagentSessions = cloneArchiveSubagentSessions(archive.subagentSessions ?? []);
   ctx.activeBundle().loopEnabled = archive.loopEnabled === true;
-  pruneRewindMetadataAfterCheckpoint(ctx.activeBundle().rewind, checkpointSequence);
+  const pruned = pruneRewindMetadataAfterCheckpoint(ctx.activeBundle().rewind, checkpointSequence);
+  // 元数据裁剪后同步清理对应 sidecar 文件；失败不影响回退流程（下次会话删除仍会整目录清理）
+  void deleteRewindSidecarFiles(
+    spiritAgentDataDir(),
+    ctx.activeBundle().rewind.sessionId,
+    pruned,
+  );
   ctx.activeBundle().pendingUnboundFileChangeIds = [];
   ctx.activeBundle().messageIdCounter = nextMessageIdFromMessages(ctx.activeBundle().messages);
   ctx.activeBundle().conversationRevision += 1;

--- a/apps/desktop/src/host/rewind.ts
+++ b/apps/desktop/src/host/rewind.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { ChatArchive } from '@spiritagent/agent-core';
@@ -131,16 +131,56 @@ export function upsertRewindCheckpointMetadata(
   metadata.checkpoints.sort((left, right) => left.sequence - right.sequence);
 }
 
+export interface PrunedRewindEntries {
+  checkpointIds: string[];
+  fileChangeIds: string[];
+}
+
 export function pruneRewindMetadataAfterCheckpoint(
   metadata: StoredDesktopRewindMetadata,
   checkpointSequence: number,
-): void {
+): PrunedRewindEntries {
+  const prunedCheckpointIds = metadata.checkpoints
+    .filter((checkpoint) => checkpoint.sequence >= checkpointSequence)
+    .map((checkpoint) => checkpoint.id);
+  const prunedFileChangeIds = metadata.fileChanges
+    .filter((change) => change.sequence > checkpointSequence)
+    .map((change) => change.id);
   metadata.checkpoints = metadata.checkpoints.filter(
     (checkpoint) => checkpoint.sequence < checkpointSequence,
   );
   metadata.fileChanges = metadata.fileChanges.filter(
     (change) => change.sequence <= checkpointSequence,
   );
+  return { checkpointIds: prunedCheckpointIds, fileChangeIds: prunedFileChangeIds };
+}
+
+/** Delete sidecar JSON files for pruned checkpoints / file changes (best-effort). */
+export async function deleteRewindSidecarFiles(
+  spiritDataDir: string,
+  sessionId: string,
+  pruned: PrunedRewindEntries,
+): Promise<void> {
+  await Promise.all([
+    ...pruned.checkpointIds.map((id) =>
+      rm(checkpointPath(spiritDataDir, sessionId, id), { force: true }).catch(() => {}),
+    ),
+    ...pruned.fileChangeIds.map((id) =>
+      rm(fileChangePath(spiritDataDir, sessionId, id), { force: true }).catch(() => {}),
+    ),
+  ]);
+}
+
+/** Delete the whole `<dataDir>/rewind/<sessionId>/` sidecar directory (session deletion). */
+export async function deleteSessionRewindData(
+  spiritDataDir: string,
+  sessionId: string,
+): Promise<void> {
+  const trimmed = sessionId.trim();
+  if (!trimmed) {
+    return;
+  }
+  await rm(sessionRewindDir(spiritDataDir, trimmed), { recursive: true, force: true });
 }
 
 export function canRewindMessage(

--- a/apps/desktop/src/host/runtime-event-orchestrator.ts
+++ b/apps/desktop/src/host/runtime-event-orchestrator.ts
@@ -633,7 +633,8 @@ export class DesktopRuntimeEventOrchestrator {
           },
           summaryCopy,
         ),
-        { argumentsJson: event.argumentsJson },
+        // preview: 每个参数增量批次都会重算行数增删；大编辑跳过 LCS，完成事件再全量算
+        { argumentsJson: event.argumentsJson, preview: true },
       );
       this.options.assistantMessages.upsertToolMessage(event.toolCallId, runningTool, batchId);
       this.options.messageTimeline?.()?.upsertToolMessage(event.toolCallId, runningTool);

--- a/apps/desktop/src/host/service-mcp.ts
+++ b/apps/desktop/src/host/service-mcp.ts
@@ -31,6 +31,23 @@ export function sharedMcpServiceForWorkspace(
   return service;
 }
 
+/**
+ * 与 LSP 的 disposeLspServicesExcept 对应：workspace 切换时收缩 MCP 目录缓存。
+ * McpService 无持久连接（每次调用 connect→close），删除 Map 条目即可释放内存。
+ */
+export function disposeMcpServicesExcept(
+  cache: Map<string, McpService>,
+  keepWorkspaceRoot?: string,
+): void {
+  const keepPrefix = keepWorkspaceRoot ? `${path.resolve(keepWorkspaceRoot)}|` : undefined;
+  for (const key of [...cache.keys()]) {
+    if (keepPrefix !== undefined && key.startsWith(keepPrefix)) {
+      continue;
+    }
+    cache.delete(key);
+  }
+}
+
 export async function addDesktopMcpServer(input: {
   request: AddMcpServerRequest;
   workspaceRoot: string;

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2519,6 +2519,8 @@ class DesktopHostService {
         const bundle = this.sessionRegistry.findBySessionPath(sessionPath);
         return isSessionBundleBusy(bundle);
       },
+      clearSessionTitleGeneration: (sessionPath) =>
+        this.clearSessionTitleGenerationForSession(sessionPath),
     };
   }
 
@@ -3127,8 +3129,10 @@ class DesktopHostService {
     }
   }
 
-  private prepareSessionTitleForFirstUserTurn(displayText: string): void {
-    const bundle = this.activeBundle();
+  private prepareSessionTitleForFirstUserTurn(
+    displayText: string,
+    bundle: SessionBundle = this.activeBundle(),
+  ): void {
     if (!resetSessionTitleForFirstUserTurn(bundle, displayText)) {
       return;
     }
@@ -3147,8 +3151,20 @@ class DesktopHostService {
     this.sessionTitleGenerationInFlight.delete(filePath);
   }
 
-  private scheduleSessionTitleGenerationIfNeeded(seedText: string): void {
-    const bundle = this.activeBundle();
+  /** 会话删除后释放标题生成状态；在途生成时保留递增后的 epoch 条目使其完成后失效。 */
+  private clearSessionTitleGenerationForSession(sessionPath: string): void {
+    const filePath = path.resolve(sessionPath);
+    if (this.sessionTitleGenerationInFlight.has(filePath)) {
+      this.invalidateSessionTitleGeneration(filePath);
+      return;
+    }
+    this.sessionTitleGenerationEpoch.delete(filePath);
+  }
+
+  private scheduleSessionTitleGenerationIfNeeded(
+    seedText: string,
+    bundle: SessionBundle = this.activeBundle(),
+  ): void {
     const activeSession = bundle.activeSession;
     if (!activeSession || activeSession.readOnly === true || activeSession.kind === 'ephemeral') {
       return;

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -663,6 +663,9 @@ class DesktopHostService {
     }
   >();
   private lastToolSnapshotLogSignature: string | undefined;
+  /** buildSnapshot 高频调用；MCP servers / hooks 列表按 workspace+binding 键缓存，配置增删命令处显式失效。 */
+  private mcpServersListCache: { key: string; items: ReturnType<typeof listDesktopMcpServersFromDisk> } | undefined;
+  private hooksListCache: { key: string; items: ReturnType<typeof listDesktopHookListItems> } | undefined;
   /** One MCP catalog per workspace — survives per-session DesktopToolExecutor rebuilds. */
   private readonly mcpServiceByWorkspaceRoot = new Map<string, McpService>();
   private readonly lspServiceByWorkspaceRoot = new Map<string, import('@spiritagent/host-internal/lsp').LspService>();
@@ -768,6 +771,7 @@ class DesktopHostService {
       setLastRuntimeError: (error) => {
         this.lastRuntimeError = error;
       },
+      invalidateConfigListCaches: () => this.invalidateConfigListCaches(),
       buildSnapshot: () => this.buildSnapshot(),
     };
   }
@@ -3455,6 +3459,40 @@ class DesktopHostService {
     };
   }
 
+  private listMcpServersCached(
+    workspaceRoot: string,
+    workspaceBinding: DesktopWorkspaceBinding,
+  ): ReturnType<typeof listDesktopMcpServersFromDisk> {
+    const key = `${path.resolve(workspaceRoot)}|${workspaceBinding}`;
+    if (this.mcpServersListCache?.key !== key) {
+      this.mcpServersListCache = {
+        key,
+        items: listDesktopMcpServersFromDisk(workspaceRoot, workspaceBinding),
+      };
+    }
+    return this.mcpServersListCache.items;
+  }
+
+  private listHooksCached(
+    workspaceRoot: string,
+    workspaceBinding: DesktopWorkspaceBinding,
+  ): ReturnType<typeof listDesktopHookListItems> {
+    const key = `${path.resolve(workspaceRoot)}|${workspaceBinding}`;
+    if (this.hooksListCache?.key !== key) {
+      this.hooksListCache = {
+        key,
+        items: listDesktopHookListItems(workspaceRoot, workspaceBinding),
+      };
+    }
+    return this.hooksListCache.items;
+  }
+
+  /** MCP / hooks 配置文件被命令写入后调用；workspace 切换靠键变化自然失效。 */
+  private invalidateConfigListCaches(): void {
+    this.mcpServersListCache = undefined;
+    this.hooksListCache = undefined;
+  }
+
   private buildSnapshot(): DesktopSnapshot {
     const state = this.requireState();
     const pendingApproval = this.runtime?.currentPendingApproval();
@@ -3512,8 +3550,8 @@ class DesktopHostService {
         this.activeBundle().toolExecutor?.mcpStatusSnapshot()
         ?? this.toolExecutor?.mcpStatusSnapshot()
         ?? emptyMcpStatusSnapshot(),
-      mcpServers: listDesktopMcpServersFromDisk(state.workspaceRoot, state.workspaceBinding),
-      hooksList: listDesktopHookListItems(state.workspaceRoot, state.workspaceBinding),
+      mcpServers: this.listMcpServersCached(state.workspaceRoot, state.workspaceBinding),
+      hooksList: this.listHooksCached(state.workspaceRoot, state.workspaceBinding),
       lsp: this.lspSnapshot,
       conversation: {
         revision: activeBundle.conversationRevision,

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -486,6 +486,7 @@ import {
 } from './hook-runtime.js';
 import type { HookRunner, SessionEndHookInput, SessionStartHookInput } from '@spiritagent/agent-core';
 import {
+  disposeMcpServicesExcept,
   sharedMcpServiceForWorkspace,
 } from './service-mcp.js';
 import {
@@ -2767,6 +2768,7 @@ class DesktopHostService {
         && bundle.toolExecutorWorkspaceRoot !== workspaceRoot
       ) {
         await disposeLspServicesExcept(this.lspServiceByWorkspaceRoot, workspaceRoot);
+        disposeMcpServicesExcept(this.mcpServiceByWorkspaceRoot, workspaceRoot);
       }
       bundle.toolExecutor = await this.buildToolExecutorForBundle(bundle, dreamScope, todoScope);
       bundle.toolExecutorWorkspaceRoot = workspaceRoot;

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -818,21 +818,21 @@ class DesktopHostService {
       notifySessionListUpdated: () => this.notifySessionListUpdated(),
       refreshRuntimeForBundle: (bundle) => this.refreshRuntimeForBundle(bundle),
       syncActiveRuntimePointer: () => this.syncActiveRuntimePointer(),
-      clearAssistantContinuationMarkers: () => this.clearAssistantContinuationMarkers(),
+      clearAssistantContinuationMarkers: (bundle) => this.clearAssistantContinuationMarkers(bundle),
       resolveTodoSessionKeyForBundle: (bundle) => this.resolveTodoSessionKeyForBundle(bundle),
-      ensureActiveSession: (displayText) => this.ensureActiveSession(displayText),
-      prepareSessionTitleForFirstUserTurn: (displayText) =>
-        this.prepareSessionTitleForFirstUserTurn(displayText),
+      ensureActiveSession: (displayText, bundle) => this.ensureActiveSession(displayText, bundle),
+      prepareSessionTitleForFirstUserTurn: (displayText, bundle) =>
+        this.prepareSessionTitleForFirstUserTurn(displayText, bundle),
       reconcileTodoScopeAfterSessionPathChange: (bundle, previousSessionKey) =>
         this.reconcileTodoScopeAfterSessionPathChange(bundle, previousSessionKey),
       maybeRefreshRuntimeAfterTodoScopeChange: (bundle, previousSessionKey) =>
         this.maybeRefreshRuntimeAfterTodoScopeChange(bundle, previousSessionKey),
-      buildRewindCheckpointSnapshot: () => this.buildRewindCheckpointSnapshot(),
-      allocateMessageId: () => this.allocateMessageId(),
-      resetStreamingPlacementState: (full) => this.resetStreamingPlacementState(full),
-      persistCurrentSessionIfNeeded: () => this.persistCurrentSessionIfNeeded(),
-      scheduleSessionTitleGenerationIfNeeded: (seedText) =>
-        this.scheduleSessionTitleGenerationIfNeeded(seedText),
+      buildRewindCheckpointSnapshot: (bundle) => this.buildRewindCheckpointSnapshot(bundle),
+      allocateMessageId: (bundle) => this.allocateMessageId(bundle),
+      resetStreamingPlacementState: (full, bundle) => this.resetStreamingPlacementState(full, bundle),
+      persistCurrentSessionIfNeeded: (bundle) => this.persistCurrentSessionIfNeeded(bundle),
+      scheduleSessionTitleGenerationIfNeeded: (seedText, bundle) =>
+        this.scheduleSessionTitleGenerationIfNeeded(seedText, bundle),
       dispatchUserMessageExtensionEvent: (text, displayText, messageId) =>
         this.dispatchExtensionEvent({
           type: 'onUserMessage',
@@ -844,10 +844,14 @@ class DesktopHostService {
         }),
       ensureToolExecutor: (bundle) => this.ensureToolExecutor(bundle),
       refreshArchiveFromRuntime: (bundle) => this.refreshArchiveFromRuntime(bundle),
-      recordRewindCheckpoint: (messageId, beforeUserCheckpoint) =>
-        this.recordRewindCheckpoint(messageId, beforeUserCheckpoint as DesktopRewindCheckpointSnapshot | undefined),
+      recordRewindCheckpoint: (messageId, beforeUserCheckpoint, bundle) =>
+        this.recordRewindCheckpoint(
+          messageId,
+          beforeUserCheckpoint as DesktopRewindCheckpointSnapshot | undefined,
+          bundle,
+        ),
       orchestrationFor: (bundle) => this.orchestrationFor(bundle),
-      rebuildMessageTimelineFromMessages: () => this.rebuildMessageTimelineFromMessages(),
+      rebuildMessageTimelineFromMessages: (bundle) => this.rebuildMessageTimelineFromMessages(bundle),
       flushDeferredRuntimeRefreshIfIdle: (bundle) => this.flushDeferredRuntimeRefreshIfIdle(bundle),
       refreshTodoSnapshotForBundle: (bundle) => this.refreshTodoSnapshotForBundle(bundle),
       buildSnapshot: () => this.buildSnapshot(),
@@ -1129,9 +1133,10 @@ class DesktopHostService {
     };
   }
 
-  private conversationContinuationContext(): ConversationContinuationContext {
+  /** 传 bundle 时上下文作用于该 bundle（后台队列 drain），否则默认前台 active。 */
+  private conversationContinuationContext(bundle?: SessionBundle): ConversationContinuationContext {
     return {
-      activeBundle: () => this.activeBundle(),
+      activeBundle: () => bundle ?? this.activeBundle(),
       activeSessionId: () => this.sessionRegistry.activeSessionId(),
       orchestrationFor: (bundle) => this.orchestrationFor(bundle),
       lastToolSnapshotLogSignature: () => this.lastToolSnapshotLogSignature,
@@ -1154,17 +1159,21 @@ class DesktopHostService {
     };
   }
 
-  private rewindHostContext(): RewindHostContext {
+  /** 传 bundle 时 rewind 记录作用于该 bundle（后台队列 drain），否则默认前台 active。 */
+  private rewindHostContext(bundle?: SessionBundle): RewindHostContext {
+    const target = () => bundle ?? this.activeBundle();
     return {
       state: () => this.state,
       requireState: () => this.requireState(),
-      activeBundle: () => this.activeBundle(),
+      activeBundle: () => target(),
       activeSessionId: () => this.sessionRegistry.activeSessionId(),
-      runtime: () => this.runtime,
+      runtime: () => (bundle ? bundle.runtime : this.runtime),
       requireRuntime: () => this.requireRuntime(),
-      desktopMessages: () => this.desktopMessages(),
-      archiveMessages: () => this.archiveMessages(),
-      archiveAssistantAux: () => this.archiveAssistantAux(),
+      desktopMessages: () => target().messageTimeline.toMessages(),
+      archiveMessages: () =>
+        buildArchiveMessagesFromConversation(target().messageTimeline.toMessages()),
+      archiveAssistantAux: () =>
+        buildArchiveAssistantAuxFromConversation(target().messageTimeline.toMessages()),
       resolveTodoSessionKeyForBundle: (bundle) => this.resolveTodoSessionKeyForBundle(bundle),
       cancelTodoClearing: (sessionKey) => this.cancelTodoClearing(sessionKey),
       refreshTodoSnapshotForBundle: (bundle) => this.refreshTodoSnapshotForBundle(bundle),
@@ -4012,10 +4021,9 @@ class DesktopHostService {
     }
   }
 
-  private ensureActiveSession(seedText: string): void {
-    const bundle = this.activeBundle();
+  private ensureActiveSession(seedText: string, bundle: SessionBundle = this.activeBundle()): void {
     if (bundle.activeSession) {
-      this.promoteProvisionalSessionIfNeeded(seedText);
+      this.promoteProvisionalSessionIfNeeded(seedText, bundle);
       return;
     }
 
@@ -4026,8 +4034,10 @@ class DesktopHostService {
     };
   }
 
-  private promoteProvisionalSessionIfNeeded(seedText: string): void {
-    const bundle = this.activeBundle();
+  private promoteProvisionalSessionIfNeeded(
+    seedText: string,
+    bundle: SessionBundle = this.activeBundle(),
+  ): void {
     const activeSession = bundle.activeSession;
     if (!activeSession || !isProvisionalSessionPath(activeSession.filePath)) {
       return;
@@ -4085,8 +4095,7 @@ class DesktopHostService {
     });
   }
 
-  private rebuildMessageTimelineFromMessages(): void {
-    const bundle = this.activeBundle();
+  private rebuildMessageTimelineFromMessages(bundle: SessionBundle = this.activeBundle()): void {
     bundle.messageTimeline = this.createMessageTimelineFromMessages(bundle.messages);
   }
 
@@ -4132,8 +4141,8 @@ class DesktopHostService {
     this.activeBundle().messages = this.desktopMessages();
   }
 
-  private clearAssistantContinuationMarkers(): void {
-    clearAssistantContinuationMarkersFromService(this.conversationContinuationContext());
+  private clearAssistantContinuationMarkers(bundle?: SessionBundle): void {
+    clearAssistantContinuationMarkersFromService(this.conversationContinuationContext(bundle));
   }
 
   private markAssistantMessageContinuable(content: string): void {
@@ -4189,16 +4198,19 @@ class DesktopHostService {
   private async recordRewindCheckpoint(
     messageId: number,
     beforeUserCheckpoint?: DesktopRewindCheckpointSnapshot,
+    bundle?: SessionBundle,
   ): Promise<void> {
-    return recordRewindCheckpointFromService(this.rewindHostContext(), messageId, beforeUserCheckpoint);
+    return recordRewindCheckpointFromService(this.rewindHostContext(bundle), messageId, beforeUserCheckpoint);
   }
 
   private async applyTodosAfterRewind(snapshot: DesktopRewindCheckpointSnapshot): Promise<void> {
     return applyTodosAfterRewindFromService(this.rewindHostContext(), snapshot);
   }
 
-  private async buildRewindCheckpointSnapshot(): Promise<DesktopRewindCheckpointSnapshot> {
-    return buildRewindCheckpointSnapshotFromService(this.rewindHostContext());
+  private async buildRewindCheckpointSnapshot(
+    bundle?: SessionBundle,
+  ): Promise<DesktopRewindCheckpointSnapshot> {
+    return buildRewindCheckpointSnapshotFromService(this.rewindHostContext(bundle));
   }
 
   private restoreBeforeRewindCheckpoint(
@@ -4208,13 +4220,14 @@ class DesktopHostService {
     restoreBeforeRewindCheckpointFromService(this.rewindHostContext(), snapshot, checkpointSequence);
   }
 
-  private async persistCurrentSessionIfNeeded(): Promise<void> {
-    const bundle = this.sessionRegistry.getActive();
-    if (!bundle) {
+  private async persistCurrentSessionIfNeeded(bundle?: SessionBundle): Promise<void> {
+    const target = bundle ?? this.sessionRegistry.getActive();
+    if (!target) {
       return;
     }
-    await this.persistSessionBundle(bundle, {
-      fromRuntime: this.runtime,
+    await this.persistSessionBundle(target, {
+      // syncActiveRuntimePointer 维持 this.runtime ≡ active.runtime；显式 bundle 时取其自身 runtime
+      fromRuntime: bundle ? bundle.runtime : this.runtime,
       bumpListSortAt: true,
     });
   }
@@ -4263,8 +4276,7 @@ class DesktopHostService {
     return runtime;
   }
 
-  private allocateMessageId(): number {
-    const bundle = this.activeBundle();
+  private allocateMessageId(bundle: SessionBundle = this.activeBundle()): number {
     const next = bundle.messageIdCounter;
     bundle.messageIdCounter += 1;
     return next;

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -71,6 +71,13 @@ export interface SessionBundle {
   cachedTodoSnapshot?: import('../types.js').ConversationTodoSnapshot;
   /** Bumped on rewind restore; exposed as `conversation.revision` in snapshots. */
   conversationRevision: number;
+  /** refreshArchiveFromRuntime 的投影缓存：timeline 实例 + 修订号未变时跳过重算。 */
+  archiveProjectionCache?: {
+    timeline: DesktopMessageTimeline;
+    revision: number;
+    archiveMessages: ChatArchive['messages'];
+    archiveAssistantAux: ChatArchive['assistantAux'];
+  };
   /** busy tick 落盘节流：上次 tick 落盘时间（内存态，不持久化）。 */
   lastTickPersistAtMs?: number;
   /** Last successful create_plan absolute path for this session. */

--- a/apps/desktop/src/host/session-delete.ts
+++ b/apps/desktop/src/host/session-delete.ts
@@ -1,30 +1,42 @@
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import i18n from '../lib/i18n-host.js';
 import type { DesktopSnapshot } from '../types.js';
+import { deleteSessionRewindData } from './rewind.js';
 import {
+  ensureStoredSessionBundleRegistered,
   finishSessionActivationCommand,
   type SessionActivationContext,
 } from './session-activation.js';
+import type { SessionBundle } from './session-bundle.js';
+import { sameSessionPath } from './session-path.js';
+import type { SessionSplitHostContext } from './session-split.js';
+import { isEphemeralDebugSessionPath } from './sessions.js';
 import {
-  ensureActiveFromVisiblePanePaths,
-  type SessionSplitHostContext,
-} from './session-split.js';
-import {
-  isEphemeralDebugSessionPath,
-  removeEphemeralSessionRecord,
-} from './sessions.js';
-import { deleteStoredSession } from './storage.js';
-
-function sameSessionPath(left: string, right: string): boolean {
-  return path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase();
-}
+  deleteStoredSession,
+  isSplitProvisionalSessionPath,
+  spiritAgentDataDir,
+} from './storage.js';
 
 export interface SessionDeleteContext
   extends SessionActivationContext,
     Pick<SessionSplitHostContext, 'visiblePaneSessionPaths' | 'setVisiblePaneSessionPaths'> {
   removeEphemeralSession(filePath: string): void;
   bundleRuntimeIsBusy(sessionPath: string): boolean;
+  clearSessionTitleGeneration(sessionPath: string): void;
+}
+
+/** 会话文件删除前读取 rewind sessionId，用于联动清理 rewind sidecar 目录。 */
+async function readRewindSessionIdFromDisk(filePath: string): Promise<string | undefined> {
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as { rewind?: { sessionId?: unknown } };
+    const sessionId = parsed.rewind?.sessionId;
+    return typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export async function deleteSessionCommand(
@@ -54,43 +66,78 @@ export async function deleteSessionCommand(
       await ctx.runSessionEndForBundle?.(closingBundle, 'close');
     }
 
-    registry.removeBySessionPath(resolvedPath);
-
-    if (isEphemeralDebugSessionPath(resolvedPath)) {
-      ctx.removeEphemeralSession(resolvedPath);
-    } else {
-      await deleteStoredSession(resolvedPath);
-    }
-
     const visiblePaths = ctx.visiblePaneSessionPaths();
     const deletedFromMultiPane =
       visiblePaths.length > 1
       && visiblePaths.some((entry) => sameSessionPath(entry, resolvedPath));
+    const nextVisible = deletedFromMultiPane
+      ? visiblePaths.filter((entry) => !sameSessionPath(entry, resolvedPath))
+      : visiblePaths;
+    const needsSuccessor = wasActive || !registry.hasActive();
 
-    if (deletedFromMultiPane) {
-      const nextVisible = visiblePaths.filter((entry) => !sameSessionPath(entry, resolvedPath));
-      ctx.setVisiblePaneSessionPaths(nextVisible);
-      if (!registry.hasActive()) {
-        ctx.clearSubagentViewerTarget();
-        await ensureActiveFromVisiblePanePaths(ctx, nextVisible);
-        const active = registry.getActive();
-        if (active) {
-          await finishSessionActivationCommand(ctx, active);
+    // 预加载继任者：在旧 bundle 移除前完成磁盘加载，
+    // 使后面「移除旧 bundle → 确立新 active」可同步原子完成，
+    // 避免 activeId 悬空跨 await（节流快照定时器在 await 间隙触发会 requireActive 崩溃）。
+    let successor: SessionBundle | undefined;
+    if (needsSuccessor && deletedFromMultiPane) {
+      for (const sessionPath of nextVisible) {
+        let candidate = registry.findBySessionPath(sessionPath);
+        if (!candidate && !isSplitProvisionalSessionPath(sessionPath)) {
+          try {
+            candidate = (await ensureStoredSessionBundleRegistered(ctx, sessionPath)) ?? undefined;
+          } catch {
+            // 持久化布局可能引用已删除的会话文件
+          }
+        }
+        if (candidate) {
+          successor = candidate;
+          break;
         }
       }
-      ctx.setLastRuntimeError('');
-      return ctx.buildSnapshot();
     }
 
-    if (wasActive) {
-      ctx.clearSubagentViewerTarget();
-      const bundle = registry.beginNewActive(state.workspaceRoot);
-      await ctx.finalizeTodoScopeForNewActiveBundle(bundle, state.workspaceRoot);
-      ctx.resetStreamingPlacementState(true, bundle);
-      await finishSessionActivationCommand(ctx, bundle);
-      ctx.setLastRuntimeError('');
-      return ctx.buildSnapshot();
+    // —— 原子段开始：移除旧 bundle 并同步确立新 active，期间不得有 await ——
+    const removedBundle = registry.removeBySessionPath(resolvedPath);
+    if (deletedFromMultiPane) {
+      ctx.setVisiblePaneSessionPaths(nextVisible);
     }
+    let newActive: SessionBundle | undefined;
+    let newActiveIsFreshDraft = false;
+    if (needsSuccessor) {
+      ctx.clearSubagentViewerTarget();
+      if (deletedFromMultiPane && successor) {
+        newActive = registry.activateExisting(successor);
+      } else if (deletedFromMultiPane) {
+        newActive = registry.ensureDraft(state.workspaceRoot);
+      } else {
+        newActive = registry.beginNewActive(state.workspaceRoot);
+        newActiveIsFreshDraft = true;
+      }
+      ctx.syncActiveRuntimePointer();
+    }
+    // —— 原子段结束：activeId 已恢复有效，可安全跨 await ——
+
+    if (newActive) {
+      if (newActiveIsFreshDraft) {
+        await ctx.finalizeTodoScopeForNewActiveBundle(newActive, state.workspaceRoot);
+        ctx.resetStreamingPlacementState(true, newActive);
+      }
+      await finishSessionActivationCommand(ctx, newActive);
+    }
+
+    let rewindSessionId = removedBundle?.rewind.sessionId;
+    if (isEphemeralDebugSessionPath(resolvedPath)) {
+      ctx.removeEphemeralSession(resolvedPath);
+    } else {
+      if (!rewindSessionId) {
+        rewindSessionId = await readRewindSessionIdFromDisk(resolvedPath);
+      }
+      await deleteStoredSession(resolvedPath);
+    }
+    if (rewindSessionId) {
+      await deleteSessionRewindData(spiritAgentDataDir(), rewindSessionId);
+    }
+    ctx.clearSessionTitleGeneration(resolvedPath);
 
     ctx.setLastRuntimeError('');
     return ctx.buildSnapshot();

--- a/apps/desktop/src/host/session-path.ts
+++ b/apps/desktop/src/host/session-path.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+
+/**
+ * 会话文件路径的比较键：Windows 文件系统不区分大小写，统一折叠为小写；
+ * 其余平台保持大小写敏感。注册表查找与删除比较必须共用此归一化，
+ * 避免 session-delete 与 session-registry 语义不一致。
+ */
+export function normalizeSessionPathKey(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+export function sameSessionPath(left: string, right: string): boolean {
+  return normalizeSessionPathKey(left) === normalizeSessionPathKey(right);
+}

--- a/apps/desktop/src/host/session-persistence.ts
+++ b/apps/desktop/src/host/session-persistence.ts
@@ -62,6 +62,9 @@ export async function persistDesktopSessionBundle(
     : (bundle.listSortSavedAtUnixMs ?? Date.now());
   const sessionTitleSource = bundle.sessionTitleSource ?? 'seed';
   bundle.sessionTitleSource = sessionTitleSource;
+  const subagentDesktopTimelines = serializeSubagentTimelinesFromMessages(
+    bundle.subagentDesktopMessagesBySessionId,
+  );
   const stored = buildStoredDesktopSession({
     llmHistory: archive.llmHistory,
     subagentSessions: archive.subagentSessions,
@@ -77,13 +80,7 @@ export async function persistDesktopSessionBundle(
     approvalLevel: bundle.approvalLevel,
     ...(bundle.activeModel ? { activeModel: bundle.activeModel } : {}),
     ...(bundle.contextUsage ? { contextUsage: { ...bundle.contextUsage } } : {}),
-    ...(serializeSubagentTimelinesFromMessages(bundle.subagentDesktopMessagesBySessionId)
-      ? {
-          subagentDesktopTimelines: serializeSubagentTimelinesFromMessages(
-            bundle.subagentDesktopMessagesBySessionId,
-          ),
-        }
-      : {}),
+    ...(subagentDesktopTimelines ? { subagentDesktopTimelines } : {}),
     ...(bundle.queuedUserTurns.length > 0
       ? { queuedUserTurns: cloneQueuedUserTurns(bundle.queuedUserTurns) }
       : {}),

--- a/apps/desktop/src/host/session-registry.ts
+++ b/apps/desktop/src/host/session-registry.ts
@@ -10,6 +10,7 @@ import {
 } from './session-bundle.js';
 import { rehydrateFinishTaskNoticesForRestoredSession } from './finish-task-notice-rehydrate.js';
 import type { RestoredSessionState } from './sessions.js';
+import { normalizeSessionPathKey } from './session-path.js';
 import { defaultNewSessionPath, provisionalNewSessionPath, splitPaneSessionPath } from './storage.js';
 
 const MAX_LOADED_BUNDLES = 8;
@@ -64,11 +65,15 @@ export class SessionRegistry {
     if (direct) {
       return direct;
     }
+    const normalized = normalizeSessionPathKey(filePath);
     for (const bundle of this.bundles.values()) {
-      if (path.resolve(bundle.id) === resolved) {
+      if (normalizeSessionPathKey(bundle.id) === normalized) {
         return bundle;
       }
-      if (bundle.activeSession && path.resolve(bundle.activeSession.filePath) === resolved) {
+      if (
+        bundle.activeSession
+        && normalizeSessionPathKey(bundle.activeSession.filePath) === normalized
+      ) {
         return bundle;
       }
     }
@@ -104,7 +109,7 @@ export class SessionRegistry {
 
   setProtectedSessionPaths(paths: Iterable<string>): void {
     this.protectedSessionPaths = new Set(
-      [...paths].map((entry) => path.resolve(entry)),
+      [...paths].map((entry) => normalizeSessionPathKey(entry)),
     );
   }
 
@@ -114,7 +119,7 @@ export class SessionRegistry {
       bundle.id,
       bundle.activeSession?.filePath,
     ].filter((entry): entry is string => Boolean(entry?.trim()));
-    return candidates.some((entry) => this.protectedSessionPaths.has(path.resolve(entry)));
+    return candidates.some((entry) => this.protectedSessionPaths.has(normalizeSessionPathKey(entry)));
   }
 
   all(): Iterable<SessionBundle> {
@@ -271,13 +276,13 @@ export class SessionRegistry {
       return undefined;
     }
     const mapKey = this.mapKeyFor(bundle);
-    const resolvedPath = path.resolve(filePath);
+    const normalizedPath = normalizeSessionPathKey(filePath);
     if (mapKey) {
       this.bundles.delete(mapKey);
     }
     if (
       this.activeId !== undefined
-      && (this.activeId === mapKey || path.resolve(this.activeId) === resolvedPath)
+      && (this.activeId === mapKey || normalizeSessionPathKey(this.activeId) === normalizedPath)
     ) {
       this.activeId = undefined;
     }

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -413,7 +413,7 @@ export async function tickSessionCommand(
     bundle.lastTickPersistAtMs = Date.now();
   }
   await ctx.flushDeferredRuntimeRefreshIfIdle(bundle);
-  await ctx.refreshTodoSnapshotForBundle(bundle);
+  // TODO 快照仅由 onTodoStoreMutated 回调驱动刷新（见 service.ts todoItemsWriter 挂钩），tick 内不再轮询
   await drainQueuedUserTurnIfIdle(ctx, bundle);
 }
 

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -74,6 +74,8 @@ export interface SubmitUserTurnAfterInitializedOptions {
   explicitWorkspaceFiles?: PendingWorkspaceFile[];
   /** Reuse message id from a queued turn when draining the queue. */
   preallocatedMessageId?: number;
+  /** 目标 bundle；默认前台 active。排队消息 drain 时必须传队列所属 bundle，防止串会话。 */
+  bundle?: SessionBundle;
 }
 
 export interface SessionTurnOrchestratorContext {
@@ -93,23 +95,23 @@ export interface SessionTurnOrchestratorContext {
   notifySessionListUpdated(): void;
   refreshRuntimeForBundle(bundle: SessionBundle): Promise<void>;
   syncActiveRuntimePointer(): void;
-  clearAssistantContinuationMarkers(): void;
+  clearAssistantContinuationMarkers(bundle?: SessionBundle): void;
   resolveTodoSessionKeyForBundle(bundle: SessionBundle): string;
-  ensureActiveSession(displayText: string): void;
-  prepareSessionTitleForFirstUserTurn(displayText: string): void;
+  ensureActiveSession(displayText: string, bundle?: SessionBundle): void;
+  prepareSessionTitleForFirstUserTurn(displayText: string, bundle?: SessionBundle): void;
   reconcileTodoScopeAfterSessionPathChange(bundle: SessionBundle, previousSessionKey: string): Promise<void>;
   maybeRefreshRuntimeAfterTodoScopeChange(bundle: SessionBundle, previousSessionKey: string): Promise<void>;
-  buildRewindCheckpointSnapshot(): Promise<unknown>;
-  allocateMessageId(): number;
-  resetStreamingPlacementState(full: boolean): void;
-  persistCurrentSessionIfNeeded(): Promise<void>;
-  scheduleSessionTitleGenerationIfNeeded(seedText: string): void;
+  buildRewindCheckpointSnapshot(bundle?: SessionBundle): Promise<unknown>;
+  allocateMessageId(bundle?: SessionBundle): number;
+  resetStreamingPlacementState(full: boolean, bundle?: SessionBundle): void;
+  persistCurrentSessionIfNeeded(bundle?: SessionBundle): Promise<void>;
+  scheduleSessionTitleGenerationIfNeeded(seedText: string, bundle?: SessionBundle): void;
   dispatchUserMessageExtensionEvent(text: string, displayText: string, messageId: number): Promise<void>;
   ensureToolExecutor(bundle?: SessionBundle): Promise<unknown>;
   refreshArchiveFromRuntime(bundle?: SessionBundle): void;
-  recordRewindCheckpoint(messageId: number, beforeUserCheckpoint?: unknown): Promise<void>;
+  recordRewindCheckpoint(messageId: number, beforeUserCheckpoint?: unknown, bundle?: SessionBundle): Promise<void>;
   orchestrationFor(bundle: SessionBundle): TurnOrchestration;
-  rebuildMessageTimelineFromMessages(): void;
+  rebuildMessageTimelineFromMessages(bundle?: SessionBundle): void;
   flushDeferredRuntimeRefreshIfIdle(bundle?: SessionBundle): Promise<void>;
   refreshTodoSnapshotForBundle(bundle: SessionBundle): Promise<void>;
   buildSnapshot(): DesktopSnapshot;
@@ -131,7 +133,7 @@ export async function submitUserTurnAfterInitializedCommand(
   text: string,
   options: SubmitUserTurnAfterInitializedOptions = {},
 ): Promise<DesktopSnapshot> {
-  const bundle = ctx.activeBundle();
+  const bundle = options.bundle ?? ctx.activeBundle();
   const trimmed = text.trim();
   const explicitWorkspaceFiles = options.explicitWorkspaceFiles ?? [];
   const displayText = (options.displayText ?? defaultDisplayTextForUserTurn(text, explicitWorkspaceFiles)).trim();
@@ -150,39 +152,39 @@ export async function submitUserTurnAfterInitializedCommand(
   }
 
   ctx.requireState();
-  if (ctx.activeBundle().activeSession?.readOnly) {
+  if (bundle.activeSession?.readOnly) {
     throw new Error(i18n.t('error.readonlySessionSend'));
   }
   if (!options.preserveRewindWarnings) {
-    ctx.activeBundle().rewindWarnings = [];
+    bundle.rewindWarnings = [];
   }
-  ctx.clearAssistantContinuationMarkers();
+  ctx.clearAssistantContinuationMarkers(bundle);
   const todoSessionKeyBeforeEnsure = ctx.resolveTodoSessionKeyForBundle(bundle);
-  ctx.ensureActiveSession(displayText);
-  ctx.prepareSessionTitleForFirstUserTurn(displayText);
+  ctx.ensureActiveSession(displayText, bundle);
+  ctx.prepareSessionTitleForFirstUserTurn(displayText, bundle);
   await ctx.reconcileTodoScopeAfterSessionPathChange(bundle, todoSessionKeyBeforeEnsure);
   await ctx.maybeRefreshRuntimeAfterTodoScopeChange(bundle, todoSessionKeyBeforeEnsure);
-  const beforeUserCheckpoint = await ctx.buildRewindCheckpointSnapshot();
+  const beforeUserCheckpoint = await ctx.buildRewindCheckpointSnapshot(bundle);
   const localFileAttachments =
     explicitWorkspaceFiles.length > 0
       ? pendingWorkspaceFilesToAttachmentSnapshots(explicitWorkspaceFiles)
       : undefined;
   const userMessage: ConversationMessageSnapshot = {
-    id: options.preallocatedMessageId ?? ctx.allocateMessageId(),
+    id: options.preallocatedMessageId ?? ctx.allocateMessageId(bundle),
     role: 'user',
     content: displayText,
     pending: false,
     ...(localFileAttachments ? { localFileAttachments } : {}),
   };
-  ctx.activeBundle().messages.push(userMessage);
-  ctx.activeBundle().messageTimeline.beginUserTurn(userMessage.content, {
+  bundle.messages.push(userMessage);
+  bundle.messageTimeline.beginUserTurn(userMessage.content, {
     messageId: userMessage.id,
     ...(localFileAttachments ? { localFileAttachments } : {}),
   });
-  ctx.resetStreamingPlacementState(false);
+  ctx.resetStreamingPlacementState(false, bundle);
   const todoSessionKeyBeforePersist = ctx.resolveTodoSessionKeyForBundle(bundle);
-  await ctx.persistCurrentSessionIfNeeded();
-  ctx.scheduleSessionTitleGenerationIfNeeded(displayText);
+  await ctx.persistCurrentSessionIfNeeded(bundle);
+  ctx.scheduleSessionTitleGenerationIfNeeded(displayText, bundle);
   await ctx.reconcileTodoScopeAfterSessionPathChange(bundle, todoSessionKeyBeforePersist);
   await ctx.maybeRefreshRuntimeAfterTodoScopeChange(bundle, todoSessionKeyBeforePersist);
   await ctx.dispatchUserMessageExtensionEvent(trimmed, displayText, userMessage.id);
@@ -204,41 +206,44 @@ export async function submitUserTurnAfterInitializedCommand(
         beforeUserCheckpoint,
       });
     } catch (error) {
-      ctx.activeBundle().currentTurnSkills = [];
-      ctx.orchestrationFor(ctx.activeBundle()).assistantMessages.handleMessageRemoved(
-        ctx.activeBundle().messages.length - 1,
+      bundle.currentTurnSkills = [];
+      ctx.orchestrationFor(bundle).assistantMessages.handleMessageRemoved(
+        bundle.messages.length - 1,
         userMessage.id,
         'send-user-rollback',
       );
-      ctx.activeBundle().messages.pop();
-      ctx.rebuildMessageTimelineFromMessages();
+      bundle.messages.pop();
+      ctx.rebuildMessageTimelineFromMessages(bundle);
       throw error;
     }
     return ctx.buildSnapshot();
   }
 
   // Re-resolve after promote/persist may have replaced bundle.runtime (todo scope refresh).
-  const runtime = ctx.requireRuntime();
+  const runtime = bundle.runtime;
+  if (!runtime) {
+    throw new Error(i18n.t('error.runtimeNotReady'));
+  }
   await ctx.ensureToolExecutor(bundle);
   try {
     await runtime.startUserTurnStreaming(trimmed, [], explicitWorkspaceFiles, turnSkills);
-    ctx.refreshArchiveFromRuntime();
-    await ctx.recordRewindCheckpoint(userMessage.id, beforeUserCheckpoint);
+    ctx.refreshArchiveFromRuntime(bundle);
+    await ctx.recordRewindCheckpoint(userMessage.id, beforeUserCheckpoint, bundle);
     await runtime.poll();
     applyDrainedRuntimeHostEvents(ctx, bundle, runtime.drainEvents());
   } catch (error) {
-    ctx.activeBundle().currentTurnSkills = [];
-    ctx.orchestrationFor(ctx.activeBundle()).assistantMessages.handleMessageRemoved(
-      ctx.activeBundle().messages.length - 1,
+    bundle.currentTurnSkills = [];
+    ctx.orchestrationFor(bundle).assistantMessages.handleMessageRemoved(
+      bundle.messages.length - 1,
       userMessage.id,
       'send-user-rollback',
     );
-    ctx.activeBundle().messages.pop();
-    ctx.rebuildMessageTimelineFromMessages();
+    bundle.messages.pop();
+    ctx.rebuildMessageTimelineFromMessages(bundle);
     throw error;
   }
 
-  const orchestration = ctx.orchestrationFor(ctx.activeBundle());
+  const orchestration = ctx.orchestrationFor(bundle);
   orchestration.runtimeEvents.consumeCompletedTurnResult();
   orchestration.runtimeEvents.syncPendingToolStates();
   orchestration.runtimeEvents.syncAssistantPrefixFromHistoryBeforeToolRow();
@@ -281,10 +286,11 @@ export async function sendQueuedUserTurnNowCommand(
       preallocatedMessageId: item.messageId,
       explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(item),
       turnSkills: turnSkillsFromQueuedItem(item),
+      bundle,
     });
   } catch (error) {
     bundle.queuedUserTurns.splice(index, 0, item);
-    await ctx.persistCurrentSessionIfNeeded();
+    await ctx.persistCurrentSessionIfNeeded(bundle);
     throw error;
   }
 }
@@ -306,10 +312,12 @@ export async function drainQueuedUserTurnIfIdle(
       preallocatedMessageId: next.messageId,
       explicitWorkspaceFiles: explicitWorkspaceFilesFromQueuedItem(next),
       turnSkills: turnSkillsFromQueuedItem(next),
+      // 后台 bundle busy→idle 时也会 drain：必须提交回队列所属 bundle，而非前台 active
+      bundle,
     });
   } catch (error) {
     bundle.queuedUserTurns.unshift(next);
-    await ctx.persistCurrentSessionIfNeeded();
+    await ctx.persistCurrentSessionIfNeeded(bundle);
     throw error;
   }
 }

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -154,17 +154,32 @@ export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopS
   };
 }
 
+/** buildSnapshot / 上下文用量高频调用；目录缓存文件只在 writeModelCatalogCache 后变化，按模型键集合做内存缓存。 */
+let modelCatalogHintsMemo: { key: string; hints: DesktopModelCatalogHint[] } | undefined;
+
+export function invalidateModelCatalogHintsMemo(): void {
+  modelCatalogHintsMemo = undefined;
+}
+
 export function buildModelCatalogHints(config: DesktopConfigFile): DesktopModelCatalogHint[] {
   const seen = new Set<string>();
+  for (const model of config.models) {
+    const base = model.apiBase.trim() || DEFAULT_API_BASE;
+    const transportKind = model.transportKind ?? (model.provider === 'anthropic' ? 'anthropic' : 'openai-compatible');
+    seen.add(`${model.provider ?? 'custom'}::${transportKind}::${base}`);
+  }
+  const memoKey = [...seen].join('\n');
+  if (modelCatalogHintsMemo?.key === memoKey) {
+    return modelCatalogHintsMemo.hints;
+  }
   const hints: DesktopModelCatalogHint[] = [];
   for (const model of config.models) {
     const base = model.apiBase.trim() || DEFAULT_API_BASE;
     const transportKind = model.transportKind ?? (model.provider === 'anthropic' ? 'anthropic' : 'openai-compatible');
     const cacheKey = `${model.provider ?? 'custom'}::${transportKind}::${base}`;
-    if (seen.has(cacheKey)) {
+    if (!seen.delete(cacheKey)) {
       continue;
     }
-    seen.add(cacheKey);
     const hit = readModelCatalogCacheSync(base, model.provider, transportKind);
     if (hit && hit.modelIds.length > 0) {
       hints.push({
@@ -177,5 +192,6 @@ export function buildModelCatalogHints(config: DesktopConfigFile): DesktopModelC
       });
     }
   }
+  modelCatalogHintsMemo = { key: memoKey, hints };
   return hints;
 }

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -712,23 +712,30 @@ export async function listStoredSessions(): Promise<SessionListItem[]> {
     files.map(async (filePath) => {
       try {
         const raw = await readFile(filePath, 'utf8');
-        const parsed = normalizeStoredSession(JSON.parse(raw) as Partial<StoredDesktopSession>);
-        const info = await stat(filePath);
+        // 侧栏列表只需元数据：仅做 schema 版本检查并直取字段，
+        // 跳过 normalizeStoredSession 的全量 timeline 校验与 rewind 归一化
+        const parsed = JSON.parse(raw) as Partial<StoredDesktopSession>;
+        assertChatSchemaVersionV2(parsed.chatSchemaVersion);
+        const timeline = Array.isArray(parsed.desktopMessageTimeline)
+          ? (parsed.desktopMessageTimeline as PersistedDesktopTimelineTurnSnapshot[])
+          : undefined;
         const gitBranch = normalizeGitBranch(parsed.gitBranch);
+        const modifiedAtUnixMs =
+          typeof parsed.savedAtUnixMs === 'number'
+            ? parsed.savedAtUnixMs
+            : Math.round((await stat(filePath)).mtimeMs);
         return {
           path: filePath,
           displayName:
             normalizeDisplayName(parsed.sessionDisplayName) ??
-            deriveDisplayNameFromTimeline(parsed.desktopMessageTimeline),
+            deriveDisplayNameFromTimeline(timeline),
           workspaceRoot:
             resolveStoredWorkspaceRoot(parsed.workspaceRoot) ?? discoverWorkspaceRoot(),
           ...(gitBranch ? { gitBranch } : {}),
-          modifiedAtUnixMs:
-            typeof parsed.savedAtUnixMs === 'number'
-              ? parsed.savedAtUnixMs
-              : Math.round(info.mtimeMs),
+          modifiedAtUnixMs,
         } satisfies SessionListItem;
-      } catch {
+      } catch (error) {
+        console.warn(`[desktop-host] skip unreadable session file: ${filePath}`, error);
         return undefined;
       }
     }),

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -3,6 +3,7 @@ import {
   mkdir,
   readdir,
   readFile,
+  rename,
   stat,
   unlink,
   writeFile,
@@ -750,7 +751,15 @@ export async function saveStoredSession(
 ): Promise<string> {
   const resolved = resolveSessionPath(filePath);
   await mkdir(path.dirname(resolved), { recursive: true });
-  await writeFile(resolved, `${JSON.stringify(session, null, 2)}\n`, 'utf8');
+  // 原子写：先写同目录 tmp 再 rename，避免写入中途崩溃 / 断电留下截断的会话文件
+  const tmpPath = `${resolved}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await writeFile(tmpPath, `${JSON.stringify(session, null, 2)}\n`, 'utf8');
+    await rename(tmpPath, resolved);
+  } catch (error) {
+    await unlink(tmpPath).catch(() => {});
+    throw error;
+  }
   return resolved;
 }
 

--- a/apps/desktop/src/lib/edit-file-line-delta.ts
+++ b/apps/desktop/src/lib/edit-file-line-delta.ts
@@ -30,6 +30,27 @@ export function lineChangeCounts(oldText: string, newText: string): EditFileLine
   };
 }
 
+/**
+ * preview（流式参数）阶段每个增量批次都会重算一次 LCS；大编辑下 O(n·m) 会拖垮事件循环。
+ * 超过该单元格数（old 行数 × new 行数）时 preview 跳过统计，工具完成事件再全量计算。
+ */
+const PREVIEW_MAX_LCS_CELLS = 40_000;
+
+function lineChangeCountsForPhase(
+  oldText: string,
+  newText: string,
+  preview: boolean,
+): EditFileLineDelta | undefined {
+  if (preview) {
+    const oldCount = splitLines(oldText).length;
+    const newCount = splitLines(newText).length;
+    if (oldCount * newCount > PREVIEW_MAX_LCS_CELLS) {
+      return undefined;
+    }
+  }
+  return lineChangeCounts(oldText, newText);
+}
+
 function longestCommonSubsequenceLength(a: string[], b: string[]): number {
   if (a.length === 0 || b.length === 0) {
     return 0;
@@ -237,6 +258,8 @@ function extractDeleteFilePath(
 export type AttachEditFileLineDeltaSource = {
   request?: unknown;
   argumentsJson?: string;
+  /** 流式参数预览阶段：大编辑跳过 LCS，完成时再算。 */
+  preview?: boolean;
   resolveDeleteFileLines?: (inputPath: string) => EditFileLineDelta | undefined;
   resolveDeleteFileBaseline?: (inputPath: string) => string | undefined;
 };
@@ -244,6 +267,7 @@ export type AttachEditFileLineDeltaSource = {
 export function toolLineDeltaFromRequest(
   toolName: string,
   request: unknown,
+  options?: { preview?: boolean },
 ): EditFileLineDelta | undefined {
   if (!TOOLS_WITH_LINE_DELTA.has(toolName) || !request || typeof request !== 'object') {
     return undefined;
@@ -266,8 +290,8 @@ export function toolLineDeltaFromRequest(
     return undefined;
   }
 
-  const delta = lineChangeCounts(oldText, newText);
-  if (delta.added === 0 && delta.removed === 0) {
+  const delta = lineChangeCountsForPhase(oldText, newText, options?.preview === true);
+  if (!delta || (delta.added === 0 && delta.removed === 0)) {
     return undefined;
   }
   return delta;
@@ -281,6 +305,7 @@ export function editFileLineDeltaFromRequest(request: unknown): EditFileLineDelt
 export function toolLineDeltaFromArgumentsJson(
   toolName: string,
   argumentsJson: string,
+  options?: { preview?: boolean },
 ): EditFileLineDelta | undefined {
   const trimmed = argumentsJson.trim();
   if (!trimmed || !TOOLS_WITH_LINE_DELTA.has(toolName)) {
@@ -288,7 +313,7 @@ export function toolLineDeltaFromArgumentsJson(
   }
 
   try {
-    return toolLineDeltaFromRequest(toolName, JSON.parse(trimmed) as unknown);
+    return toolLineDeltaFromRequest(toolName, JSON.parse(trimmed) as unknown, options);
   } catch {
     if (toolName === 'create_file' || toolName === 'create_plan') {
       const content = tryExtractPartialJsonStringValue(trimmed, 'content');
@@ -304,8 +329,8 @@ export function toolLineDeltaFromArgumentsJson(
     if (oldText === undefined && newText === undefined) {
       return undefined;
     }
-    const delta = lineChangeCounts(oldText ?? '', newText ?? '');
-    if (delta.added === 0 && delta.removed === 0) {
+    const delta = lineChangeCountsForPhase(oldText ?? '', newText ?? '', options?.preview === true);
+    if (!delta || (delta.added === 0 && delta.removed === 0)) {
       return undefined;
     }
     return delta;
@@ -352,10 +377,11 @@ export function attachEditFileLineDelta(
     return tool;
   }
 
+  const phaseOptions = source.preview === true ? { preview: true } : undefined;
   let delta =
     source.argumentsJson !== undefined
-      ? toolLineDeltaFromArgumentsJson(tool.toolName, source.argumentsJson)
-      : toolLineDeltaFromRequest(tool.toolName, source.request);
+      ? toolLineDeltaFromArgumentsJson(tool.toolName, source.argumentsJson, phaseOptions)
+      : toolLineDeltaFromRequest(tool.toolName, source.request, phaseOptions);
 
   const deleteInputPath =
     tool.toolName === 'delete_file'

--- a/apps/desktop/test/lib/edit-file-line-delta.test.mjs
+++ b/apps/desktop/test/lib/edit-file-line-delta.test.mjs
@@ -40,6 +40,25 @@ test('editFileLineDeltaFromArgumentsJson updates while new_text streams', () => 
   assert.deepEqual(delta, { removed: 1, added: 2 });
 });
 
+test('preview skips LCS for large edits; final pass still computes', () => {
+  const oldText = Array.from({ length: 300 }, (_, i) => `old ${i}`).join('\n');
+  const newText = Array.from({ length: 300 }, (_, i) => `new ${i}`).join('\n');
+  const json = JSON.stringify({ path: 'x.ts', old_text: oldText, new_text: newText });
+  assert.equal(toolLineDeltaFromArgumentsJson('edit_file', json, { preview: true }), undefined);
+  assert.deepEqual(toolLineDeltaFromArgumentsJson('edit_file', json), {
+    removed: 300,
+    added: 300,
+  });
+});
+
+test('preview keeps LCS for small edits', () => {
+  const json = JSON.stringify({ path: 'x.ts', old_text: 'a\nb', new_text: 'a\nc\nd' });
+  assert.deepEqual(toolLineDeltaFromArgumentsJson('edit_file', json, { preview: true }), {
+    removed: 1,
+    added: 2,
+  });
+});
+
 test('editFileLineDeltaFromArgumentsJson parses complete JSON', () => {
   const json = JSON.stringify({
     path: 'm.ts',


### PR DESCRIPTION
## Summary

- 删除活跃会话时 activeId 清除与重建不再跨 await 悬空，避免节流快照定时器触发 requireActive 崩溃
- drain 排队消息提交到队列所属 bundle，修复后台 busy 会话消息串进前台
- 会话文件 tmp+rename 原子写、路径 Windows 大小写归一化、rewind sidecar 与 title epoch 联动清理
- 流式 tick 归档缓存、TODO 轮询移除、快照 MCP/hooks 读盘缓存、preview LCS 阈值与侧栏轻量列表

## Test plan

- [x] apps/desktop `tsc --noEmit`（改动文件无新增错误）
- [x] `test/lib/edit-file-line-delta.test.mjs` 通过
- [x] 手动：删除 busy 后台时前台空闲会话、分屏后台排队消息后切换前台