### PR TITLE
feat(desktop): Windows F11 绑定系统全屏

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -65,6 +65,7 @@ import {
   registerBrowserGuestF12,
   unregisterBrowserGuestF12,
 } from './workspace-browser-guest.js';
+import { toggleBrowserWindowFullScreen } from './window-fullscreen.js';
 
 import type { DesktopSnapshot } from '../src/types.js';
 
@@ -655,13 +656,6 @@ function applyNativeWindowBackdrop(
     });
   } catch {
     // 未启用 overlay 或平台限制时忽略
-  }
-}
-
-function toggleBrowserWindowFullScreen(host: WebContents): void {
-  const window = BrowserWindow.fromWebContents(host);
-  if (window && !window.isDestroyed()) {
-    window.setFullScreen(!window.isFullScreen());
   }
 }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -658,6 +658,13 @@ function applyNativeWindowBackdrop(
   }
 }
 
+function toggleBrowserWindowFullScreen(host: WebContents): void {
+  const window = BrowserWindow.fromWebContents(host);
+  if (window && !window.isDestroyed()) {
+    window.setFullScreen(!window.isFullScreen());
+  }
+}
+
 async function createMainWindow(): Promise<BrowserWindow> {
   const blurOnDisk = readBackdropBlurFromDisk();
   const initialDark = nativeTheme.shouldUseDarkColors;
@@ -776,10 +783,20 @@ async function createMainWindow(): Promise<BrowserWindow> {
     return { action: 'deny' };
   });
 
-  // Windows 无系统菜单且顶栏 MenubarShortcut 不绑定快捷键；主进程监听 F12 以便渲染崩溃时仍可开 DevTools。
+  // Windows 无系统菜单且顶栏 MenubarShortcut 不绑定快捷键；F11/F12 由主进程绑定（macOS 全屏仍走系统菜单 role）。
   const isDevChrome = Boolean(DEV_SERVER_URL) || !app.isPackaged;
   window.webContents.on('before-input-event', (event, input) => {
-    if (isDevChrome && input.type === 'keyDown' && input.key === 'F12') {
+    if (input.type !== 'keyDown') {
+      return;
+    }
+
+    if (process.platform === 'win32' && input.key === 'F11') {
+      event.preventDefault();
+      toggleBrowserWindowFullScreen(window.webContents);
+      return;
+    }
+
+    if (isDevChrome && input.key === 'F12') {
       event.preventDefault();
       window.webContents.toggleDevTools();
     }
@@ -1046,8 +1063,8 @@ if (gotSpiritSingleInstanceLock) {
           break;
         case 'toggleFullscreen': {
           const w = win ?? BrowserWindow.getFocusedWindow();
-          if (w) {
-            w.setFullScreen(!w.isFullScreen());
+          if (w && !w.isDestroyed()) {
+            toggleBrowserWindowFullScreen(w.webContents);
           }
           break;
         }

--- a/apps/desktop/electron/window-fullscreen.ts
+++ b/apps/desktop/electron/window-fullscreen.ts
@@ -1,0 +1,8 @@
+import { BrowserWindow, type WebContents } from 'electron';
+
+export function toggleBrowserWindowFullScreen(host: WebContents): void {
+  const window = BrowserWindow.fromWebContents(host);
+  if (window && !window.isDestroyed()) {
+    window.setFullScreen(!window.isFullScreen());
+  }
+}

--- a/apps/desktop/electron/workspace-browser-guest.ts
+++ b/apps/desktop/electron/workspace-browser-guest.ts
@@ -1,5 +1,7 @@
 import { webContents, type WebContents } from 'electron';
 
+import { toggleBrowserWindowFullScreen } from './window-fullscreen.js';
+
 type GuestF12Registration = {
   host: WebContents;
   tabId: string;
@@ -41,7 +43,17 @@ export function registerBrowserGuestF12(
   const guest = requireOwnedWebviewGuest(host, guestWebContentsId);
 
   const onBeforeInput = (event: Electron.Event, input: Electron.Input) => {
-    if (input.type === 'keyDown' && input.key === 'F12') {
+    if (input.type !== 'keyDown') {
+      return;
+    }
+
+    if (process.platform === 'win32' && input.key === 'F11') {
+      event.preventDefault();
+      toggleBrowserWindowFullScreen(host);
+      return;
+    }
+
+    if (input.key === 'F12') {
       event.preventDefault();
       if (!host.isDestroyed()) {
         host.send('desktop:browser-guest-f12', { tabId });


### PR DESCRIPTION
## Summary

- 在 Windows Desktop 主进程 `before-input-event` 绑定 F11，调用 `BrowserWindow.setFullScreen()` 走系统原生全屏
- 抽取 `window-fullscreen.ts` 供主窗口与 workspace webview guest 共用切换逻辑
- workspace 内嵌浏览器 Tab 聚焦时 F11 同样切换宿主窗口全屏；macOS 与 Linux 不改动
- 不新增 Kbd 提示 UI，标题栏既有「切换全屏」菜单与 F11 装饰文案保持一致

## Test plan

- [x] `npm --prefix apps/desktop run build:electron` 编译通过
- [x] Windows 主界面按 F11 进入/退出全屏
- [x] Windows workspace webview Tab 内按 F11 切换主窗口全屏
- [x] 标题栏「切换全屏」菜单与 F11 行为一致
- [x] F12 DevTools 行为不受影响
- [x] macOS 无 win32 专用 F11 handler（回归：仍走系统菜单全屏）