### PR TITLE
fix(desktop): 修复 pane 草稿丢失与 Composer 补全快捷键问题

### DIFF
--- a/apps/desktop/src/components/composer-rich-input.tsx
+++ b/apps/desktop/src/components/composer-rich-input.tsx
@@ -21,7 +21,6 @@ import { caretToDomRange, selectionToCaret } from "@/lib/composer-segment-select
 import {
   caretAtEnd,
   caretToPlainTextOffset,
-  plainTextOffsetToCaret,
   replaceSkillSlashQueryInSegments,
   replaceWorkspaceFileReferenceInSegments,
   normalizeWorkspaceFilePath,
@@ -340,13 +339,26 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         return;
       }
       const report = () => reportSelectionChange();
+      // document 级 selectionchange 每个 Composer 实例都会挂一份（分屏多 pane）；
+      // 选区不落在本输入框内时直接跳过，避免全局任意选区变化都触发 segments 全量遍历。
+      const onDocumentSelectionChange = () => {
+        const selection = window.getSelection();
+        if (
+          !selection
+          || selection.rangeCount === 0
+          || !div.contains(selection.getRangeAt(0).commonAncestorContainer)
+        ) {
+          return;
+        }
+        report();
+      };
       div.addEventListener("mouseup", report);
       div.addEventListener("keyup", report);
-      document.addEventListener("selectionchange", report);
+      document.addEventListener("selectionchange", onDocumentSelectionChange);
       return () => {
         div.removeEventListener("mouseup", report);
         div.removeEventListener("keyup", report);
-        document.removeEventListener("selectionchange", report);
+        document.removeEventListener("selectionchange", onDocumentSelectionChange);
       };
     }, [onSelectionChange, reportSelectionChange]);
 
@@ -757,35 +769,33 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
       reportSelectionChange();
     }, [reportSelectionChange]);
 
+    /**
+     * 只读测量：请求的 plainTextOffset 来自 onSelectionChange 上报的实时光标，
+     * 因此仅当当前选区确实位于该偏移时读取其 rect；不再用 removeAllRanges/addRange
+     * 真实搬移选区（会触发全局 selectionchange 风暴并干扰其他 pane 的选区）。
+     * 选区不在请求位置时返回 null，由调用方回退到 composer 底部锚点。
+     */
     const getPlainTextCaretClientRect = useCallback((plainTextOffset: number): DOMRect | null => {
       const root = divRef.current;
       if (!root) {
         return null;
       }
 
-      const segments = segmentsRef.current;
-      const caret = plainTextOffsetToCaret(segments, plainTextOffset);
       const selection = window.getSelection();
-      const savedRanges: Range[] = [];
-      if (selection) {
-        for (let index = 0; index < selection.rangeCount; index += 1) {
-          savedRanges.push(selection.getRangeAt(index).cloneRange());
-        }
+      if (!selection || selection.rangeCount === 0) {
+        return null;
+      }
+      const range = selection.getRangeAt(0);
+      if (!root.contains(range.commonAncestorContainer)) {
+        return null;
       }
 
-      caretToDomRange(root, segments, caret);
-
-      let rect: DOMRect | null = null;
-      if (selection && selection.rangeCount > 0) {
-        rect = selection.getRangeAt(0).getBoundingClientRect();
+      const segments = segmentsRef.current;
+      const caret = selectionToCaret(root, segments);
+      if (!caret || caretToPlainTextOffset(segments, caret) !== plainTextOffset) {
+        return null;
       }
-
-      selection?.removeAllRanges();
-      for (const range of savedRanges) {
-        selection?.addRange(range);
-      }
-
-      return rect;
+      return range.cloneRange().getBoundingClientRect();
     }, []);
 
     useImperativeHandle(
@@ -1354,35 +1364,24 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, Props>(
         const editorPaddingLeft = parseFloat(getComputedStyle(editor).paddingLeft) || 0;
         const defaultPlaceholderLeft = editorPaddingLeft + (editorRect.left - shellRect.left);
 
-        const segs = segmentsRef.current;
-        const caret = caretAfterAgentModeChip(segs);
+        // 只读测量：焦点在编辑器内时直接读当前选区 rect；否则以 chip 右缘为锚点，
+        // 不再通过 removeAllRanges/addRange 搬移全局选区来量 caret 位置。
         const selection = window.getSelection();
-        const savedRanges: Range[] = [];
-        if (selection) {
-          for (let index = 0; index < selection.rangeCount; index += 1) {
-            savedRanges.push(selection.getRangeAt(index).cloneRange());
-          }
-        }
-
-        let caretRect: DOMRect | null = null;
+        let caretLeftInShell: number | null = null;
         if (
           selection
           && selection.rangeCount > 0
           && editor.contains(selection.anchorNode)
         ) {
-          caretRect = selection.getRangeAt(0).getBoundingClientRect();
+          const caretRect = selection.getRangeAt(0).cloneRange().getBoundingClientRect();
+          caretLeftInShell = caretRect.left - shellRect.left;
         } else {
-          caretToDomRange(editor, segs, caret);
-          if (selection && selection.rangeCount > 0) {
-            caretRect = selection.getRangeAt(0).getBoundingClientRect();
-          }
-          selection?.removeAllRanges();
-          for (const range of savedRanges) {
-            selection?.addRange(range);
+          const chipRect = chip.getBoundingClientRect();
+          if (chipRect.width > 0 || chipRect.height > 0) {
+            caretLeftInShell = chipRect.right - shellRect.left;
           }
         }
 
-        const caretLeftInShell = caretRect ? caretRect.left - shellRect.left : null;
         setAgentModeChipPlaceholderLeft(caretLeftInShell ?? defaultPlaceholderLeft);
       };
 

--- a/apps/desktop/src/hooks/use-monaco-code-completion.ts
+++ b/apps/desktop/src/hooks/use-monaco-code-completion.ts
@@ -186,6 +186,7 @@ export function useMonacoCodeCompletion(options: {
       applyDeletePreviewEdit(editor, state.spec);
       clearDeletePreview();
     };
+    acceptDeletePreviewRef.current = acceptDeletePreview;
 
     const executeFetch = async (
       requestPosition: monaco.Position,
@@ -325,14 +326,6 @@ export function useMonacoCodeCompletion(options: {
       freeInlineCompletions: () => {},
     });
 
-    editor.addCommand(
-      monaco.KeyCode.Tab,
-      () => {
-        acceptDeletePreview();
-      },
-      DELETE_PREVIEW_CONTEXT_KEY,
-    );
-
     const contentDisposable = editor.onDidChangeModelContent(() => {
       const position = editor.getPosition();
       const model = editor.getModel();
@@ -359,6 +352,7 @@ export function useMonacoCodeCompletion(options: {
     });
 
     return () => {
+      acceptDeletePreviewRef.current = null;
       contentDisposable.dispose();
       cursorDisposable.dispose();
       if (debounceTimerRef.current !== undefined) {

--- a/apps/desktop/src/hooks/use-monaco-code-completion.ts
+++ b/apps/desktop/src/hooks/use-monaco-code-completion.ts
@@ -99,6 +99,7 @@ export function useMonacoCodeCompletion(options: {
   const cacheRef = useRef<CompletionCache | null>(null);
   const deletePreviewRef = useRef<DeletePreviewState | null>(null);
   const deletePreviewActiveRef = useRef<monaco.editor.IContextKey<boolean> | null>(null);
+  const acceptDeletePreviewRef = useRef<(() => void) | null>(null);
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const fetchTokenRef = useRef(0);
   const fetchInFlightRef = useRef(false);
@@ -109,15 +110,40 @@ export function useMonacoCodeCompletion(options: {
   relativePathRef.current = relativePath;
   baselineRef.current = baselineText;
 
+  // Context key 与 Tab 命令随 editor 实例创建一次：context key 属于该 editor 的
+  // contextKeyService，跨实例缓存会把状态写到已销毁的 editor 上，导致重建后
+  // Tab 接受静默失效；addCommand 不可注销，只能靠随 editor 一起销毁。
+  useEffect(() => {
+    if (!editor) {
+      deletePreviewActiveRef.current = null;
+      return;
+    }
+    deletePreviewActiveRef.current = editor.createContextKey<boolean>(
+      DELETE_PREVIEW_CONTEXT_KEY,
+      false,
+    );
+    editor.addCommand(
+      monaco.KeyCode.Tab,
+      () => {
+        acceptDeletePreviewRef.current?.();
+      },
+      DELETE_PREVIEW_CONTEXT_KEY,
+    );
+    return () => {
+      deletePreviewActiveRef.current = null;
+    };
+  }, [editor]);
+
   useEffect(() => {
     if (!editor || !api || readOnly || !enabled) {
       return;
     }
 
     const languageId = monacoLanguageId(relativePath);
-    const deletePreviewActiveKey =
-      deletePreviewActiveRef.current ?? editor.createContextKey(DELETE_PREVIEW_CONTEXT_KEY, false);
-    deletePreviewActiveRef.current = deletePreviewActiveKey;
+    const deletePreviewActiveKey = deletePreviewActiveRef.current;
+    if (!deletePreviewActiveKey) {
+      return;
+    }
 
     const clearInlineGhostCache = () => {
       cacheRef.current = null;

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -15,8 +15,8 @@ import {
 } from "@spiritagent/host-internal/workspace-file-reference-query";
 
 import type { ComposerRichInputHandle } from "@/components/composer-rich-input";
-import { segmentsToMessageText } from "@/components/composer-rich-input";
-import { extractComposerChipMetadata } from "@/lib/composer-segment-model";
+import { segmentsToMessageText, segmentsToPlainText } from "@/components/composer-rich-input";
+import { extractComposerChipMetadata, normalizeComposerPlain } from "@/lib/composer-segment-model";
 import { currentAgentModeSegment } from "@/lib/composer-agent-mode-segments";
 import { cycleAgentMode, type DesktopAgentMode } from "@/lib/agent-mode";
 import { currentWorkspaceFileReferenceQueryFromSegments } from "@/lib/composer-file-reference-query";
@@ -78,6 +78,9 @@ import type {
 import type { RichSegment } from "@/lib/composer-segment-model";
 
 type DesktopRuntime = ReturnType<typeof useDesktopRuntime>;
+
+/** 与非 pane 路径（useDesktopRuntime）一致的草稿落盘防抖间隔。 */
+const PANE_COMPOSER_DRAFT_PERSIST_DEBOUNCE_MS = 400;
 
 export type UseComposerControllerOptions = {
   runtime: DesktopRuntime;
@@ -176,22 +179,6 @@ export function useComposerController({
   } | null>(null);
   const composerRichInputRef = useRef<ComposerRichInputHandle | null>(null);
 
-  const persistPaneComposerDraft = useCallback(() => {
-    if (!isPaneIsolated || !paneComposerDraftKey) {
-      return;
-    }
-    writeComposerDraft(paneComposerDraftKey, {
-      text: composerText,
-      localFilePaths: composerLocalFileAttachments.map((item) => item.path),
-      segments: composerRichInputRef.current?.getSegments() ?? [],
-    });
-  }, [
-    composerLocalFileAttachments,
-    paneComposerDraftKey,
-    composerText,
-    isPaneIsolated,
-  ]);
-
   const clearPaneComposerDraft = useCallback(() => {
     if (!isPaneIsolated || !paneComposerDraftKey) {
       return;
@@ -223,6 +210,47 @@ export function useComposerController({
     setComposerLocalFileAttachments,
     runtime.readLocalImagePreviewDataUrl,
   );
+
+  const panePendingDraftPersistRef = useRef<(() => void) | null>(null);
+
+  // pane 草稿防抖落盘：文本经 notifyParents 更新 composerText，chip 变更经 segments commit
+  // 递增 composerSegmentsRevision，两者都会触发本效果。text 由落盘时刻的 segments 派生，
+  // 避免闭包中的 composerText 滞后于 segments 造成 text 与 segments 不一致。
+  useEffect(() => {
+    if (!isPaneIsolated || !paneComposerDraftKey) {
+      panePendingDraftPersistRef.current = null;
+      return;
+    }
+    const persist = () => {
+      panePendingDraftPersistRef.current = null;
+      const richInput = composerRichInputRef.current;
+      if (!richInput) {
+        return;
+      }
+      const segments = richInput.getSegments();
+      writeComposerDraft(paneComposerDraftKey, {
+        text: normalizeComposerPlain(segmentsToPlainText(segments)),
+        localFilePaths: composerLocalFileAttachments.map((item) => item.path),
+        segments,
+      });
+    };
+    panePendingDraftPersistRef.current = persist;
+    const timeout = window.setTimeout(persist, PANE_COMPOSER_DRAFT_PERSIST_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeout);
+  }, [
+    composerLocalFileAttachments,
+    composerSegmentsRevision,
+    composerText,
+    isPaneIsolated,
+    paneComposerDraftKey,
+  ]);
+
+  // pane 切会话 / 卸载时冲刷未落盘草稿（对应非 pane 路径切会话时的 cacheSessionUi 立即写入）。
+  useEffect(() => {
+    return () => {
+      panePendingDraftPersistRef.current?.();
+    };
+  }, [paneComposerDraftKey]);
 
   const composerDirectMediaMode = useMemo(() => {
     if (!snapshot?.config) {
@@ -1154,14 +1182,12 @@ export function useComposerController({
   }, [slashQuery]);
 
   const handleComposerSegmentsCommit = useCallback(() => {
-    const segments = composerRichInputRef.current?.getSegments() ?? [];
-    if (isPaneIsolated) {
-      persistPaneComposerDraft();
-    } else {
-      runtime.setComposerDraftSegments(segments);
+    if (!isPaneIsolated) {
+      runtime.setComposerDraftSegments(composerRichInputRef.current?.getSegments() ?? []);
     }
+    // pane 路径依赖 revision 触发上方防抖落盘效果，无需在此同步写入。
     setComposerSegmentsRevision((revision) => revision + 1);
-  }, [isPaneIsolated, persistPaneComposerDraft, runtime]);
+  }, [isPaneIsolated, runtime]);
 
   return {
     composerText,

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -212,6 +212,34 @@ export function useComposerController({
   );
 
   const panePendingDraftPersistRef = useRef<(() => void) | null>(null);
+  const paneDraftFlushSnapshotRef = useRef<{
+    key: string;
+    localFilePaths: string[];
+    segments: RichSegment[];
+  } | null>(null);
+
+  // 卸载 ComposerRichInput 后 ref 为空，须用最近一次同步的快照在切 pane/卸载时落盘。
+  useEffect(() => {
+    if (!isPaneIsolated || !paneComposerDraftKey) {
+      paneDraftFlushSnapshotRef.current = null;
+      return;
+    }
+    const richInput = composerRichInputRef.current;
+    if (!richInput) {
+      return;
+    }
+    paneDraftFlushSnapshotRef.current = {
+      key: paneComposerDraftKey,
+      localFilePaths: composerLocalFileAttachments.map((item) => item.path),
+      segments: richInput.getSegments(),
+    };
+  }, [
+    composerLocalFileAttachments,
+    composerSegmentsRevision,
+    composerText,
+    isPaneIsolated,
+    paneComposerDraftKey,
+  ]);
 
   // pane 草稿防抖落盘：文本经 notifyParents 更新 composerText，chip 变更经 segments commit
   // 递增 composerSegmentsRevision，两者都会触发本效果。text 由落盘时刻的 segments 派生，
@@ -247,8 +275,21 @@ export function useComposerController({
 
   // pane 切会话 / 卸载时冲刷未落盘草稿（对应非 pane 路径切会话时的 cacheSessionUi 立即写入）。
   useEffect(() => {
+    const flushKey = paneComposerDraftKey;
     return () => {
+      if (!flushKey) {
+        return;
+      }
       panePendingDraftPersistRef.current?.();
+      const snapshot = paneDraftFlushSnapshotRef.current;
+      if (!snapshot || snapshot.key !== flushKey) {
+        return;
+      }
+      writeComposerDraft(flushKey, {
+        text: normalizeComposerPlain(segmentsToPlainText(snapshot.segments)),
+        localFilePaths: snapshot.localFilePaths,
+        segments: snapshot.segments,
+      });
     };
   }, [paneComposerDraftKey]);
 

--- a/apps/desktop/src/hooks/useDesktopKeyboardShortcuts.ts
+++ b/apps/desktop/src/hooks/useDesktopKeyboardShortcuts.ts
@@ -10,6 +10,7 @@ import {
   isModShortcutPressed,
 } from "@/lib/desktop-shell";
 import {
+  isEditableShortcutTarget,
   resolveModCommaSettingsShortcutAction,
   resolveModBackslashSplitShortcutAction,
   resolveModPShortcutAction,
@@ -205,12 +206,8 @@ export function useDesktopKeyboardShortcuts({
       if (!isModShortcutPressed(event) || event.key.toLowerCase() !== "n") {
         return;
       }
-      const target = event.target as HTMLElement | null;
-      if (target) {
-        const tag = target.tagName;
-        if (tag === "TEXTAREA" || target.isContentEditable) {
-          return;
-        }
+      if (isEditableShortcutTarget(event.target as HTMLElement | null)) {
+        return;
       }
       event.preventDefault();
       handleNewSession();

--- a/apps/desktop/src/hooks/useWorkspaceToolsController.ts
+++ b/apps/desktop/src/hooks/useWorkspaceToolsController.ts
@@ -80,11 +80,25 @@ export function useWorkspaceToolsController({
   const [workspaceToolsWidthPx, setWorkspaceToolsWidthPx] = useState(readWorkspaceToolsWidthPx);
 
   useEffect(() => {
+    // resize 拖动期间事件连发；rAF 合帧后再读 localStorage 中的宽度比例，
+    // 避免每次 resize 都同步读存储（存储值会随分隔条拖拽更新，不能只缓存首值）。
+    let frame = 0;
     const onResize = () => {
-      setWorkspaceToolsWidthPx(readWorkspaceToolsWidthPx());
+      if (frame !== 0) {
+        return;
+      }
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        setWorkspaceToolsWidthPx(readWorkspaceToolsWidthPx());
+      });
     };
     window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    return () => {
+      if (frame !== 0) {
+        window.cancelAnimationFrame(frame);
+      }
+      window.removeEventListener("resize", onResize);
+    };
   }, []);
   const [workspacePrRevealNonce, setWorkspacePrRevealNonce] = useState(0);
   const [workspacePrRevealTargetId, setWorkspacePrRevealTargetId] = useState<string | null>(null);

--- a/apps/desktop/src/lib/desktop-keyboard-shortcut-eligibility.ts
+++ b/apps/desktop/src/lib/desktop-keyboard-shortcut-eligibility.ts
@@ -67,7 +67,7 @@ export type SettingsShortcutSurfaceContext = {
   activeSurface: ConversationAbortShortcutContext["activeSurface"];
 };
 
-function isEditableShortcutTarget(target: HTMLElement | null): boolean {
+export function isEditableShortcutTarget(target: HTMLElement | null): boolean {
   if (!target) {
     return false;
   }

--- a/packages/host-internal/src/workspace-file-reference-query.ts
+++ b/packages/host-internal/src/workspace-file-reference-query.ts
@@ -104,6 +104,52 @@ export function deriveWorkspaceDirectoryPathsFromFiles(files: readonly string[])
   return Array.from(directories);
 }
 
+interface PreparedReferenceCandidate {
+  path: string;
+  isDirectory: boolean;
+  pathLower: string;
+  basenameLower: string;
+  basenameLength: number;
+  pathLength: number;
+}
+
+interface PreparedReferenceIndex {
+  files: PreparedReferenceCandidate[];
+  directories: PreparedReferenceCandidate[];
+}
+
+/**
+ * 按 files 数组引用缓存预计算候选（小写、basename、目录推导），
+ * 避免每次按键对全量文件重复 toLowerCase / Array.from / 目录推导。
+ */
+const preparedReferenceIndexCache = new WeakMap<readonly string[], PreparedReferenceIndex>();
+
+function prepareReferenceCandidate(path: string): PreparedReferenceCandidate {
+  const normalizedPath = normalizeWorkspaceReferenceDirectoryPath(path);
+  const basename = referencePathBasename(path);
+  return {
+    path,
+    isDirectory: isWorkspaceReferenceDirectoryPath(path),
+    pathLower: normalizedPath.toLowerCase(),
+    basenameLower: basename.toLowerCase(),
+    basenameLength: Array.from(basename).length,
+    pathLength: Array.from(normalizedPath).length,
+  };
+}
+
+function preparedReferenceIndexForFiles(files: readonly string[]): PreparedReferenceIndex {
+  const cached = preparedReferenceIndexCache.get(files);
+  if (cached) {
+    return cached;
+  }
+  const prepared: PreparedReferenceIndex = {
+    files: files.map(prepareReferenceCandidate),
+    directories: deriveWorkspaceDirectoryPathsFromFiles(files).map(prepareReferenceCandidate),
+  };
+  preparedReferenceIndexCache.set(files, prepared);
+  return prepared;
+}
+
 export function computeWorkspaceFileReferenceSuggestions(
   query: string,
   files: readonly string[],
@@ -113,50 +159,34 @@ export function computeWorkspaceFileReferenceSuggestions(
     .replace(/^@/u, '')
     .trim()
     .toLowerCase();
+  const needleChars = Array.from(needle);
 
   const includeDirectories = options?.includeDirectories !== false;
-  const directories = includeDirectories ? deriveWorkspaceDirectoryPathsFromFiles(files) : [];
-  const candidates = [...directories, ...files];
+  const index = preparedReferenceIndexForFiles(files);
+  const candidates = includeDirectories
+    ? [...index.directories, ...index.files]
+    : index.files;
 
-  const scored = candidates
-    .map((path) => {
-      const isDirectory = isWorkspaceReferenceDirectoryPath(path);
-      const score = scoreWorkspaceFileReferenceCandidate(needle, path);
-      if (!score) {
-        return undefined;
-      }
-
-      return {
-        score: score.score,
-        isDirectory,
-        basenameLength: score.basenameLength,
-        pathLength: score.pathLength,
-        path,
-      };
-    })
-    .filter(
-      (
-        item,
-      ): item is {
-        score: number;
-        isDirectory: boolean;
-        basenameLength: number;
-        pathLength: number;
-        path: string;
-      } => item !== undefined,
-    );
+  const scored: { score: number; candidate: PreparedReferenceCandidate }[] = [];
+  for (const candidate of candidates) {
+    const score = scorePreparedReferenceCandidate(needle, needleChars, candidate);
+    if (score === undefined) {
+      continue;
+    }
+    scored.push({ score, candidate });
+  }
 
   scored.sort((left, right) => {
     return (
       right.score - left.score ||
-      Number(right.isDirectory) - Number(left.isDirectory) ||
-      left.basenameLength - right.basenameLength ||
-      left.pathLength - right.pathLength ||
-      left.path.localeCompare(right.path)
+      Number(right.candidate.isDirectory) - Number(left.candidate.isDirectory) ||
+      left.candidate.basenameLength - right.candidate.basenameLength ||
+      left.candidate.pathLength - right.candidate.pathLength ||
+      left.candidate.path.localeCompare(right.candidate.path)
     );
   });
 
-  return scored.slice(0, DEFAULT_SUGGESTION_LIMIT).map((item) => item.path);
+  return scored.slice(0, DEFAULT_SUGGESTION_LIMIT).map((item) => item.candidate.path);
 }
 
 export function charCountToCodeUnitIndex(input: string, cursorChars: number): number {
@@ -246,90 +276,81 @@ function referencePathBasename(path: string): string {
   return normalized.split('/').at(-1) ?? normalized;
 }
 
-function scoreWorkspaceFileReferenceCandidate(
+function scorePreparedReferenceCandidate(
   needle: string,
-  path: string,
-): { score: number; basenameLength: number; pathLength: number } | undefined {
-  const normalizedPath = normalizeWorkspaceReferenceDirectoryPath(path);
-  const pathLower = normalizedPath.toLowerCase();
-  const basename = referencePathBasename(path);
-  const basenameLower = basename.toLowerCase();
-  const basenameLength = Array.from(basename).length;
-  const pathLength = Array.from(normalizedPath).length;
-  const isDirectory = isWorkspaceReferenceDirectoryPath(path);
+  needleChars: readonly string[],
+  candidate: PreparedReferenceCandidate,
+): number | undefined {
+  const { isDirectory, pathLower, basenameLower, basenameLength, pathLength } = candidate;
 
   if (!needle) {
-    return { score: isDirectory ? 1 : 0, basenameLength, pathLength };
+    return isDirectory ? 1 : 0;
   }
   if (basenameLower === needle) {
-    return { score: isDirectory ? 10_100 : 10_000, basenameLength, pathLength };
+    return isDirectory ? 10_100 : 10_000;
   }
   if (pathLower === needle) {
-    return { score: 9_700, basenameLength, pathLength };
+    return 9_700;
   }
   if (basenameLower.startsWith(needle)) {
-    return { score: 9_400 - basenameLength, basenameLength, pathLength };
+    return 9_400 - basenameLength;
   }
   if (pathLower.endsWith(needle)) {
-    return { score: 9_100 - pathLength, basenameLength, pathLength };
+    return 9_100 - pathLength;
   }
 
   const basenamePosition = basenameLower.indexOf(needle);
   if (basenamePosition >= 0) {
-    return { score: 8_600 - basenamePosition * 10, basenameLength, pathLength };
+    return 8_600 - basenamePosition * 10;
   }
 
   const pathPosition = pathLower.indexOf(needle);
   if (pathPosition >= 0) {
-    return { score: 8_100 - pathPosition, basenameLength, pathLength };
+    return 8_100 - pathPosition;
   }
 
-  const basenameSubsequenceScore = subsequenceScore(needle, basenameLower);
+  const basenameSubsequenceScore = subsequenceScore(needleChars, basenameLower);
   if (basenameSubsequenceScore !== undefined) {
-    return { score: 7_000 + basenameSubsequenceScore, basenameLength, pathLength };
+    return 7_000 + basenameSubsequenceScore;
   }
 
-  const pathSubsequenceScore = subsequenceScore(needle, pathLower);
+  const pathSubsequenceScore = subsequenceScore(needleChars, pathLower);
   if (pathSubsequenceScore !== undefined) {
-    return { score: 6_000 + pathSubsequenceScore, basenameLength, pathLength };
+    return 6_000 + pathSubsequenceScore;
   }
 
   return undefined;
 }
 
-function subsequenceScore(needle: string, haystack: string): number | undefined {
-  const needleChars = Array.from(needle);
-  const haystackChars = Array.from(haystack);
+/** haystack 经 for..of 按码点迭代，避免每候选 Array.from 整串物化。 */
+function subsequenceScore(
+  needleChars: readonly string[],
+  haystack: string,
+): number | undefined {
+  let needleIndex = 0;
   let haystackIndex = 0;
   let firstMatch: number | undefined;
   let lastMatch = 0;
   let consecutiveBonus = 0;
   let previousMatch: number | undefined;
 
-  for (const needleChar of needleChars) {
-    let found: number | undefined;
-    while (haystackIndex < haystackChars.length) {
-      if (haystackChars[haystackIndex] === needleChar) {
-        found = haystackIndex;
-        haystackIndex += 1;
-        break;
+  for (const haystackChar of haystack) {
+    if (needleIndex >= needleChars.length) {
+      break;
+    }
+    if (haystackChar === needleChars[needleIndex]) {
+      firstMatch ??= haystackIndex;
+      if (previousMatch !== undefined && haystackIndex === previousMatch + 1) {
+        consecutiveBonus += 12;
       }
-      haystackIndex += 1;
+      previousMatch = haystackIndex;
+      lastMatch = haystackIndex;
+      needleIndex += 1;
     }
-
-    if (found === undefined) {
-      return undefined;
-    }
-
-    firstMatch ??= found;
-    if (previousMatch !== undefined && found === previousMatch + 1) {
-      consecutiveBonus += 12;
-    }
-    previousMatch = found;
-    lastMatch = found;
+    haystackIndex += 1;
   }
 
-  if (firstMatch === undefined) {
+  if (needleIndex < needleChars.length || firstMatch === undefined) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

- pane 草稿 400ms 防抖落盘，text 由 segments 派生，切会话不再丢未发送内容
- Monaco context key 与 Tab 命令随 editor 实例生命周期；Ctrl+N 排除 INPUT
- @ 补全 files 引用记忆化、selectionchange 归属守卫与只读 caret 测量、工具面板 resize rAF 合帧

## Test plan

- [x] apps/desktop 与 host-internal `tsc --noEmit` 通过
- [x] composer-segments、keyboard-shortcut-eligibility、layout-prefs、workspace-file-references 单测通过