### PR TITLE
fix(desktop): 加固 Web Host 配对与 Electron 主进程资源回收

### DIFF
--- a/apps/desktop/electron/http-host.ts
+++ b/apps/desktop/electron/http-host.ts
@@ -6,6 +6,7 @@ import {
   type Server,
   type ServerResponse,
 } from 'node:http';
+import { isIP } from 'node:net';
 import path from 'node:path';
 
 import { parseModelProviderId, parsePresetModelProviderId } from '@spiritagent/host-internal/model-provider-presets';
@@ -38,6 +39,8 @@ export interface DesktopHttpAuthOptions {
   getTokenHash(): string | undefined;
   getPairingCode(): string;
   completePairing(authTokenHash: string): Promise<void>;
+  /** 配对失败达到上限时回调；宿主应作废当前配对码，重启 Web Host 后重新生成。 */
+  onPairingLockout?(): void;
 }
 
 export interface DesktopHttpStaticOptions {
@@ -85,6 +88,7 @@ export function createDesktopHttpHost(options: DesktopHttpHostOptions): DesktopH
 
       const nextServer = createServer(
         createDesktopHttpRequestHandler({
+          host: options.host,
           invokeHostCommand: options.invokeHostCommand,
           onHostCommandResult: options.onHostCommandResult,
           auth: options.auth,
@@ -157,17 +161,25 @@ export function createDesktopHttpHost(options: DesktopHttpHostOptions): DesktopH
   };
 }
 
+export const MAX_PAIRING_FAILURES = 5;
+
 export function createDesktopHttpRequestHandler({
+  host,
   invokeHostCommand,
   onHostCommandResult,
   auth,
   static: staticOptions,
 }: {
+  /** 服务监听的 host；用于 Host 头校验（防 DNS rebinding）。 */
+  host: string;
   invokeHostCommand: DesktopHostCommandInvoker;
   onHostCommandResult?: DesktopHostCommandResultHandler;
   auth?: DesktopHttpAuthOptions;
   static?: DesktopHttpStaticOptions;
 }) {
+  // 配对失败计数随 handler（即单次 Web Host 运行周期）存续；重启 Web Host 才重置。
+  let pairingFailureCount = 0;
+
   return async (request: IncomingMessage, response: ServerResponse) => {
     const runHostCommand = async (command: HostCommandName, payload?: unknown) => {
       const result = await invokeHostCommand(command, payload);
@@ -187,6 +199,11 @@ export function createDesktopHttpRequestHandler({
 
       const { pathname } = new URL(request.url, 'http://localhost');
 
+      if (pathname.startsWith('/api/') && !isAllowedRequestHostHeader(request.headers.host, host)) {
+        writeJson(request, response, 403, { error: 'Host header is not allowed.' });
+        return;
+      }
+
       if (request.method === 'OPTIONS') {
         if (!writeCors(request, response)) {
           writeJson(request, response, 403, { error: 'CORS origin is not allowed.' });
@@ -204,6 +221,13 @@ export function createDesktopHttpRequestHandler({
           pathname,
           runHostCommand,
           auth,
+          onPairingFailure: () => {
+            pairingFailureCount += 1;
+            if (pairingFailureCount === MAX_PAIRING_FAILURES) {
+              auth?.onPairingLockout?.();
+            }
+          },
+          isPairingLocked: () => pairingFailureCount >= MAX_PAIRING_FAILURES,
         });
         return;
       }
@@ -246,12 +270,16 @@ async function handleApiRequest({
   pathname,
   runHostCommand,
   auth,
+  onPairingFailure,
+  isPairingLocked,
 }: {
   request: IncomingMessage;
   response: ServerResponse;
   pathname: string;
   runHostCommand: (command: HostCommandName, payload?: unknown) => Promise<unknown>;
   auth?: DesktopHttpAuthOptions;
+  onPairingFailure: () => void;
+  isPairingLocked: () => boolean;
 }): Promise<void> {
   if (request.method === 'GET' && pathname === '/api/pairing/status') {
     writeJson(request, response, 200, {
@@ -267,10 +295,20 @@ async function handleApiRequest({
       return;
     }
 
+    if (isPairingLocked()) {
+      writeJson(request, response, 429, {
+        code: 'PAIRING_LOCKED',
+        error: '配对失败次数过多，请重启 Web Host 生成新的配对码。',
+      });
+      return;
+    }
+
     const body = await readJsonBody(request);
     const jsonBody = isJsonObject(body) ? body : undefined;
     const code = typeof jsonBody?.code === 'string' ? jsonBody.code.trim() : '';
-    if (!code || code !== auth.getPairingCode()) {
+    const expectedCode = auth.getPairingCode();
+    if (!code || !expectedCode || !safePairingCodeEquals(code, expectedCode)) {
+      onPairingFailure();
       writeJson(request, response, 401, {
         code: 'PAIRING_FAILED',
         error: '配对码不正确。',
@@ -1459,6 +1497,51 @@ function safeTokenHashEquals(left: string, right: string): boolean {
   const leftBuffer = Buffer.from(left, 'hex');
   const rightBuffer = Buffer.from(right, 'hex');
   return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+/** 常数时间比较配对码；长度固定 6 位，长度差异不泄露有效信息。 */
+function safePairingCodeEquals(candidate: string, expected: string): boolean {
+  const candidateBuffer = Buffer.from(candidate, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  return (
+    candidateBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(candidateBuffer, expectedBuffer)
+  );
+}
+
+/**
+ * 防 DNS rebinding：API 请求的 Host 头仅允许配置的监听 host 或回环形式。
+ * 绑定 0.0.0.0 / :: 时客户端用本机任意 IP 访问，Host 为 IP 字面量；rebinding 攻击的
+ * Host 必然是攻击者域名（非 IP），故此时放行 IP 字面量不削弱防护。
+ */
+export function isAllowedRequestHostHeader(
+  hostHeader: string | string[] | undefined,
+  configuredHost: string,
+): boolean {
+  const raw = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
+  if (!raw) {
+    return false;
+  }
+
+  let hostname: string;
+  try {
+    hostname = new URL(`http://${raw.trim()}`).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  const bareHostname = hostname.replace(/^\[|\]$/gu, '');
+
+  const configured = configuredHost.trim().toLowerCase();
+  if (bareHostname === configured || hostname === configured) {
+    return true;
+  }
+  if (bareHostname === 'localhost' || bareHostname === '127.0.0.1' || bareHostname === '::1') {
+    return true;
+  }
+  if ((configured === '0.0.0.0' || configured === '::') && isIP(bareHostname) !== 0) {
+    return true;
+  }
+  return false;
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<unknown> {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1089,19 +1089,19 @@ if (gotSpiritSingleInstanceLock) {
 
   ipcMain.handle(
     'desktop:browser-guest-unregister-f12',
-    (_event: IpcMainInvokeEvent, payload: { guestWebContentsId?: number }) => {
+    (event: IpcMainInvokeEvent, payload: { guestWebContentsId?: number }) => {
       const guestWebContentsId = payload?.guestWebContentsId;
       if (typeof guestWebContentsId !== 'number' || !Number.isFinite(guestWebContentsId)) {
         throw new Error('Invalid browser guest webContents id');
       }
-      unregisterBrowserGuestF12(guestWebContentsId);
+      unregisterBrowserGuestF12(event.sender, guestWebContentsId);
     },
   );
 
   ipcMain.handle(
     'desktop:browser-guest-bind-devtools',
     (
-      _event: IpcMainInvokeEvent,
+      event: IpcMainInvokeEvent,
       payload: { pageWebContentsId?: number; devtoolsWebContentsId?: number },
     ) => {
       const pageWebContentsId = payload?.pageWebContentsId;
@@ -1114,29 +1114,29 @@ if (gotSpiritSingleInstanceLock) {
       ) {
         throw new Error('Invalid browser devtools bind payload');
       }
-      bindBrowserGuestDevtools(pageWebContentsId, devtoolsWebContentsId);
+      bindBrowserGuestDevtools(event.sender, pageWebContentsId, devtoolsWebContentsId);
     },
   );
 
   ipcMain.handle(
     'desktop:browser-guest-open-devtools',
-    (_event: IpcMainInvokeEvent, payload: { pageWebContentsId?: number }) => {
+    (event: IpcMainInvokeEvent, payload: { pageWebContentsId?: number }) => {
       const pageWebContentsId = payload?.pageWebContentsId;
       if (typeof pageWebContentsId !== 'number' || !Number.isFinite(pageWebContentsId)) {
         throw new Error('Invalid browser page webContents id');
       }
-      return openBrowserGuestDevtools(pageWebContentsId);
+      return openBrowserGuestDevtools(event.sender, pageWebContentsId);
     },
   );
 
   ipcMain.handle(
     'desktop:browser-guest-close-devtools',
-    (_event: IpcMainInvokeEvent, payload: { pageWebContentsId?: number }) => {
+    (event: IpcMainInvokeEvent, payload: { pageWebContentsId?: number }) => {
       const pageWebContentsId = payload?.pageWebContentsId;
       if (typeof pageWebContentsId !== 'number' || !Number.isFinite(pageWebContentsId)) {
         throw new Error('Invalid browser page webContents id');
       }
-      closeBrowserGuestDevtools(pageWebContentsId);
+      closeBrowserGuestDevtools(event.sender, pageWebContentsId);
     },
   );
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -198,6 +198,7 @@ function getDesktopWebHost(config: DesktopWebHostConfigFile): DesktopHttpHost {
         getTokenHash: () => desktopWebHostConfig?.authTokenHash,
         getPairingCode: () => desktopWebHostPairingCode,
         completePairing: completeDesktopWebHostPairing,
+        onPairingLockout: handleDesktopWebHostPairingLockout,
       },
       static: {
         root: rendererDistPath(),
@@ -381,6 +382,21 @@ async function syncDesktopWebHostWithConfig(
       host: config.host,
       port: config.port,
       error: message,
+    });
+  }
+}
+
+/** 配对失败达上限：作废当前配对码并停止对外展示；重启 Web Host 时重新生成。 */
+function handleDesktopWebHostPairingLockout(): void {
+  console.warn('[spirit-desktop] web host pairing locked after too many failures');
+  desktopWebHostPairingCode = '';
+  if (desktopWebHost?.isRunning() && desktopWebHostConfig) {
+    const state = desktopWebHost.getState();
+    setDesktopWebHostRuntimeStatus({
+      state: 'running',
+      host: desktopWebHostConfig.host,
+      port: desktopWebHostConfig.port,
+      ...(state.url ? { url: state.url } : {}),
     });
   }
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -668,6 +668,16 @@ async function createMainWindow(): Promise<BrowserWindow> {
   window.once('closed', () => {
     workspacePtyManager.disposeAllForWebContents(webContentsId);
   });
+  // 渲染进程崩溃或主 frame 重新导航（reload / 加载新页面）后，旧渲染侧的 PTY 会话与
+  // 500ms 轮询定时器无人接管，须在此回收；同文档内导航（SPA 路由）不触发。
+  window.webContents.on('render-process-gone', () => {
+    workspacePtyManager.disposeAllForWebContents(webContentsId);
+  });
+  window.webContents.on('did-start-navigation', (details) => {
+    if (details.isMainFrame && !details.isSameDocument) {
+      workspacePtyManager.disposeAllForWebContents(webContentsId);
+    }
+  });
 
   registerDesktopNotifications(window, {
     onApprovalAction: handleApprovalNotificationAction,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,6 +1,6 @@
 import './load-env.js';
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { copyFile, lstat, mkdir, readFile, realpath, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -461,19 +461,39 @@ function electronRootBackgroundForBackdrop(blurEnabled: boolean, darkContent: bo
 }
 
 /** 配置键仍为 `windowsMica`，表示各平台原生窗口模糊（Win Mica / macOS Vibrancy）。 */
+let cachedBackdropBlur: { mtimeMs: number; size: number; value: boolean } | undefined;
+
+/**
+ * 该值经 `desktop:read-native-backdrop-blur` 同步 IPC 暴露给渲染层：index.html 首帧
+ * 内联脚本须在渲染前同步拿到，无法改为异步。为避免每次同步 IPC 都读盘解析整个
+ * 配置文件，这里按 mtime/size 缓存，仅在配置文件变化时重新读取。
+ */
 function readBackdropBlurFromDisk(): boolean {
   const filePath = configFilePath();
-  if (!existsSync(filePath)) {
+  let mtimeMs: number;
+  let size: number;
+  try {
+    const stats = statSync(filePath);
+    mtimeMs = stats.mtimeMs;
+    size = stats.size;
+  } catch {
     return true;
   }
+  if (cachedBackdropBlur && cachedBackdropBlur.mtimeMs === mtimeMs && cachedBackdropBlur.size === size) {
+    return cachedBackdropBlur.value;
+  }
+
+  let value = true;
   try {
     const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as {
       windowsMica?: boolean;
     };
-    return parsed.windowsMica !== false;
+    value = parsed.windowsMica !== false;
   } catch {
-    return true;
+    value = true;
   }
+  cachedBackdropBlur = { mtimeMs, size, value };
+  return value;
 }
 
 const MACOS_WINDOW_VIBRANCY = 'under-window' as const;

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -444,8 +444,24 @@ function resolveWindowIconPath(): string | undefined {
   return undefined;
 }
 
+const WINDOWS_JUMP_LIST_REFRESH_COALESCE_MS = 1_000;
+let windowsJumpListRefreshTimer: ReturnType<typeof setTimeout> | undefined;
+
+/**
+ * 会话列表更新可能高频触发（每次都要 listSessions + app.setJumpList）；jump list
+ * 仅需最终一致，这里尾沿合并为一次刷新。此处为 jump list 唯一节流点。
+ */
 function refreshWindowsJumpList(): void {
-  void syncWindowsJumpList(resolveWindowIconPath());
+  if (process.platform !== 'win32') {
+    return;
+  }
+  if (windowsJumpListRefreshTimer !== undefined) {
+    return;
+  }
+  windowsJumpListRefreshTimer = setTimeout(() => {
+    windowsJumpListRefreshTimer = undefined;
+    void syncWindowsJumpList(resolveWindowIconPath());
+  }, WINDOWS_JUMP_LIST_REFRESH_COALESCE_MS);
 }
 
 /** 与 `src/styles.css` Void 暗色 `--background`（#000000）一致；关 Mica 时窗口底色用此值，避免 WebView 透底呈 Chromium #121212 */

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -153,6 +153,8 @@ const DEV_SERVER_URL = process.env.VITE_DEV_SERVER_URL;
 let desktopWebHost: DesktopHttpHost | undefined;
 let desktopWebHostConfig: DesktopWebHostConfigFile | undefined;
 let desktopWebHostPairingCode = createDesktopWebPairingCode();
+/** 配对失败达上限后为 true；HTTP handler 内失败计数未重置前不得重新生成配对码。 */
+let desktopWebHostPairingLocked = false;
 let quittingAfterDesktopWebHostStop = false;
 let unsubscribeDesktopDreamUpdates: (() => void) | undefined;
 let unsubscribeDesktopAutomationsUpdates: (() => void) | undefined;
@@ -320,7 +322,7 @@ async function syncDesktopWebHostWithConfig(
   desktopWebHostConfig = config;
   if (config.authTokenHash) {
     desktopWebHostPairingCode = '';
-  } else if (!desktopWebHostPairingCode) {
+  } else if (!desktopWebHostPairingCode && !desktopWebHostPairingLocked) {
     desktopWebHostPairingCode = createDesktopWebPairingCode();
   }
 
@@ -359,6 +361,14 @@ async function syncDesktopWebHostWithConfig(
     desktopWebHost = undefined;
   }
 
+  // 重启 HTTP handler 会重置 handler 内配对失败计数；此时才解除锁定并签发新码。
+  if (!config.authTokenHash) {
+    desktopWebHostPairingLocked = false;
+    if (!desktopWebHostPairingCode) {
+      desktopWebHostPairingCode = createDesktopWebPairingCode();
+    }
+  }
+
   setDesktopWebHostRuntimeStatus({
     state: 'starting',
     host: config.host,
@@ -389,6 +399,7 @@ async function syncDesktopWebHostWithConfig(
 /** 配对失败达上限：作废当前配对码并停止对外展示；重启 Web Host 时重新生成。 */
 function handleDesktopWebHostPairingLockout(): void {
   console.warn('[spirit-desktop] web host pairing locked after too many failures');
+  desktopWebHostPairingLocked = true;
   desktopWebHostPairingCode = '';
   if (desktopWebHost?.isRunning() && desktopWebHostConfig) {
     const state = desktopWebHost.getState();

--- a/apps/desktop/electron/web-host.ts
+++ b/apps/desktop/electron/web-host.ts
@@ -33,6 +33,11 @@ const webHost = createDesktopHttpHost({
   auth: {
     getTokenHash: () => webHostConfig.authTokenHash,
     getPairingCode: () => pairingCode,
+    // 配对失败达上限：作废配对码；须重启 web-host 进程重新生成。
+    onPairingLockout: () => {
+      console.warn('Spirit desktop web pairing locked after too many failures; restart web host to get a new code.');
+      pairingCode = '';
+    },
     completePairing: async (authTokenHash) => {
       await invokeDesktopHostCommand('setWebHostAuthTokenHash', { authTokenHash });
       webHostConfig = (await loadConfig()).webHost;

--- a/apps/desktop/electron/workspace-browser-guest.ts
+++ b/apps/desktop/electron/workspace-browser-guest.ts
@@ -8,16 +8,37 @@ type GuestF12Registration = {
 
 const f12ByGuestId = new Map<number, GuestF12Registration>();
 
+/**
+ * IPC 传入的 webContentsId 可为任意值；存活目标必须是 <webview> guest 且其宿主
+ * （embedder）为发起 IPC 的 sender，防止渲染进程操纵其他窗口 / 主窗口的 webContents。
+ * 目标已销毁（如 tab 关闭竞态）时返回 null，由调用方决定是否视为无效。
+ */
+function findOwnedWebviewGuest(host: WebContents, guestWebContentsId: number): WebContents | null {
+  const guest = webContents.fromId(guestWebContentsId);
+  if (!guest || guest.isDestroyed()) {
+    return null;
+  }
+  if (guest.getType() !== 'webview' || guest.hostWebContents?.id !== host.id) {
+    throw new Error('Invalid browser guest webContents');
+  }
+  return guest;
+}
+
+function requireOwnedWebviewGuest(host: WebContents, guestWebContentsId: number): WebContents {
+  const guest = findOwnedWebviewGuest(host, guestWebContentsId);
+  if (!guest) {
+    throw new Error('Invalid browser guest webContents');
+  }
+  return guest;
+}
+
 export function registerBrowserGuestF12(
   host: WebContents,
   tabId: string,
   guestWebContentsId: number,
 ): void {
-  unregisterBrowserGuestF12(guestWebContentsId);
-  const guest = webContents.fromId(guestWebContentsId);
-  if (!guest || guest.isDestroyed()) {
-    throw new Error('Invalid browser guest webContents');
-  }
+  unregisterBrowserGuestF12(host, guestWebContentsId);
+  const guest = requireOwnedWebviewGuest(host, guestWebContentsId);
 
   const onBeforeInput = (event: Electron.Event, input: Electron.Input) => {
     if (input.type === 'keyDown' && input.key === 'F12') {
@@ -32,9 +53,9 @@ export function registerBrowserGuestF12(
   f12ByGuestId.set(guestWebContentsId, { host, tabId, onBeforeInput });
 }
 
-export function unregisterBrowserGuestF12(guestWebContentsId: number): void {
+export function unregisterBrowserGuestF12(host: WebContents, guestWebContentsId: number): void {
   const registration = f12ByGuestId.get(guestWebContentsId);
-  if (!registration) {
+  if (!registration || registration.host.id !== host.id) {
     return;
   }
   const guest = webContents.fromId(guestWebContentsId);
@@ -45,29 +66,27 @@ export function unregisterBrowserGuestF12(guestWebContentsId: number): void {
 }
 
 export function bindBrowserGuestDevtools(
+  host: WebContents,
   pageGuestId: number,
   devtoolsGuestId: number,
 ): void {
-  const page = webContents.fromId(pageGuestId);
-  const devtools = webContents.fromId(devtoolsGuestId);
-  if (!page || page.isDestroyed() || !devtools || devtools.isDestroyed()) {
-    throw new Error('Invalid browser devtools bind target');
-  }
+  const page = requireOwnedWebviewGuest(host, pageGuestId);
+  const devtools = requireOwnedWebviewGuest(host, devtoolsGuestId);
   page.setDevToolsWebContents(devtools);
 }
 
-export function openBrowserGuestDevtools(pageGuestId: number): boolean {
-  const page = webContents.fromId(pageGuestId);
-  if (!page || page.isDestroyed() || page.isDevToolsOpened()) {
+export function openBrowserGuestDevtools(host: WebContents, pageGuestId: number): boolean {
+  const page = findOwnedWebviewGuest(host, pageGuestId);
+  if (!page || page.isDevToolsOpened()) {
     return false;
   }
   page.openDevTools({ mode: 'detach', activate: true });
   return true;
 }
 
-export function closeBrowserGuestDevtools(pageGuestId: number): void {
-  const page = webContents.fromId(pageGuestId);
-  if (!page || page.isDestroyed() || !page.isDevToolsOpened()) {
+export function closeBrowserGuestDevtools(host: WebContents, pageGuestId: number): void {
+  const page = findOwnedWebviewGuest(host, pageGuestId);
+  if (!page || !page.isDevToolsOpened()) {
     return;
   }
   page.closeDevTools();

--- a/apps/desktop/test/host/web-host-pairing.test.mjs
+++ b/apps/desktop/test/host/web-host-pairing.test.mjs
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  MAX_PAIRING_FAILURES,
+  createDesktopHttpRequestHandler,
+  isAllowedRequestHostHeader,
+} from '../../dist-electron/electron/http-host.js';
+
+function makeRequest({ method, url, host = '127.0.0.1:7788', body }) {
+  const chunks = body === undefined ? [] : [Buffer.from(JSON.stringify(body), 'utf8')];
+  return {
+    method,
+    url,
+    // host 传 null 表示请求缺失 Host 头
+    headers: host === null ? {} : { host },
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    },
+  };
+}
+
+function makeResponse() {
+  return {
+    statusCode: 0,
+    headers: {},
+    body: '',
+    setHeader(name, value) {
+      this.headers[name] = value;
+    },
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      Object.assign(this.headers, headers ?? {});
+    },
+    end(payload) {
+      this.body = payload === undefined ? '' : String(payload);
+    },
+    once() {},
+  };
+}
+
+function makePairingHandler({ pairingCode = '123456' } = {}) {
+  const state = { tokenHash: undefined, lockoutCalls: 0 };
+  const handler = createDesktopHttpRequestHandler({
+    host: '127.0.0.1',
+    invokeHostCommand: async () => ({}),
+    auth: {
+      getTokenHash: () => state.tokenHash,
+      getPairingCode: () => pairingCode,
+      completePairing: async (authTokenHash) => {
+        state.tokenHash = authTokenHash;
+      },
+      onPairingLockout: () => {
+        state.lockoutCalls += 1;
+      },
+    },
+  });
+  return { handler, state };
+}
+
+async function postPairing(handler, code, host = '127.0.0.1:7788') {
+  const response = makeResponse();
+  await handler(makeRequest({ method: 'POST', url: '/api/pairing', host, body: { code } }), response);
+  return response;
+}
+
+test('配对码正确时返回 token 并完成配对', async () => {
+  const { handler, state } = makePairingHandler();
+  const response = await postPairing(handler, '123456');
+  assert.equal(response.statusCode, 200);
+  const parsed = JSON.parse(response.body);
+  assert.equal(typeof parsed.token, 'string');
+  assert.ok(parsed.token.length > 0);
+  assert.equal(typeof state.tokenHash, 'string');
+  assert.equal(state.lockoutCalls, 0);
+});
+
+test('连续失败达上限后锁定：正确配对码也拒绝，且触发 onPairingLockout 一次', async () => {
+  const { handler, state } = makePairingHandler();
+
+  for (let attempt = 1; attempt <= MAX_PAIRING_FAILURES; attempt += 1) {
+    const response = await postPairing(handler, '000000');
+    assert.equal(response.statusCode, 401, `第 ${attempt} 次失败应为 401`);
+    assert.equal(JSON.parse(response.body).code, 'PAIRING_FAILED');
+  }
+  assert.equal(state.lockoutCalls, 1);
+
+  const locked = await postPairing(handler, '123456');
+  assert.equal(locked.statusCode, 429);
+  assert.equal(JSON.parse(locked.body).code, 'PAIRING_LOCKED');
+  assert.equal(state.tokenHash, undefined);
+  assert.equal(state.lockoutCalls, 1);
+});
+
+test('未达上限时正确配对码仍可完成配对', async () => {
+  const { handler, state } = makePairingHandler();
+
+  for (let attempt = 1; attempt < MAX_PAIRING_FAILURES; attempt += 1) {
+    const response = await postPairing(handler, '999999');
+    assert.equal(response.statusCode, 401);
+  }
+  assert.equal(state.lockoutCalls, 0);
+
+  const success = await postPairing(handler, '123456');
+  assert.equal(success.statusCode, 200);
+  assert.equal(typeof state.tokenHash, 'string');
+});
+
+test('配对码已作废（空串）时不接受任意输入', async () => {
+  const { handler, state } = makePairingHandler({ pairingCode: '' });
+  const response = await postPairing(handler, '');
+  assert.equal(response.statusCode, 401);
+  assert.equal(state.tokenHash, undefined);
+});
+
+test('API 请求校验 Host 头：非法 Host 返回 403，合法 Host 放行', async () => {
+  const { handler } = makePairingHandler();
+
+  const rejected = makeResponse();
+  await handler(
+    makeRequest({ method: 'GET', url: '/api/pairing/status', host: 'attacker.example.com:7788' }),
+    rejected,
+  );
+  assert.equal(rejected.statusCode, 403);
+
+  const missing = makeResponse();
+  await handler(makeRequest({ method: 'GET', url: '/api/pairing/status', host: null }), missing);
+  assert.equal(missing.statusCode, 403);
+
+  for (const allowedHost of ['127.0.0.1:7788', 'localhost:7788', '[::1]:7788']) {
+    const accepted = makeResponse();
+    await handler(
+      makeRequest({ method: 'GET', url: '/api/pairing/status', host: allowedHost }),
+      accepted,
+    );
+    assert.equal(accepted.statusCode, 200, `Host ${allowedHost} 应放行`);
+  }
+});
+
+test('isAllowedRequestHostHeader：配置 host 与回环形式', () => {
+  assert.equal(isAllowedRequestHostHeader('127.0.0.1:7788', '127.0.0.1'), true);
+  assert.equal(isAllowedRequestHostHeader('localhost', '127.0.0.1'), true);
+  assert.equal(isAllowedRequestHostHeader('[::1]:7788', '127.0.0.1'), true);
+  assert.equal(isAllowedRequestHostHeader('myhost.lan:7788', 'myhost.lan'), true);
+
+  assert.equal(isAllowedRequestHostHeader('attacker.com', '127.0.0.1'), false);
+  assert.equal(isAllowedRequestHostHeader('attacker.com:7788', '127.0.0.1'), false);
+  assert.equal(isAllowedRequestHostHeader('127.0.0.1.attacker.com', '127.0.0.1'), false);
+  assert.equal(isAllowedRequestHostHeader('192.168.1.5:7788', '127.0.0.1'), false);
+  assert.equal(isAllowedRequestHostHeader(undefined, '127.0.0.1'), false);
+  assert.equal(isAllowedRequestHostHeader('', '127.0.0.1'), false);
+});
+
+test('isAllowedRequestHostHeader：绑定通配地址时放行 IP 字面量、拒绝域名', () => {
+  assert.equal(isAllowedRequestHostHeader('192.168.1.5:7788', '0.0.0.0'), true);
+  assert.equal(isAllowedRequestHostHeader('[fe80::1]:7788', '::'), true);
+  assert.equal(isAllowedRequestHostHeader('attacker.com:7788', '0.0.0.0'), false);
+});


### PR DESCRIPTION
## Summary

- Web Host 配对码 5 次失败锁定、常数时间比较与 Host 头校验，降低 DNS rebinding 与暴力破解风险
- 渲染进程崩溃或主 frame 导航时回收 PTY 与 500ms 轮询定时器
- browser-guest DevTools IPC 校验 webview 归属与 sender
- backdrop blur 配置按 mtime 缓存；Windows jump list 1s 尾沿去抖

## Test plan

- [x] `tsc -p tsconfig.electron.json` 与 `tsconfig.preload.cjs.json` 通过
- [x] `tsx --test test/host/web-host-pairing.test.mjs` 7 项通过