### PR TITLE
feat(desktop, cli, host-internal): config v2 providerGroups 与 ModelRef

### DIFF
--- a/apps/cli/src/adapters.rs
+++ b/apps/cli/src/adapters.rs
@@ -6,7 +6,8 @@ use crate::{
     mcp::spirit_agent_data_dir,
     model_registry::{
         AppConfig, config_file_path, has_model_api_key, keyring_entry, load_config,
-        remove_model_api_key, save_config, save_model_api_key,
+        load_group_api_key_from_keyring, remove_model_api_key, save_config, save_group_api_key,
+        save_model_api_key,
     },
     ports::{AppPaths, ChatArchive, ChatRepository, ConfigStore, SecretStore},
 };
@@ -60,6 +61,19 @@ impl ConfigStore for JsonConfigStore {
 }
 
 pub struct KeyringSecretStore;
+
+impl KeyringSecretStore {
+    pub fn load_group_api_key(&self, group_id: &str) -> Result<Option<String>> {
+        match load_group_api_key_from_keyring(group_id) {
+            Ok(value) if !value.trim().is_empty() => Ok(Some(value)),
+            Ok(_) | Err(_) => Ok(None),
+        }
+    }
+
+    pub fn save_group_api_key(&self, group_id: &str, api_key: &str) -> Result<()> {
+        save_group_api_key(group_id, api_key)
+    }
+}
 
 impl SecretStore for KeyringSecretStore {
     fn load_global_api_key(&self) -> Result<Option<String>> {

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -170,7 +170,7 @@ pub fn handle_model_cli(action: ModelCommand) -> Result<()> {
             provider_site,
             alibaba_workspace_id,
         } => {
-            if cfg.find_model_ref_by_name(&name).is_some() {
+            if cfg.has_model_name(&name) {
                 println!("模型已存在: {}", name);
             } else {
                 let provider = parse_model_provider(provider)?;
@@ -419,9 +419,9 @@ pub fn handle_model_cli(action: ModelCommand) -> Result<()> {
             }
         }
         ModelCommand::Use { name } => {
-            let Some(model_ref) = cfg.find_model_ref_by_name(&name) else {
-                return Err(anyhow!("模型不存在，请先添加: {}", name));
-            };
+            let model_ref = cfg
+                .parse_model_ref_selector(&name)
+                .map_err(|err| anyhow!(err))?;
             cfg.active_model = model_ref;
             config_store.save(&cfg)?;
             println!("已切换当前模型为: {}", name);
@@ -510,9 +510,9 @@ pub fn handle_config_cli(action: ConfigCommand) -> Result<()> {
             println!("已更新当前模型 API Base: {}", url);
         }
         ConfigCommand::SetImageModel { name } => {
-            let Some(model_ref) = cfg.find_model_ref_by_name(&name) else {
-                return Err(anyhow!("模型不存在，请先添加: {}", name));
-            };
+            let model_ref = cfg
+                .parse_model_ref_selector(&name)
+                .map_err(|err| anyhow!(err))?;
             let Some(profile) = cfg.resolve_model_profile(&model_ref) else {
                 return Err(anyhow!("模型不存在，请先添加: {}", name));
             };
@@ -532,9 +532,9 @@ pub fn handle_config_cli(action: ConfigCommand) -> Result<()> {
             println!("已清除图片生成模型。CLI 当前仅在配置图片模型后暴露 generate_image 工具。");
         }
         ConfigCommand::SetVideoModel { name } => {
-            let Some(model_ref) = cfg.find_model_ref_by_name(&name) else {
-                return Err(anyhow!("模型不存在，请先添加: {}", name));
-            };
+            let model_ref = cfg
+                .parse_model_ref_selector(&name)
+                .map_err(|err| anyhow!(err))?;
             let Some(profile) = cfg.resolve_model_profile(&model_ref) else {
                 return Err(anyhow!("模型不存在，请先添加: {}", name));
             };

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -10,7 +10,9 @@ use crate::{
     },
     model_provider_presets::{azure_api_base_from_resource_name, model_add_alibaba_site_api_base, model_add_alibaba_site_requires_workspace_id, model_add_default_custom_api_base, model_add_kimi_code_api_base, model_add_minimax_site_api_base, model_add_moonshot_site_api_base, model_add_preset_api_base_by_provider, model_add_siliconflow_site_api_base, validate_azure_resource_name},
     model_registry::{
-        AppConfig, DEFAULT_API_BASE, ModelProfile, ModelProvider, ModelTransportKind,
+        AppConfig, DEFAULT_API_BASE, ModelEntry, ModelProfile, ModelProvider, ModelRef,
+        ModelTransportKind, ProviderGroupConnectDraft, default_preset_provider_group_id,
+        save_group_api_key,
     },
     ports::{AppPaths, ConfigStore, SecretStore},
     ts_bridge::TsBridgeRuntime,
@@ -135,17 +137,22 @@ pub fn handle_model_cli(action: ModelCommand) -> Result<()> {
 
     match action {
         ModelCommand::List => {
-            println!("当前模型: {}", cfg.active_model);
+            println!("当前模型: {}", cfg.active_model_name());
             println!("模型列表:");
-            for model in &cfg.models {
-                let key_saved = secret_store.has_model_api_key(&model.name).unwrap_or(false);
+            for model in cfg.flatten_models() {
+                let key_saved = crate::model_registry::load_group_api_key_from_keyring(&model.group_id)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or_else(|_| {
+                        secret_store.has_model_api_key(&model.name).unwrap_or(false)
+                    });
                 println!(
-                    "  - {}\n    api_base: {}\n    provider: {}\n    reasoning_effort: {}\n    capabilities: {}\n    key: {}",
+                    "  - {} ({})\n    api_base: {}\n    provider: {}\n    reasoning_effort: {}\n    capabilities: {}\n    key: {}",
                     model.name,
+                    model.group_id,
                     model.api_base,
                     format_model_provider(model.provider),
                     model.reasoning_effort.as_deref().unwrap_or("未设置"),
-                    format_model_capabilities(model),
+                    format_model_capabilities(&model),
                     if key_saved { "已保存" } else { "未保存" }
                 );
             }
@@ -163,7 +170,7 @@ pub fn handle_model_cli(action: ModelCommand) -> Result<()> {
             provider_site,
             alibaba_workspace_id,
         } => {
-            if cfg.has_model(&name) {
+            if cfg.find_model_ref_by_name(&name).is_some() {
                 println!("模型已存在: {}", name);
             } else {
                 let provider = parse_model_provider(provider)?;
@@ -306,99 +313,104 @@ pub fn handle_model_cli(action: ModelCommand) -> Result<()> {
                     Some(value) => Some(value),
                 };
 
-                let mut extra = serde_json::Map::new();
-                if !capabilities.is_empty() {
-                    extra.insert("capabilities".to_string(), serde_json::json!(capabilities));
-                }
-                if transport_kind == ModelTransportKind::Anthropic
-                    || transport_kind == ModelTransportKind::OpenResponses
-                    || transport_kind == ModelTransportKind::Bedrock
-                {
-                    extra.insert(
-                        "transportKind".to_string(),
-                        serde_json::json!(transport_kind.as_str()),
-                    );
-                }
-                if let Some(resource_name) = azure_resource_name {
-                    extra.insert(
-                        "azureResourceName".to_string(),
-                        serde_json::json!(resource_name),
-                    );
-                }
-                if let Some(site) = provider_site
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                {
-                    extra.insert("providerSite".to_string(), serde_json::json!(site));
-                }
-                if let Some(workspace_id) = alibaba_workspace_id
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                {
-                    extra.insert("alibabaWorkspaceId".to_string(), serde_json::json!(workspace_id));
-                }
-
-                cfg.add_model(ModelProfile {
+                let resolved_provider = provider.unwrap_or(ModelProvider::Custom);
+                let group_id = default_preset_provider_group_id(resolved_provider);
+                let connect = ProviderGroupConnectDraft {
+                    transport_kind: (transport_kind == ModelTransportKind::Anthropic
+                        || transport_kind == ModelTransportKind::OpenResponses
+                        || transport_kind == ModelTransportKind::Bedrock)
+                        .then(|| transport_kind.as_str().to_string()),
+                    provider_site: provider_site
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(ToOwned::to_owned),
+                    alibaba_workspace_id: alibaba_workspace_id
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                        .map(ToOwned::to_owned),
+                    azure_resource_name,
+                    ..ProviderGroupConnectDraft::default()
+                };
+                let entry = ModelEntry {
                     name: name.clone(),
-                    api_base: api_base.clone(),
-                    provider,
                     reasoning_effort: reasoning_effort.clone(),
+                    thinking_enabled: None,
+                    supported_reasoning_efforts: None,
+                    capabilities: if capabilities.is_empty() {
+                        None
+                    } else {
+                        Some(capabilities.clone())
+                    },
                     context_length,
-                    extra,
-                });
+                    supports_thinking_type: None,
+                };
+                cfg.add_model_to_group(
+                    &group_id,
+                    resolved_provider,
+                    api_base.clone(),
+                    connect,
+                    entry,
+                );
+                let model_ref = ModelRef {
+                    group_id: group_id.clone(),
+                    name: name.clone(),
+                };
                 if cfg.image_generation_model.is_none()
                     && cfg
-                        .models
-                        .iter()
-                        .find(|model| model.name == name)
-                        .is_some_and(ModelProfile::supports_image_generation)
+                        .resolve_model_profile(&model_ref)
+                        .is_some_and(|profile| profile.supports_image_generation())
                 {
-                    cfg.image_generation_model = Some(name.clone());
+                    cfg.image_generation_model = Some(model_ref.clone());
                 }
                 if cfg.video_generation_model.is_none()
                     && cfg
-                        .models
-                        .iter()
-                        .find(|model| model.name == name)
-                        .is_some_and(ModelProfile::supports_video_generation)
+                        .resolve_model_profile(&model_ref)
+                        .is_some_and(|profile| profile.supports_video_generation())
                 {
-                    cfg.video_generation_model = Some(name.clone());
+                    cfg.video_generation_model = Some(model_ref.clone());
                 }
-                cfg.active_model = name.clone();
-                secret_store.save_model_api_key(&name, &key_value)?;
+                cfg.active_model = model_ref;
+                save_group_api_key(&group_id, &key_value)?;
                 config_store.save(&cfg)?;
                 println!("已添加模型: {}，并已设为当前模型", name);
                 println!("api_base: {}", api_base);
-                println!("provider: {}", format_model_provider(provider));
+                println!("provider: {}", format_model_provider(Some(resolved_provider)));
                 println!(
                     "reasoning_effort: {}",
                     reasoning_effort.as_deref().unwrap_or("未设置")
                 );
                 println!(
                     "capabilities: {}",
-                    cfg.models
-                        .iter()
-                        .find(|model| model.name == name)
-                        .map(format_model_capabilities)
-                        .unwrap_or_else(|| "未设置".to_string())
+                    cfg.resolve_model_profile(&ModelRef {
+                        group_id,
+                        name: name.clone(),
+                    })
+                    .map(|profile| format_model_capabilities(&profile))
+                    .unwrap_or_else(|| "未设置".to_string())
                 );
             }
         }
         ModelCommand::Remove { name } => {
-            let before = cfg.models.len();
-            cfg.models.retain(|m| m.name != name);
-            if cfg.models.len() == before {
+            if !cfg.remove_model_by_name(&name) {
                 println!("模型不存在: {}", name);
             } else {
-                if cfg.active_model == name {
-                    cfg.active_model = cfg.models.first().map(|m| m.name.clone()).unwrap_or_default();
+                if cfg.active_model.name == name {
+                    cfg.active_model = cfg.first_model_ref();
                 }
-                if cfg.image_generation_model.as_deref() == Some(name.as_str()) {
+                if cfg
+                    .image_generation_model
+                    .as_ref()
+                    .is_some_and(|model_ref| model_ref.name == name)
+                {
                     cfg.image_generation_model = None;
                 }
-                if cfg.video_generation_model.as_deref() == Some(name.as_str()) {
+                if cfg
+                    .video_generation_model
+                    .as_ref()
+                    .is_some_and(|model_ref| model_ref.name == name)
+                {
                     cfg.video_generation_model = None;
                 }
                 config_store.save(&cfg)?;
@@ -407,15 +419,15 @@ pub fn handle_model_cli(action: ModelCommand) -> Result<()> {
             }
         }
         ModelCommand::Use { name } => {
-            if !cfg.has_model(&name) {
+            let Some(model_ref) = cfg.find_model_ref_by_name(&name) else {
                 return Err(anyhow!("模型不存在，请先添加: {}", name));
-            }
-            cfg.active_model = name.clone();
+            };
+            cfg.active_model = model_ref;
             config_store.save(&cfg)?;
             println!("已切换当前模型为: {}", name);
         }
         ModelCommand::Current => {
-            println!("当前模型: {}", cfg.active_model);
+            println!("当前模型: {}", cfg.active_model_name());
         }
     }
 
@@ -431,25 +443,36 @@ pub fn handle_config_cli(action: ConfigCommand) -> Result<()> {
     match action {
         ConfigCommand::Show => {
             println!("配置文件: {}", app_paths.config_file().display());
-            println!("active_model: {}", cfg.active_model);
+            println!("active_model: {}", cfg.active_model_name());
             println!(
                 "image_generation_model: {}",
-                cfg.image_generation_model.as_deref().unwrap_or("未设置")
+                cfg.image_generation_model
+                    .as_ref()
+                    .map(|model_ref| model_ref.name.as_str())
+                    .unwrap_or("未设置")
             );
             println!(
                 "video_generation_model: {}",
-                cfg.video_generation_model.as_deref().unwrap_or("未设置")
+                cfg.video_generation_model
+                    .as_ref()
+                    .map(|model_ref| model_ref.name.as_str())
+                    .unwrap_or("未设置")
             );
             println!("models:");
-            for model in &cfg.models {
-                let key_saved = secret_store.has_model_api_key(&model.name).unwrap_or(false);
+            for model in cfg.flatten_models() {
+                let key_saved = crate::model_registry::load_group_api_key_from_keyring(&model.group_id)
+                    .map(|value| !value.trim().is_empty())
+                    .unwrap_or_else(|_| {
+                        secret_store.has_model_api_key(&model.name).unwrap_or(false)
+                    });
                 println!(
-                    "  - {}\n    api_base: {}\n    provider: {}\n    reasoning_effort: {}\n    capabilities: {}\n    key: {}",
+                    "  - {} ({})\n    api_base: {}\n    provider: {}\n    reasoning_effort: {}\n    capabilities: {}\n    key: {}",
                     model.name,
+                    model.group_id,
                     model.api_base,
                     format_model_provider(model.provider),
                     model.reasoning_effort.as_deref().unwrap_or("未设置"),
-                    format_model_capabilities(model),
+                    format_model_capabilities(&model),
                     if key_saved { "已保存" } else { "未保存" }
                 );
             }
@@ -480,25 +503,26 @@ pub fn handle_config_cli(action: ConfigCommand) -> Result<()> {
             );
         }
         ConfigCommand::SetBase { url } => {
-            if let Some(active) = cfg.active_model_profile_mut() {
-                active.api_base = url.clone();
+            if let Some(group) = cfg.active_provider_group_mut() {
+                group.api_base = url.clone();
             }
             config_store.save(&cfg)?;
             println!("已更新当前模型 API Base: {}", url);
         }
         ConfigCommand::SetImageModel { name } => {
-            let profile = cfg
-                .models
-                .iter()
-                .find(|model| model.name == name)
-                .ok_or_else(|| anyhow!("模型不存在，请先添加: {}", name))?;
+            let Some(model_ref) = cfg.find_model_ref_by_name(&name) else {
+                return Err(anyhow!("模型不存在，请先添加: {}", name));
+            };
+            let Some(profile) = cfg.resolve_model_profile(&model_ref) else {
+                return Err(anyhow!("模型不存在，请先添加: {}", name));
+            };
             if !profile.supports_image_generation() {
                 return Err(anyhow!(
                     "模型 {} 未声明 imageGeneration capability，不能作为图片生成模型",
                     name
                 ));
             }
-            cfg.image_generation_model = Some(name.clone());
+            cfg.image_generation_model = Some(model_ref);
             config_store.save(&cfg)?;
             println!("已设置图片生成模型: {}", name);
         }
@@ -508,18 +532,19 @@ pub fn handle_config_cli(action: ConfigCommand) -> Result<()> {
             println!("已清除图片生成模型。CLI 当前仅在配置图片模型后暴露 generate_image 工具。");
         }
         ConfigCommand::SetVideoModel { name } => {
-            let profile = cfg
-                .models
-                .iter()
-                .find(|model| model.name == name)
-                .ok_or_else(|| anyhow!("模型不存在，请先添加: {}", name))?;
+            let Some(model_ref) = cfg.find_model_ref_by_name(&name) else {
+                return Err(anyhow!("模型不存在，请先添加: {}", name));
+            };
+            let Some(profile) = cfg.resolve_model_profile(&model_ref) else {
+                return Err(anyhow!("模型不存在，请先添加: {}", name));
+            };
             if !profile.supports_video_generation() {
                 return Err(anyhow!(
                     "模型 {} 未声明 videoGeneration capability，不能作为视频生成模型",
                     name
                 ));
             }
-            cfg.video_generation_model = Some(name.clone());
+            cfg.video_generation_model = Some(model_ref);
             config_store.save(&cfg)?;
             println!("已设置视频生成模型: {}", name);
         }

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -12,7 +12,7 @@ use crate::{
     model_registry::{
         AppConfig, DEFAULT_API_BASE, ModelEntry, ModelProfile, ModelProvider, ModelRef,
         ModelTransportKind, ProviderGroupConnectDraft, default_preset_provider_group_id,
-        save_group_api_key,
+        model_refs_equal, save_group_api_key,
     },
     ports::{AppPaths, ConfigStore, SecretStore},
     ts_bridge::TsBridgeRuntime,
@@ -393,28 +393,31 @@ pub fn handle_model_cli(action: ModelCommand) -> Result<()> {
             }
         }
         ModelCommand::Remove { name } => {
-            if !cfg.remove_model_by_name(&name) {
+            let model_ref = cfg
+                .parse_model_ref_selector(&name)
+                .map_err(|err| anyhow!(err))?;
+            if !cfg.remove_model(&model_ref) {
                 println!("模型不存在: {}", name);
             } else {
-                if cfg.active_model.name == name {
+                if model_refs_equal(&cfg.active_model, &model_ref) {
                     cfg.active_model = cfg.first_model_ref();
                 }
                 if cfg
                     .image_generation_model
                     .as_ref()
-                    .is_some_and(|model_ref| model_ref.name == name)
+                    .is_some_and(|slot| model_refs_equal(slot, &model_ref))
                 {
                     cfg.image_generation_model = None;
                 }
                 if cfg
                     .video_generation_model
                     .as_ref()
-                    .is_some_and(|model_ref| model_ref.name == name)
+                    .is_some_and(|slot| model_refs_equal(slot, &model_ref))
                 {
                     cfg.video_generation_model = None;
                 }
                 config_store.save(&cfg)?;
-                let _ = secret_store.remove_model_api_key(&name);
+                let _ = secret_store.remove_model_api_key(&model_ref.name);
                 println!("已删除模型: {}", name);
             }
         }

--- a/apps/cli/src/model_catalog_display.rs
+++ b/apps/cli/src/model_catalog_display.rs
@@ -278,6 +278,7 @@ mod tests {
     #[test]
     fn build_model_display_titles_formats_non_gateway_providers() {
         let models = vec![ModelProfile {
+            group_id: "openai".to_string(),
             name: "gpt-4o-mini".to_string(),
             api_base: "https://api.openai.com/v1".to_string(),
             provider: Some(ModelProvider::Openai),

--- a/apps/cli/src/model_registry.rs
+++ b/apps/cli/src/model_registry.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 pub const DEFAULT_API_BASE: &str = "https://api.openai.com/v1";
+pub const SPIRIT_CONFIG_SCHEMA_VERSION: u64 = 2;
 const ENV_API_KEY: &str = "SPIRIT_API_KEY";
 const KEYRING_SERVICE: &str = "SpiritAgent";
 const KEYRING_ACCOUNT_API_KEY: &str = "openai_api_key";
@@ -140,8 +141,154 @@ impl FromStr for ModelTransportKind {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelRef {
+    #[serde(rename = "groupId", alias = "group_id")]
+    pub group_id: String,
+    pub name: String,
+}
+
+impl ModelRef {
+    pub fn empty() -> Self {
+        Self {
+            group_id: String::new(),
+            name: String::new(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.group_id.trim().is_empty() || self.name.trim().is_empty()
+    }
+}
+
+pub fn model_refs_equal(a: &ModelRef, b: &ModelRef) -> bool {
+    a.group_id == b.group_id && a.name == b.name
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelEntry {
+    pub name: String,
+    #[serde(
+        rename = "reasoningEffort",
+        alias = "reasoning_effort",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reasoning_effort: Option<String>,
+    #[serde(
+        rename = "thinkingEnabled",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub thinking_enabled: Option<bool>,
+    #[serde(
+        rename = "supportedReasoningEfforts",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub supported_reasoning_efforts: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Vec<String>>,
+    #[serde(
+        rename = "contextLength",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub context_length: Option<u64>,
+    #[serde(
+        rename = "supportsThinkingType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub supports_thinking_type: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderGroup {
+    pub id: String,
+    pub provider: ModelProvider,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(rename = "apiBase", alias = "api_base")]
+    pub api_base: String,
+    #[serde(
+        rename = "transportKind",
+        alias = "transport_kind",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub transport_kind: Option<String>,
+    #[serde(
+        rename = "providerSite",
+        alias = "provider_site",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub provider_site: Option<String>,
+    #[serde(
+        rename = "alibabaWorkspaceId",
+        alias = "alibaba_workspace_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub alibaba_workspace_id: Option<String>,
+    #[serde(
+        rename = "alibabaBillingMode",
+        alias = "alibaba_billing_mode",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub alibaba_billing_mode: Option<String>,
+    #[serde(
+        rename = "awsRegion",
+        alias = "aws_region",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub aws_region: Option<String>,
+    #[serde(
+        rename = "azureResourceName",
+        alias = "azure_resource_name",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub azure_resource_name: Option<String>,
+    #[serde(
+        rename = "cloudflareAccountId",
+        alias = "cloudflare_account_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cloudflare_account_id: Option<String>,
+    #[serde(
+        rename = "cloudflareGatewayId",
+        alias = "cloudflare_gateway_id",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cloudflare_gateway_id: Option<String>,
+    #[serde(
+        rename = "vertexProject",
+        alias = "vertex_project",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub vertex_project: Option<String>,
+    #[serde(
+        rename = "vertexLocation",
+        alias = "vertex_location",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub vertex_location: Option<String>,
+    pub models: Vec<ModelEntry>,
+}
+
+/// Resolved model profile: provider group connect fields merged with a model entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelProfile {
+    #[serde(rename = "groupId", alias = "group_id", default, skip_serializing_if = "String::is_empty")]
+    pub group_id: String,
     pub name: String,
     #[serde(rename = "apiBase", alias = "api_base")]
     pub api_base: String,
@@ -226,6 +373,11 @@ impl ModelProfile {
                 .iter()
                 .any(|capability| capability == "videoGeneration")
         })
+    }
+
+    pub fn supports_chat(&self) -> bool {
+        self.explicit_capabilities()
+            .is_none_or(|capabilities| capabilities.iter().any(|capability| capability == "chat"))
     }
 
     pub fn explicit_capabilities(&self) -> Option<Vec<String>> {
@@ -335,23 +487,33 @@ impl Default for NetworksConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
-    pub models: Vec<ModelProfile>,
+    #[serde(rename = "schemaVersion", alias = "schema_version", default = "default_schema_version")]
+    pub schema_version: u64,
+    #[serde(rename = "providerGroups", alias = "provider_groups", default)]
+    pub provider_groups: Vec<ProviderGroup>,
     #[serde(rename = "activeModel", alias = "active_model")]
-    pub active_model: String,
+    pub active_model: ModelRef,
     #[serde(
         rename = "imageGenerationModel",
         alias = "image_generation_model",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub image_generation_model: Option<String>,
+    pub image_generation_model: Option<ModelRef>,
     #[serde(
         rename = "videoGenerationModel",
         alias = "video_generation_model",
         default,
         skip_serializing_if = "Option::is_none"
     )]
-    pub video_generation_model: Option<String>,
+    pub video_generation_model: Option<ModelRef>,
+    #[serde(
+        rename = "lightweightChatModel",
+        alias = "lightweight_chat_model",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub lightweight_chat_model: Option<ModelRef>,
     #[serde(
         rename = "uiLocale",
         alias = "ui_locale",
@@ -365,20 +527,19 @@ pub struct AppConfig {
     pub extra: Map<String, Value>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct LegacyAppConfig {
-    api_base: String,
-    models: Vec<String>,
-    active_model: String,
+fn default_schema_version() -> u64 {
+    SPIRIT_CONFIG_SCHEMA_VERSION
 }
 
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
-            models: vec![],
-            active_model: String::new(),
+            schema_version: SPIRIT_CONFIG_SCHEMA_VERSION,
+            provider_groups: vec![],
+            active_model: ModelRef::empty(),
             image_generation_model: None,
             video_generation_model: None,
+            lightweight_chat_model: None,
             ui_locale: None,
             networks: NetworksConfig::default(),
             extra: Map::new(),
@@ -386,32 +547,438 @@ impl Default for AppConfig {
     }
 }
 
+pub fn default_preset_provider_group_id(provider: ModelProvider) -> String {
+    provider.as_str().to_string()
+}
+
+pub fn resolve_model_profile_from_parts(
+    group: &ProviderGroup,
+    model: &ModelEntry,
+) -> Option<ModelProfile> {
+    if group.id.trim().is_empty() || model.name.trim().is_empty() {
+        return None;
+    }
+
+    let mut extra = Map::new();
+    if let Some(transport_kind) = group.transport_kind.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        extra.insert(
+            "transportKind".to_string(),
+            Value::String(transport_kind.to_string()),
+        );
+    }
+    if let Some(site) = group.provider_site.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        extra.insert("providerSite".to_string(), Value::String(site.to_string()));
+    }
+    if let Some(workspace_id) = group
+        .alibaba_workspace_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert(
+            "alibabaWorkspaceId".to_string(),
+            Value::String(workspace_id.to_string()),
+        );
+    }
+    if let Some(billing_mode) = group
+        .alibaba_billing_mode
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert(
+            "alibabaBillingMode".to_string(),
+            Value::String(billing_mode.to_string()),
+        );
+    }
+    if let Some(region) = group.aws_region.as_deref().map(str::trim).filter(|v| !v.is_empty()) {
+        extra.insert("awsRegion".to_string(), Value::String(region.to_string()));
+    }
+    if let Some(resource_name) = group
+        .azure_resource_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert(
+            "azureResourceName".to_string(),
+            Value::String(resource_name.to_string()),
+        );
+    }
+    if let Some(account_id) = group
+        .cloudflare_account_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert(
+            "cloudflareAccountId".to_string(),
+            Value::String(account_id.to_string()),
+        );
+    }
+    if let Some(gateway_id) = group
+        .cloudflare_gateway_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert(
+            "cloudflareGatewayId".to_string(),
+            Value::String(gateway_id.to_string()),
+        );
+    }
+    if let Some(project) = group
+        .vertex_project
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert("vertexProject".to_string(), Value::String(project.to_string()));
+    }
+    if let Some(location) = group
+        .vertex_location
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert(
+            "vertexLocation".to_string(),
+            Value::String(location.to_string()),
+        );
+    }
+    if let Some(capabilities) = model.capabilities.as_ref().filter(|caps| !caps.is_empty()) {
+        extra.insert("capabilities".to_string(), Value::Array(
+            capabilities.iter().map(|cap| Value::String(cap.clone())).collect(),
+        ));
+    }
+    if let Some(efforts) = model
+        .supported_reasoning_efforts
+        .as_ref()
+        .filter(|efforts| !efforts.is_empty())
+    {
+        extra.insert(
+            "supportedReasoningEfforts".to_string(),
+            Value::Array(
+                efforts
+                    .iter()
+                    .map(|effort| Value::String(effort.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    if model.thinking_enabled == Some(false) {
+        extra.insert("thinkingEnabled".to_string(), Value::Bool(false));
+    }
+    if let Some(thinking_type) = model
+        .supports_thinking_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+    {
+        extra.insert(
+            "supportsThinkingType".to_string(),
+            Value::String(thinking_type.to_string()),
+        );
+    }
+
+    Some(ModelProfile {
+        group_id: group.id.clone(),
+        name: model.name.clone(),
+        api_base: group.api_base.clone(),
+        provider: Some(group.provider),
+        reasoning_effort: model.reasoning_effort.clone(),
+        context_length: model.context_length,
+        extra,
+    })
+}
+
 impl AppConfig {
-    pub fn active_model_profile(&self) -> Option<&ModelProfile> {
-        self.models.iter().find(|m| m.name == self.active_model)
+    pub fn active_model_name(&self) -> &str {
+        self.active_model.name.as_str()
     }
 
-    pub fn active_model_profile_mut(&mut self) -> Option<&mut ModelProfile> {
-        self.models.iter_mut().find(|m| m.name == self.active_model)
+    pub fn find_provider_group(&self, group_id: &str) -> Option<&ProviderGroup> {
+        let normalized = group_id.trim();
+        if normalized.is_empty() {
+            return None;
+        }
+        self.provider_groups.iter().find(|group| group.id == normalized)
     }
 
-    pub fn image_generation_model_profile(&self) -> Option<&ModelProfile> {
-        let name = self.image_generation_model.as_deref()?;
-        self.models.iter().find(|m| m.name == name)
+    pub fn find_provider_group_mut(&mut self, group_id: &str) -> Option<&mut ProviderGroup> {
+        let normalized = group_id.trim();
+        if normalized.is_empty() {
+            return None;
+        }
+        self.provider_groups
+            .iter_mut()
+            .find(|group| group.id == normalized)
     }
 
-    pub fn video_generation_model_profile(&self) -> Option<&ModelProfile> {
-        let name = self.video_generation_model.as_deref()?;
-        self.models.iter().find(|m| m.name == name)
+    pub fn find_model_entry_in_group<'a>(
+        group: &'a ProviderGroup,
+        name: &str,
+    ) -> Option<&'a ModelEntry> {
+        let normalized = name.trim();
+        if normalized.is_empty() {
+            return None;
+        }
+        group.models.iter().find(|model| model.name == normalized)
     }
 
-    pub fn has_model(&self, name: &str) -> bool {
-        self.models.iter().any(|m| m.name == name)
+    pub fn find_model_entry_in_group_mut<'a>(
+        group: &'a mut ProviderGroup,
+        name: &str,
+    ) -> Option<&'a mut ModelEntry> {
+        let normalized = name.trim();
+        if normalized.is_empty() {
+            return None;
+        }
+        group.models.iter_mut().find(|model| model.name == normalized)
     }
 
-    pub fn add_model(&mut self, profile: ModelProfile) {
-        self.models.push(profile);
+    pub fn resolve_model_profile(&self, model_ref: &ModelRef) -> Option<ModelProfile> {
+        if model_ref.is_empty() {
+            return None;
+        }
+        let group = self.find_provider_group(&model_ref.group_id)?;
+        let model = Self::find_model_entry_in_group(group, &model_ref.name)?;
+        resolve_model_profile_from_parts(group, model)
     }
+
+    pub fn flatten_models(&self) -> Vec<ModelProfile> {
+        let mut resolved = Vec::new();
+        for group in &self.provider_groups {
+            for model in &group.models {
+                if let Some(profile) = resolve_model_profile_from_parts(group, model) {
+                    resolved.push(profile);
+                }
+            }
+        }
+        resolved
+    }
+
+    pub fn list_all_model_refs(&self) -> Vec<ModelRef> {
+        let mut refs = Vec::new();
+        for group in &self.provider_groups {
+            for model in &group.models {
+                refs.push(ModelRef {
+                    group_id: group.id.clone(),
+                    name: model.name.clone(),
+                });
+            }
+        }
+        refs
+    }
+
+    pub fn first_model_ref(&self) -> ModelRef {
+        let Some(group) = self.provider_groups.first() else {
+            return ModelRef::empty();
+        };
+        let Some(model) = group.models.first() else {
+            return ModelRef::empty();
+        };
+        ModelRef {
+            group_id: group.id.clone(),
+            name: model.name.clone(),
+        }
+    }
+
+    pub fn find_model_ref_by_name(&self, name: &str) -> Option<ModelRef> {
+        let normalized = name.trim();
+        if normalized.is_empty() {
+            return None;
+        }
+        for group in &self.provider_groups {
+            if group.models.iter().any(|model| model.name == normalized) {
+                return Some(ModelRef {
+                    group_id: group.id.clone(),
+                    name: normalized.to_string(),
+                });
+            }
+        }
+        None
+    }
+
+    pub fn has_model_in_group(&self, group_id: &str, name: &str) -> bool {
+        let Some(group) = self.find_provider_group(group_id) else {
+            return false;
+        };
+        Self::find_model_entry_in_group(group, name).is_some()
+    }
+
+    pub fn model_ref_exists(&self, model_ref: &ModelRef) -> bool {
+        self.resolve_model_profile(model_ref).is_some()
+    }
+
+    pub fn active_model_profile(&self) -> Option<ModelProfile> {
+        self.resolve_model_profile(&self.active_model)
+    }
+
+    pub fn active_provider_group_mut(&mut self) -> Option<&mut ProviderGroup> {
+        let group_id = self.active_model.group_id.clone();
+        self.find_provider_group_mut(&group_id)
+    }
+
+    pub fn active_model_entry_mut(&mut self) -> Option<&mut ModelEntry> {
+        let group_id = self.active_model.group_id.clone();
+        let name = self.active_model.name.clone();
+        let group = self.find_provider_group_mut(&group_id)?;
+        Self::find_model_entry_in_group_mut(group, &name)
+    }
+
+    pub fn image_generation_model_profile(&self) -> Option<ModelProfile> {
+        let model_ref = self.image_generation_model.as_ref()?;
+        self.resolve_model_profile(model_ref)
+    }
+
+    pub fn video_generation_model_profile(&self) -> Option<ModelProfile> {
+        let model_ref = self.video_generation_model.as_ref()?;
+        self.resolve_model_profile(model_ref)
+    }
+
+    pub fn lightweight_chat_model_profile(&self) -> Option<ModelProfile> {
+        let model_ref = self.lightweight_chat_model.as_ref()?;
+        self.resolve_model_profile(model_ref)
+    }
+
+    pub fn add_model_to_group(
+        &mut self,
+        group_id: &str,
+        provider: ModelProvider,
+        api_base: String,
+        connect: ProviderGroupConnectDraft,
+        entry: ModelEntry,
+    ) {
+        let normalized_group_id = group_id.trim().to_string();
+        if let Some(group) = self.find_provider_group_mut(&normalized_group_id) {
+            group.api_base = api_base;
+            connect.apply_to_group(group);
+            if !group.models.iter().any(|model| model.name == entry.name) {
+                group.models.push(entry);
+            }
+            return;
+        }
+
+        let mut group = ProviderGroup {
+            id: normalized_group_id,
+            provider,
+            label: None,
+            api_base,
+            transport_kind: None,
+            provider_site: None,
+            alibaba_workspace_id: None,
+            alibaba_billing_mode: None,
+            aws_region: None,
+            azure_resource_name: None,
+            cloudflare_account_id: None,
+            cloudflare_gateway_id: None,
+            vertex_project: None,
+            vertex_location: None,
+            models: vec![entry],
+        };
+        connect.apply_to_group(&mut group);
+        self.provider_groups.push(group);
+    }
+
+    pub fn remove_model_by_name(&mut self, name: &str) -> bool {
+        let normalized = name.trim();
+        if normalized.is_empty() {
+            return false;
+        }
+        let mut removed = false;
+        for group in &mut self.provider_groups {
+            let before = group.models.len();
+            group.models.retain(|model| model.name != normalized);
+            if group.models.len() != before {
+                removed = true;
+            }
+        }
+        self.provider_groups
+            .retain(|group| !group.models.is_empty());
+        removed
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ProviderGroupConnectDraft {
+    pub transport_kind: Option<String>,
+    pub provider_site: Option<String>,
+    pub alibaba_workspace_id: Option<String>,
+    pub alibaba_billing_mode: Option<String>,
+    pub aws_region: Option<String>,
+    pub azure_resource_name: Option<String>,
+    pub cloudflare_account_id: Option<String>,
+    pub cloudflare_gateway_id: Option<String>,
+    pub vertex_project: Option<String>,
+    pub vertex_location: Option<String>,
+}
+
+impl ProviderGroupConnectDraft {
+    fn apply_to_group(&self, group: &mut ProviderGroup) {
+        if let Some(value) = normalize_optional_string(self.transport_kind.clone()) {
+            group.transport_kind = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.provider_site.clone()) {
+            group.provider_site = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.alibaba_workspace_id.clone()) {
+            group.alibaba_workspace_id = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.alibaba_billing_mode.clone()) {
+            group.alibaba_billing_mode = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.aws_region.clone()) {
+            group.aws_region = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.azure_resource_name.clone()) {
+            group.azure_resource_name = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.cloudflare_account_id.clone()) {
+            group.cloudflare_account_id = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.cloudflare_gateway_id.clone()) {
+            group.cloudflare_gateway_id = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.vertex_project.clone()) {
+            group.vertex_project = Some(value);
+        }
+        if let Some(value) = normalize_optional_string(self.vertex_location.clone()) {
+            group.vertex_location = Some(value);
+        }
+    }
+}
+
+pub fn make_test_app_config_with_models(
+    group_id: &str,
+    provider: ModelProvider,
+    api_base: &str,
+    model_names: &[&str],
+    active_name: &str,
+) -> AppConfig {
+    let mut cfg = AppConfig::default();
+    for name in model_names {
+        cfg.add_model_to_group(
+            group_id,
+            provider,
+            api_base.to_string(),
+            ProviderGroupConnectDraft::default(),
+            ModelEntry {
+                name: (*name).to_string(),
+                reasoning_effort: None,
+                thinking_enabled: None,
+                supported_reasoning_efforts: None,
+                capabilities: None,
+                context_length: None,
+                supports_thinking_type: None,
+            },
+        );
+    }
+    cfg.active_model = ModelRef {
+        group_id: group_id.to_string(),
+        name: active_name.to_string(),
+    };
+    cfg
 }
 
 pub fn config_file_path() -> PathBuf {
@@ -433,36 +1000,24 @@ pub fn load_config() -> Result<AppConfig> {
 }
 
 fn deserialize_config(content: &str, path: &Path) -> Result<AppConfig> {
-    if let Ok(mut cfg) = serde_json::from_str::<AppConfig>(content) {
-        normalize_config(&mut cfg);
-        return Ok(cfg);
+    let raw: Value = serde_json::from_str(content)
+        .with_context(|| format!("解析配置失败: {}", path.display()))?;
+
+    let version = raw
+        .get("schemaVersion")
+        .or_else(|| raw.get("schema_version"))
+        .and_then(Value::as_u64);
+    if version != Some(SPIRIT_CONFIG_SCHEMA_VERSION) {
+        return Err(anyhow::anyhow!(
+            "config.json 须为 schemaVersion {}；请删除旧版配置后重新连接提供商。",
+            SPIRIT_CONFIG_SCHEMA_VERSION
+        ));
     }
 
-    let legacy: LegacyAppConfig = serde_json::from_str(content)
+    let mut cfg: AppConfig = serde_json::from_value(raw)
         .with_context(|| format!("解析配置失败: {}", path.display()))?;
-    let mut migrated = AppConfig {
-        models: legacy
-            .models
-            .into_iter()
-            .map(|name| ModelProfile {
-                name,
-                api_base: legacy.api_base.clone(),
-                provider: None,
-                reasoning_effort: None,
-                context_length: None,
-                extra: Map::new(),
-            })
-            .collect(),
-        active_model: legacy.active_model,
-        image_generation_model: None,
-        video_generation_model: None,
-        ui_locale: None,
-        networks: NetworksConfig::default(),
-        extra: Map::new(),
-    };
-    normalize_config(&mut migrated);
-    save_config(&migrated)?;
-    Ok(migrated)
+    normalize_config(&mut cfg);
+    Ok(cfg)
 }
 
 pub fn save_config(cfg: &AppConfig) -> Result<()> {
@@ -482,68 +1037,132 @@ fn serialize_config(cfg: &AppConfig) -> Result<String> {
 }
 
 fn normalize_config(cfg: &mut AppConfig) {
+    cfg.schema_version = SPIRIT_CONFIG_SCHEMA_VERSION;
     cfg.networks.llm_http_version =
         crate::ports::normalize_llm_http_version(&cfg.networks.llm_http_version);
 
-    if cfg.models.is_empty() {
-        cfg.active_model.clear();
+    if cfg.provider_groups.is_empty()
+        || cfg
+            .provider_groups
+            .iter()
+            .all(|group| group.models.is_empty())
+    {
+        cfg.active_model = ModelRef::empty();
         cfg.image_generation_model = None;
         cfg.video_generation_model = None;
+        cfg.lightweight_chat_model = None;
         return;
     }
 
-    if !cfg.models.iter().any(|m| m.name == cfg.active_model) {
-        cfg.active_model = cfg.models[0].name.clone();
+    if !cfg.model_ref_exists(&cfg.active_model) {
+        cfg.active_model = cfg.first_model_ref();
     }
 
-    cfg.image_generation_model =
-        normalize_image_generation_model(cfg.image_generation_model.take(), cfg.models.as_slice());
-    cfg.video_generation_model =
-        normalize_video_generation_model(cfg.video_generation_model.take(), cfg.models.as_slice());
+    let flattened = cfg.flatten_models();
+    cfg.image_generation_model = normalize_slot_model_ref(
+        cfg.image_generation_model.take(),
+        &flattened,
+        ModelProfile::supports_image_generation,
+    );
+    cfg.video_generation_model = normalize_slot_model_ref(
+        cfg.video_generation_model.take(),
+        &flattened,
+        ModelProfile::supports_video_generation,
+    );
+    cfg.lightweight_chat_model = normalize_lightweight_chat_model_ref(
+        cfg.lightweight_chat_model.take(),
+        &flattened,
+    );
 
-    for model in &mut cfg.models {
-        if model.api_base.trim().is_empty() {
-            model.api_base = DEFAULT_API_BASE.to_string();
+    for group in &mut cfg.provider_groups {
+        if group.api_base.trim().is_empty() {
+            group.api_base = DEFAULT_API_BASE.to_string();
         }
-        model.reasoning_effort = normalize_reasoning_effort_value(
-            normalize_optional_string(model.reasoning_effort.take()),
-            model.provider,
-            model.transport_kind(),
-            &model.name,
-        );
-        model.extra.remove("transportImplementation");
-        model.extra.remove("transport_implementation");
-        normalize_transport_kind(model);
+        let provider = group.provider;
+        let transport_kind = group
+            .transport_kind
+            .as_deref()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or_else(|| match provider {
+                ModelProvider::Anthropic => ModelTransportKind::Anthropic,
+                ModelProvider::AmazonBedrock => ModelTransportKind::Bedrock,
+                ModelProvider::Azure => ModelTransportKind::OpenResponses,
+                _ => ModelTransportKind::OpenAiCompatible,
+            });
+        let normalized_transport = normalize_group_transport_kind(provider, transport_kind);
+        group.transport_kind = match normalized_transport {
+            ModelTransportKind::Anthropic
+            | ModelTransportKind::OpenResponses
+            | ModelTransportKind::Bedrock => Some(normalized_transport.as_str().to_string()),
+            ModelTransportKind::OpenAiCompatible => None,
+        };
+
+        for model in &mut group.models {
+            model.reasoning_effort = normalize_reasoning_effort_value(
+                normalize_optional_string(model.reasoning_effort.take()),
+                Some(provider),
+                normalized_transport,
+                &model.name,
+            );
+        }
     }
 }
 
-fn normalize_transport_kind(model: &mut ModelProfile) {
-    let mut transport_kind = model.transport_kind();
+fn normalize_group_transport_kind(
+    provider: ModelProvider,
+    transport_kind: ModelTransportKind,
+) -> ModelTransportKind {
+    let mut transport_kind = transport_kind;
     if matches!(
-        model.provider,
-        Some(ModelProvider::Google) | Some(ModelProvider::GoogleVertexAi)
+        provider,
+        ModelProvider::Google | ModelProvider::GoogleVertexAi
     ) && matches!(
         transport_kind,
         ModelTransportKind::OpenResponses | ModelTransportKind::Anthropic
     ) {
         transport_kind = ModelTransportKind::OpenAiCompatible;
     }
-    if matches!(model.provider, Some(ModelProvider::GoogleVertexAi))
-        && transport_kind == ModelTransportKind::Bedrock
+    if provider == ModelProvider::GoogleVertexAi && transport_kind == ModelTransportKind::Bedrock
     {
         transport_kind = ModelTransportKind::OpenAiCompatible;
     }
-    model.extra.remove("transportKind");
-    model.extra.remove("transport_kind");
+    transport_kind
+}
 
-    if transport_kind == ModelTransportKind::Anthropic
-        || transport_kind == ModelTransportKind::OpenResponses
-        || transport_kind == ModelTransportKind::Bedrock
-    {
-        model.extra.insert(
-            "transportKind".to_string(),
-            Value::String(transport_kind.as_str().to_string()),
-        );
+fn normalize_slot_model_ref(
+    value: Option<ModelRef>,
+    models: &[ModelProfile],
+    predicate: impl Fn(&ModelProfile) -> bool,
+) -> Option<ModelRef> {
+    let model_ref = value?;
+    if model_ref.is_empty() {
+        return None;
+    }
+    let profile = models
+        .iter()
+        .find(|model| model.group_id == model_ref.group_id && model.name == model_ref.name)?;
+    if predicate(profile) {
+        Some(model_ref)
+    } else {
+        None
+    }
+}
+
+fn normalize_lightweight_chat_model_ref(
+    value: Option<ModelRef>,
+    models: &[ModelProfile],
+) -> Option<ModelRef> {
+    let model_ref = value?;
+    if model_ref.is_empty() {
+        return None;
+    }
+    let profile = models
+        .iter()
+        .find(|model| model.group_id == model_ref.group_id && model.name == model_ref.name)?;
+    if profile.supports_chat() {
+        Some(model_ref)
+    } else {
+        None
     }
 }
 
@@ -603,32 +1222,6 @@ pub(crate) fn normalize_reasoning_effort_value(
     })
 }
 
-fn normalize_image_generation_model(
-    value: Option<String>,
-    models: &[ModelProfile],
-) -> Option<String> {
-    let name = normalize_optional_string(value)?;
-    let profile = models.iter().find(|model| model.name == name)?;
-    if profile.supports_image_generation() {
-        Some(name)
-    } else {
-        None
-    }
-}
-
-fn normalize_video_generation_model(
-    value: Option<String>,
-    models: &[ModelProfile],
-) -> Option<String> {
-    let name = normalize_optional_string(value)?;
-    let profile = models.iter().find(|model| model.name == name)?;
-    if profile.supports_video_generation() {
-        Some(name)
-    } else {
-        None
-    }
-}
-
 fn normalize_optional_string(value: Option<String>) -> Option<String> {
     let trimmed = value?.trim().to_string();
     if trimmed.is_empty() {
@@ -645,9 +1238,39 @@ fn is_deepseek_v4_reasoning_model(model: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{deserialize_config, normalize_reasoning_effort_value, serialize_config, ModelProvider, ModelTransportKind};
+    use super::{
+        deserialize_config, normalize_reasoning_effort_value, serialize_config, AppConfig,
+        ModelEntry, ModelProvider, ModelRef, ModelTransportKind,
+        ProviderGroupConnectDraft, SPIRIT_CONFIG_SCHEMA_VERSION,
+    };
     use serde_json::Value;
     use std::path::Path;
+
+    fn test_profile(
+        group_id: &str,
+        name: &str,
+        api_base: &str,
+        provider: ModelProvider,
+    ) -> super::ModelProfile {
+        super::ModelProfile {
+            group_id: group_id.to_string(),
+            name: name.to_string(),
+            api_base: api_base.to_string(),
+            provider: Some(provider),
+            reasoning_effort: None,
+            context_length: None,
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn rejects_non_v2_schema_version() {
+        let config = r#"{"schemaVersion":1,"models":[],"activeModel":""}"#;
+        let err = deserialize_config(config, Path::new("config.json")).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains(&format!("schemaVersion {SPIRIT_CONFIG_SCHEMA_VERSION}")));
+    }
 
     #[test]
     fn normalize_reasoning_effort_preserves_moonshot_style_for_kimi_code() {
@@ -675,23 +1298,28 @@ mod tests {
     fn preserves_unknown_top_level_and_model_fields() {
         let config = r#"
 {
-  "models": [
+  "schemaVersion": 2,
+  "providerGroups": [
     {
-            "name": "agent-test-model",
-            "apiBase": "https://example.invalid/v1",
-            "provider": "custom",
-            "transportImplementation": "ai-sdk",
-      "reasoningEffort": "minimal"
+      "id": "custom",
+      "provider": "custom",
+      "apiBase": "https://example.invalid/v1",
+      "models": [
+        {
+          "name": "agent-test-model",
+          "reasoningEffort": "minimal"
+        }
+      ]
     }
   ],
-    "activeModel": "agent-test-model",
-    "imageGenerationModel": "agent-test-model",
+  "activeModel": { "groupId": "custom", "name": "agent-test-model" },
+  "imageGenerationModel": { "groupId": "custom", "name": "agent-test-model" },
   "uiLocale": "zh-CN",
   "windowsMica": true,
   "recentWorkspaces": ["D:/SpiritAgent", "D:/Other"],
   "dreams": {
     "enabled": true,
-        "collectorModel": "collector-test-model",
+    "collectorModel": "collector-test-model",
     "debugMode": true
   }
 }
@@ -715,33 +1343,26 @@ mod tests {
             Some("collector-test-model")
         );
         assert_eq!(
-            json.get("models")
+            json.get("providerGroups")
                 .and_then(Value::as_array)
-                .and_then(|models| models.first())
-                .and_then(|model| model.get("transportImplementation"))
-                .and_then(Value::as_str),
-            None
-        );
-        assert_eq!(
-            json.get("models")
+                .and_then(|groups| groups.first())
+                .and_then(|group| group.get("models"))
                 .and_then(Value::as_array)
                 .and_then(|models| models.first())
                 .and_then(|model| model.get("reasoningEffort"))
                 .and_then(Value::as_str),
             Some("default")
         );
-        assert_eq!(
-            json.get("imageGenerationModel").and_then(Value::as_str),
-            None
-        );
+        assert_eq!(parsed.image_generation_model, None);
     }
 
     #[test]
     fn normalizing_empty_models_keeps_unknown_desktop_fields() {
         let config = r#"
 {
-  "models": [],
-  "activeModel": "",
+  "schemaVersion": 2,
+  "providerGroups": [],
+  "activeModel": { "groupId": "", "name": "" },
   "windowsMica": false,
   "dreams": {
     "enabled": true,
@@ -765,46 +1386,40 @@ mod tests {
             Some(true)
         );
         assert_eq!(
-            json.get("models").and_then(Value::as_array).map(Vec::len),
+            json.get("providerGroups")
+                .and_then(Value::as_array)
+                .map(Vec::len),
             Some(0)
         );
         assert_eq!(
-            json.get("activeModel").and_then(Value::as_str),
+            json.get("activeModel")
+                .and_then(|active| active.get("name"))
+                .and_then(Value::as_str),
             Some("")
         );
     }
 
     #[test]
     fn model_profile_supports_image_input_uses_explicit_capabilities_for_moonshot() {
-        let kimi_without_capabilities = super::ModelProfile {
-            name: "kimi-k2.6".to_string(),
-            api_base: "https://api.moonshot.cn/v1".to_string(),
-            provider: Some(super::ModelProvider::Moonshot),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::new(),
-        };
+        let kimi_without_capabilities =
+            test_profile("moonshot-ai", "kimi-k2.6", "https://api.moonshot.cn/v1", ModelProvider::Moonshot);
         let mut kimi_with_image = kimi_without_capabilities.clone();
         kimi_with_image.extra.insert(
             "capabilities".to_string(),
             serde_json::json!(["chat", "image"]),
         );
-        let deepseek = super::ModelProfile {
-            name: "deepseek-v4-pro".to_string(),
-            api_base: "https://api.deepseek.com/v1".to_string(),
-            provider: Some(super::ModelProvider::Deepseek),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::new(),
-        };
-        let custom = super::ModelProfile {
-            name: "my-custom-model".to_string(),
-            api_base: "https://example.invalid/v1".to_string(),
-            provider: Some(super::ModelProvider::Custom),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::new(),
-        };
+        let deepseek = test_profile(
+            "deepseek",
+            "deepseek-v4-pro",
+            "https://api.deepseek.com/v1",
+            ModelProvider::Deepseek,
+        );
+        let custom = test_profile(
+            "custom",
+            "my-custom-model",
+            "https://example.invalid/v1",
+            ModelProvider::Custom,
+        );
 
         assert!(!kimi_without_capabilities.supports_image_input());
         assert!(kimi_with_image.supports_image_input());
@@ -814,14 +1429,12 @@ mod tests {
 
     #[test]
     fn model_profile_supports_image_input_uses_explicit_capabilities_for_xiaomi() {
-        let mimo_without_capabilities = super::ModelProfile {
-            name: "mimo-v2-flash".to_string(),
-            api_base: "https://api.xiaomimimo.com/v1".to_string(),
-            provider: Some(super::ModelProvider::Xiaomi),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::new(),
-        };
+        let mimo_without_capabilities = test_profile(
+            "xiaomi",
+            "mimo-v2-flash",
+            "https://api.xiaomimimo.com/v1",
+            ModelProvider::Xiaomi,
+        );
         let mut mimo_with_image = mimo_without_capabilities.clone();
         mimo_with_image.extra.insert(
             "capabilities".to_string(),
@@ -834,27 +1447,23 @@ mod tests {
 
     #[test]
     fn explicit_capabilities_override_provider_image_input_inference() {
-        let mut deepseek = super::ModelProfile {
-            name: "deepseek-v4-pro".to_string(),
-            api_base: "https://api.deepseek.com/v1".to_string(),
-            provider: Some(super::ModelProvider::Deepseek),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::new(),
-        };
+        let mut deepseek = test_profile(
+            "deepseek",
+            "deepseek-v4-pro",
+            "https://api.deepseek.com/v1",
+            ModelProvider::Deepseek,
+        );
         deepseek.extra.insert(
             "capabilities".to_string(),
             serde_json::json!(["chat", "image"]),
         );
 
-        let mut custom = super::ModelProfile {
-            name: "my-custom-model".to_string(),
-            api_base: "https://example.invalid/v1".to_string(),
-            provider: Some(super::ModelProvider::Custom),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::new(),
-        };
+        let mut custom = test_profile(
+            "custom",
+            "my-custom-model",
+            "https://example.invalid/v1",
+            ModelProvider::Custom,
+        );
         custom
             .extra
             .insert("capabilities".to_string(), serde_json::json!(["chat"]));
@@ -867,27 +1476,30 @@ mod tests {
     fn image_generation_model_requires_explicit_capability() {
         let config = r#"
 {
-    "models": [
+    "schemaVersion": 2,
+    "providerGroups": [
         {
-            "name": "chat-model",
+            "id": "custom",
+            "provider": "custom",
             "apiBase": "https://example.invalid/v1",
-            "capabilities": ["chat"]
-        },
-        {
-            "name": "image-model",
-            "apiBase": "https://example.invalid/v1",
-            "capabilities": ["imageGeneration"]
+            "models": [
+                { "name": "chat-model", "capabilities": ["chat"] },
+                { "name": "image-model", "capabilities": ["imageGeneration"] }
+            ]
         }
     ],
-    "activeModel": "chat-model",
-    "imageGenerationModel": "image-model"
+    "activeModel": { "groupId": "custom", "name": "chat-model" },
+    "imageGenerationModel": { "groupId": "custom", "name": "image-model" }
 }
 "#;
 
         let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
         assert_eq!(
-            parsed.image_generation_model.as_deref(),
-            Some("image-model")
+            parsed.image_generation_model,
+            Some(ModelRef {
+                group_id: "custom".to_string(),
+                name: "image-model".to_string(),
+            })
         );
 
         let invalid = config.replace("image-model\"", "chat-model\"");
@@ -899,27 +1511,30 @@ mod tests {
     fn video_generation_model_requires_explicit_capability() {
         let config = r#"
 {
-    "models": [
+    "schemaVersion": 2,
+    "providerGroups": [
         {
-            "name": "chat-model",
+            "id": "custom",
+            "provider": "custom",
             "apiBase": "https://example.invalid/v1",
-            "capabilities": ["chat"]
-        },
-        {
-            "name": "video-model",
-            "apiBase": "https://example.invalid/v1",
-            "capabilities": ["videoGeneration"]
+            "models": [
+                { "name": "chat-model", "capabilities": ["chat"] },
+                { "name": "video-model", "capabilities": ["videoGeneration"] }
+            ]
         }
     ],
-    "activeModel": "chat-model",
-    "videoGenerationModel": "video-model"
+    "activeModel": { "groupId": "custom", "name": "chat-model" },
+    "videoGenerationModel": { "groupId": "custom", "name": "video-model" }
 }
 "#;
 
         let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
         assert_eq!(
-            parsed.video_generation_model.as_deref(),
-            Some("video-model")
+            parsed.video_generation_model,
+            Some(ModelRef {
+                group_id: "custom".to_string(),
+                name: "video-model".to_string(),
+            })
         );
 
         let invalid = config.replace("video-model\"", "chat-model\"");
@@ -931,22 +1546,25 @@ mod tests {
     fn deserializes_alibaba_provider_from_desktop_config() {
         let config = r#"
 {
-    "models": [
+    "schemaVersion": 2,
+    "providerGroups": [
         {
-            "name": "qwen3.6-plus",
-            "apiBase": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "id": "alibaba",
             "provider": "alibaba",
-            "reasoningEffort": "medium"
+            "apiBase": "https://dashscope.aliyuncs.com/compatible-mode/v1",
+            "models": [
+                { "name": "qwen3.6-plus", "reasoningEffort": "medium" }
+            ]
         }
     ],
-    "activeModel": "qwen3.6-plus"
+    "activeModel": { "groupId": "alibaba", "name": "qwen3.6-plus" }
 }
 "#;
 
         let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
         let active = parsed.active_model_profile().expect("active model");
 
-        assert_eq!(active.provider, Some(super::ModelProvider::Alibaba));
+        assert_eq!(active.provider, Some(ModelProvider::Alibaba));
         assert_eq!(active.reasoning_effort.as_deref(), Some("medium"));
     }
 
@@ -954,27 +1572,27 @@ mod tests {
     fn deserializes_anthropic_transport_kind_from_desktop_config() {
         let config = r#"
 {
-    "models": [
+    "schemaVersion": 2,
+    "providerGroups": [
         {
-            "name": "claude-sonnet-4-5",
-            "apiBase": "https://api.anthropic.com/v1",
+            "id": "anthropic",
             "provider": "anthropic",
+            "apiBase": "https://api.anthropic.com/v1",
             "transportKind": "anthropic",
-            "reasoningEffort": "high"
+            "models": [
+                { "name": "claude-sonnet-4-5", "reasoningEffort": "high" }
+            ]
         }
     ],
-    "activeModel": "claude-sonnet-4-5"
+    "activeModel": { "groupId": "anthropic", "name": "claude-sonnet-4-5" }
 }
 "#;
 
         let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
         let active = parsed.active_model_profile().expect("active model");
 
-        assert_eq!(active.provider, Some(super::ModelProvider::Anthropic));
-        assert_eq!(
-            active.transport_kind(),
-            super::ModelTransportKind::Anthropic
-        );
+        assert_eq!(active.provider, Some(ModelProvider::Anthropic));
+        assert_eq!(active.transport_kind(), ModelTransportKind::Anthropic);
         assert_eq!(active.reasoning_effort.as_deref(), Some("high"));
     }
 
@@ -982,16 +1600,19 @@ mod tests {
     fn deserializes_vercel_ai_gateway_provider_from_desktop_config() {
         let config = r#"
 {
-    "models": [
+    "schemaVersion": 2,
+    "providerGroups": [
         {
-            "name": "gateway-model",
-            "apiBase": "https://ai-gateway.vercel.sh/v1",
+            "id": "vercel-ai-gateway",
             "provider": "vercel-ai-gateway",
+            "apiBase": "https://ai-gateway.vercel.sh/v1",
             "transportKind": "open-responses",
-            "reasoningEffort": "medium"
+            "models": [
+                { "name": "gateway-model", "reasoningEffort": "medium" }
+            ]
         }
     ],
-    "activeModel": "gateway-model"
+    "activeModel": { "groupId": "vercel-ai-gateway", "name": "gateway-model" }
 }
 "#;
 
@@ -1000,15 +1621,12 @@ mod tests {
         let json: Value = serde_json::from_str(&serialized).expect("json value");
         let active = parsed.active_model_profile().expect("active model");
 
+        assert_eq!(active.provider, Some(ModelProvider::VercelAiGateway));
         assert_eq!(
-            active.provider,
-            Some(super::ModelProvider::VercelAiGateway)
-        );
-        assert_eq!(
-            json.get("models")
+            json.get("providerGroups")
                 .and_then(Value::as_array)
-                .and_then(|models| models.first())
-                .and_then(|model| model.get("provider"))
+                .and_then(|groups| groups.first())
+                .and_then(|group| group.get("provider"))
                 .and_then(Value::as_str),
             Some("vercel-ai-gateway")
         );
@@ -1018,15 +1636,18 @@ mod tests {
     fn normalizes_custom_openai_reasoning_effort_to_generic_values() {
         let config = r#"
 {
-    "models": [
+    "schemaVersion": 2,
+    "providerGroups": [
         {
-            "name": "custom-openai-model",
-            "apiBase": "https://example.invalid/v1",
+            "id": "custom",
             "provider": "custom",
-            "reasoningEffort": "minimal"
+            "apiBase": "https://example.invalid/v1",
+            "models": [
+                { "name": "custom-openai-model", "reasoningEffort": "minimal" }
+            ]
         }
     ],
-    "activeModel": "custom-openai-model"
+    "activeModel": { "groupId": "custom", "name": "custom-openai-model" }
 }
 "#;
 
@@ -1040,23 +1661,26 @@ mod tests {
     fn normalizes_custom_anthropic_reasoning_effort_to_anthropic_values() {
         let config = r#"
 {
-    "models": [
+    "schemaVersion": 2,
+    "providerGroups": [
         {
-            "name": "claude-custom",
-            "apiBase": "https://api.anthropic.com/v1",
+            "id": "custom",
             "provider": "custom",
+            "apiBase": "https://api.anthropic.com/v1",
             "transportKind": "anthropic",
-            "reasoningEffort": "max"
+            "models": [
+                { "name": "claude-custom", "reasoningEffort": "max" }
+            ]
         }
     ],
-    "activeModel": "claude-custom"
+    "activeModel": { "groupId": "custom", "name": "claude-custom" }
 }
 "#;
 
         let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
         let active = parsed.active_model_profile().expect("active model");
 
-        assert_eq!(active.transport_kind(), super::ModelTransportKind::Anthropic);
+        assert_eq!(active.transport_kind(), ModelTransportKind::Anthropic);
         assert_eq!(active.reasoning_effort.as_deref(), Some("max"));
     }
 
@@ -1064,15 +1688,18 @@ mod tests {
     fn roundtrips_model_context_length_field() {
         let config = r#"
 {
-  "models": [
+  "schemaVersion": 2,
+  "providerGroups": [
     {
-      "name": "custom-model",
-      "apiBase": "https://example.invalid/v1",
+      "id": "custom",
       "provider": "custom",
-      "contextLength": 128000
+      "apiBase": "https://example.invalid/v1",
+      "models": [
+        { "name": "custom-model", "contextLength": 128000 }
+      ]
     }
   ],
-  "activeModel": "custom-model"
+  "activeModel": { "groupId": "custom", "name": "custom-model" }
 }
 "#;
 
@@ -1083,7 +1710,10 @@ mod tests {
         let serialized = serialize_config(&parsed).expect("serialize config");
         let json: Value = serde_json::from_str(&serialized).expect("json value");
         assert_eq!(
-            json.get("models")
+            json.get("providerGroups")
+                .and_then(Value::as_array)
+                .and_then(|groups| groups.first())
+                .and_then(|group| group.get("models"))
                 .and_then(Value::as_array)
                 .and_then(|models| models.first())
                 .and_then(|model| model.get("contextLength"))
@@ -1091,21 +1721,30 @@ mod tests {
             Some(128_000)
         );
 
-        let without_context = super::ModelProfile {
-            name: "plain".to_string(),
-            api_base: "https://example.invalid/v1".to_string(),
-            provider: Some(super::ModelProvider::Custom),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::new(),
-        };
-        let mut cfg = super::AppConfig::default();
-        cfg.models = vec![without_context];
+        let mut cfg = AppConfig::default();
+        cfg.add_model_to_group(
+            "custom",
+            ModelProvider::Custom,
+            "https://example.invalid/v1".to_string(),
+            ProviderGroupConnectDraft::default(),
+            ModelEntry {
+                name: "plain".to_string(),
+                reasoning_effort: None,
+                thinking_enabled: None,
+                supported_reasoning_efforts: None,
+                capabilities: None,
+                context_length: None,
+                supports_thinking_type: None,
+            },
+        );
         let serialized_without = serialize_config(&cfg).expect("serialize config");
         let json_without: Value = serde_json::from_str(&serialized_without).expect("json value");
         assert_eq!(
             json_without
-                .get("models")
+                .get("providerGroups")
+                .and_then(Value::as_array)
+                .and_then(|groups| groups.first())
+                .and_then(|group| group.get("models"))
                 .and_then(Value::as_array)
                 .and_then(|models| models.first())
                 .and_then(|model| model.get("contextLength")),
@@ -1115,93 +1754,105 @@ mod tests {
 
     #[test]
     fn normalize_transport_kind_downgrades_google_open_responses() {
-        let mut model = super::ModelProfile {
-            name: "gemini-flash".to_string(),
-            api_base: "https://generativelanguage.googleapis.com/v1beta".to_string(),
-            provider: Some(super::ModelProvider::Google),
-            reasoning_effort: None,
-            context_length: None,
-            extra: serde_json::Map::from_iter([(
-                "transportKind".to_string(),
-                serde_json::json!("open-responses"),
-            )]),
-        };
-        super::normalize_transport_kind(&mut model);
-        assert_eq!(model.transport_kind(), super::ModelTransportKind::OpenAiCompatible);
-        assert!(model.extra.get("transportKind").is_none());
+        let config = r#"
+{
+  "schemaVersion": 2,
+  "providerGroups": [
+    {
+      "id": "google",
+      "provider": "google",
+      "apiBase": "https://generativelanguage.googleapis.com/v1beta",
+      "transportKind": "open-responses",
+      "models": [{ "name": "gemini-flash" }]
+    }
+  ],
+  "activeModel": { "groupId": "google", "name": "gemini-flash" }
+}
+"#;
+        let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
+        let active = parsed.active_model_profile().expect("active model");
+        assert_eq!(active.transport_kind(), ModelTransportKind::OpenAiCompatible);
     }
 
     #[test]
     fn deserializes_siliconflow_provider_site_from_desktop_config() {
         let raw = r#"{
-          "models": [{
-            "name": "deepseek-ai/DeepSeek-V3",
-            "apiBase": "https://api.siliconflow.cn/v1",
+          "schemaVersion": 2,
+          "providerGroups": [{
+            "id": "siliconflow",
             "provider": "siliconflow",
+            "apiBase": "https://api.siliconflow.cn/v1",
             "providerSite": "cn",
-            "transportKind": "anthropic"
+            "transportKind": "anthropic",
+            "models": [{ "name": "deepseek-ai/DeepSeek-V3" }]
           }],
-          "activeModel": "deepseek-ai/DeepSeek-V3"
+          "activeModel": { "groupId": "siliconflow", "name": "deepseek-ai/DeepSeek-V3" }
         }"#;
-        let cfg: super::AppConfig = serde_json::from_str(raw).expect("parse config");
-        let model = cfg.models.first().expect("model");
-        assert_eq!(model.provider, Some(super::ModelProvider::Siliconflow));
+        let parsed = deserialize_config(raw, Path::new("config.json")).expect("parse config");
+        let model = parsed.active_model_profile().expect("model");
+        assert_eq!(model.provider, Some(ModelProvider::Siliconflow));
         assert_eq!(model.provider_site().as_deref(), Some("cn"));
-        assert_eq!(model.transport_kind(), super::ModelTransportKind::Anthropic);
+        assert_eq!(model.transport_kind(), ModelTransportKind::Anthropic);
     }
 
     #[test]
     fn deserializes_moonshot_provider_site_from_desktop_config() {
         let raw = r#"{
-          "models": [{
-            "name": "kimi-k2",
-            "apiBase": "https://api.moonshot.ai/v1",
+          "schemaVersion": 2,
+          "providerGroups": [{
+            "id": "moonshot-ai",
             "provider": "moonshot-ai",
-            "providerSite": "intl"
+            "apiBase": "https://api.moonshot.ai/v1",
+            "providerSite": "intl",
+            "models": [{ "name": "kimi-k2" }]
           }],
-          "activeModel": "kimi-k2"
+          "activeModel": { "groupId": "moonshot-ai", "name": "kimi-k2" }
         }"#;
-        let cfg: super::AppConfig = serde_json::from_str(raw).expect("parse config");
-        let model = cfg.models.first().expect("model");
-        assert_eq!(model.provider, Some(super::ModelProvider::Moonshot));
+        let parsed = deserialize_config(raw, Path::new("config.json")).expect("parse config");
+        let model = parsed.active_model_profile().expect("model");
+        assert_eq!(model.provider, Some(ModelProvider::Moonshot));
         assert_eq!(model.provider_site().as_deref(), Some("intl"));
     }
 
     #[test]
     fn deserializes_minimax_provider_site_from_desktop_config() {
         let raw = r#"{
-          "models": [{
-            "name": "MiniMax-M2.5",
-            "apiBase": "https://api.minimax.io/anthropic/v1",
+          "schemaVersion": 2,
+          "providerGroups": [{
+            "id": "minimax",
             "provider": "minimax",
+            "apiBase": "https://api.minimax.io/anthropic/v1",
             "providerSite": "intl",
-            "transportKind": "anthropic"
+            "transportKind": "anthropic",
+            "models": [{ "name": "MiniMax-M2.5" }]
           }],
-          "activeModel": "MiniMax-M2.5"
+          "activeModel": { "groupId": "minimax", "name": "MiniMax-M2.5" }
         }"#;
-        let cfg: super::AppConfig = serde_json::from_str(raw).expect("parse config");
-        let model = cfg.models.first().expect("model");
-        assert_eq!(model.provider, Some(super::ModelProvider::Minimax));
+        let parsed = deserialize_config(raw, Path::new("config.json")).expect("parse config");
+        let model = parsed.active_model_profile().expect("model");
+        assert_eq!(model.provider, Some(ModelProvider::Minimax));
         assert_eq!(model.provider_site().as_deref(), Some("intl"));
-        assert_eq!(model.transport_kind(), super::ModelTransportKind::Anthropic);
+        assert_eq!(model.transport_kind(), ModelTransportKind::Anthropic);
     }
 
     #[test]
     fn deserializes_alibaba_provider_site_and_workspace_from_desktop_config() {
         let raw = r#"{
-          "models": [{
-            "name": "qwen3.6-plus",
-            "apiBase": "https://ws123.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+          "schemaVersion": 2,
+          "providerGroups": [{
+            "id": "alibaba",
             "provider": "alibaba",
+            "apiBase": "https://ws123.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
             "providerSite": "ap-southeast-1",
             "alibabaWorkspaceId": "ws123",
-            "transportKind": "openai-compatible"
+            "transportKind": "openai-compatible",
+            "models": [{ "name": "qwen3.6-plus" }]
           }],
-          "activeModel": "qwen3.6-plus"
+          "activeModel": { "groupId": "alibaba", "name": "qwen3.6-plus" }
         }"#;
-        let cfg: super::AppConfig = serde_json::from_str(raw).expect("parse config");
-        let model = cfg.models.first().expect("model");
-        assert_eq!(model.provider, Some(super::ModelProvider::Alibaba));
+        let parsed = deserialize_config(raw, Path::new("config.json")).expect("parse config");
+        let model = parsed.active_model_profile().expect("model");
+        assert_eq!(model.provider, Some(ModelProvider::Alibaba));
         assert_eq!(model.provider_site().as_deref(), Some("ap-southeast-1"));
         assert_eq!(model.alibaba_workspace_id().as_deref(), Some("ws123"));
     }
@@ -1209,21 +1860,52 @@ mod tests {
     #[test]
     fn deserializes_alibaba_token_plan_billing_mode_from_desktop_config() {
         let raw = r#"{
-          "models": [{
-            "name": "qwen3.6-plus",
-            "apiBase": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+          "schemaVersion": 2,
+          "providerGroups": [{
+            "id": "alibaba",
             "provider": "alibaba",
+            "apiBase": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
             "alibabaBillingMode": "token-plan",
-            "transportKind": "openai-compatible"
+            "transportKind": "openai-compatible",
+            "models": [{ "name": "qwen3.6-plus" }]
           }],
-          "activeModel": "qwen3.6-plus"
+          "activeModel": { "groupId": "alibaba", "name": "qwen3.6-plus" }
         }"#;
-        let cfg: super::AppConfig = serde_json::from_str(raw).expect("parse config");
-        let model = cfg.models.first().expect("model");
-        assert_eq!(model.provider, Some(super::ModelProvider::Alibaba));
+        let parsed = deserialize_config(raw, Path::new("config.json")).expect("parse config");
+        let model = parsed.active_model_profile().expect("model");
+        assert_eq!(model.provider, Some(ModelProvider::Alibaba));
         assert_eq!(model.alibaba_billing_mode().as_deref(), Some("token-plan"));
         assert!(model.provider_site().is_none());
         assert!(model.alibaba_workspace_id().is_none());
+    }
+
+    #[test]
+    fn active_model_profile_merges_group_and_model_entry() {
+        let mut cfg = AppConfig::default();
+        cfg.add_model_to_group(
+            "openai",
+            ModelProvider::Openai,
+            "https://api.openai.com/v1".to_string(),
+            ProviderGroupConnectDraft::default(),
+            ModelEntry {
+                name: "gpt-4o-mini".to_string(),
+                reasoning_effort: Some("medium".to_string()),
+                thinking_enabled: None,
+                supported_reasoning_efforts: None,
+                capabilities: Some(vec!["chat".to_string()]),
+                context_length: None,
+                supports_thinking_type: None,
+            },
+        );
+        cfg.active_model = ModelRef {
+            group_id: "openai".to_string(),
+            name: "gpt-4o-mini".to_string(),
+        };
+        let active = cfg.active_model_profile().expect("active model");
+        assert_eq!(active.group_id, "openai");
+        assert_eq!(active.name, "gpt-4o-mini");
+        assert_eq!(active.api_base, "https://api.openai.com/v1");
+        assert_eq!(active.provider, Some(ModelProvider::Openai));
     }
 }
 
@@ -1240,90 +1922,85 @@ fn model_key_account(model_name: &str) -> String {
     format!("model::{}", model_name)
 }
 
-fn provider_key_account(provider_id: &str) -> String {
-    format!("provider::{}", provider_id)
+fn group_key_account(group_id: &str) -> String {
+    format!("group::{}", group_id)
 }
 
-pub fn load_provider_api_key_from_keyring(provider_id: &str) -> Result<String> {
-    let entry = keyring_entry_for_account(&provider_key_account(provider_id))?;
+fn group_access_key_id_account(group_id: &str) -> String {
+    format!("group::{group_id}::access-key-id")
+}
+
+fn group_secret_access_key_account(group_id: &str) -> String {
+    format!("group::{group_id}::secret-access-key")
+}
+
+fn group_vertex_client_email_account(group_id: &str) -> String {
+    format!("group::{group_id}::client-email")
+}
+
+fn group_vertex_private_key_account(group_id: &str) -> String {
+    format!("group::{group_id}::private-key")
+}
+
+pub fn load_group_api_key_from_keyring(group_id: &str) -> Result<String> {
+    let entry = keyring_entry_for_account(&group_key_account(group_id))?;
     entry
         .get_password()
-        .with_context(|| format!("读取 provider {} 的 API Key 失败", provider_id))
+        .with_context(|| format!("读取 provider group {} 的 API Key 失败", group_id))
 }
 
-fn provider_access_key_id_account(provider_id: &str) -> String {
-    format!("provider::{provider_id}::access-key-id")
-}
-
-fn provider_secret_access_key_account(provider_id: &str) -> String {
-    format!("provider::{provider_id}::secret-access-key")
-}
-
-pub fn load_provider_access_key_id_from_keyring(provider_id: &str) -> Result<String> {
-    let entry = keyring_entry_for_account(&provider_access_key_id_account(provider_id))?;
+pub fn load_group_access_key_id_from_keyring(group_id: &str) -> Result<String> {
+    let entry = keyring_entry_for_account(&group_access_key_id_account(group_id))?;
     entry.get_password().with_context(|| {
-        format!("读取 provider {provider_id} 的 IAM Access Key ID 失败")
+        format!("读取 provider group {group_id} 的 IAM Access Key ID 失败")
     })
 }
 
-pub fn load_provider_secret_access_key_from_keyring(provider_id: &str) -> Result<String> {
-    let entry = keyring_entry_for_account(&provider_secret_access_key_account(provider_id))?;
+pub fn load_group_secret_access_key_from_keyring(group_id: &str) -> Result<String> {
+    let entry = keyring_entry_for_account(&group_secret_access_key_account(group_id))?;
     entry.get_password().with_context(|| {
-        format!("读取 provider {provider_id} 的 IAM Secret Access Key 失败")
+        format!("读取 provider group {group_id} 的 IAM Secret Access Key 失败")
     })
 }
 
-pub fn has_bedrock_runtime_credentials_in_keyring() -> Result<bool> {
-    if load_provider_api_key_from_keyring(ModelProvider::AmazonBedrock.as_str())
+pub fn has_bedrock_runtime_credentials_in_keyring(group_id: &str) -> Result<bool> {
+    if load_group_api_key_from_keyring(group_id)
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false)
     {
         return Ok(true);
     }
 
-    let access_key_id = load_provider_access_key_id_from_keyring(ModelProvider::AmazonBedrock.as_str())
+    let access_key_id = load_group_access_key_id_from_keyring(group_id)
         .map(|value| !value.trim().is_empty())
         .unwrap_or(false);
-    let secret_access_key =
-        load_provider_secret_access_key_from_keyring(ModelProvider::AmazonBedrock.as_str())
-            .map(|value| !value.trim().is_empty())
-            .unwrap_or(false);
+    let secret_access_key = load_group_secret_access_key_from_keyring(group_id)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false);
     Ok(access_key_id && secret_access_key)
 }
 
-fn provider_vertex_client_email_account(provider_id: &str) -> String {
-    format!("provider::{provider_id}::client-email")
-}
-
-fn provider_vertex_private_key_account(provider_id: &str) -> String {
-    format!("provider::{provider_id}::private-key")
-}
-
-pub fn load_provider_vertex_client_email_from_keyring(provider_id: &str) -> Result<String> {
-    let entry = keyring_entry_for_account(&provider_vertex_client_email_account(provider_id))?;
+pub fn load_group_vertex_client_email_from_keyring(group_id: &str) -> Result<String> {
+    let entry = keyring_entry_for_account(&group_vertex_client_email_account(group_id))?;
     entry.get_password().with_context(|| {
-        format!("读取 provider {provider_id} 的 Vertex client email 失败")
+        format!("读取 provider group {group_id} 的 Vertex client email 失败")
     })
 }
 
-pub fn load_provider_vertex_private_key_from_keyring(provider_id: &str) -> Result<String> {
-    let entry = keyring_entry_for_account(&provider_vertex_private_key_account(provider_id))?;
+pub fn load_group_vertex_private_key_from_keyring(group_id: &str) -> Result<String> {
+    let entry = keyring_entry_for_account(&group_vertex_private_key_account(group_id))?;
     entry.get_password().with_context(|| {
-        format!("读取 provider {provider_id} 的 Vertex private key 失败")
+        format!("读取 provider group {group_id} 的 Vertex private key 失败")
     })
 }
 
-pub fn has_google_vertex_service_account_in_keyring() -> Result<bool> {
-    let client_email = load_provider_vertex_client_email_from_keyring(
-        ModelProvider::GoogleVertexAi.as_str(),
-    )
-    .map(|value| !value.trim().is_empty())
-    .unwrap_or(false);
-    let private_key = load_provider_vertex_private_key_from_keyring(
-        ModelProvider::GoogleVertexAi.as_str(),
-    )
-    .map(|value| !value.trim().is_empty())
-    .unwrap_or(false);
+pub fn has_google_vertex_service_account_in_keyring(group_id: &str) -> Result<bool> {
+    let client_email = load_group_vertex_client_email_from_keyring(group_id)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false);
+    let private_key = load_group_vertex_private_key_from_keyring(group_id)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false);
     Ok(client_email && private_key)
 }
 
@@ -1331,6 +2008,7 @@ pub fn has_google_vertex_runtime_credentials(
     api_key: &str,
     vertex_project: Option<&str>,
     vertex_location: Option<&str>,
+    group_id: &str,
 ) -> bool {
     if !api_key.trim().is_empty() {
         return true;
@@ -1340,34 +2018,34 @@ pub fn has_google_vertex_runtime_credentials(
     if !has_project_location {
         return false;
     }
-    if has_google_vertex_service_account_in_keyring().unwrap_or(false) {
+    if has_google_vertex_service_account_in_keyring(group_id).unwrap_or(false) {
         return true;
     }
     true
 }
 
-pub fn save_provider_api_key(provider_id: &str, api_key: &str) -> Result<()> {
-    let entry = keyring_entry_for_account(&provider_key_account(provider_id))?;
+pub fn save_group_api_key(group_id: &str, api_key: &str) -> Result<()> {
+    let entry = keyring_entry_for_account(&group_key_account(group_id))?;
     entry
         .set_password(api_key.trim())
-        .with_context(|| format!("保存 provider {provider_id} 的 API Key 失败"))
+        .with_context(|| format!("保存 provider group {group_id} 的 API Key 失败"))
 }
 
-pub fn save_provider_vertex_credentials(
-    provider_id: &str,
+pub fn save_group_vertex_credentials(
+    group_id: &str,
     client_email: &str,
     private_key: &str,
 ) -> Result<()> {
     let client_email = client_email.trim();
     let private_key = private_key.trim();
-    let email_entry = keyring_entry_for_account(&provider_vertex_client_email_account(provider_id))?;
+    let email_entry = keyring_entry_for_account(&group_vertex_client_email_account(group_id))?;
     email_entry
         .set_password(client_email)
-        .with_context(|| format!("保存 provider {provider_id} 的 Vertex client email 失败"))?;
-    let key_entry = keyring_entry_for_account(&provider_vertex_private_key_account(provider_id))?;
+        .with_context(|| format!("保存 provider group {group_id} 的 Vertex client email 失败"))?;
+    let key_entry = keyring_entry_for_account(&group_vertex_private_key_account(group_id))?;
     key_entry
         .set_password(private_key)
-        .with_context(|| format!("保存 provider {provider_id} 的 Vertex private key 失败"))
+        .with_context(|| format!("保存 provider group {group_id} 的 Vertex private key 失败"))
 }
 
 pub fn save_model_api_key(model_name: &str, api_key: &str) -> Result<()> {
@@ -1402,8 +2080,15 @@ pub fn has_model_api_key(model_name: &str) -> Result<bool> {
     }
 }
 
-pub fn resolve_api_key_for_model(model_name: &str) -> Result<String> {
+pub fn resolve_api_key_for_model(group_id: &str, model_name: &str) -> Result<String> {
     if let Ok(value) = env::var(ENV_API_KEY) {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    if let Ok(value) = load_group_api_key_from_keyring(group_id) {
         let trimmed = value.trim();
         if !trimmed.is_empty() {
             return Ok(trimmed.to_string());

--- a/apps/cli/src/model_registry.rs
+++ b/apps/cli/src/model_registry.rs
@@ -165,6 +165,10 @@ pub fn model_refs_equal(a: &ModelRef, b: &ModelRef) -> bool {
     a.group_id == b.group_id && a.name == b.name
 }
 
+pub fn model_ref_key(model_ref: &ModelRef) -> String {
+    format!("{}::{}", model_ref.group_id, model_ref.name)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelEntry {
     pub name: String,
@@ -784,20 +788,75 @@ impl AppConfig {
         }
     }
 
-    pub fn find_model_ref_by_name(&self, name: &str) -> Option<ModelRef> {
+    pub fn find_model_refs_by_name(&self, name: &str) -> Vec<ModelRef> {
         let normalized = name.trim();
         if normalized.is_empty() {
-            return None;
+            return Vec::new();
         }
+        let mut refs = Vec::new();
         for group in &self.provider_groups {
-            if group.models.iter().any(|model| model.name == normalized) {
-                return Some(ModelRef {
-                    group_id: group.id.clone(),
-                    name: normalized.to_string(),
-                });
+            for model in &group.models {
+                if model.name == normalized {
+                    refs.push(ModelRef {
+                        group_id: group.id.clone(),
+                        name: model.name.clone(),
+                    });
+                }
             }
         }
-        None
+        refs
+    }
+
+    pub fn has_model_name(&self, name: &str) -> bool {
+        !self.find_model_refs_by_name(name).is_empty()
+    }
+
+    pub fn parse_model_ref_selector(&self, selector: &str) -> Result<ModelRef, String> {
+        let trimmed = selector.trim();
+        if trimmed.is_empty() {
+            return Err("模型标识不能为空".to_string());
+        }
+        if let Some((group_id, name)) = trimmed.split_once("::") {
+            let group_id = group_id.trim();
+            let name = name.trim();
+            if group_id.is_empty() || name.is_empty() {
+                return Err(format!("无效的模型标识: {}", trimmed));
+            }
+            let model_ref = ModelRef {
+                group_id: group_id.to_string(),
+                name: name.to_string(),
+            };
+            if !self.model_ref_exists(&model_ref) {
+                return Err(format!("模型不存在: {}", trimmed));
+            }
+            return Ok(model_ref);
+        }
+        let matches = self.find_model_refs_by_name(trimmed);
+        match matches.len() {
+            0 => Err(format!("模型不存在，请先添加: {}", trimmed)),
+            1 => Ok(matches[0].clone()),
+            _ => {
+                let examples = matches
+                    .iter()
+                    .take(3)
+                    .map(model_ref_key)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(format!(
+                    "存在多个同名模型，请使用 groupId::name 指定，例如: {}",
+                    examples
+                ))
+            }
+        }
+    }
+
+    pub fn find_model_ref_by_name(&self, name: &str) -> Option<ModelRef> {
+        let matches = self.find_model_refs_by_name(name);
+        if matches.len() == 1 {
+            Some(matches[0].clone())
+        } else {
+            None
+        }
     }
 
     pub fn has_model_in_group(&self, group_id: &str, name: &str) -> bool {

--- a/apps/cli/src/model_registry.rs
+++ b/apps/cli/src/model_registry.rs
@@ -940,22 +940,33 @@ impl AppConfig {
         self.provider_groups.push(group);
     }
 
-    pub fn remove_model_by_name(&mut self, name: &str) -> bool {
-        let normalized = name.trim();
-        if normalized.is_empty() {
+    pub fn remove_model(&mut self, model_ref: &ModelRef) -> bool {
+        let Some(group) = self
+            .provider_groups
+            .iter_mut()
+            .find(|group| group.id == model_ref.group_id)
+        else {
+            return false;
+        };
+        let before = group.models.len();
+        group
+            .models
+            .retain(|model| model.name != model_ref.name);
+        if group.models.len() == before {
             return false;
         }
-        let mut removed = false;
-        for group in &mut self.provider_groups {
-            let before = group.models.len();
-            group.models.retain(|model| model.name != normalized);
-            if group.models.len() != before {
-                removed = true;
-            }
+        if group.models.is_empty() {
+            let group_id = model_ref.group_id.clone();
+            self.provider_groups.retain(|group| group.id != group_id);
         }
-        self.provider_groups
-            .retain(|group| !group.models.is_empty());
-        removed
+        true
+    }
+
+    pub fn remove_model_by_name(&mut self, name: &str) -> bool {
+        let Ok(model_ref) = self.parse_model_ref_selector(name) else {
+            return false;
+        };
+        self.remove_model(&model_ref)
     }
 }
 

--- a/apps/cli/src/ts_bridge/tests/integration.rs
+++ b/apps/cli/src/ts_bridge/tests/integration.rs
@@ -1,7 +1,9 @@
 use super::{ENV_RUNTIME_BACKEND_NODE_PATH, TsBridgeRuntime};
 use crate::ts_bridge::json_rpc::resolve_bridge_script;
 use crate::{
-    model_registry::{AppConfig, DEFAULT_API_BASE, ModelProfile, NetworksConfig},
+    model_registry::{
+        DEFAULT_API_BASE, ModelProvider, make_test_app_config_with_models,
+    },
     ports::SecretStore,
 };
 use anyhow::Result;
@@ -54,22 +56,13 @@ fn make_test_runtime() -> Option<TsBridgeRuntime> {
         return None;
     }
 
-    let config = AppConfig {
-        models: vec![ModelProfile {
-            name: "gpt-4o-mini".to_string(),
-            api_base: DEFAULT_API_BASE.to_string(),
-            provider: None,
-            reasoning_effort: None,
-            context_length: None,
-            extra: Default::default(),
-        }],
-        active_model: "gpt-4o-mini".to_string(),
-        image_generation_model: None,
-        video_generation_model: None,
-        ui_locale: None,
-        networks: NetworksConfig::default(),
-        extra: Default::default(),
-    };
+    let config = make_test_app_config_with_models(
+        "openai",
+        ModelProvider::Openai,
+        DEFAULT_API_BASE,
+        &["gpt-4o-mini"],
+        "gpt-4o-mini",
+    );
 
     TsBridgeRuntime::new(config, Arc::new(StubSecretStore), workspace_root).ok()
 }

--- a/apps/cli/src/ts_bridge/tests/mod.rs
+++ b/apps/cli/src/ts_bridge/tests/mod.rs
@@ -12,7 +12,10 @@ use crate::ts_bridge::{
 };
 use crate::{
     host_runtime::RuntimeEvent,
-    model_registry::{AppConfig, DEFAULT_API_BASE, ModelProfile, ModelProvider, NetworksConfig},
+    model_registry::{
+        DEFAULT_API_BASE, ModelEntry, ModelProvider, ModelRef,
+        ProviderGroupConnectDraft, make_test_app_config_with_models,
+    },
     ports::SecretStore,
 };
 use anyhow::{Result, anyhow};
@@ -67,32 +70,13 @@ fn make_test_runtime() -> Option<TsBridgeRuntime> {
         return None;
     }
 
-    let config = AppConfig {
-        models: vec![
-            ModelProfile {
-                name: "gpt-4o-mini".to_string(),
-                api_base: DEFAULT_API_BASE.to_string(),
-                provider: None,
-                reasoning_effort: None,
-                context_length: None,
-                extra: Default::default(),
-            },
-            ModelProfile {
-                name: "gpt-4.1-mini".to_string(),
-                api_base: DEFAULT_API_BASE.to_string(),
-                provider: None,
-                reasoning_effort: None,
-                context_length: None,
-                extra: Default::default(),
-            },
-        ],
-        active_model: "gpt-4o-mini".to_string(),
-        image_generation_model: None,
-        video_generation_model: None,
-        ui_locale: None,
-        networks: NetworksConfig::default(),
-        extra: Default::default(),
-    };
+    let config = make_test_app_config_with_models(
+        "openai",
+        ModelProvider::Openai,
+        DEFAULT_API_BASE,
+        &["gpt-4o-mini", "gpt-4.1-mini"],
+        "gpt-4o-mini",
+    );
 
     TsBridgeRuntime::new(config, Arc::new(StubSecretStore), workspace_root).ok()
 }
@@ -144,7 +128,10 @@ fn validate_config_change_allows_transport_switch_while_busy() {
     runtime.apply_snapshot(busy_snapshot());
 
     let mut next = runtime.config().clone();
-    next.active_model = "gpt-4.1-mini".to_string();
+    next.active_model = ModelRef {
+        group_id: "openai".to_string(),
+        name: "gpt-4.1-mini".to_string(),
+    };
 
     assert!(
         runtime.validate_config_change(&next).is_ok(),
@@ -162,11 +149,14 @@ fn replace_config_defers_bridge_transport_while_busy_and_flushes_when_idle() {
     assert!(!runtime.deferred_transport_replace_for_test());
 
     let mut next = runtime.config().clone();
-    next.active_model = "gpt-4.1-mini".to_string();
+    next.active_model = ModelRef {
+        group_id: "openai".to_string(),
+        name: "gpt-4.1-mini".to_string(),
+    };
     runtime.replace_config(next);
 
     assert!(runtime.deferred_transport_replace_for_test());
-    assert_eq!(runtime.config().active_model, "gpt-4.1-mini");
+    assert_eq!(runtime.config().active_model.name, "gpt-4.1-mini");
 
     runtime.apply_snapshot(idle_snapshot());
     assert!(
@@ -185,14 +175,21 @@ fn validate_config_change_allows_non_transport_updates_while_busy() {
 
     let mut next = runtime.config().clone();
     next.ui_locale = Some("zh-CN".to_string());
-    next.models.push(ModelProfile {
-        name: "gpt-4.1".to_string(),
-        api_base: DEFAULT_API_BASE.to_string(),
-        provider: None,
-        reasoning_effort: None,
-        context_length: None,
-        extra: Default::default(),
-    });
+    next.add_model_to_group(
+        "openai",
+        ModelProvider::Openai,
+        DEFAULT_API_BASE.to_string(),
+        ProviderGroupConnectDraft::default(),
+        ModelEntry {
+            name: "gpt-4.1".to_string(),
+            reasoning_effort: None,
+            thinking_enabled: None,
+            supported_reasoning_efforts: None,
+            capabilities: None,
+            context_length: None,
+            supports_thinking_type: None,
+        },
+    );
 
     assert!(runtime.validate_config_change(&next).is_ok());
 }
@@ -204,11 +201,12 @@ fn resolve_transport_config_json_includes_model_knobs() {
     };
 
     let mut next = runtime.config().clone();
-    let active = next
-        .active_model_profile_mut()
-        .expect("active model should exist");
-    active.provider = Some(ModelProvider::Custom);
-    active.reasoning_effort = Some("minimal".to_string());
+    if let Some(entry) = next.active_model_entry_mut() {
+        entry.reasoning_effort = Some("minimal".to_string());
+    }
+    if let Some(group) = next.active_provider_group_mut() {
+        group.provider = ModelProvider::Custom;
+    }
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -232,25 +230,32 @@ fn resolve_transport_config_json_includes_video_generation_model_for_open_respon
     };
 
     let mut next = runtime.config().clone();
-    let active = next
-        .active_model_profile_mut()
-        .expect("active model should exist");
-    active.provider = Some(ModelProvider::Volcengine);
-    active
-        .extra
-        .insert("transportKind".to_string(), json!("open-responses"));
-    next.models.push(ModelProfile {
+    if let Some(group) = next.active_provider_group_mut() {
+        group.provider = ModelProvider::Volcengine;
+        group.transport_kind = Some("open-responses".to_string());
+    }
+    next.add_model_to_group(
+        "volcengine",
+        ModelProvider::Volcengine,
+        "https://ark.cn-beijing.volces.com/api/v3".to_string(),
+        ProviderGroupConnectDraft {
+            transport_kind: Some("open-responses".to_string()),
+            ..Default::default()
+        },
+        ModelEntry {
+            name: "seedance-video".to_string(),
+            reasoning_effort: None,
+            thinking_enabled: None,
+            supported_reasoning_efforts: None,
+            capabilities: Some(vec!["videoGeneration".to_string()]),
+            context_length: None,
+            supports_thinking_type: None,
+        },
+    );
+    next.video_generation_model = Some(ModelRef {
+        group_id: "volcengine".to_string(),
         name: "seedance-video".to_string(),
-        api_base: "https://ark.cn-beijing.volces.com/api/v3".to_string(),
-        provider: Some(ModelProvider::Volcengine),
-        reasoning_effort: None,
-        context_length: None,
-        extra: serde_json::Map::from_iter([(
-            "capabilities".to_string(),
-            json!(["videoGeneration"]),
-        )]),
     });
-    next.video_generation_model = Some("seedance-video".to_string());
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -280,22 +285,28 @@ fn resolve_transport_config_json_includes_image_generation_model() {
     };
 
     let mut next = runtime.config().clone();
-    next.active_model_profile_mut()
-        .expect("active model should exist")
-        .extra
-        .insert("capabilities".to_string(), json!(["chat"]));
-    next.models.push(ModelProfile {
+    if let Some(entry) = next.active_model_entry_mut() {
+        entry.capabilities = Some(vec!["chat".to_string()]);
+    }
+    next.add_model_to_group(
+        "custom",
+        ModelProvider::Custom,
+        "https://images.example.invalid/v1".to_string(),
+        ProviderGroupConnectDraft::default(),
+        ModelEntry {
+            name: "image-model".to_string(),
+            reasoning_effort: None,
+            thinking_enabled: None,
+            supported_reasoning_efforts: None,
+            capabilities: Some(vec!["imageGeneration".to_string()]),
+            context_length: None,
+            supports_thinking_type: None,
+        },
+    );
+    next.image_generation_model = Some(ModelRef {
+        group_id: "custom".to_string(),
         name: "image-model".to_string(),
-        api_base: "https://images.example.invalid/v1".to_string(),
-        provider: Some(ModelProvider::Custom),
-        reasoning_effort: None,
-        context_length: None,
-        extra: serde_json::Map::from_iter([(
-            "capabilities".to_string(),
-            json!(["imageGeneration"]),
-        )]),
     });
-    next.image_generation_model = Some("image-model".to_string());
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -339,13 +350,10 @@ fn resolve_transport_config_json_uses_xai_official_responses_provider() {
     };
 
     let mut next = runtime.config().clone();
-    let active = next
-        .active_model_profile_mut()
-        .expect("active model should exist");
-    active.provider = Some(ModelProvider::Xai);
-    active
-        .extra
-        .insert("transportKind".to_string(), json!("open-responses"));
+    if let Some(group) = next.active_provider_group_mut() {
+        group.provider = ModelProvider::Xai;
+        group.transport_kind = Some("open-responses".to_string());
+    }
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -378,18 +386,29 @@ fn resolve_transport_config_json_uses_azure_official_responses_provider() {
     }
 
     let mut next = runtime.config().clone();
-    next.models.push(ModelProfile {
+    next.add_model_to_group(
+        "azure",
+        ModelProvider::Azure,
+        "https://my-openai-resource.openai.azure.com/openai/v1".to_string(),
+        ProviderGroupConnectDraft {
+            transport_kind: Some("open-responses".to_string()),
+            azure_resource_name: Some("my-openai-resource".to_string()),
+            ..Default::default()
+        },
+        ModelEntry {
+            name: "my-gpt4o-deploy".to_string(),
+            reasoning_effort: None,
+            thinking_enabled: None,
+            supported_reasoning_efforts: None,
+            capabilities: None,
+            context_length: None,
+            supports_thinking_type: None,
+        },
+    );
+    next.active_model = ModelRef {
+        group_id: "azure".to_string(),
         name: "my-gpt4o-deploy".to_string(),
-        api_base: "https://my-openai-resource.openai.azure.com/openai/v1".to_string(),
-        provider: Some(ModelProvider::Azure),
-        reasoning_effort: None,
-        context_length: None,
-        extra: serde_json::Map::from_iter([
-            ("transportKind".to_string(), json!("open-responses")),
-            ("azureResourceName".to_string(), json!("my-openai-resource")),
-        ]),
-    });
-    next.active_model = "my-gpt4o-deploy".to_string();
+    };
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -443,18 +462,29 @@ fn resolve_transport_config_json_recomputes_azure_base_url_from_resource_name() 
     }
 
     let mut next = runtime.config().clone();
-    next.models.push(ModelProfile {
+    next.add_model_to_group(
+        "azure",
+        ModelProvider::Azure,
+        "https://stale-host.example/openai/v1".to_string(),
+        ProviderGroupConnectDraft {
+            transport_kind: Some("open-responses".to_string()),
+            azure_resource_name: Some("my-openai-resource".to_string()),
+            ..Default::default()
+        },
+        ModelEntry {
+            name: "my-gpt4o-deploy".to_string(),
+            reasoning_effort: None,
+            thinking_enabled: None,
+            supported_reasoning_efforts: None,
+            capabilities: None,
+            context_length: None,
+            supports_thinking_type: None,
+        },
+    );
+    next.active_model = ModelRef {
+        group_id: "azure".to_string(),
         name: "my-gpt4o-deploy".to_string(),
-        api_base: "https://stale-host.example/openai/v1".to_string(),
-        provider: Some(ModelProvider::Azure),
-        reasoning_effort: None,
-        context_length: None,
-        extra: serde_json::Map::from_iter([
-            ("transportKind".to_string(), json!("open-responses")),
-            ("azureResourceName".to_string(), json!("my-openai-resource")),
-        ]),
-    });
-    next.active_model = "my-gpt4o-deploy".to_string();
+    };
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -486,15 +516,28 @@ fn resolve_transport_config_json_routes_bedrock_mantle_openai_to_open_responses(
     }
 
     let mut next = runtime.config().clone();
-    next.models.push(ModelProfile {
+    next.add_model_to_group(
+        "amazon-bedrock",
+        ModelProvider::AmazonBedrock,
+        "https://bedrock-runtime.us-east-2.amazonaws.com".to_string(),
+        ProviderGroupConnectDraft {
+            aws_region: Some("us-east-2".to_string()),
+            ..Default::default()
+        },
+        ModelEntry {
+            name: "openai.gpt-5.5".to_string(),
+            reasoning_effort: None,
+            thinking_enabled: None,
+            supported_reasoning_efforts: None,
+            capabilities: None,
+            context_length: None,
+            supports_thinking_type: None,
+        },
+    );
+    next.active_model = ModelRef {
+        group_id: "amazon-bedrock".to_string(),
         name: "openai.gpt-5.5".to_string(),
-        api_base: "https://bedrock-runtime.us-east-2.amazonaws.com".to_string(),
-        provider: Some(ModelProvider::AmazonBedrock),
-        reasoning_effort: None,
-        context_length: None,
-        extra: serde_json::Map::from_iter([("awsRegion".to_string(), json!("us-east-2"))]),
-    });
-    next.active_model = "openai.gpt-5.5".to_string();
+    };
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -532,14 +575,13 @@ fn resolve_transport_config_json_uses_anthropic_union_shape() {
     };
 
     let mut next = runtime.config().clone();
-    let active = next
-        .active_model_profile_mut()
-        .expect("active model should exist");
-    active.provider = Some(ModelProvider::Anthropic);
-    active.reasoning_effort = Some("max".to_string());
-    active
-        .extra
-        .insert("transportKind".to_string(), json!("anthropic"));
+    if let Some(group) = next.active_provider_group_mut() {
+        group.provider = ModelProvider::Anthropic;
+        group.transport_kind = Some("anthropic".to_string());
+    }
+    if let Some(entry) = next.active_model_entry_mut() {
+        entry.reasoning_effort = Some("max".to_string());
+    }
 
     let transport = runtime
         .resolve_transport_config_json_for(&next)
@@ -561,37 +603,43 @@ fn transport_config_change_detects_model_knobs() {
     };
 
     let mut next = runtime.config().clone();
-    next.active_model_profile_mut()
-        .expect("active model should exist")
-        .provider = Some(ModelProvider::Custom);
+    if let Some(group) = next.active_provider_group_mut() {
+        group.provider = ModelProvider::Custom;
+    }
     assert!(runtime.transport_config_will_change(&next));
 
     let mut next = runtime.config().clone();
-    next.active_model_profile_mut()
-        .expect("active model should exist")
-        .extra
-        .insert("transportKind".to_string(), json!("anthropic"));
+    if let Some(group) = next.active_provider_group_mut() {
+        group.transport_kind = Some("anthropic".to_string());
+    }
     assert!(runtime.transport_config_will_change(&next));
 
     let mut next = runtime.config().clone();
-    next.active_model_profile_mut()
-        .expect("active model should exist")
-        .reasoning_effort = Some("low".to_string());
+    if let Some(entry) = next.active_model_entry_mut() {
+        entry.reasoning_effort = Some("low".to_string());
+    }
     assert!(runtime.transport_config_will_change(&next));
 
     let mut next = runtime.config().clone();
-    next.models.push(ModelProfile {
+    next.add_model_to_group(
+        "openai",
+        ModelProvider::Openai,
+        DEFAULT_API_BASE.to_string(),
+        ProviderGroupConnectDraft::default(),
+        ModelEntry {
+            name: "image-model".to_string(),
+            reasoning_effort: None,
+            thinking_enabled: None,
+            supported_reasoning_efforts: None,
+            capabilities: Some(vec!["imageGeneration".to_string()]),
+            context_length: None,
+            supports_thinking_type: None,
+        },
+    );
+    next.image_generation_model = Some(ModelRef {
+        group_id: "openai".to_string(),
         name: "image-model".to_string(),
-        api_base: DEFAULT_API_BASE.to_string(),
-        provider: None,
-        reasoning_effort: None,
-        context_length: None,
-        extra: serde_json::Map::from_iter([(
-            "capabilities".to_string(),
-            json!(["imageGeneration"]),
-        )]),
     });
-    next.image_generation_model = Some("image-model".to_string());
     assert!(runtime.transport_config_will_change(&next));
 }
 

--- a/apps/cli/src/ts_bridge/transport/config.rs
+++ b/apps/cli/src/ts_bridge/transport/config.rs
@@ -7,8 +7,8 @@ use crate::{
         azure_api_base_from_resource_name, resolve_azure_resource_name, resolve_profile_api_base,
     },
     model_registry::{
-        AppConfig, ModelProvider, load_provider_access_key_id_from_keyring,
-        load_provider_secret_access_key_from_keyring, normalize_reasoning_effort_value,
+        AppConfig, ModelProvider, load_group_access_key_id_from_keyring,
+        load_group_secret_access_key_from_keyring, normalize_reasoning_effort_value,
     },
     ts_bridge::constants::{ENV_API_BASE, ENV_API_KEY},
 };
@@ -31,6 +31,15 @@ pub(crate) fn build_mcp_only_transport_config(workspace_root: &Path) -> Value {
     })
 }
 
+fn profile_transport_signature(profile: &crate::model_registry::ModelProfile) -> (String, Option<ModelProvider>, crate::model_registry::ModelTransportKind, Option<String>) {
+    (
+        profile.api_base.clone(),
+        profile.provider,
+        profile.transport_kind(),
+        profile.reasoning_effort.clone(),
+    )
+}
+
 pub(crate) fn transport_config_will_change(stored_config: &AppConfig, config: &AppConfig) -> bool {
     if stored_config.active_model != config.active_model {
         return true;
@@ -38,30 +47,12 @@ pub(crate) fn transport_config_will_change(stored_config: &AppConfig, config: &A
 
     if stored_config
         .active_model_profile()
-        .map(|profile| profile.api_base.as_str())
+        .as_ref()
+        .map(profile_transport_signature)
         != config
             .active_model_profile()
-            .map(|profile| profile.api_base.as_str())
-    {
-        return true;
-    }
-
-    if stored_config
-        .active_model_profile()
-        .map(|profile| profile.transport_kind())
-        != config
-            .active_model_profile()
-            .map(|profile| profile.transport_kind())
-    {
-        return true;
-    }
-
-    if stored_config
-        .active_model_profile()
-        .and_then(|profile| profile.reasoning_effort.as_deref())
-        != config
-            .active_model_profile()
-            .and_then(|profile| profile.reasoning_effort.as_deref())
+            .as_ref()
+            .map(profile_transport_signature)
     {
         return true;
     }
@@ -70,21 +61,29 @@ pub(crate) fn transport_config_will_change(stored_config: &AppConfig, config: &A
         return true;
     }
 
-    if stored_config.image_generation_model_profile().map(|profile| {
-        (
-            profile.api_base.as_str(),
-            profile.provider,
-            profile.transport_kind(),
-            profile.supports_image_generation(),
-        )
-    }) != config.image_generation_model_profile().map(|profile| {
-        (
-            profile.api_base.as_str(),
-            profile.provider,
-            profile.transport_kind(),
-            profile.supports_image_generation(),
-        )
-    }) {
+    if stored_config
+        .image_generation_model_profile()
+        .as_ref()
+        .map(|profile| {
+            (
+                profile.api_base.clone(),
+                profile.provider,
+                profile.transport_kind(),
+                profile.supports_image_generation(),
+            )
+        })
+        != config
+            .image_generation_model_profile()
+            .as_ref()
+            .map(|profile| {
+                (
+                    profile.api_base.clone(),
+                    profile.provider,
+                    profile.transport_kind(),
+                    profile.supports_image_generation(),
+                )
+            })
+    {
         return true;
     }
 
@@ -92,30 +91,28 @@ pub(crate) fn transport_config_will_change(stored_config: &AppConfig, config: &A
         return true;
     }
 
-    if stored_config.video_generation_model_profile().map(|profile| {
-        (
-            profile.api_base.as_str(),
-            profile.provider,
-            profile.transport_kind(),
-            profile.supports_video_generation(),
-        )
-    }) != config.video_generation_model_profile().map(|profile| {
-        (
-            profile.api_base.as_str(),
-            profile.provider,
-            profile.transport_kind(),
-            profile.supports_video_generation(),
-        )
-    }) {
-        return true;
-    }
-
     stored_config
-        .active_model_profile()
-        .map(|profile| profile.provider)
+        .video_generation_model_profile()
+        .as_ref()
+        .map(|profile| {
+            (
+                profile.api_base.clone(),
+                profile.provider,
+                profile.transport_kind(),
+                profile.supports_video_generation(),
+            )
+        })
         != config
-            .active_model_profile()
-            .map(|profile| profile.provider)
+            .video_generation_model_profile()
+            .as_ref()
+            .map(|profile| {
+                (
+                    profile.api_base.clone(),
+                    profile.provider,
+                    profile.transport_kind(),
+                    profile.supports_video_generation(),
+                )
+            })
 }
 
 pub(crate) fn attach_video_generation_config(
@@ -129,8 +126,12 @@ pub(crate) fn attach_video_generation_config(
     if !video_profile.supports_video_generation() {
         return Ok(());
     }
-    let Some(video_api_key) =
-        resolve_optional_key_from_store(host, &video_profile.name, video_profile.provider)?
+    let Some(video_api_key) = resolve_optional_key_from_store(
+        host,
+        &video_profile.group_id,
+        &video_profile.name,
+        video_profile.provider,
+    )?
     else {
         return Ok(());
     };
@@ -138,7 +139,7 @@ pub(crate) fn attach_video_generation_config(
     let mut video_generation = serde_json::json!({
         "apiKey": video_api_key,
         "model": video_profile.name,
-        "baseUrl": resolve_profile_api_base(video_profile),
+        "baseUrl": resolve_profile_api_base(&video_profile),
     });
     if let Some(provider) = video_profile.provider {
         if let Some(obj) = video_generation.as_object_mut() {
@@ -148,7 +149,7 @@ pub(crate) fn attach_video_generation_config(
             );
         }
     }
-    if let Some(model_capabilities) = model_capabilities_json(video_profile) {
+    if let Some(model_capabilities) = model_capabilities_json(&video_profile) {
         if let Some(obj) = video_generation.as_object_mut() {
             obj.insert("modelCapabilities".to_string(), model_capabilities);
         }
@@ -170,15 +171,25 @@ pub(crate) fn resolve_transport_config_json_for(host: &TransportHost<'_>, config
     let api_key = if let Ok(value) = env::var(ENV_API_KEY) {
         let trimmed = value.trim();
         if trimmed.is_empty() {
-            super::keys::resolve_key_from_store(host, &active.name, active.provider)?
+            super::keys::resolve_key_from_store(
+                host,
+                &active.group_id,
+                &active.name,
+                active.provider,
+            )?
         } else {
             trimmed.to_string()
         }
     } else {
-        super::keys::resolve_key_from_store(host, &active.name, active.provider)?
+        super::keys::resolve_key_from_store(
+            host,
+            &active.group_id,
+            &active.name,
+            active.provider,
+        )?
     };
 
-    let api_base = env::var(ENV_API_BASE).unwrap_or_else(|_| resolve_profile_api_base(active));
+    let api_base = env::var(ENV_API_BASE).unwrap_or_else(|_| resolve_profile_api_base(&active));
 
     let normalized_reasoning_effort = normalize_reasoning_effort_value(
         active.reasoning_effort.clone(),
@@ -249,11 +260,11 @@ pub(crate) fn resolve_transport_config_json_for(host: &TransportHost<'_>, config
                     if let Some(obj) = transport.as_object_mut() {
                         obj.insert("apiKey".to_string(), json!(api_key));
                     }
-                } else if let Ok(access_key_id) =
-                    load_provider_access_key_id_from_keyring(ModelProvider::AmazonBedrock.as_str())
+                } else                 if let Ok(access_key_id) =
+                    load_group_access_key_id_from_keyring(&active.group_id)
                 {
-                    if let Ok(secret_access_key) = load_provider_secret_access_key_from_keyring(
-                        ModelProvider::AmazonBedrock.as_str(),
+                    if let Ok(secret_access_key) = load_group_secret_access_key_from_keyring(
+                        &active.group_id,
                     ) {
                         let access_key_id = access_key_id.trim();
                         let secret_access_key = secret_access_key.trim();
@@ -288,12 +299,12 @@ pub(crate) fn resolve_transport_config_json_for(host: &TransportHost<'_>, config
                     obj.insert("apiKey".to_string(), json!(api_key));
                 }
             }
-            if let Ok(access_key_id) =
-                load_provider_access_key_id_from_keyring(ModelProvider::AmazonBedrock.as_str())
-            {
-                if let Ok(secret_access_key) = load_provider_secret_access_key_from_keyring(
-                    ModelProvider::AmazonBedrock.as_str(),
-                ) {
+                if let Ok(access_key_id) =
+                    load_group_access_key_id_from_keyring(&active.group_id)
+                {
+                    if let Ok(secret_access_key) = load_group_secret_access_key_from_keyring(
+                        &active.group_id,
+                    ) {
                     let access_key_id = access_key_id.trim();
                     let secret_access_key = secret_access_key.trim();
                     if !access_key_id.is_empty() && !secret_access_key.is_empty() {
@@ -318,7 +329,7 @@ pub(crate) fn resolve_transport_config_json_for(host: &TransportHost<'_>, config
             })
         };
 
-    if let Some(model_capabilities) = model_capabilities_json(active) {
+    if let Some(model_capabilities) = model_capabilities_json(&active) {
         if let Some(obj) = transport.as_object_mut() {
             obj.insert("modelCapabilities".to_string(), model_capabilities);
         }
@@ -376,13 +387,17 @@ pub(crate) fn resolve_transport_config_json_for(host: &TransportHost<'_>, config
         }
         if let Some(image_profile) = config.image_generation_model_profile() {
             if image_profile.supports_image_generation() {
-                    if let Some(image_api_key) =
-                        resolve_optional_key_from_store(host, &image_profile.name, image_profile.provider)?
+                    if let Some(image_api_key) = resolve_optional_key_from_store(
+                        host,
+                        &image_profile.group_id,
+                        &image_profile.name,
+                        image_profile.provider,
+                    )?
                 {
                     let mut image_generation = serde_json::json!({
                         "apiKey": image_api_key,
                         "model": image_profile.name,
-                        "baseUrl": resolve_profile_api_base(image_profile),
+                        "baseUrl": resolve_profile_api_base(&image_profile),
                     });
                     if let Some(provider) = image_profile.provider {
                         if let Some(obj) = image_generation.as_object_mut() {
@@ -392,7 +407,7 @@ pub(crate) fn resolve_transport_config_json_for(host: &TransportHost<'_>, config
                             );
                         }
                     }
-                    if let Some(model_capabilities) = model_capabilities_json(image_profile) {
+                    if let Some(model_capabilities) = model_capabilities_json(&image_profile) {
                         if let Some(obj) = image_generation.as_object_mut() {
                             obj.insert("modelCapabilities".to_string(), model_capabilities);
                         }
@@ -404,7 +419,7 @@ pub(crate) fn resolve_transport_config_json_for(host: &TransportHost<'_>, config
             }
         }
     }
-    attach_google_vertex_transport_fields(&mut transport, active)?;
+    attach_google_vertex_transport_fields(&mut transport, &active)?;
     attach_video_generation_config(host, &mut transport, config)?;
     Ok(transport)
 }

--- a/apps/cli/src/ts_bridge/transport/keys.rs
+++ b/apps/cli/src/ts_bridge/transport/keys.rs
@@ -8,25 +8,22 @@ use super::TransportHost;
 
 pub(crate) fn resolve_key_from_store(
     host: &TransportHost<'_>,
+    group_id: &str,
     model_name: &str,
     provider: Option<ModelProvider>,
 ) -> Result<String> {
     if provider == Some(ModelProvider::AmazonBedrock) {
-        if let Ok(value) =
-            crate::model_registry::load_provider_api_key_from_keyring(ModelProvider::AmazonBedrock.as_str())
-        {
+        if let Ok(value) = crate::model_registry::load_group_api_key_from_keyring(group_id) {
             let trimmed = value.trim();
             if !trimmed.is_empty() {
                 return Ok(trimmed.to_string());
             }
         }
-        if crate::model_registry::has_bedrock_runtime_credentials_in_keyring()? {
+        if crate::model_registry::has_bedrock_runtime_credentials_in_keyring(group_id)? {
             return Ok(String::new());
         }
     } else if provider == Some(ModelProvider::GoogleVertexAi) {
-        if let Ok(value) = crate::model_registry::load_provider_api_key_from_keyring(
-            ModelProvider::GoogleVertexAi.as_str(),
-        ) {
+        if let Ok(value) = crate::model_registry::load_group_api_key_from_keyring(group_id) {
             let trimmed = value.trim();
             if !trimmed.is_empty() {
                 return Ok(trimmed.to_string());
@@ -37,14 +34,13 @@ pub(crate) fn resolve_key_from_store(
                 "",
                 profile.vertex_project().as_deref(),
                 profile.vertex_location().as_deref(),
+                group_id,
             ) {
                 return Ok(String::new());
             }
         }
-    } else if let Some(provider) = provider {
-        if let Ok(value) =
-            crate::model_registry::load_provider_api_key_from_keyring(provider.as_str())
-        {
+    } else if !group_id.trim().is_empty() {
+        if let Ok(value) = crate::model_registry::load_group_api_key_from_keyring(group_id) {
             let trimmed = value.trim();
             if !trimmed.is_empty() {
                 return Ok(trimmed.to_string());
@@ -82,8 +78,9 @@ pub(crate) fn resolve_key_from_store(
 
 pub(crate) fn resolve_optional_key_from_store(
     host: &TransportHost<'_>,
+    group_id: &str,
     model_name: &str,
-    provider: Option<ModelProvider>,
+    _provider: Option<ModelProvider>,
 ) -> Result<Option<String>> {
     if let Ok(value) = env::var(ENV_API_KEY) {
         let trimmed = value.trim();
@@ -91,10 +88,8 @@ pub(crate) fn resolve_optional_key_from_store(
             return Ok(Some(trimmed.to_string()));
         }
     }
-    if let Some(provider) = provider {
-        if let Ok(value) =
-            crate::model_registry::load_provider_api_key_from_keyring(provider.as_str())
-        {
+    if !group_id.trim().is_empty() {
+        if let Ok(value) = crate::model_registry::load_group_api_key_from_keyring(group_id) {
             let trimmed = value.trim();
             if !trimmed.is_empty() {
                 return Ok(Some(trimmed.to_string()));

--- a/apps/cli/src/ts_bridge/transport/provider.rs
+++ b/apps/cli/src/ts_bridge/transport/provider.rs
@@ -32,17 +32,17 @@ pub(crate) fn attach_google_vertex_transport_fields(
         obj.insert("vertexLocation".to_string(), json!(location));
     }
 
-    if let Ok(client_email) = crate::model_registry::load_provider_vertex_client_email_from_keyring(
-        ModelProvider::GoogleVertexAi.as_str(),
-    ) {
+    if let Ok(client_email) =
+        crate::model_registry::load_group_vertex_client_email_from_keyring(&profile.group_id)
+    {
         let trimmed = client_email.trim();
         if !trimmed.is_empty() {
             obj.insert("vertexClientEmail".to_string(), json!(trimmed));
         }
     }
-    if let Ok(private_key) = crate::model_registry::load_provider_vertex_private_key_from_keyring(
-        ModelProvider::GoogleVertexAi.as_str(),
-    ) {
+    if let Ok(private_key) =
+        crate::model_registry::load_group_vertex_private_key_from_keyring(&profile.group_id)
+    {
         let trimmed = private_key.trim();
         if !trimmed.is_empty() {
             obj.insert("vertexPrivateKey".to_string(), json!(trimmed));

--- a/apps/cli/src/tui.rs
+++ b/apps/cli/src/tui.rs
@@ -520,7 +520,7 @@ impl TuiShell {
         alibaba_workspace_id: Option<&str>,
     ) -> Result<(), String> {
         let mut config = self.runtime.config().clone();
-        if config.find_model_ref_by_name(name).is_some() {
+        if config.has_model_name(name) {
             return Err(t!("tui.model_add.duplicate", name = name).into_owned());
         }
 

--- a/apps/cli/src/tui.rs
+++ b/apps/cli/src/tui.rs
@@ -17,7 +17,7 @@ use crate::{
     host_runtime::{RuntimeEvent, ToolUiRequest, build_tool_result_block, format_tool_ui_message},
     locale, logging,
     mcp_types::{ManagedMcpServer, McpDiscoveredPrompt},
-    model_registry::{DEFAULT_API_BASE, ModelProfile, ModelProvider},
+    model_registry::{DEFAULT_API_BASE, ModelProvider},
     openai_models_list,
     plan::{self, PlanMetadata},
     ports::{
@@ -160,7 +160,7 @@ impl TuiShell {
         let initial_mcp_status = runtime.mcp_status_snapshot();
 
         let messages = vec![welcome_message(
-            &config.active_model,
+            config.active_model_name(),
             &initial_mcp_status.welcome_line(),
         )];
 
@@ -416,7 +416,7 @@ impl TuiShell {
         self.last_turn_can_continue = false;
         let mcp_status = self.runtime.mcp_status_snapshot();
         self.messages.push(welcome_message(
-            &self.runtime.config().active_model,
+            self.runtime.config().active_model_name(),
             &mcp_status.welcome_line(),
         ));
         self.last_mcp_status_revision = mcp_status.revision;
@@ -520,41 +520,49 @@ impl TuiShell {
         alibaba_workspace_id: Option<&str>,
     ) -> Result<(), String> {
         let mut config = self.runtime.config().clone();
-        if config.has_model(name) {
+        if config.find_model_ref_by_name(name).is_some() {
             return Err(t!("tui.model_add.duplicate", name = name).into_owned());
         }
 
-        let mut extra = serde_json::Map::new();
-        if transport_kind == crate::model_registry::ModelTransportKind::Anthropic
-            || transport_kind == crate::model_registry::ModelTransportKind::OpenResponses
-        {
-            extra.insert(
-                "transportKind".to_string(),
-                serde_json::json!(transport_kind.as_str()),
-            );
-        }
-        if let Some(resource_name) = azure_resource_name.map(str::trim).filter(|v| !v.is_empty()) {
-            extra.insert(
-                "azureResourceName".to_string(),
-                serde_json::json!(resource_name),
-            );
-        }
-        if let Some(site) = provider_site.map(str::trim).filter(|v| !v.is_empty()) {
-            extra.insert("providerSite".to_string(), serde_json::json!(site));
-        }
-        if let Some(workspace_id) = alibaba_workspace_id.map(str::trim).filter(|v| !v.is_empty()) {
-            extra.insert("alibabaWorkspaceId".to_string(), serde_json::json!(workspace_id));
-        }
-
-        config.add_model(ModelProfile {
-            name: name.to_string(),
-            api_base: api_base.to_string(),
+        let provider = provider.unwrap_or(ModelProvider::Custom);
+        let group_id = crate::model_registry::default_preset_provider_group_id(provider);
+        let connect = crate::model_registry::ProviderGroupConnectDraft {
+            transport_kind: (transport_kind == crate::model_registry::ModelTransportKind::Anthropic
+                || transport_kind == crate::model_registry::ModelTransportKind::OpenResponses)
+                .then(|| transport_kind.as_str().to_string()),
+            provider_site: provider_site
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+            alibaba_workspace_id: alibaba_workspace_id
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+            azure_resource_name: azure_resource_name
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+            ..Default::default()
+        };
+        config.add_model_to_group(
+            &group_id,
             provider,
-            reasoning_effort: None,
-            context_length,
-            extra,
-        });
-        config.active_model = name.to_string();
+            api_base.to_string(),
+            connect,
+            crate::model_registry::ModelEntry {
+                name: name.to_string(),
+                reasoning_effort: None,
+                thinking_enabled: None,
+                supported_reasoning_efforts: None,
+                capabilities: None,
+                context_length,
+                supports_thinking_type: None,
+            },
+        );
+        config.active_model = crate::model_registry::ModelRef {
+            group_id,
+            name: name.to_string(),
+        };
 
         if let Err(err) = self.runtime.validate_config_change(&config) {
             return Err(err.to_string());
@@ -623,7 +631,7 @@ impl TuiShell {
             ));
             return;
         }
-        let active_model = self.runtime.config().active_model.clone();
+        let active_model = self.runtime.config().active_model_name().to_string();
         let mcp_welcome_line = snapshot.welcome_line();
         let previous_status_line = first_message
             .content

--- a/apps/cli/src/tui/commands.rs
+++ b/apps/cli/src/tui/commands.rs
@@ -36,16 +36,16 @@ impl TuiShell {
             }
             ["use", model] => {
                 let mut config = self.runtime.config().clone();
-                let Some(model_ref) = config.find_model_ref_by_name(model) else {
-                    self.messages.push(ChatMessage {
-                        role: MessageRole::Agent,
-                        content: format!(
-                            "模型不存在: {}，先用 `/model add` 打开表单添加，或 `/model add {} <api_base> <api_key>`",
-                            model, model
-                        ),
-                        tool_block: None,
-                    });
-                    return;
+                let model_ref = match config.parse_model_ref_selector(model) {
+                    Ok(model_ref) => model_ref,
+                    Err(message) => {
+                        self.messages.push(ChatMessage {
+                            role: MessageRole::Agent,
+                            content: message,
+                            tool_block: None,
+                        });
+                        return;
+                    }
                 };
                 config.active_model = model_ref;
                 if let Err(err) = self.runtime.validate_config_change(&config) {

--- a/apps/cli/src/tui/commands.rs
+++ b/apps/cli/src/tui/commands.rs
@@ -117,7 +117,18 @@ impl TuiShell {
             }
             ["remove", model] => {
                 let mut config = self.runtime.config().clone();
-                if !config.remove_model_by_name(model) {
+                let model_ref = match config.parse_model_ref_selector(model) {
+                    Ok(model_ref) => model_ref,
+                    Err(message) => {
+                        self.messages.push(ChatMessage {
+                            role: MessageRole::Agent,
+                            content: message,
+                            tool_block: None,
+                        });
+                        return;
+                    }
+                };
+                if !config.remove_model(&model_ref) {
                     self.messages.push(ChatMessage {
                         role: MessageRole::Agent,
                         content: format!("模型不存在: {}", model),
@@ -125,20 +136,20 @@ impl TuiShell {
                     });
                     return;
                 }
-                if config.active_model.name == *model {
+                if crate::model_registry::model_refs_equal(&config.active_model, &model_ref) {
                     config.active_model = config.first_model_ref();
                 }
                 if config
                     .image_generation_model
                     .as_ref()
-                    .is_some_and(|model_ref| model_ref.name == *model)
+                    .is_some_and(|slot| crate::model_registry::model_refs_equal(slot, &model_ref))
                 {
                     config.image_generation_model = None;
                 }
                 if config
                     .video_generation_model
                     .as_ref()
-                    .is_some_and(|model_ref| model_ref.name == *model)
+                    .is_some_and(|slot| crate::model_registry::model_refs_equal(slot, &model_ref))
                 {
                     config.video_generation_model = None;
                 }
@@ -149,7 +160,7 @@ impl TuiShell {
                         tool_block: None,
                     });
                 } else {
-                    let _ = self.secret_store.remove_model_api_key(model);
+                    let _ = self.secret_store.remove_model_api_key(&model_ref.name);
                     self.runtime.replace_config(config);
                     self.messages.push(ChatMessage {
                         role: MessageRole::Agent,

--- a/apps/cli/src/tui/commands.rs
+++ b/apps/cli/src/tui/commands.rs
@@ -12,8 +12,8 @@ impl TuiShell {
                 let list = self
                     .runtime
                     .config()
-                    .models
-                    .iter()
+                    .flatten_models()
+                    .into_iter()
                     .map(|m| format!("{} ({})", m.name, m.api_base))
                     .collect::<Vec<_>>()
                     .join(", ");
@@ -21,7 +21,7 @@ impl TuiShell {
                     role: MessageRole::Agent,
                     content: format!(
                         "当前模型: {}\n模型列表: {}",
-                        self.runtime.config().active_model,
+                        self.runtime.config().active_model_name(),
                         list
                     ),
                     tool_block: None,
@@ -36,7 +36,7 @@ impl TuiShell {
             }
             ["use", model] => {
                 let mut config = self.runtime.config().clone();
-                if !config.has_model(model) {
+                let Some(model_ref) = config.find_model_ref_by_name(model) else {
                     self.messages.push(ChatMessage {
                         role: MessageRole::Agent,
                         content: format!(
@@ -46,8 +46,8 @@ impl TuiShell {
                         tool_block: None,
                     });
                     return;
-                }
-                config.active_model = (*model).to_string();
+                };
+                config.active_model = model_ref;
                 if let Err(err) = self.runtime.validate_config_change(&config) {
                     self.messages.push(ChatMessage {
                         role: MessageRole::Agent,
@@ -117,9 +117,7 @@ impl TuiShell {
             }
             ["remove", model] => {
                 let mut config = self.runtime.config().clone();
-                let before = config.models.len();
-                config.models.retain(|m| m.name != *model);
-                if config.models.len() == before {
+                if !config.remove_model_by_name(model) {
                     self.messages.push(ChatMessage {
                         role: MessageRole::Agent,
                         content: format!("模型不存在: {}", model),
@@ -127,17 +125,21 @@ impl TuiShell {
                     });
                     return;
                 }
-                if config.active_model == *model {
-                    config.active_model = config
-                        .models
-                        .first()
-                        .map(|m| m.name.clone())
-                        .unwrap_or_default();
+                if config.active_model.name == *model {
+                    config.active_model = config.first_model_ref();
                 }
-                if config.image_generation_model.as_deref() == Some(model) {
+                if config
+                    .image_generation_model
+                    .as_ref()
+                    .is_some_and(|model_ref| model_ref.name == *model)
+                {
                     config.image_generation_model = None;
                 }
-                if config.video_generation_model.as_deref() == Some(model) {
+                if config
+                    .video_generation_model
+                    .as_ref()
+                    .is_some_and(|model_ref| model_ref.name == *model)
+                {
                     config.video_generation_model = None;
                 }
                 if let Err(err) = self.config_store.save(&config) {

--- a/apps/cli/src/tui/forms.rs
+++ b/apps/cli/src/tui/forms.rs
@@ -521,66 +521,58 @@ impl TuiShell {
         let mut added: usize = 0;
 
         for id in ids {
-            if config.has_model(id) {
+            if config.find_model_ref_by_name(id).is_some() {
                 continue;
             }
-            let mut extra = serde_json::Map::new();
-            if parsed.transport_kind == crate::model_registry::ModelTransportKind::Anthropic
-                || parsed.transport_kind == crate::model_registry::ModelTransportKind::OpenResponses
-            {
-                extra.insert(
-                    "transportKind".to_string(),
-                    serde_json::json!(parsed.transport_kind.as_str()),
-                );
-            }
-            if parsed.provider == crate::model_registry::ModelProvider::GoogleVertexAi {
-                if let Some(project) = parsed.vertex_project.as_deref() {
-                    extra.insert("vertexProject".to_string(), serde_json::json!(project));
-                }
-                if let Some(location) = parsed.vertex_location.as_deref() {
-                    extra.insert("vertexLocation".to_string(), serde_json::json!(location));
-                }
-            }
-            if let Some(site) = parsed.provider_site.as_deref() {
-                extra.insert("providerSite".to_string(), serde_json::json!(site));
-            }
-            if let Some(workspace_id) = parsed.alibaba_workspace_id.as_deref() {
-                extra.insert("alibabaWorkspaceId".to_string(), serde_json::json!(workspace_id));
-            }
-            if parsed.alibaba_billing_mode.as_deref() == Some("token-plan") {
-                extra.insert(
-                    "alibabaBillingMode".to_string(),
-                    serde_json::json!("token-plan"),
-                );
-            }
-            config.add_model(ModelProfile {
-                name: id.clone(),
-                api_base: parsed.api_base.clone(),
-                provider: Some(parsed.provider),
-                reasoning_effort: None,
-                context_length: None,
-                extra,
-            });
+            let group_id =
+                crate::model_registry::default_preset_provider_group_id(parsed.provider);
+            let connect = crate::model_registry::ProviderGroupConnectDraft {
+                transport_kind: (parsed.transport_kind
+                    == crate::model_registry::ModelTransportKind::Anthropic
+                    || parsed.transport_kind
+                        == crate::model_registry::ModelTransportKind::OpenResponses)
+                    .then(|| parsed.transport_kind.as_str().to_string()),
+                provider_site: parsed.provider_site.clone(),
+                alibaba_workspace_id: parsed.alibaba_workspace_id.clone(),
+                alibaba_billing_mode: parsed.alibaba_billing_mode.clone(),
+                vertex_project: parsed.vertex_project.clone(),
+                vertex_location: parsed.vertex_location.clone(),
+                ..Default::default()
+            };
+            config.add_model_to_group(
+                &group_id,
+                parsed.provider,
+                parsed.api_base.clone(),
+                connect,
+                crate::model_registry::ModelEntry {
+                    name: id.clone(),
+                    reasoning_effort: None,
+                    thinking_enabled: None,
+                    supported_reasoning_efforts: None,
+                    capabilities: None,
+                    context_length: None,
+                    supports_thinking_type: None,
+                },
+            );
             if parsed.provider == crate::model_registry::ModelProvider::GoogleVertexAi {
                 if !parsed.api_key.trim().is_empty() {
-                    if let Err(err) = crate::model_registry::save_provider_api_key(
-                        crate::model_registry::ModelProvider::GoogleVertexAi.as_str(),
+                    if let Err(err) = crate::model_registry::save_group_api_key(
+                        &group_id,
                         parsed.api_key.as_str(),
                     ) {
                         return Err(t!("tui.model_add.key_save_failed", err = err.to_string()).into_owned());
                     }
                 } else if parsed.vertex_client_email.is_some() && parsed.vertex_private_key.is_some() {
-                    if let Err(err) = crate::model_registry::save_provider_vertex_credentials(
-                        crate::model_registry::ModelProvider::GoogleVertexAi.as_str(),
+                    if let Err(err) = crate::model_registry::save_group_vertex_credentials(
+                        &group_id,
                         parsed.vertex_client_email.as_deref().unwrap_or(""),
                         parsed.vertex_private_key.as_deref().unwrap_or(""),
                     ) {
                         return Err(t!("tui.model_add.key_save_failed", err = err.to_string()).into_owned());
                     }
                 }
-            } else if let Err(err) = self
-                .secret_store
-                .save_model_api_key(id, parsed.api_key.as_str())
+            } else if let Err(err) =
+                crate::model_registry::save_group_api_key(&group_id, parsed.api_key.as_str())
             {
                 return Err(t!("tui.model_add.key_save_failed", err = err.to_string()).into_owned());
             }
@@ -595,7 +587,11 @@ impl TuiShell {
         }
 
         let active = first_new.expect("added > 0");
-        config.active_model = active.clone();
+        let group_id = crate::model_registry::default_preset_provider_group_id(parsed.provider);
+        config.active_model = crate::model_registry::ModelRef {
+            group_id,
+            name: active.clone(),
+        };
 
         if let Err(err) = self.runtime.validate_config_change(&config) {
             return Err(err.to_string());

--- a/apps/cli/src/tui/forms.rs
+++ b/apps/cli/src/tui/forms.rs
@@ -521,7 +521,7 @@ impl TuiShell {
         let mut added: usize = 0;
 
         for id in ids {
-            if config.find_model_ref_by_name(id).is_some() {
+            if config.has_model_name(id) {
                 continue;
             }
             let group_id =

--- a/apps/cli/src/tui/pickers.rs
+++ b/apps/cli/src/tui/pickers.rs
@@ -1,5 +1,6 @@
 use super::image_paths::list_local_image_files;
 use super::*;
+use crate::model_registry::ModelRef;
 
 pub(crate) const APPROVAL_LEVEL_OPTIONS: [&str; 3] = ["default", "auto-approval", "full-approval"];
 pub(crate) const LLM_HTTP_VERSION_OPTIONS: [&str; 2] = ["http1.1", "http2"];
@@ -104,15 +105,19 @@ impl TuiShell {
     }
 
     pub fn confirm_model_picker(&mut self) {
-        let Some(selected) = self
+        let Some(profile) = self
             .runtime
             .config()
-            .list_all_model_refs()
+            .flatten_models()
             .get(self.model_picker_index)
             .cloned()
         else {
             self.model_picker_active = false;
             return;
+        };
+        let selected = ModelRef {
+            group_id: profile.group_id.clone(),
+            name: profile.name.clone(),
         };
 
         let mut config = self.runtime.config().clone();
@@ -348,11 +353,11 @@ impl TuiShell {
         self.model_picker_index = self
             .runtime
             .config()
-            .list_all_model_refs()
+            .flatten_models()
             .iter()
-            .position(|model_ref| {
-                model_ref.group_id == self.runtime.config().active_model.group_id
-                    && model_ref.name == self.runtime.config().active_model.name
+            .position(|profile| {
+                profile.group_id == self.runtime.config().active_model.group_id
+                    && profile.name == self.runtime.config().active_model.name
             })
             .unwrap_or(0);
         self.model_display_titles = crate::model_catalog_display::build_model_display_titles(

--- a/apps/cli/src/tui/pickers.rs
+++ b/apps/cli/src/tui/pickers.rs
@@ -38,11 +38,11 @@ impl TuiShell {
     }
 
     pub fn select_next_model(&mut self) {
-        if self.runtime.config().models.is_empty() {
+        let total = self.runtime.config().flatten_models().len();
+        if total == 0 {
             return;
         }
-        self.model_picker_index =
-            (self.model_picker_index + 1) % self.runtime.config().models.len();
+        self.model_picker_index = (self.model_picker_index + 1) % total;
     }
 
     pub fn select_next_language(&mut self) {
@@ -64,11 +64,12 @@ impl TuiShell {
     }
 
     pub fn select_prev_model(&mut self) {
-        if self.runtime.config().models.is_empty() {
+        let total = self.runtime.config().flatten_models().len();
+        if total == 0 {
             return;
         }
         if self.model_picker_index == 0 {
-            self.model_picker_index = self.runtime.config().models.len() - 1;
+            self.model_picker_index = total - 1;
         } else {
             self.model_picker_index -= 1;
         }
@@ -106,9 +107,9 @@ impl TuiShell {
         let Some(selected) = self
             .runtime
             .config()
-            .models
+            .list_all_model_refs()
             .get(self.model_picker_index)
-            .map(|m| m.name.clone())
+            .cloned()
         else {
             self.model_picker_active = false;
             return;
@@ -136,7 +137,7 @@ impl TuiShell {
             self.apply_runtime_events();
             self.messages.push(ChatMessage {
                 role: MessageRole::Agent,
-                content: t!("tui.model_picker.switch_success", model = selected).into_owned(),
+                content: t!("tui.model_picker.switch_success", model = selected.name).into_owned(),
                 tool_block: None,
             });
         }
@@ -334,7 +335,7 @@ impl TuiShell {
     }
 
     pub(super) fn open_model_picker(&mut self) {
-        if self.runtime.config().models.is_empty() {
+        if self.runtime.config().flatten_models().is_empty() {
             self.messages.push(ChatMessage {
                 role: MessageRole::Agent,
                 content: "当前没有可选模型，请先 `/model add` 添加（或一行 `/model add <name> <api_base> <api_key>`）。"
@@ -347,12 +348,15 @@ impl TuiShell {
         self.model_picker_index = self
             .runtime
             .config()
-            .models
+            .list_all_model_refs()
             .iter()
-            .position(|m| m.name == self.runtime.config().active_model)
+            .position(|model_ref| {
+                model_ref.group_id == self.runtime.config().active_model.group_id
+                    && model_ref.name == self.runtime.config().active_model.name
+            })
             .unwrap_or(0);
         self.model_display_titles = crate::model_catalog_display::build_model_display_titles(
-            &self.runtime.config().models,
+            &self.runtime.config().flatten_models(),
         );
         self.reset_primary_picker_overlay();
         self.model_picker_active = true;

--- a/apps/cli/src/ui/input.rs
+++ b/apps/cli/src/ui/input.rs
@@ -109,7 +109,7 @@ pub(in crate::ui) fn build_footer_line(app: &TuiViewModel, width: usize) -> Line
         "{}{}{}{}",
         left_prefix, approval_label, left_after_approval, left_suffix_plain
     );
-    let right_label = app.config.active_model.as_str();
+    let right_label = app.config.active_model_name();
     let side_padding = if width >= 12 {
         2
     } else if width >= 6 {

--- a/apps/cli/src/ui/pickers.rs
+++ b/apps/cli/src/ui/pickers.rs
@@ -423,21 +423,23 @@ pub(in crate::ui) fn build_model_picker_lines(
     app: &TuiViewModel,
     max_items: usize,
 ) -> Vec<Line<'static>> {
-    if app.config.models.is_empty() {
+    let models = app.config.flatten_models();
+    if models.is_empty() {
         return vec![Line::from(t!("ui.picker.models.empty").into_owned())];
     }
 
     let selected = app
         .model_picker_index
-        .min(app.config.models.len().saturating_sub(1));
-    let total = app.config.models.len();
+        .min(models.len().saturating_sub(1));
+    let total = models.len();
     let (start, end) = inline_picker_bounds(total, selected, max_items);
 
     let mut lines = Vec::new();
     for idx in start..end {
-        let model = &app.config.models[idx];
+        let model = &models[idx];
         let is_selected = idx == selected;
-        let is_active = model.name == app.config.active_model;
+        let is_active = model.group_id == app.config.active_model.group_id
+            && model.name == app.config.active_model.name;
         let display_title =
             crate::model_catalog_display::model_display_title(&model.name, &app.model_display_titles);
 

--- a/apps/desktop/electron/http-host.ts
+++ b/apps/desktop/electron/http-host.ts
@@ -1171,7 +1171,19 @@ async function handleApiRequest({
       await runHostCommand('switchPaneModel', {
         request: {
           sessionPath: typeof jsonBody?.sessionPath === 'string' ? jsonBody.sessionPath : '',
-          modelName: typeof jsonBody?.modelName === 'string' ? jsonBody.modelName : '',
+          modelRef:
+            typeof jsonBody?.modelRef === 'object' && jsonBody.modelRef !== null
+              ? {
+                  groupId:
+                    typeof (jsonBody.modelRef as { groupId?: unknown }).groupId === 'string'
+                      ? (jsonBody.modelRef as { groupId: string }).groupId
+                      : '',
+                  name:
+                    typeof (jsonBody.modelRef as { name?: unknown }).name === 'string'
+                      ? (jsonBody.modelRef as { name: string }).name
+                      : '',
+                }
+              : { groupId: '', name: '' },
         },
       }),
     );

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -55,6 +55,9 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   removeProviderModels(provider: string) {
     return ipcRenderer.invoke('desktop:invoke', 'removeProviderModels', { request: { provider } });
   },
+  removeProviderGroup(request: unknown) {
+    return ipcRenderer.invoke('desktop:invoke', 'removeProviderGroup', { request });
+  },
   addMcpServer(request: unknown) {
     return ipcRenderer.invoke('desktop:invoke', 'addMcpServer', { request });
   },

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -272,7 +272,7 @@ contextBridge.exposeInMainWorld('spiritDesktop', {
   }) {
     return ipcRenderer.invoke('desktop:invoke', 'switchPaneWorkspace', { request });
   },
-  switchPaneModel(request: { sessionPath: string; modelName: string }) {
+  switchPaneModel(request: { sessionPath: string; modelRef: { groupId: string; name: string } }) {
     return ipcRenderer.invoke('desktop:invoke', 'switchPaneModel', { request });
   },
   setPanePendingGitBranch(request: { sessionPath: string; branch: string }) {

--- a/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
+++ b/apps/desktop/scripts/check-renderer-host-internal-imports.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Desktop renderer 仅允许从 host-internal 的 renderer-safe 子路径做 value import。
- * 主入口 @spiritagent/host-internal 的 value import 会拉入 node:fs 依赖链。
+ * Desktop renderer 仅允许从 host-internal 的 renderer-safe 子路径 import。
+ * 主入口 @spiritagent/host-internal 会拉入 extensions / node:fs 依赖链（含 import type）。
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
@@ -12,10 +12,12 @@ const desktopSrc = join(repoRoot, 'apps', 'desktop', 'src');
 
 /** value import 允许的 host-internal 子路径（不含 node 依赖）。 */
 const RENDERER_SAFE_HOST_INTERNAL_SUBPATHS = new Set([
+  'config-v2',
   'workspace-file-reference-query',
   'model-provider-presets',
   'model-display-name',
   'openai-api-base',
+  'azure-resource',
   'bedrock-region',
   'bedrock-mantle',
   'google-vertex-endpoints',
@@ -24,17 +26,26 @@ const RENDERER_SAFE_HOST_INTERNAL_SUBPATHS = new Set([
   'github-pull-request-url',
   'github-pull-request-checks-pages',
   'github-pull-request-conversation-pages',
+  'github/types',
+  'approval-level',
+  'work-location',
+  'local-file-composer-route',
   'image-file-support',
 ]);
 
-const RENDERER_SCAN_ROOTS = ['components', 'hooks', 'lib', 'App.tsx'];
+const RENDERER_EXCLUDED_PREFIXES = [
+  join(desktopSrc, 'host'),
+];
 
-const IMPORT_RE =
-  /import\s+(?:type\s+)?(?:[\w*{}\s,]+\s+from\s+)?['"]@spiritagent\/host-internal(?:\/([^'"]+))?['"]/gu;
+function isRendererExcluded(filePath) {
+  return RENDERER_EXCLUDED_PREFIXES.some(
+    (prefix) => filePath === prefix || filePath.startsWith(`${prefix}/`),
+  );
+}
 
 function collectSourceFiles(entryPath) {
   const stat = statSync(entryPath);
-  if (stat.isFile() && /\.(tsx?|mts)$/u.test(entryPath)) {
+  if (stat.isFile() && /\.(tsx?|mts|d\.ts)$/u.test(entryPath)) {
     return [entryPath];
   }
   if (!stat.isDirectory()) {
@@ -42,55 +53,95 @@ function collectSourceFiles(entryPath) {
   }
   const files = [];
   for (const name of readdirSync(entryPath)) {
-    files.push(...collectSourceFiles(join(entryPath, name)));
+    const childPath = join(entryPath, name);
+    if (RENDERER_EXCLUDED_PREFIXES.some((prefix) => childPath === prefix || childPath.startsWith(`${prefix}/`))) {
+      continue;
+    }
+    files.push(...collectSourceFiles(childPath));
   }
   return files;
 }
 
-function isTypeOnlyImport(line) {
-  return /^\s*import\s+type\s+/u.test(line);
+function scanHostStorageImports(filePath, content) {
+  const violations = [];
+  if (isRendererExcluded(filePath)) {
+    return violations;
+  }
+  const hostImports = content.matchAll(
+    /from\s+['"](?:@\/host\/|\.\.\/host\/|\.\/host\/)[^'"]*['"]/gu,
+  );
+  for (const match of hostImports) {
+    const line = content.slice(0, match.index).split(/\r?\n/u).length;
+    violations.push({
+      file: relative(repoRoot, filePath),
+      line,
+      reason: 'renderer 禁止 import apps/desktop/src/host（会拉入 host-internal 主入口）',
+    });
+  }
+  return violations;
 }
 
 function scanFile(filePath) {
   const content = readFileSync(filePath, 'utf8');
-  const lines = content.split(/\r?\n/u);
   const violations = [];
 
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index];
-    if (!line.includes('@spiritagent/host-internal')) {
-      continue;
-    }
-    if (isTypeOnlyImport(line)) {
-      continue;
-    }
+  const importBlocks = content.matchAll(
+    /import\s+(?:type\s+)?(?:(?!;|\n\s*import)[\s\S])*?from\s+['"]@spiritagent\/host-internal(?:\/([^'"]+))?['"]/gu,
+  );
 
-    for (const match of line.matchAll(IMPORT_RE)) {
-      const subpath = match[1];
-      if (!subpath) {
-        violations.push({
-          file: relative(repoRoot, filePath),
-          line: index + 1,
-          reason: '禁止从 @spiritagent/host-internal 主入口做 value import',
-        });
-        continue;
-      }
-      if (!RENDERER_SAFE_HOST_INTERNAL_SUBPATHS.has(subpath)) {
-        violations.push({
-          file: relative(repoRoot, filePath),
-          line: index + 1,
-          reason: `子路径 "${subpath}" 不在 renderer-safe allowlist`,
-        });
-      }
+  for (const match of importBlocks) {
+    const line = content.slice(0, match.index).split(/\r?\n/u).length;
+    const subpath = match[1];
+    if (!subpath) {
+      violations.push({
+        file: relative(repoRoot, filePath),
+        line,
+        reason: '禁止从 @spiritagent/host-internal 主入口 import（含 import type）',
+      });
+      continue;
+    }
+    const importStatement = match[0];
+    if (/^\s*import\s+type\s+/u.test(importStatement.trimStart())) {
+      continue;
+    }
+    if (!RENDERER_SAFE_HOST_INTERNAL_SUBPATHS.has(subpath)) {
+      violations.push({
+        file: relative(repoRoot, filePath),
+        line,
+        reason: `子路径 "${subpath}" 不在 renderer-safe allowlist`,
+      });
     }
   }
+
+  const inlineTypeImports = content.matchAll(
+    /import\(['"]@spiritagent\/host-internal(?:\/([^'"]+))?['"]\)/gu,
+  );
+  for (const match of inlineTypeImports) {
+    const line = content.slice(0, match.index).split(/\r?\n/u).length;
+    const subpath = match[1];
+    if (!subpath) {
+      violations.push({
+        file: relative(repoRoot, filePath),
+        line,
+        reason: '禁止 inline import("@spiritagent/host-internal") 主入口',
+      });
+      continue;
+    }
+    if (!RENDERER_SAFE_HOST_INTERNAL_SUBPATHS.has(subpath)) {
+      violations.push({
+        file: relative(repoRoot, filePath),
+        line,
+        reason: `inline import 子路径 "${subpath}" 不在 renderer-safe allowlist`,
+      });
+    }
+  }
+
+  violations.push(...scanHostStorageImports(filePath, content));
 
   return violations;
 }
 
-const files = RENDERER_SCAN_ROOTS.flatMap((entry) =>
-  collectSourceFiles(join(desktopSrc, entry)),
-);
+const files = collectSourceFiles(desktopSrc);
 
 const violations = files.flatMap(scanFile);
 

--- a/apps/desktop/src/adapters/electron.ts
+++ b/apps/desktop/src/adapters/electron.ts
@@ -43,6 +43,9 @@ export async function createElectronHostApi(): Promise<HostApi> {
     removeProviderModels(provider) {
       return bridge.removeProviderModels(provider);
     },
+    removeProviderGroup(request) {
+      return bridge.removeProviderGroup(request);
+    },
     addMcpServer(request) {
       return bridge.addMcpServer(request);
     },

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -1,5 +1,10 @@
 import type { HostApi } from '../host-api';
 import type {
+  ApprovalLevel,
+  LocalFileComposerRoute,
+  WorkLocationKind,
+} from '../types.js';
+import type {
   AddModelRequest,
   AddMcpServerRequest,
   AddProviderModelsRequest,
@@ -226,13 +231,13 @@ export function createWebHostApi(): HostApi {
     setLoopEnabled(enabled: boolean) {
       return post<DesktopSnapshot>(baseUrl, '/api/loop', { enabled });
     },
-    setApprovalLevel(approvalLevel: import('@spiritagent/host-internal').ApprovalLevel) {
+    setApprovalLevel(approvalLevel: ApprovalLevel) {
       return post<DesktopSnapshot>(baseUrl, '/api/approval', { approvalLevel });
     },
     setPendingGitBranch(branch: string) {
       return post<DesktopSnapshot>(baseUrl, '/api/git/pending-branch', { branch });
     },
-    setWorkLocation(workLocation: import('@spiritagent/host-internal').WorkLocationKind) {
+    setWorkLocation(workLocation: WorkLocationKind) {
       return post<DesktopSnapshot>(baseUrl, '/api/git/work-location', { workLocation });
     },
     checkoutGitBranch(request: import('../types.js').CheckoutGitBranchRequest) {
@@ -515,7 +520,7 @@ export function createWebHostApi(): HostApi {
       return post<HostTextFileStatResult>(baseUrl, '/api/host/file/stat', { absolutePath });
     },
     classifyLocalFileComposerRoute(absolutePath: string) {
-      return post<import('@spiritagent/host-internal').LocalFileComposerRoute>(
+      return post<LocalFileComposerRoute>(
         baseUrl,
         '/api/host/file/classify-composer-route',
         { absolutePath },

--- a/apps/desktop/src/adapters/web.ts
+++ b/apps/desktop/src/adapters/web.ts
@@ -141,6 +141,9 @@ export function createWebHostApi(): HostApi {
     removeProviderModels(provider: DesktopModelProvider) {
       return post<DesktopSnapshot>(baseUrl, '/api/models/remove-provider', { provider });
     },
+    removeProviderGroup(request: import('../types').RemoveProviderGroupRequest) {
+      return post<DesktopSnapshot>(baseUrl, '/api/models/remove-provider-group', request);
+    },
     addMcpServer(request: AddMcpServerRequest) {
       return post<DesktopSnapshot>(baseUrl, '/api/mcps', request);
     },

--- a/apps/desktop/src/components/approval-level-menu.tsx
+++ b/apps/desktop/src/components/approval-level-menu.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ApprovalLevel } from "@spiritagent/host-internal";
+import type { ApprovalLevel } from "@spiritagent/host-internal/approval-level";
 import { Brain, ChevronDown, ShieldBan, ShieldCheck, type LucideIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 

--- a/apps/desktop/src/components/automation-settings-panel.tsx
+++ b/apps/desktop/src/components/automation-settings-panel.tsx
@@ -25,7 +25,7 @@ import type {
   ModelRef,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
-import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal";
+import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
 import {
   resolveWorkspaceBindingForStoredRoot,
 } from "@/lib/workspace-display-label";

--- a/apps/desktop/src/components/automation-settings-panel.tsx
+++ b/apps/desktop/src/components/automation-settings-panel.tsx
@@ -22,8 +22,10 @@ import type {
   DesktopUpdateAutomationRequest,
   DesktopWorkspaceBinding,
   GitHubAutomationRepositoriesSnapshot,
+  ModelRef,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
+import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal";
 import {
   resolveWorkspaceBindingForStoredRoot,
 } from "@/lib/workspace-display-label";
@@ -73,7 +75,7 @@ export function AutomationSettingsPanel({
   const [trigger, setTrigger] = useState<DesktopAutomationTrigger>(defaultDesktopTimeTrigger());
   const [workspaceRoot, setWorkspaceRoot] = useState("");
   const [workspaceBinding, setWorkspaceBinding] = useState<DesktopWorkspaceBinding>("project");
-  const [modelName, setModelName] = useState("");
+  const [modelRef, setModelRef] = useState<ModelRef>(emptyModelRef());
   const [reasoningEffort, setReasoningEffort] = useState<DesktopModelReasoningEffort | undefined>();
   const [approvalLevel, setApprovalLevel] = useState<ApprovalLevel>("default");
 
@@ -95,7 +97,12 @@ export function AutomationSettingsPanel({
       resolveWorkspaceBindingForStoredRoot(definition.workspaceRoot, homeDirectory),
     );
     setWorkspaceRoot(definition.workspaceRoot);
-    setModelName(definition.modelName);
+    const matchedModel = snapshot.config.models.find((model) => model.name === definition.modelName);
+    setModelRef(
+      matchedModel
+        ? (matchedModel.ref ?? { groupId: matchedModel.groupId ?? "", name: matchedModel.name })
+        : { groupId: "", name: definition.modelName },
+    );
     setReasoningEffort(definition.reasoningEffort);
     setApprovalLevel(definition.approvalLevel);
   }, [automationId, definition, snapshot?.userHomeDirectory]);
@@ -124,8 +131,8 @@ export function AutomationSettingsPanel({
     if (resolvedWorkspaceRoot !== definition.workspaceRoot) {
       next.workspaceRoot = resolvedWorkspaceRoot;
     }
-    if (modelName !== definition.modelName) {
-      next.modelName = modelName;
+    if (modelRef.name !== definition.modelName) {
+      next.modelName = modelRef.name;
     }
     if (reasoningEffort !== definition.reasoningEffort) {
       next.reasoningEffort = reasoningEffort;
@@ -135,14 +142,14 @@ export function AutomationSettingsPanel({
     }
 
     return Object.keys(next).length > 0 ? next : null;
-  }, [approvalLevel, definition, modelName, overview, reasoningEffort, resolvedWorkspaceRoot, trigger, title]);
+  }, [approvalLevel, definition, modelRef, overview, reasoningEffort, resolvedWorkspaceRoot, trigger, title]);
 
   const canSave =
     title.trim().length > 0
     && overview.trim().length > 0
     && (workspaceBinding === "none" || workspaceRoot.trim().length > 0)
     && resolvedWorkspaceRoot.trim().length > 0
-    && modelName.trim().length > 0
+    && modelRef.name.trim().length > 0
     && isValidDesktopAutomationTrigger(trigger)
     && (trigger.kind !== "github" || githubConnected)
     && patch !== null;
@@ -210,16 +217,22 @@ export function AutomationSettingsPanel({
                 <ModelPickerMenu
                   models={snapshot.config.models}
                   catalogHints={snapshot.config.modelCatalogHints}
-                  activeModelName={modelName}
+                  providerGroups={snapshot.config.providerGroups}
+                  activeModelRef={modelRef}
                   activeReasoningEffort={reasoningEffort}
                   disabled={disabled}
-                  onModelSelect={(name) => {
-                    setModelName(name);
-                    const profile = snapshot.config.models.find((model) => model.name === name);
+                  onModelSelect={(ref) => {
+                    setModelRef(ref);
+                    const profile = snapshot.config.models.find((model) =>
+                      modelRefsEqual(
+                        model.ref ?? { groupId: model.groupId ?? "", name: model.name },
+                        ref,
+                      ),
+                    );
                     setReasoningEffort(profile?.reasoningEffort);
                   }}
-                  onModelReasoningEffortSelect={(name, effort) => {
-                    setModelName(name);
+                  onModelReasoningEffortSelect={(ref, effort) => {
+                    setModelRef(ref);
                     setReasoningEffort(effort);
                   }}
                 />

--- a/apps/desktop/src/components/automation-settings-panel.tsx
+++ b/apps/desktop/src/components/automation-settings-panel.tsx
@@ -25,7 +25,7 @@ import type {
   ModelRef,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
-import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
+import { emptyModelRef, isEmptyModelRef, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
 import {
   resolveWorkspaceBindingForStoredRoot,
 } from "@/lib/workspace-display-label";
@@ -97,12 +97,7 @@ export function AutomationSettingsPanel({
       resolveWorkspaceBindingForStoredRoot(definition.workspaceRoot, homeDirectory),
     );
     setWorkspaceRoot(definition.workspaceRoot);
-    const matchedModel = snapshot.config.models.find((model) => model.name === definition.modelName);
-    setModelRef(
-      matchedModel
-        ? (matchedModel.ref ?? { groupId: matchedModel.groupId ?? "", name: matchedModel.name })
-        : { groupId: "", name: definition.modelName },
-    );
+    setModelRef(definition.modelRef ?? emptyModelRef());
     setReasoningEffort(definition.reasoningEffort);
     setApprovalLevel(definition.approvalLevel);
   }, [automationId, definition, snapshot?.userHomeDirectory]);
@@ -131,8 +126,8 @@ export function AutomationSettingsPanel({
     if (resolvedWorkspaceRoot !== definition.workspaceRoot) {
       next.workspaceRoot = resolvedWorkspaceRoot;
     }
-    if (modelRef.name !== definition.modelName) {
-      next.modelName = modelRef.name;
+    if (!modelRefsEqual(modelRef, definition.modelRef)) {
+      next.modelRef = modelRef;
     }
     if (reasoningEffort !== definition.reasoningEffort) {
       next.reasoningEffort = reasoningEffort;
@@ -149,7 +144,7 @@ export function AutomationSettingsPanel({
     && overview.trim().length > 0
     && (workspaceBinding === "none" || workspaceRoot.trim().length > 0)
     && resolvedWorkspaceRoot.trim().length > 0
-    && modelRef.name.trim().length > 0
+    && !isEmptyModelRef(modelRef)
     && isValidDesktopAutomationTrigger(trigger)
     && (trigger.kind !== "github" || githubConnected)
     && patch !== null;

--- a/apps/desktop/src/components/composer/composer-surface.tsx
+++ b/apps/desktop/src/components/composer/composer-surface.tsx
@@ -30,6 +30,7 @@ import { Button } from "@/components/ui/button";
 import type { SaveLocalImageAs } from "@/components/tool-call/tool-call-types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
+import { modelRefsEqual } from "@spiritagent/host-internal";
 import type { BrowserElementAttachment } from "@/lib/browser-element-attachment";
 import {
   DESKTOP_COMPOSER_SURFACE_BACKDROP,
@@ -37,7 +38,7 @@ import {
 } from "@/lib/desktop-chrome";
 import { cn } from "@/lib/utils";
 import { segmentsToPlainText } from "@/lib/composer-segment-model";
-import type { DesktopModelReasoningEffort, DesktopSnapshot } from "@/types";
+import type { DesktopModelReasoningEffort, DesktopSnapshot, ModelRef } from "@/types";
 
 function isComposerChromeInteractiveTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
@@ -58,7 +59,8 @@ export type ComposerSurfaceProps = {
   agentModeChipPlaceholder?: string;
   models: DesktopSnapshot["config"]["models"];
   catalogHints?: DesktopSnapshot["config"]["modelCatalogHints"];
-  activeModel: string;
+  providerGroups?: DesktopSnapshot["config"]["providerGroups"];
+  activeModel: ModelRef;
   agentMode: DesktopAgentMode;
   loopEnabled: boolean;
   canSend: boolean;
@@ -68,9 +70,9 @@ export type ComposerSurfaceProps = {
   readOnly?: boolean;
   onSubmit(): void;
   onAbort?(): void;
-  onModelSelect(name: string): void;
-  onModelReasoningEffortSelect(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
-  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void | Promise<boolean>;
+  onModelSelect(ref: ModelRef): void;
+  onModelReasoningEffortSelect(ref: ModelRef, reasoningEffort: DesktopModelReasoningEffort): void;
+  onModelThinkingEnabledSelect?(ref: ModelRef, enabled: boolean): void | Promise<boolean>;
   onAgentModeChange(mode: DesktopAgentMode): void;
   onLoopEnabledChange?(enabled: boolean): void;
   richInputRef?: RefObject<ComposerRichInputHandle | null>;
@@ -100,6 +102,7 @@ export function ComposerSurface({
   agentModeChipPlaceholder,
   models,
   catalogHints,
+  providerGroups,
   activeModel,
   agentMode,
   loopEnabled = false,
@@ -136,7 +139,13 @@ export function ComposerSurface({
   const { t } = useTranslation();
   const [fileDragOver, setFileDragOver] = useState(false);
   const activeModelProfile = useMemo(
-    () => models.find((model) => model.name === activeModel),
+    () =>
+      models.find((model) =>
+        modelRefsEqual(
+          model.ref ?? { groupId: model.groupId ?? "", name: model.name },
+          activeModel,
+        ),
+      ),
     [activeModel, models],
   );
 
@@ -255,7 +264,8 @@ export function ComposerSurface({
             <ModelPickerMenu
               models={models}
               catalogHints={catalogHints}
-              activeModelName={activeModel}
+              providerGroups={providerGroups}
+              activeModelRef={activeModel}
               activeReasoningEffort={activeModelProfile?.reasoningEffort}
               disabled={readOnly}
               onModelSelect={onModelSelect}

--- a/apps/desktop/src/components/composer/composer-surface.tsx
+++ b/apps/desktop/src/components/composer/composer-surface.tsx
@@ -30,7 +30,7 @@ import { Button } from "@/components/ui/button";
 import type { SaveLocalImageAs } from "@/components/tool-call/tool-call-types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { DesktopAgentMode } from "@/lib/agent-mode";
-import { modelRefsEqual } from "@spiritagent/host-internal";
+import { modelRefsEqual } from "@spiritagent/host-internal/config-v2";
 import type { BrowserElementAttachment } from "@/lib/browser-element-attachment";
 import {
   DESKTOP_COMPOSER_SURFACE_BACKDROP,

--- a/apps/desktop/src/components/conversation/composer-dock.tsx
+++ b/apps/desktop/src/components/conversation/composer-dock.tsx
@@ -420,12 +420,12 @@ export const ComposerDock = forwardRef<HTMLDivElement, ComposerDockProps>(functi
                 activeModel={snapshot?.config.activeModel ?? runtime.settings.activeModel}
                 agentMode={runtime.settings.agentMode}
                 loopEnabled={snapshot?.conversation.loopEnabled === true}
-                onModelSelect={(name) => {
+                onModelSelect={(ref) => {
                   if (useIsolatedPaneWorkspace && paneSessionPath) {
-                    void runtime.switchPaneModel(paneSessionPath, name);
+                    void runtime.switchPaneModel(paneSessionPath, ref.name);
                     return;
                   }
-                  runtime.setActiveModel(name);
+                  runtime.setActiveModel(ref);
                 }}
                 onModelReasoningEffortSelect={runtime.setModelReasoningEffort}
                 onModelThinkingEnabledSelect={runtime.setModelThinkingEnabled}

--- a/apps/desktop/src/components/conversation/composer-dock.tsx
+++ b/apps/desktop/src/components/conversation/composer-dock.tsx
@@ -422,7 +422,7 @@ export const ComposerDock = forwardRef<HTMLDivElement, ComposerDockProps>(functi
                 loopEnabled={snapshot?.conversation.loopEnabled === true}
                 onModelSelect={(ref) => {
                   if (useIsolatedPaneWorkspace && paneSessionPath) {
-                    void runtime.switchPaneModel(paneSessionPath, ref.name);
+                    void runtime.switchPaneModel(paneSessionPath, ref);
                     return;
                   }
                   runtime.setActiveModel(ref);

--- a/apps/desktop/src/components/conversation/conversation-list.tsx
+++ b/apps/desktop/src/components/conversation/conversation-list.tsx
@@ -40,6 +40,7 @@ import type {
   ConversationMessageSnapshot,
   DesktopSnapshot,
   MessageRewindDraftState,
+  ModelRef,
   PendingAssistantAux,
 } from "@/types";
 import type { PointerEvent, ReactNode, RefObject } from "react";
@@ -92,7 +93,7 @@ export type ConversationListProps = {
   rewindRichInputRef: RefObject<ComposerRichInputHandle | null>;
   models: DesktopSnapshot["config"]["models"];
   catalogHints: DesktopSnapshot["config"]["modelCatalogHints"] | undefined;
-  activeModel: string;
+  activeModel: ModelRef;
   agentMode: DesktopAgentMode;
   onOpenSubagentViewer: ((toolCallId: string) => void) | undefined;
   onOpenReadFile: ((target: EditorFileTarget) => void) | undefined;

--- a/apps/desktop/src/components/conversation/message-card.tsx
+++ b/apps/desktop/src/components/conversation/message-card.tsx
@@ -34,6 +34,7 @@ import type {
   ConversationMessageSnapshot,
   DesktopModelReasoningEffort,
   DesktopSnapshot,
+  ModelRef,
   PendingAssistantAux,
 } from "@/types";
 
@@ -137,7 +138,7 @@ function MessageCardImpl({
   canPickLocalFile: boolean;
   models: DesktopSnapshot["config"]["models"];
   catalogHints?: DesktopSnapshot["config"]["modelCatalogHints"];
-  activeModel: string;
+  activeModel: ModelRef;
   agentMode: DesktopAgentMode;
   onContinue(message: ConversationMessageSnapshot): void;
   onRewindSegmentsChange(segments: import("@/lib/composer-segment-model").RichSegment[]): void;
@@ -148,9 +149,9 @@ function MessageCardImpl({
   onRewindPaste(event: ReactClipboardEvent<HTMLTextAreaElement>): void;
   onRewindDragOver(event: ReactDragEvent<HTMLElement>): void;
   onRewindDrop(event: ReactDragEvent<HTMLElement>): void;
-  onModelSelect(name: string): void;
-  onModelReasoningEffortSelect(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
-  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void | Promise<boolean>;
+  onModelSelect(ref: ModelRef): void;
+  onModelReasoningEffortSelect(ref: ModelRef, reasoningEffort: DesktopModelReasoningEffort): void;
+  onModelThinkingEnabledSelect?(ref: ModelRef, enabled: boolean): void | Promise<boolean>;
   onAgentModeChange(mode: DesktopAgentMode): void;
   readManagedImagePreviewDataUrl: ReadManagedImagePreview;
   readManagedVideoPreviewUrl: ReadManagedVideoPreview;

--- a/apps/desktop/src/components/create-automation-dialog.tsx
+++ b/apps/desktop/src/components/create-automation-dialog.tsx
@@ -31,7 +31,7 @@ import type {
   ModelRef,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
-import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal";
+import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
 import { cn } from "@/lib/utils";
 
 type CreateAutomationDialogProps = {

--- a/apps/desktop/src/components/create-automation-dialog.tsx
+++ b/apps/desktop/src/components/create-automation-dialog.tsx
@@ -31,7 +31,7 @@ import type {
   ModelRef,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
-import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
+import { emptyModelRef, isEmptyModelRef, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
 import { cn } from "@/lib/utils";
 
 type CreateAutomationDialogProps = {
@@ -114,7 +114,7 @@ export function CreateAutomationDialog({
     && overview.trim().length > 0
     && (workspaceBinding === "none" || workspaceRoot.trim().length > 0)
     && resolvedWorkspaceRoot.trim().length > 0
-    && modelRef.name.trim().length > 0
+    && !isEmptyModelRef(modelRef)
     && isValidDesktopAutomationTrigger(trigger)
     && (trigger.kind !== "github" || githubConnected);
 
@@ -215,7 +215,7 @@ export function CreateAutomationDialog({
                   overview: overview.trim(),
                   trigger,
                   workspaceRoot: resolvedWorkspaceRoot,
-                  modelName: modelRef.name,
+                  modelRef,
                   ...(reasoningEffort ? { reasoningEffort } : {}),
                   approvalLevel,
                 });

--- a/apps/desktop/src/components/create-automation-dialog.tsx
+++ b/apps/desktop/src/components/create-automation-dialog.tsx
@@ -28,8 +28,10 @@ import type {
   DesktopSnapshot,
   DesktopWorkspaceBinding,
   GitHubAutomationRepositoriesSnapshot,
+  ModelRef,
   SearchGitHubAutomationRepositoriesSnapshot,
 } from "@/types";
+import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal";
 import { cn } from "@/lib/utils";
 
 type CreateAutomationDialogProps = {
@@ -68,7 +70,7 @@ export function CreateAutomationDialog({
   const [trigger, setTrigger] = useState<DesktopAutomationTrigger>(defaultDesktopTimeTrigger());
   const [workspaceRoot, setWorkspaceRoot] = useState("");
   const [workspaceBinding, setWorkspaceBinding] = useState<DesktopWorkspaceBinding>("project");
-  const [modelName, setModelName] = useState("");
+  const [modelRef, setModelRef] = useState<ModelRef>(emptyModelRef());
   const [reasoningEffort, setReasoningEffort] = useState<DesktopModelReasoningEffort | undefined>();
   const [approvalLevel, setApprovalLevel] = useState<ApprovalLevel>("default");
 
@@ -93,8 +95,13 @@ export function CreateAutomationDialog({
         ? snapshot.userHomeDirectory
         : snapshot.workspaceRoot,
     );
-    setModelName(snapshot.config.activeModel);
-    const activeModel = snapshot.config.models.find((model) => model.name === snapshot.config.activeModel);
+    setModelRef(snapshot.config.activeModel);
+    const activeModel = snapshot.config.models.find((model) =>
+      modelRefsEqual(
+        model.ref ?? { groupId: model.groupId ?? "", name: model.name },
+        snapshot.config.activeModel,
+      ),
+    );
     setReasoningEffort(activeModel?.reasoningEffort);
     setApprovalLevel(snapshot.conversation.approvalLevel);
   }, [open, snapshot]);
@@ -107,7 +114,7 @@ export function CreateAutomationDialog({
     && overview.trim().length > 0
     && (workspaceBinding === "none" || workspaceRoot.trim().length > 0)
     && resolvedWorkspaceRoot.trim().length > 0
-    && modelName.trim().length > 0
+    && modelRef.name.trim().length > 0
     && isValidDesktopAutomationTrigger(trigger)
     && (trigger.kind !== "github" || githubConnected);
 
@@ -168,16 +175,22 @@ export function CreateAutomationDialog({
                 <ModelPickerMenu
                   models={snapshot.config.models}
                   catalogHints={snapshot.config.modelCatalogHints}
-                  activeModelName={modelName}
+                  providerGroups={snapshot.config.providerGroups}
+                  activeModelRef={modelRef}
                   activeReasoningEffort={reasoningEffort}
                   disabled={disabled}
-                  onModelSelect={(name) => {
-                    setModelName(name);
-                    const profile = snapshot.config.models.find((model) => model.name === name);
+                  onModelSelect={(ref) => {
+                    setModelRef(ref);
+                    const profile = snapshot.config.models.find((model) =>
+                      modelRefsEqual(
+                        model.ref ?? { groupId: model.groupId ?? "", name: model.name },
+                        ref,
+                      ),
+                    );
                     setReasoningEffort(profile?.reasoningEffort);
                   }}
-                  onModelReasoningEffortSelect={(name, effort) => {
-                    setModelName(name);
+                  onModelReasoningEffortSelect={(ref, effort) => {
+                    setModelRef(ref);
                     setReasoningEffort(effort);
                   }}
                 />
@@ -202,7 +215,7 @@ export function CreateAutomationDialog({
                   overview: overview.trim(),
                   trigger,
                   workspaceRoot: resolvedWorkspaceRoot,
-                  modelName,
+                  modelName: modelRef.name,
                   ...(reasoningEffort ? { reasoningEffort } : {}),
                   approvalLevel,
                 });

--- a/apps/desktop/src/components/minimal-tool-call-card.tsx
+++ b/apps/desktop/src/components/minimal-tool-call-card.tsx
@@ -9,6 +9,7 @@ import {
   FileToolLspDiagnosticsHover,
   FileToolLspDiagnosticsHoverTrigger,
 } from "@/components/file-tool-lsp-diagnostics-hover";
+import { ShellToolCommandHighlight } from "@/components/shell-tool-command-highlight";
 import { ToolCallDiffView } from "@/components/tool-call-diff-view";
 import { useToolCallDiffHost } from "@/components/tool-call-diff-host-context";
 import { useCollapsibleChildMount } from "@/hooks/use-collapsible-child-mount";
@@ -31,7 +32,10 @@ import {
   toolHasExpandableContent,
   type ShellToolSummaryParts,
 } from "@/lib/tool-call-display";
-import { parseShellToolCommand, parseShellToolResult } from "@/lib/shell-tool-display";
+import {
+  parseShellToolResult,
+  resolveShellToolExpandedCommand,
+} from "@/lib/shell-tool-display";
 import {
   clickableToolCardTriggerClass,
   shouldShowLspDiagnosticsOnToolCard,
@@ -428,11 +432,8 @@ function ShellToolExpandedBody({
         <div className="space-y-1">
           <div className="overflow-hidden rounded-md border border-border/20 bg-muted/15 p-2 text-xs leading-relaxed text-muted-foreground">
             {commandLine ? (
-              <div className="flex items-center gap-2">
-                <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-mono">
-                  <span className="select-none text-muted-foreground/75">$ </span>
-                  {commandLine}
-                </pre>
+              <div className="flex items-start gap-2">
+                <ShellToolCommandHighlight command={commandLine} />
                 {showTerminateButton ? (
                   <Button
                     type="button"
@@ -542,7 +543,7 @@ export function MinimalToolCallCard({
   const isFileDiff = isFileDiffTool(tool.toolName);
   const isResponsesBuiltIn = isResponsesBuiltInToolCard(tool.toolName);
   const shellCommand = useMemo(
-    () => (isShell ? tool.headlineDetail?.trim() || parseShellToolCommand(tool) : undefined),
+    () => (isShell ? resolveShellToolExpandedCommand(tool) : undefined),
     [isShell, tool.argsExcerpt, tool.detailLines, tool.headlineDetail],
   );
   const expandable = toolHasExpandableContent(tool);

--- a/apps/desktop/src/components/model-picker-inspector-panel.tsx
+++ b/apps/desktop/src/components/model-picker-inspector-panel.tsx
@@ -29,8 +29,13 @@ import {
 import type {
   DesktopModelReasoningEffort,
   ModelProfileSnapshot,
+  ModelRef,
   PreviewModelCatalogEntry,
 } from '@/types';
+
+function modelInspectorRef(model: ModelProfileSnapshot): ModelRef {
+  return model.ref ?? { groupId: model.groupId ?? '', name: model.name };
+}
 
 export function modelPickerInspectorNeedsWideLayout(
   model: ModelProfileSnapshot,
@@ -65,8 +70,8 @@ type ModelPickerInspectorPanelProps = {
   catalogEntry?: PreviewModelCatalogEntry;
   providerLabel: string;
   density?: 'default' | 'list';
-  onReasoningEffortChange: (modelName: string, effort: DesktopModelReasoningEffort) => void;
-  onThinkingEnabledChange?: (modelName: string, enabled: boolean) => void | Promise<boolean>;
+  onReasoningEffortChange: (modelRef: ModelRef, effort: DesktopModelReasoningEffort) => void;
+  onThinkingEnabledChange?: (modelRef: ModelRef, enabled: boolean) => void | Promise<boolean>;
 };
 
 export function ModelPickerInspectorPanel({
@@ -79,6 +84,7 @@ export function ModelPickerInspectorPanel({
 }: ModelPickerInspectorPanelProps) {
   const { t } = useTranslation();
   const isList = density === 'list';
+  const modelRef = modelInspectorRef(model);
   const modelContext = {
     ...(model.provider ? { provider: model.provider } : {}),
     model: model.name,
@@ -121,7 +127,7 @@ export function ModelPickerInspectorPanel({
               checked={thinkingEnabled}
               onCheckedChange={(checked) => {
                 setPendingThinkingEnabled(checked);
-                void Promise.resolve(onThinkingEnabledChange?.(model.name, checked)).then(
+                void Promise.resolve(onThinkingEnabledChange?.(modelRef, checked)).then(
                   (ok) => {
                     if (ok === false) {
                       setPendingThinkingEnabled(null);
@@ -138,7 +144,7 @@ export function ModelPickerInspectorPanel({
             <Select
               value={model.reasoningEffort}
               onValueChange={(value) => {
-                onReasoningEffortChange(model.name, value as DesktopModelReasoningEffort);
+                onReasoningEffortChange(modelRef, value as DesktopModelReasoningEffort);
               }}
             >
               <SelectTrigger className={selectTriggerClass}>

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -40,10 +40,21 @@ import {
   resolveModelThinkingEnabled,
 } from "@spiritagent/agent-core/model-thinking-controls";
 import { groupModelsForPicker } from "@/lib/model-picker-groups";
-import type { DesktopModelReasoningEffort, DesktopSnapshot, ModelProfileSnapshot, PreviewModelCatalogEntry } from "@/types";
+import type {
+  DesktopModelReasoningEffort,
+  DesktopSnapshot,
+  ModelProfileSnapshot,
+  ModelRef,
+  PreviewModelCatalogEntry,
+} from "@/types";
+import { modelRefKey, modelRefsEqual } from "@spiritagent/host-internal";
 import { cn } from "@/lib/utils";
 
 type ModelPickerItem = DesktopSnapshot["config"]["models"][number];
+
+function modelPickerItemRef(model: ModelPickerItem): ModelRef {
+  return model.ref ?? { groupId: model.groupId ?? "", name: model.name };
+}
 
 function resolveModelPickerDetailTooltipWidthClass(
   activeItem: unknown,
@@ -88,14 +99,15 @@ const ModelPickerRow = memo(function ModelPickerRow({
   model: ModelPickerItem;
   displayTitle: string;
   isActive: boolean;
-  onSelectModel: (modelName: string) => void;
+  onSelectModel: (ref: ModelRef) => void;
 }) {
+  const modelRef = modelPickerItemRef(model);
   return (
     <TooltipItem item={model}>
       <DropdownMenuItem
         className={cn(isActive && "bg-accent/40")}
         onSelect={() => {
-          onSelectModel(model.name);
+          onSelectModel(modelRef);
         }}
       >
         <span className={cn(DESKTOP_OVERLAY_LIST_ITEM_PRIMARY, "min-w-0 truncate")}>
@@ -109,14 +121,15 @@ const ModelPickerRow = memo(function ModelPickerRow({
 export type ModelPickerMenuProps = {
   models: DesktopSnapshot["config"]["models"];
   catalogHints?: DesktopSnapshot["config"]["modelCatalogHints"];
-  activeModelName: string;
+  providerGroups?: DesktopSnapshot["config"]["providerGroups"];
+  activeModelRef: ModelRef;
   activeReasoningEffort?: DesktopModelReasoningEffort;
   disabled?: boolean;
   open?: boolean;
   onOpenChange?(open: boolean): void;
-  onModelSelect(name: string): void;
-  onModelReasoningEffortSelect?(name: string, reasoningEffort: DesktopModelReasoningEffort): void;
-  onModelThinkingEnabledSelect?(name: string, enabled: boolean): void | Promise<boolean>;
+  onModelSelect(ref: ModelRef): void;
+  onModelReasoningEffortSelect?(ref: ModelRef, reasoningEffort: DesktopModelReasoningEffort): void;
+  onModelThinkingEnabledSelect?(ref: ModelRef, enabled: boolean): void | Promise<boolean>;
   triggerClassName?: string;
   menuContentClassName?: string;
 };
@@ -124,7 +137,8 @@ export type ModelPickerMenuProps = {
 export function ModelPickerMenu({
   models,
   catalogHints,
-  activeModelName,
+  providerGroups,
+  activeModelRef,
   activeReasoningEffort,
   disabled,
   open: openProp,
@@ -156,7 +170,9 @@ export function ModelPickerMenu({
     [isControlled, onOpenChange],
   );
 
-  const activeModelProfile = models.find((model) => model.name === activeModelName);
+  const activeModelProfile = models.find((model) =>
+    modelRefsEqual(modelPickerItemRef(model), activeModelRef),
+  );
   const displayTitleByModelName = useMemo(
     () => buildModelCatalogDisplayTitleMap(models, catalogHints),
     [catalogHints, models],
@@ -166,8 +182,8 @@ export function ModelPickerMenu({
     [catalogHints, models],
   );
   const modelGroups = useMemo(
-    () => groupModelsForPicker(models, catalogHints),
-    [catalogHints, models],
+    () => groupModelsForPicker(models, catalogHints, providerGroups),
+    [catalogHints, models, providerGroups],
   );
   const filteredModelGroups = useMemo(() => {
     const query = modelFilter.trim().toLowerCase();
@@ -200,9 +216,9 @@ export function ModelPickerMenu({
     });
   }, [tooltipActions]);
 
-  const handleSelectModel = useCallback((name: string) => {
+  const handleSelectModel = useCallback((ref: ModelRef) => {
     dismissOpenListTooltip();
-    onModelSelect(name);
+    onModelSelect(ref);
     setModelFilter("");
     setModelMenuOpen(false);
   }, [dismissOpenListTooltip, onModelSelect, setModelMenuOpen]);
@@ -286,7 +302,7 @@ export function ModelPickerMenu({
                       model={activeModelProfile}
                     />
                   ) : (
-                    <span className="min-w-0 truncate">{activeModelName}</span>
+                    <span className="min-w-0 truncate">{modelRefKey(activeModelRef)}</span>
                   )}
                   <ChevronDown className="size-3 shrink-0 text-muted-foreground/80" aria-hidden />
                 </button>
@@ -306,18 +322,20 @@ export function ModelPickerMenu({
             {filteredModelGroups.length === 0
               ? null
               : filteredModelGroups.map((group) => (
-                  <div key={group.provider} className="mb-2 last:mb-0">
+                  <div key={group.groupId} className="mb-2 last:mb-0">
                     <div className={DESKTOP_OVERLAY_LIST_GROUP_LABEL}>
-                      {t(group.labelKey, { defaultValue: group.fallbackLabel })}
+                      {group.customLabel
+                        ?? t(group.labelKey, { defaultValue: group.fallbackLabel })}
                     </div>
                     {group.items.map((model) => {
                       const displayTitle = modelDisplayTitleFromMap(model.name, displayTitleByModelName);
+                      const modelRef = modelPickerItemRef(model);
                       return (
                         <ModelPickerRow
-                          key={`${group.provider}:${model.name}`}
+                          key={`${group.groupId}:${modelRefKey(modelRef)}`}
                           model={model}
                           displayTitle={displayTitle}
-                          isActive={activeModelProfile?.name === model.name}
+                          isActive={modelRefsEqual(activeModelProfile ? modelPickerItemRef(activeModelProfile) : undefined, modelRef)}
                           onSelectModel={handleSelectModel}
                         />
                       );
@@ -348,13 +366,14 @@ export function ModelPickerMenu({
               if (!hoveredModel) {
                 return null;
               }
-              const model = models.find((entry) => entry.name === hoveredModel.name) ?? hoveredModel;
+              const model = models.find((entry) => modelRefsEqual(modelPickerItemRef(entry), modelPickerItemRef(hoveredModel))) ?? hoveredModel;
               const group = filteredModelGroups.find((entry) =>
-                entry.items.some((item) => item.name === model.name),
+                entry.items.some((item) => modelRefsEqual(modelPickerItemRef(item), modelPickerItemRef(model))),
               );
-              const providerLabel = group
-                ? t(group.labelKey, { defaultValue: group.fallbackLabel })
-                : model.provider ?? model.name;
+              const providerLabel = group?.customLabel
+                ?? (group
+                  ? t(group.labelKey, { defaultValue: group.fallbackLabel })
+                  : model.provider ?? model.name);
               const catalogEntry = catalogDetailByModelName.get(model.name);
 
               return (
@@ -362,15 +381,15 @@ export function ModelPickerMenu({
                   model={model}
                   catalogEntry={catalogEntry}
                   providerLabel={providerLabel}
-                  onReasoningEffortChange={(modelName, effort) => {
-                    onModelReasoningEffortSelect?.(modelName, effort);
+                  onReasoningEffortChange={(modelRef, effort) => {
+                    onModelReasoningEffortSelect?.(modelRef, effort);
                     dismissOpenListTooltip();
-                    onModelSelect(modelName);
+                    onModelSelect(modelRef);
                     setModelFilter("");
                     setModelMenuOpen(false);
                   }}
-                  onThinkingEnabledChange={(modelName, enabled) => {
-                    onModelThinkingEnabledSelect?.(modelName, enabled);
+                  onThinkingEnabledChange={(modelRef, enabled) => {
+                    onModelThinkingEnabledSelect?.(modelRef, enabled);
                   }}
                 />
               );

--- a/apps/desktop/src/components/model-picker-menu.tsx
+++ b/apps/desktop/src/components/model-picker-menu.tsx
@@ -47,7 +47,7 @@ import type {
   ModelRef,
   PreviewModelCatalogEntry,
 } from "@/types";
-import { modelRefKey, modelRefsEqual } from "@spiritagent/host-internal";
+import { modelRefKey, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
 import { cn } from "@/lib/utils";
 
 type ModelPickerItem = DesktopSnapshot["config"]["models"][number];

--- a/apps/desktop/src/components/settings/models/model-defaults.ts
+++ b/apps/desktop/src/components/settings/models/model-defaults.ts
@@ -5,7 +5,7 @@ import {
   isEmptyModelRef,
   modelRefKey,
   modelRefsEqual,
-} from "@spiritagent/host-internal";
+} from "@spiritagent/host-internal/config-v2";
 
 export const defaultCustomModelCapabilities: DesktopModelCapability[] = ["chat", "image"];
 

--- a/apps/desktop/src/components/settings/models/model-defaults.ts
+++ b/apps/desktop/src/components/settings/models/model-defaults.ts
@@ -1,5 +1,11 @@
 import i18n from "@/lib/i18n";
-import type { DesktopModelCapability, DesktopSnapshot } from "@/types";
+import type { DesktopModelCapability, DesktopSnapshot, ModelRef } from "@/types";
+import {
+  emptyModelRef,
+  isEmptyModelRef,
+  modelRefKey,
+  modelRefsEqual,
+} from "@spiritagent/host-internal";
 
 export const defaultCustomModelCapabilities: DesktopModelCapability[] = ["chat", "image"];
 
@@ -13,6 +19,23 @@ export type ModelDefaultAssignments = {
 };
 
 export type ModelDefaultRole = keyof ModelDefaultAssignments;
+
+export function settingsModelRef(model: SettingsModelProfile): ModelRef {
+  return model.ref ?? { groupId: model.groupId ?? "", name: model.name };
+}
+
+export function resolveEffectiveModelRef(
+  settingsRef: ModelRef | undefined,
+  snapshotRef: ModelRef | undefined,
+): ModelRef {
+  if (settingsRef && !isEmptyModelRef(settingsRef)) {
+    return settingsRef;
+  }
+  if (snapshotRef && !isEmptyModelRef(snapshotRef)) {
+    return snapshotRef;
+  }
+  return emptyModelRef();
+}
 
 export const modelCapabilityOptions: Array<{
   value: DesktopModelCapability;
@@ -73,26 +96,42 @@ export function canAssignAsLightweightChatModel(
 
 export function getSupportedModelDefaultRoles(
   model: SettingsModelProfile,
-  activeModel: string,
-  imageGenerationModel: string,
-  videoGenerationModel: string,
-  lightweightChatModel: string,
+  activeModel: ModelRef,
+  imageGenerationModel: ModelRef | undefined,
+  videoGenerationModel: ModelRef | undefined,
+  lightweightChatModel: ModelRef | undefined,
 ): ModelDefaultRole[] {
+  const modelRef = settingsModelRef(model);
   const roles: ModelDefaultRole[] = [];
 
-  if (canAssignAsActiveModel(model, model.name === activeModel)) {
+  if (canAssignAsActiveModel(model, modelRefsEqual(modelRef, activeModel))) {
     roles.push("activeModel");
   }
 
-  if (canAssignAsImageGenerationModel(model, model.name === imageGenerationModel)) {
+  if (
+    canAssignAsImageGenerationModel(
+      model,
+      imageGenerationModel !== undefined && modelRefsEqual(modelRef, imageGenerationModel),
+    )
+  ) {
     roles.push("imageGenerationModel");
   }
 
-  if (canAssignAsVideoGenerationModel(model, model.name === videoGenerationModel)) {
+  if (
+    canAssignAsVideoGenerationModel(
+      model,
+      videoGenerationModel !== undefined && modelRefsEqual(modelRef, videoGenerationModel),
+    )
+  ) {
     roles.push("videoGenerationModel");
   }
 
-  if (canAssignAsLightweightChatModel(model, model.name === lightweightChatModel)) {
+  if (
+    canAssignAsLightweightChatModel(
+      model,
+      lightweightChatModel !== undefined && modelRefsEqual(modelRef, lightweightChatModel),
+    )
+  ) {
     roles.push("lightweightChatModel");
   }
 
@@ -119,3 +158,5 @@ export function modelDefaultActionLabel(roles: readonly ModelDefaultRole[]): str
 
   return i18n.t('settings.selectDefaultRole');
 }
+
+export { modelRefKey };

--- a/apps/desktop/src/components/settings/models/models-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/models/models-settings-panel.tsx
@@ -24,7 +24,10 @@ import {
   defaultCustomModelCapabilities,
   getSupportedModelDefaultRoles,
   modelDefaultActionLabel,
+  modelRefKey,
   normalizeModelCapabilitySelection,
+  resolveEffectiveModelRef,
+  settingsModelRef,
 } from "@/components/settings/models/model-defaults";
 import { ModelSettingsRowButton, ModelSettingsRowWithHover } from "@/components/settings/models/model-settings-row";
 import type { SettingsFormState, SettingsViewProps } from "@/components/settings/types";
@@ -87,8 +90,14 @@ import type {
   PreviewModelCatalogEntry,
   PreviewModelsRequest,
   PreviewModelsResponse,
+  ProviderGroupV2,
 } from "@/types";
 import { bedrockApiBaseFromRegion } from "@spiritagent/host-internal/bedrock-region";
+import {
+  defaultPresetProviderGroupId,
+  modelRefsEqual,
+  slugifyProviderGroupLabel,
+} from "@spiritagent/host-internal";
 import {
   bedrockMantleApiBaseFromRegion,
   isBedrockMantleOpenAiModel,
@@ -155,6 +164,7 @@ export function ModelsSettingsPanel({
   );
   const [bedrockConnectMode, setBedrockConnectMode] = useState<"bearer" | "iam">("bearer");
   const [vertexConnectMode, setVertexConnectMode] = useState<"adc" | "service-account" | "express">("adc");
+  const [connectCustomGroupLabel, setConnectCustomGroupLabel] = useState("");
   const [modelDefaultsDialogTarget, setModelDefaultsDialogTarget] = useState<string | null>(null);
   const [modelDefaultsDialogOpen, setModelDefaultsDialogOpen] = useState(false);
   const [modelDefaultAssignments, setModelDefaultAssignments] = useState<ModelDefaultAssignments>({
@@ -164,51 +174,70 @@ export function ModelsSettingsPanel({
     lightweightChatModel: false,
   });
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
-  const [deleteGroupTarget, setDeleteGroupTarget] = useState<DesktopModelProvider | null>(null);
+  const [deleteGroupTarget, setDeleteGroupTarget] = useState<string | null>(null);
 
   const models = snapshot?.config.models ?? [];
-  const activeModel = settings.activeModel.trim() || (snapshot?.config.activeModel ?? "");
+  const configProviderGroups = snapshot?.config.providerGroups ?? [];
+  const activeModel = resolveEffectiveModelRef(settings.activeModel, snapshot?.config.activeModel);
   const imageGenerationModel =
-    settings.imageGenerationModel.trim() || (snapshot?.config.imageGenerationModel ?? "");
+    settings.imageGenerationModel ?? snapshot?.config.imageGenerationModel;
   const videoGenerationModel =
-    settings.videoGenerationModel.trim() || (snapshot?.config.videoGenerationModel ?? "");
+    settings.videoGenerationModel ?? snapshot?.config.videoGenerationModel;
   const lightweightChatModel =
-    settings.lightweightChatModel.trim() || (snapshot?.config.lightweightChatModel ?? "");
+    settings.lightweightChatModel ?? snapshot?.config.lightweightChatModel;
   const modelDefaultsDialogModel =
     modelDefaultsDialogTarget === null
       ? null
-      : models.find((model) => model.name === modelDefaultsDialogTarget) ?? null;
+      : models.find((model) => modelRefKey(settingsModelRef(model)) === modelDefaultsDialogTarget) ?? null;
+  const modelDefaultsDialogRef =
+    modelDefaultsDialogModel === null ? null : settingsModelRef(modelDefaultsDialogModel);
   const canAssignActiveRole =
     modelDefaultsDialogModel !== null &&
-    canAssignAsActiveModel(modelDefaultsDialogModel, modelDefaultsDialogModel.name === activeModel);
+    canAssignAsActiveModel(
+      modelDefaultsDialogModel,
+      modelDefaultsDialogRef !== null && modelRefsEqual(modelDefaultsDialogRef, activeModel),
+    );
   const canAssignImageGenerationRole =
     modelDefaultsDialogModel !== null &&
     canAssignAsImageGenerationModel(
       modelDefaultsDialogModel,
-      modelDefaultsDialogModel.name === imageGenerationModel,
+      imageGenerationModel !== undefined
+        && modelDefaultsDialogRef !== null
+        && modelRefsEqual(modelDefaultsDialogRef, imageGenerationModel),
     );
   const canAssignVideoGenerationRole =
     modelDefaultsDialogModel !== null &&
     canAssignAsVideoGenerationModel(
       modelDefaultsDialogModel,
-      modelDefaultsDialogModel.name === videoGenerationModel,
+      videoGenerationModel !== undefined
+        && modelDefaultsDialogRef !== null
+        && modelRefsEqual(modelDefaultsDialogRef, videoGenerationModel),
     );
   const canAssignLightweightChatRole =
     modelDefaultsDialogModel !== null &&
     canAssignAsLightweightChatModel(
       modelDefaultsDialogModel,
-      modelDefaultsDialogModel.name === lightweightChatModel,
+      lightweightChatModel !== undefined
+        && modelDefaultsDialogRef !== null
+        && modelRefsEqual(modelDefaultsDialogRef, lightweightChatModel),
     );
-  const isModelDefaultsDialogModelActive = modelDefaultsDialogModel?.name === activeModel;
+  const isModelDefaultsDialogModelActive =
+    modelDefaultsDialogRef !== null && modelRefsEqual(modelDefaultsDialogRef, activeModel);
   const isModelDefaultsDialogModelLightweight =
-    modelDefaultsDialogModel?.name === lightweightChatModel;
+    lightweightChatModel !== undefined
+    && modelDefaultsDialogRef !== null
+    && modelRefsEqual(modelDefaultsDialogRef, lightweightChatModel);
   const hasModelDefaultAssignmentChanges =
     modelDefaultsDialogModel !== null &&
     (modelDefaultAssignments.activeModel !== isModelDefaultsDialogModelActive ||
       modelDefaultAssignments.imageGenerationModel !==
-        (modelDefaultsDialogModel.name === imageGenerationModel) ||
+        (modelDefaultsDialogRef !== null
+          && imageGenerationModel !== undefined
+          && modelRefsEqual(modelDefaultsDialogRef, imageGenerationModel)) ||
       modelDefaultAssignments.videoGenerationModel !==
-        (modelDefaultsDialogModel.name === videoGenerationModel) ||
+        (modelDefaultsDialogRef !== null
+          && videoGenerationModel !== undefined
+          && modelRefsEqual(modelDefaultsDialogRef, videoGenerationModel)) ||
       modelDefaultAssignments.lightweightChatModel !== isModelDefaultsDialogModelLightweight);
 
   const catalogDetailByModelName = useMemo(
@@ -220,18 +249,29 @@ export function ModelsSettingsPanel({
     [models, snapshot?.config.modelCatalogHints],
   );
 
-  const providerGroups = new Map<DesktopModelProvider, typeof models>();
-  const standaloneModels: typeof models = [];
-  for (const model of models) {
-    if (model.provider && model.provider !== "custom") {
-      const group = providerGroups.get(model.provider) ?? [];
-      group.push(model);
-      providerGroups.set(model.provider, group);
-    } else {
-      standaloneModels.push(model);
+  function groupDisplayLabel(group: ProviderGroupV2): string {
+    const custom = group.label?.trim();
+    if (custom) {
+      return custom;
     }
+    return providerLabel(group.provider);
   }
 
+  function modelsForGroup(group: ProviderGroupV2): SettingsModelProfile[] {
+    return group.models
+      .map((entry) =>
+        models.find((model) => model.groupId === group.id && model.name === entry.name),
+      )
+      .filter((model): model is SettingsModelProfile => model !== undefined);
+  }
+
+  function resolveConnectGroupId(provider: DesktopModelProvider): string {
+    if (provider === "custom") {
+      const label = connectCustomGroupLabel.trim();
+      return label ? slugifyProviderGroupLabel(label) : defaultPresetProviderGroupId("custom");
+    }
+    return defaultPresetProviderGroupId(provider);
+  }
   function providerLabel(provider: DesktopModelProvider): string {
     const row = PROVIDER_PICKER_ROWS.find((item) => item.id === provider);
     return row ? String(t(row.labelKey, { defaultValue: row.fallbackLabel })) : provider;
@@ -255,6 +295,7 @@ export function ModelsSettingsPanel({
     setConnectProviderSite("");
     setConnectAlibabaBillingMode("standard");
     setConnectAlibabaWorkspaceId("");
+    setConnectCustomGroupLabel("");
     setCustomConnectMode("single");
     setBedrockConnectMode("bearer");
     setVertexConnectMode("adc");
@@ -289,6 +330,7 @@ export function ModelsSettingsPanel({
     setConnectCapabilities(defaultCustomModelCapabilities);
     resetConnectTransportKindForProvider(id);
     setConnectAlibabaBillingMode("standard");
+    setConnectCustomGroupLabel("");
     setCustomConnectMode("single");
     setBedrockConnectMode("bearer");
     setVertexConnectMode("adc");
@@ -359,12 +401,16 @@ export function ModelsSettingsPanel({
       : providerLabel(selectedProvider);
 
   const openModelDefaultsDialog = (model: SettingsModelProfile) => {
-    setModelDefaultsDialogTarget(model.name);
+    const modelRef = settingsModelRef(model);
+    setModelDefaultsDialogTarget(modelRefKey(modelRef));
     setModelDefaultAssignments({
-      activeModel: model.name === activeModel,
-      imageGenerationModel: model.name === imageGenerationModel,
-      videoGenerationModel: model.name === videoGenerationModel,
-      lightweightChatModel: model.name === lightweightChatModel,
+      activeModel: modelRefsEqual(modelRef, activeModel),
+      imageGenerationModel:
+        imageGenerationModel !== undefined && modelRefsEqual(modelRef, imageGenerationModel),
+      videoGenerationModel:
+        videoGenerationModel !== undefined && modelRefsEqual(modelRef, videoGenerationModel),
+      lightweightChatModel:
+        lightweightChatModel !== undefined && modelRefsEqual(modelRef, lightweightChatModel),
     });
     setModelDefaultsDialogOpen(true);
   };
@@ -389,49 +435,52 @@ export function ModelsSettingsPanel({
 
     const patch: Partial<SettingsFormState> = {};
 
-    if (modelDefaultAssignments.activeModel && modelDefaultsDialogModel.name !== activeModel) {
-      patch.activeModel = modelDefaultsDialogModel.name;
+    if (modelDefaultAssignments.activeModel && !modelRefsEqual(modelDefaultsDialogRef!, activeModel)) {
+      patch.activeModel = modelDefaultsDialogRef!;
     }
 
     if (canAssignImageGenerationRole) {
       if (
-        modelDefaultAssignments.imageGenerationModel &&
-        modelDefaultsDialogModel.name !== imageGenerationModel
+        modelDefaultAssignments.imageGenerationModel
+        && (imageGenerationModel === undefined || !modelRefsEqual(modelDefaultsDialogRef!, imageGenerationModel))
       ) {
-        patch.imageGenerationModel = modelDefaultsDialogModel.name;
+        patch.imageGenerationModel = modelDefaultsDialogRef!;
       } else if (
-        !modelDefaultAssignments.imageGenerationModel &&
-        modelDefaultsDialogModel.name === imageGenerationModel
+        !modelDefaultAssignments.imageGenerationModel
+        && imageGenerationModel !== undefined
+        && modelRefsEqual(modelDefaultsDialogRef!, imageGenerationModel)
       ) {
-        patch.imageGenerationModel = "";
+        patch.imageGenerationModel = undefined;
       }
     }
 
     if (canAssignVideoGenerationRole) {
       if (
-        modelDefaultAssignments.videoGenerationModel &&
-        modelDefaultsDialogModel.name !== videoGenerationModel
+        modelDefaultAssignments.videoGenerationModel
+        && (videoGenerationModel === undefined || !modelRefsEqual(modelDefaultsDialogRef!, videoGenerationModel))
       ) {
-        patch.videoGenerationModel = modelDefaultsDialogModel.name;
+        patch.videoGenerationModel = modelDefaultsDialogRef!;
       } else if (
-        !modelDefaultAssignments.videoGenerationModel &&
-        modelDefaultsDialogModel.name === videoGenerationModel
+        !modelDefaultAssignments.videoGenerationModel
+        && videoGenerationModel !== undefined
+        && modelRefsEqual(modelDefaultsDialogRef!, videoGenerationModel)
       ) {
-        patch.videoGenerationModel = "";
+        patch.videoGenerationModel = undefined;
       }
     }
 
     if (canAssignLightweightChatRole) {
       if (
-        modelDefaultAssignments.lightweightChatModel &&
-        modelDefaultsDialogModel.name !== lightweightChatModel
+        modelDefaultAssignments.lightweightChatModel
+        && (lightweightChatModel === undefined || !modelRefsEqual(modelDefaultsDialogRef!, lightweightChatModel))
       ) {
-        patch.lightweightChatModel = modelDefaultsDialogModel.name;
+        patch.lightweightChatModel = modelDefaultsDialogRef!;
       } else if (
-        !modelDefaultAssignments.lightweightChatModel &&
-        modelDefaultsDialogModel.name === lightweightChatModel
+        !modelDefaultAssignments.lightweightChatModel
+        && lightweightChatModel !== undefined
+        && modelRefsEqual(modelDefaultsDialogRef!, lightweightChatModel)
       ) {
-        patch.lightweightChatModel = "";
+        patch.lightweightChatModel = undefined;
       }
     }
 
@@ -450,20 +499,22 @@ export function ModelsSettingsPanel({
   ) => {
     const patch: Partial<SettingsFormState> = {};
 
+    const modelRef = settingsModelRef(model);
+
     if (role === "activeModel") {
-      if (model.name !== activeModel) {
-        patch.activeModel = model.name;
+      if (!modelRefsEqual(modelRef, activeModel)) {
+        patch.activeModel = modelRef;
       }
     } else if (role === "imageGenerationModel") {
-      if (model.name !== imageGenerationModel) {
-        patch.imageGenerationModel = model.name;
+      if (imageGenerationModel === undefined || !modelRefsEqual(modelRef, imageGenerationModel)) {
+        patch.imageGenerationModel = modelRef;
       }
     } else if (role === "videoGenerationModel") {
-      if (model.name !== videoGenerationModel) {
-        patch.videoGenerationModel = model.name;
+      if (videoGenerationModel === undefined || !modelRefsEqual(modelRef, videoGenerationModel)) {
+        patch.videoGenerationModel = modelRef;
       }
-    } else if (model.name !== lightweightChatModel) {
-      patch.lightweightChatModel = model.name;
+    } else if (lightweightChatModel === undefined || !modelRefsEqual(modelRef, lightweightChatModel)) {
+      patch.lightweightChatModel = modelRef;
     }
 
     if (Object.keys(patch).length === 0) {
@@ -629,6 +680,7 @@ export function ModelsSettingsPanel({
       throw new Error(t('settings.noModelsReturned'));
     }
     const bulk: AddProviderModelsRequest = {
+      groupId: resolveConnectGroupId(selectedProvider),
       apiBase: effectiveApiBase,
       apiKey: connectApiKey,
       modelIds: res.modelIds,
@@ -683,12 +735,16 @@ export function ModelsSettingsPanel({
       contextLength = parsed;
     }
     await onAddModel({
+      groupId: resolveConnectGroupId("custom"),
       name,
       apiBase,
       apiKey: connectApiKey,
       provider: "custom",
       transportKind: connectTransportKind,
       capabilities: normalizeModelCapabilitySelection(connectCapabilities),
+      ...(connectCustomGroupLabel.trim()
+        ? { customGroupLabel: connectCustomGroupLabel.trim() }
+        : {}),
       ...(contextLength !== undefined ? { contextLength } : {}),
     });
     setConnectDialogOpen(false);
@@ -720,6 +776,7 @@ export function ModelsSettingsPanel({
       contextLength = parsed;
     }
     await onAddModel({
+      groupId: defaultPresetProviderGroupId("amazon-bedrock"),
       name,
       apiBase: isBedrockMantleOpenAiModel(name)
         ? bedrockMantleApiBaseFromRegion(awsRegion)
@@ -765,6 +822,7 @@ export function ModelsSettingsPanel({
       contextLength = parsed;
     }
     await onAddModel({
+      groupId: defaultPresetProviderGroupId("azure"),
       name,
       apiBase: azureApiBaseFromResourceName(azureResourceName),
       apiKey: connectApiKey,
@@ -798,6 +856,7 @@ export function ModelsSettingsPanel({
       contextLength = parsed;
     }
     await onAddModel({
+      groupId: defaultPresetProviderGroupId("google-vertex-ai"),
       name,
       apiBase: "",
       apiKey: connectApiKey,
@@ -832,17 +891,22 @@ export function ModelsSettingsPanel({
           </div>
         ) : (
           <>
-            {Array.from(providerGroups.entries()).map(([provider, groupModels]) => {
+            {configProviderGroups.map((group) => {
+              const groupModels = modelsForGroup(group);
+              if (groupModels.length === 0) {
+                return null;
+              }
               const groupHasKey = groupModels.some((m) => m.keyConfigured);
+              const groupLabel = groupDisplayLabel(group);
               return (
                 <div
-                  key={provider}
+                  key={group.id}
                   className="rounded-lg border border-border/40 bg-background/80"
                 >
                   <div className="flex items-center justify-between gap-3 border-b border-border/35 px-4 py-3">
                     <div className="flex min-w-0 items-center gap-2">
                       <span className="text-sm font-semibold text-foreground">
-                        {providerLabel(provider)}
+                        {groupLabel}
                       </span>
                       <Badge variant="secondary" className="text-muted-foreground shrink-0">
                         {groupModels.length} {t('settings.modelsCount')}
@@ -859,22 +923,27 @@ export function ModelsSettingsPanel({
                       size="sm"
                       className="shrink-0"
                       disabled={modelsBusy || modelsPreviewBusy}
-                      onClick={() => setDeleteGroupTarget(provider)}
+                      onClick={() => setDeleteGroupTarget(group.id)}
                     >
                       {t('settings.deleteGroup')}
                     </Button>
                   </div>
-                  {providerSupportsModelCatalogDetail(provider)
+                  {providerSupportsModelCatalogDetail(group.provider)
                   && groupModels.some((model) => catalogDetailByModelName.has(model.name)) ? (
                     <Tooltip<SettingsModelProfile>
-                      getItemId={(model) => model.name}
+                      getItemId={(model) => modelRefKey(settingsModelRef(model))}
                       delayDuration={300}
                     >
                       <Tooltip.Zone className="divide-y divide-border/35">
                         {groupModels.map((model) => {
-                          const isActive = model.name === activeModel;
-                          const isImageDefault = model.name === imageGenerationModel;
-                          const isLightweightDefault = model.name === lightweightChatModel;
+                          const modelRef = settingsModelRef(model);
+                          const isActive = modelRefsEqual(modelRef, activeModel);
+                          const isImageDefault =
+                            imageGenerationModel !== undefined
+                            && modelRefsEqual(modelRef, imageGenerationModel);
+                          const isLightweightDefault =
+                            lightweightChatModel !== undefined
+                            && modelRefsEqual(modelRef, lightweightChatModel);
                           const supportedDefaultRoles = getSupportedModelDefaultRoles(
                             model,
                             activeModel,
@@ -893,7 +962,7 @@ export function ModelsSettingsPanel({
                           if (!hasDetail) {
                             return (
                               <ModelSettingsRowButton
-                                key={model.name}
+                                key={modelRefKey(modelRef)}
                                 model={model}
                                 displayTitle={displayTitle}
                                 isActive={isActive}
@@ -942,7 +1011,7 @@ export function ModelsSettingsPanel({
                             <ModelCatalogDetailPanel
                               model={row}
                               catalogEntry={catalogEntry}
-                              providerLabel={providerLabel(provider)}
+                              providerLabel={groupLabel}
                             />
                           );
                         }}
@@ -951,9 +1020,14 @@ export function ModelsSettingsPanel({
                   ) : (
                     <div className="divide-y divide-border/35">
                       {groupModels.map((model) => {
-                        const isActive = model.name === activeModel;
-                        const isImageDefault = model.name === imageGenerationModel;
-                        const isLightweightDefault = model.name === lightweightChatModel;
+                        const modelRef = settingsModelRef(model);
+                        const isActive = modelRefsEqual(modelRef, activeModel);
+                        const isImageDefault =
+                          imageGenerationModel !== undefined
+                          && modelRefsEqual(modelRef, imageGenerationModel);
+                        const isLightweightDefault =
+                          lightweightChatModel !== undefined
+                          && modelRefsEqual(modelRef, lightweightChatModel);
                         const supportedDefaultRoles = getSupportedModelDefaultRoles(
                           model,
                           activeModel,
@@ -968,7 +1042,7 @@ export function ModelsSettingsPanel({
                         );
                         return (
                           <ModelSettingsRowButton
-                            key={model.name}
+                            key={modelRefKey(modelRef)}
                             model={model}
                             displayTitle={displayTitle}
                             isActive={isActive}
@@ -985,119 +1059,6 @@ export function ModelsSettingsPanel({
                 </div>
               );
             })}
-            {standaloneModels.length > 0 && (
-              <div className="overflow-hidden divide-y divide-border/35 rounded-lg border border-border/40 bg-background/80">
-                {standaloneModels.map((model) => {
-                  const isActive = model.name === activeModel;
-                  const isImageDefault = model.name === imageGenerationModel;
-                  const isLightweightDefault = model.name === lightweightChatModel;
-                  const supportedDefaultRoles = getSupportedModelDefaultRoles(
-                    model,
-                    activeModel,
-                    imageGenerationModel,
-                    videoGenerationModel,
-                    lightweightChatModel,
-                  );
-                  const defaultActionLabel = modelDefaultActionLabel(supportedDefaultRoles);
-                  const isStandaloneModelDisabled = modelsBusy || modelsPreviewBusy;
-                  const displayTitle = modelDisplayTitleFromMap(
-                    model.name,
-                    displayTitleByModelName,
-                  );
-                  const rowAriaLabel = modelSettingsRowAriaLabel(
-                    defaultActionLabel,
-                    model.name,
-                    displayTitle,
-                  );
-                  return (
-                    <div
-                      key={model.name}
-                      role="button"
-                      tabIndex={isStandaloneModelDisabled ? -1 : 0}
-                      aria-disabled={isStandaloneModelDisabled}
-                      title={rowAriaLabel}
-                      aria-label={rowAriaLabel}
-                      className={cn(
-                        "flex flex-col gap-3 px-4 py-4 outline-none sm:flex-row sm:items-center sm:justify-between sm:gap-4",
-                        !isStandaloneModelDisabled &&
-                          "cursor-pointer hover:bg-foreground/[0.06] dark:hover:bg-foreground/10 focus-visible:ring-2 focus-visible:ring-ring/50",
-                      )}
-                      onClick={() => {
-                        if (isStandaloneModelDisabled) {
-                          return;
-                        }
-                        handleModelDefaultAction(model);
-                      }}
-                      onKeyDown={(event) => {
-                        if (
-                          isStandaloneModelDisabled ||
-                          event.target !== event.currentTarget ||
-                          (event.key !== "Enter" && event.key !== " ")
-                        ) {
-                          return;
-                        }
-                        event.preventDefault();
-                        handleModelDefaultAction(model);
-                      }}
-                    >
-                      <div className="min-w-0 flex-1 space-y-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                          <span className="text-sm font-medium text-foreground">
-                            {displayTitle}
-                          </span>
-                          {isActive ? (
-                            <Badge variant="secondary" className="text-muted-foreground">
-                              {t('settings.currentInference')}
-                            </Badge>
-                          ) : null}
-                          {isImageDefault ? (
-                            <Badge variant="secondary" className="text-muted-foreground">
-                              {t('settings.currentImageGen')}
-                            </Badge>
-                          ) : null}
-                          {isLightweightDefault ? (
-                            <Badge variant="secondary" className="text-muted-foreground">
-                              {t('settings.currentLightweightChat')}
-                            </Badge>
-                          ) : null}
-                          {model.keyConfigured ? (
-                            <Badge variant="secondary" className="text-muted-foreground">
-                              {t('settings.keySaved')}
-                            </Badge>
-                          ) : null}
-                          {model.capabilities?.map((capability) => (
-                            <Badge key={capability} variant="outline" className="text-muted-foreground">
-                              {modelCapabilityLabel(capability)}
-                            </Badge>
-                          ))}
-                        </div>
-                        <p
-                          className="truncate text-xs text-muted-foreground"
-                          title={model.apiBase}
-                        >
-                          {model.apiBase}
-                        </p>
-                      </div>
-                      <div className="flex shrink-0 items-center gap-2 self-start sm:self-center">
-                        <Button
-                          type="button"
-                          variant="destructive"
-                          size="sm"
-                          className="shrink-0"
-                          disabled={modelsBusy || modelsPreviewBusy}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            setDeleteTarget(model.name);
-                          }}
-                        >
-                          {t('common.delete')}
-                        </Button>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
           </>
         )}
       </div>
@@ -1347,7 +1308,15 @@ export function ModelsSettingsPanel({
           <DialogHeader>
             <DialogTitle>{t('settings.deleteProviderGroup')}</DialogTitle>
             <DialogDescription>
-              {t('settings.deleteProviderGroupConfirm', { provider: deleteGroupTarget ? providerLabel(deleteGroupTarget) : '' })}
+              {t('settings.deleteProviderGroupConfirm', {
+                provider: deleteGroupTarget
+                  ? (configProviderGroups.find((group) => group.id === deleteGroupTarget)
+                      ? groupDisplayLabel(
+                          configProviderGroups.find((group) => group.id === deleteGroupTarget)!,
+                        )
+                      : deleteGroupTarget)
+                  : '',
+              })}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -1367,13 +1336,13 @@ export function ModelsSettingsPanel({
               size="sm"
               disabled={modelsBusy || !deleteGroupTarget}
               onClick={() => {
-                const provider = deleteGroupTarget;
-                if (!provider) {
+                const groupId = deleteGroupTarget;
+                if (!groupId) {
                   return;
                 }
                 void (async () => {
                   try {
-                    await onRemoveProviderModels(provider);
+                    await onRemoveProviderModels(groupId);
                     setDeleteGroupTarget(null);
                   } catch {
                     /* runtimeError */
@@ -1563,6 +1532,18 @@ export function ModelsSettingsPanel({
                     <p className="text-xs leading-5 text-muted-foreground">{transportSummary}</p>
                   ) : null;
                 })()}
+              </div>
+            ) : null}
+            {selectedProvider === "custom" ? (
+              <div className="grid gap-2">
+                <Label htmlFor="connect-custom-group-label">{t('settings.customGroupLabel')}</Label>
+                <DesktopFormInput
+                  id="connect-custom-group-label"
+                  value={connectCustomGroupLabel}
+                  onChange={(e) => setConnectCustomGroupLabel(e.target.value)}
+                  placeholder={t('settings.customGroupLabelPlaceholder')}
+                  autoComplete="off"
+                />
               </div>
             ) : null}
             {selectedProvider === "custom" ? (

--- a/apps/desktop/src/components/settings/models/models-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/models/models-settings-panel.tsx
@@ -57,7 +57,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   hasBedrockIamCredentials,
   hasGoogleVertexServiceAccountCredentials,
-} from "@/host/provider-api-key";
+} from "@/lib/provider-runtime-credentials";
 import {
   PROVIDER_PICKER_ROWS,
   defaultProviderConnectSite,
@@ -65,7 +65,7 @@ import {
   providerConnectSiteRequiresWorkspaceId,
   providerSupportsSiteSelection,
   resolveProviderConnectApiBase,
-} from "@/host/provider-presets";
+} from "@spiritagent/host-internal/model-provider-presets";
 import {
   buildModelCatalogDetailMap,
   buildModelCatalogDisplayTitleMap,
@@ -97,7 +97,7 @@ import {
   defaultPresetProviderGroupId,
   modelRefsEqual,
   slugifyProviderGroupLabel,
-} from "@spiritagent/host-internal";
+} from "@spiritagent/host-internal/config-v2";
 import {
   bedrockMantleApiBaseFromRegion,
   isBedrockMantleOpenAiModel,

--- a/apps/desktop/src/components/settings/types.ts
+++ b/apps/desktop/src/components/settings/types.ts
@@ -15,11 +15,11 @@ import type {
   DeleteSkillRequest,
   DesktopDreamOverviewItem,
   DesktopMcpServerInspection,
-  DesktopModelProvider,
   DesktopSnapshot,
   GitHubAuthStatus,
   GitHubDeviceAuthChallenge,
   ImportExtensionRequest,
+  ModelRef,
   PreviewModelsRequest,
   PreviewModelsResponse,
   SaveHookEntryRequest,
@@ -28,10 +28,10 @@ import type {
 } from "@/types";
 
 export type SettingsFormState = {
-  activeModel: string;
-  imageGenerationModel: string;
-  videoGenerationModel: string;
-  lightweightChatModel: string;
+  activeModel: ModelRef;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
+  lightweightChatModel?: ModelRef;
   apiBase: string;
   uiLocale: string;
   apiKey: string;
@@ -77,7 +77,7 @@ export type SettingsViewProps = {
   onAddProviderModels: (request: AddProviderModelsRequest) => Promise<void>;
   onPreviewModels: (request: PreviewModelsRequest) => Promise<PreviewModelsResponse>;
   onRemoveModel: (name: string) => Promise<void>;
-  onRemoveProviderModels: (provider: DesktopModelProvider) => Promise<void>;
+  onRemoveProviderModels: (groupId: string) => Promise<void>;
   onAddMcpServer: (request: AddMcpServerRequest) => Promise<void>;
   onImportExtension: (request: ImportExtensionRequest) => Promise<void>;
   onDeleteExtension: (request: DeleteExtensionRequest) => Promise<void>;

--- a/apps/desktop/src/components/shell-tool-command-highlight.tsx
+++ b/apps/desktop/src/components/shell-tool-command-highlight.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useMemo, useState } from "react";
+import type { TokensResult } from "shiki";
+
+import {
+  plainHighlightResult,
+  renderHighlightedCodeLines,
+  trimTrailingNewlines,
+} from "@/lib/spirit-message-code-highlight";
+import { spiritShikiCodePlugin } from "@/lib/spirit-shiki-code-plugin";
+import { SPIRIT_SHIKI_PLUS_THEMES } from "@/lib/spirit-shiki-themes";
+import { cn } from "@/lib/utils";
+
+const SHELL_HIGHLIGHT_LANGUAGE = "shell";
+const SHELL_HIGHLIGHT_THEMES = [...SPIRIT_SHIKI_PLUS_THEMES] as ["light-plus", "dark-plus"];
+
+export function ShellToolCommandHighlight({ command }: { command: string }) {
+  const normalizedCode = useMemo(() => trimTrailingNewlines(command), [command]);
+  const plainResult = useMemo(() => plainHighlightResult(normalizedCode), [normalizedCode]);
+  const [result, setResult] = useState<TokensResult>(plainResult);
+  const supportsShell = spiritShikiCodePlugin.supportsLanguage(SHELL_HIGHLIGHT_LANGUAGE);
+
+  useEffect(() => {
+    setResult(plainResult);
+    if (!supportsShell) {
+      return;
+    }
+
+    const syncResult = spiritShikiCodePlugin.highlight(
+      { code: normalizedCode, language: SHELL_HIGHLIGHT_LANGUAGE, themes: SHELL_HIGHLIGHT_THEMES },
+      (highlighted) => {
+        setResult(highlighted as TokensResult);
+      },
+    );
+    if (syncResult) {
+      setResult(syncResult as TokensResult);
+    }
+  }, [normalizedCode, plainResult, supportsShell]);
+
+  return (
+    <pre
+      className={cn(
+        "min-w-0 flex-1 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed",
+        "bg-transparent p-0 text-muted-foreground",
+      )}
+    >
+      <code>
+        <span className="select-none text-muted-foreground/75">$ </span>
+        {renderHighlightedCodeLines(result, { firstLineInline: true })}
+      </code>
+    </pre>
+  );
+}

--- a/apps/desktop/src/components/spirit-streamdown-markdown.tsx
+++ b/apps/desktop/src/components/spirit-streamdown-markdown.tsx
@@ -1,5 +1,4 @@
 import { useMemo, type ComponentProps, type ComponentType } from "react";
-import { createCodePlugin } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { Streamdown, type BlockProps } from "streamdown";
 
@@ -21,11 +20,9 @@ import { createSpiritStreamdownCodeComponent } from "@/lib/spirit-streamdown-cod
 
 const streamdownMathPlugin = math;
 
-import { SPIRIT_SHIKI_PLUS_THEMES } from "@/lib/spirit-shiki-themes";
+import { spiritShikiCodePlugin } from "@/lib/spirit-shiki-code-plugin";
 
-const spiritStreamdownCodePlugin = createCodePlugin({
-  themes: [...SPIRIT_SHIKI_PLUS_THEMES],
-});
+const spiritStreamdownCodePlugin = spiritShikiCodePlugin;
 
 export const spiritStreamdownControls = {
   code: { copy: false, download: false },

--- a/apps/desktop/src/components/work-location-menu.tsx
+++ b/apps/desktop/src/components/work-location-menu.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { WorkLocationKind } from "@spiritagent/host-internal";
+import type { WorkLocationKind } from "@spiritagent/host-internal/work-location";
 import type { LucideIcon } from "lucide-react";
 import { ChevronDown, GitFork, Monitor } from "lucide-react";
 import { useTranslation } from "react-i18next";

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -64,6 +64,7 @@ declare global {
     previewModels(request: PreviewModelsRequest): Promise<PreviewModelsResponse>;
     removeModel(name: string): Promise<DesktopSnapshot>;
     removeProviderModels(provider: DesktopModelProvider): Promise<DesktopSnapshot>;
+    removeProviderGroup(request: import('./types').RemoveProviderGroupRequest): Promise<DesktopSnapshot>;
     addMcpServer(request: AddMcpServerRequest): Promise<DesktopSnapshot>;
     deleteMcpServer(request: DeleteMcpServerRequest): Promise<DesktopSnapshot>;
     saveHookEntry(request: SaveHookEntryRequest): Promise<DesktopSnapshot>;

--- a/apps/desktop/src/env.d.ts
+++ b/apps/desktop/src/env.d.ts
@@ -46,6 +46,9 @@ import type {
   HostTextFileStatResult,
   WriteHostTextFileRequest,
   WriteWorkspaceTextFileRequest,
+  ApprovalLevel,
+  LocalFileComposerRoute,
+  WorkLocationKind,
 } from './types';
 
 declare global {
@@ -93,9 +96,9 @@ declare global {
     compactHistory(): Promise<DesktopSnapshot>;
     submitUserTurn(request: SubmitUserTurnRequest): Promise<DesktopSnapshot>;
     setLoopEnabled(enabled: boolean): Promise<DesktopSnapshot>;
-    setApprovalLevel(approvalLevel: import('@spiritagent/host-internal').ApprovalLevel): Promise<DesktopSnapshot>;
+    setApprovalLevel(approvalLevel: ApprovalLevel): Promise<DesktopSnapshot>;
     setPendingGitBranch(branch: string): Promise<DesktopSnapshot>;
-    setWorkLocation(workLocation: import('@spiritagent/host-internal').WorkLocationKind): Promise<DesktopSnapshot>;
+    setWorkLocation(workLocation: WorkLocationKind): Promise<DesktopSnapshot>;
     checkoutGitBranch(request: import('./types.js').CheckoutGitBranchRequest): Promise<DesktopSnapshot>;
     mergeWorktreeToMain(): Promise<DesktopSnapshot>;
     pushGitBranch(): Promise<DesktopSnapshot>;
@@ -242,7 +245,7 @@ declare global {
     statHostTextFile(absolutePath: string): Promise<HostTextFileStatResult>;
     classifyLocalFileComposerRoute(
       absolutePath: string,
-    ): Promise<import('@spiritagent/host-internal').LocalFileComposerRoute>;
+    ): Promise<LocalFileComposerRoute>;
     pickWorkspaceDirectory(): Promise<string | null>;
     pickLocalFile(): Promise<string | null>;
     getPathForDroppedFile(file: File): string;

--- a/apps/desktop/src/hooks/useComposerController.ts
+++ b/apps/desktop/src/hooks/useComposerController.ts
@@ -300,7 +300,7 @@ export function useComposerController({
     const mode = isAgentModeChipKind(runtime.settings.agentMode)
       ? runtime.settings.agentMode
       : currentAgentModeSegment(composerSegments);
-    if (!isAgentModeChipKind(mode)) {
+    if (mode === undefined || !isAgentModeChipKind(mode)) {
       return undefined;
     }
     if (mode === "plan") {

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -6,6 +6,8 @@ import i18n, { getStoredLanguage } from "@/lib/i18n";
 
 import type { SettingsFormState } from "@/components/settings/types";
 import { useHostApi } from "@/hooks/useHostApi";
+import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal";
+import type { ModelRef } from "@/types";
 import {
   buildPaneComposerDraftKey,
   readComposerDraft,
@@ -393,10 +395,10 @@ export function useDesktopRuntime() {
   const [approvalGuidance, setApprovalGuidance] = useState("");
   const [questionError, setQuestionError] = useState("");
   const [settings, setSettings] = useState<SettingsFormState>({
-    activeModel: "",
-    imageGenerationModel: "",
-    videoGenerationModel: "",
-    lightweightChatModel: "",
+    activeModel: emptyModelRef(),
+    imageGenerationModel: undefined,
+    videoGenerationModel: undefined,
+    lightweightChatModel: undefined,
     apiBase: "",
     uiLocale: getStoredLanguage(),
     apiKey: "",
@@ -728,8 +730,11 @@ export function useDesktopRuntime() {
     });
     setRuntimeError(effectiveNext.runtimeError ?? "");
     setSettings((current) => {
-      const activeModelProfile = effectiveNext.config.models.find(
-        (model) => model.name === effectiveNext.config.activeModel,
+      const activeModelProfile = effectiveNext.config.models.find((model) =>
+        modelRefsEqual(
+          model.ref ?? { groupId: model.groupId ?? "", name: model.name },
+          effectiveNext.config.activeModel,
+        ),
       );
       const configAgentMode = (effectiveNext.config.agentMode ?? "agent") as DesktopAgentMode;
       // 回合进行中 poll 可能仍带旧 config.agentMode；勿覆盖用户 dismiss Chip 后 saveSettingsPatch 的乐观 agentMode。
@@ -760,10 +765,10 @@ export function useDesktopRuntime() {
           : snapshotWindowsMica;
 
       return {
-        activeModel: next.config.activeModel,
-        imageGenerationModel: next.config.imageGenerationModel ?? "",
-        videoGenerationModel: next.config.videoGenerationModel ?? "",
-        lightweightChatModel: next.config.lightweightChatModel ?? "",
+        activeModel: effectiveNext.config.activeModel,
+        imageGenerationModel: effectiveNext.config.imageGenerationModel,
+        videoGenerationModel: effectiveNext.config.videoGenerationModel,
+        lightweightChatModel: effectiveNext.config.lightweightChatModel,
         apiBase: activeModelProfile?.apiBase ?? current.apiBase,
         uiLocale: next.config.uiLocale ?? getStoredLanguage(),
         apiKey: current.apiKey,
@@ -1418,6 +1423,8 @@ export function useDesktopRuntime() {
         && Boolean(nextPath)
         && prevPath !== nextPath
         && busyActionRef.current !== 'session'
+        && prevPath
+        && nextPath
         && !isProvisionalSessionPromotion(prevPath, nextPath);
       if (blockForegroundSwap && previous) {
         applySnapshot({
@@ -1574,16 +1581,21 @@ export function useDesktopRuntime() {
   );
 
   const setActiveModel = useCallback(
-    (name: string) => {
+    (modelRef: ModelRef) => {
       if (!snapshot) {
         return;
       }
 
-      const model = snapshot.config.models.find((item) => item.name === name);
+      const model = snapshot.config.models.find((item) =>
+        modelRefsEqual(
+          item.ref ?? { groupId: item.groupId ?? "", name: item.name },
+          modelRef,
+        ),
+      );
       const current = settingsRef.current;
       const next: typeof settings = {
         ...current,
-        activeModel: name,
+        activeModel: modelRef,
         apiBase: model?.apiBase ?? current.apiBase,
       };
       settingsRef.current = next;
@@ -1701,14 +1713,14 @@ export function useDesktopRuntime() {
   );
 
   const removeProviderModels = useCallback(
-    async (provider: DesktopModelProvider) => {
+    async (groupId: string) => {
       if (!api) {
         return;
       }
 
       setBusyAction("models");
       try {
-        const next = await api.removeProviderModels(provider);
+        const next = await api.removeProviderGroup({ groupId });
         applySnapshot(next);
         setRuntimeError("");
       } catch (error) {
@@ -2149,8 +2161,12 @@ export function useDesktopRuntime() {
       const resolvedApiBase =
         patch.apiBase ??
         (patch.activeModel !== undefined
-          ? snapshotRef.current?.config.models.find((model) => model.name === nextActiveModel)?.apiBase ??
-            prev.apiBase
+          ? snapshotRef.current?.config.models.find((model) =>
+              modelRefsEqual(
+                model.ref ?? { groupId: model.groupId ?? "", name: model.name },
+                nextActiveModel,
+              ),
+            )?.apiBase ?? prev.apiBase
           : prev.apiBase);
       const s = {
         ...prev,
@@ -2192,19 +2208,24 @@ export function useDesktopRuntime() {
   );
 
   const setModelReasoningEffort = useCallback(
-    async (name: string, reasoningEffort: DesktopModelReasoningEffort) => {
+    async (modelRef: ModelRef, reasoningEffort: DesktopModelReasoningEffort) => {
       if (!api || !snapshot) {
         return;
       }
 
-      const model = snapshot.config.models.find((item) => item.name === name);
+      const model = snapshot.config.models.find((item) =>
+        modelRefsEqual(
+          item.ref ?? { groupId: item.groupId ?? "", name: item.name },
+          modelRef,
+        ),
+      );
       if (!model) {
         return;
       }
 
       const next = {
         ...settingsRef.current,
-        activeModel: model.name,
+        activeModel: modelRef,
         apiBase: model.apiBase,
       };
       settingsRef.current = next;
@@ -2230,12 +2251,17 @@ export function useDesktopRuntime() {
   );
 
   const setModelThinkingEnabled = useCallback(
-    async (name: string, enabled: boolean): Promise<boolean> => {
+    async (modelRef: ModelRef, enabled: boolean): Promise<boolean> => {
       if (!api || !snapshot) {
         return false;
       }
 
-      const model = snapshot.config.models.find((item) => item.name === name);
+      const model = snapshot.config.models.find((item) =>
+        modelRefsEqual(
+          item.ref ?? { groupId: item.groupId ?? "", name: item.name },
+          modelRef,
+        ),
+      );
       if (!model) {
         return false;
       }
@@ -2243,7 +2269,7 @@ export function useDesktopRuntime() {
       const previousSettings = settingsRef.current;
       const next = {
         ...previousSettings,
-        activeModel: model.name,
+        activeModel: modelRef,
         apiBase: model.apiBase,
       };
       settingsRef.current = next;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -6,7 +6,7 @@ import i18n, { getStoredLanguage } from "@/lib/i18n";
 
 import type { SettingsFormState } from "@/components/settings/types";
 import { useHostApi } from "@/hooks/useHostApi";
-import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal";
+import { emptyModelRef, modelRefsEqual } from "@spiritagent/host-internal/config-v2";
 import type { ModelRef } from "@/types";
 import {
   buildPaneComposerDraftKey,
@@ -109,6 +109,9 @@ import type {
   ListGitHubPullRequestsRequest,
   SearchGitHubAutomationRepositoriesRequest,
   MergeGitHubPullRequestRequest,
+  ApprovalLevel,
+  LocalFileComposerRoute,
+  WorkLocationKind,
 } from "@/types";
 
 type BusyAction =
@@ -1064,7 +1067,7 @@ export function useDesktopRuntime() {
   );
 
   const setPaneWorkLocation = useCallback(
-    async (sessionPath: string, workLocation: import('@spiritagent/host-internal').WorkLocationKind): Promise<boolean> => {
+    async (sessionPath: string, workLocation: WorkLocationKind): Promise<boolean> => {
       if (!api?.setPaneWorkLocation) {
         return false;
       }
@@ -1160,7 +1163,7 @@ export function useDesktopRuntime() {
   }, [api]);
 
   const classifyLocalFileComposerRoute = useCallback(
-    async (absolutePath: string): Promise<import('@spiritagent/host-internal').LocalFileComposerRoute> => {
+    async (absolutePath: string): Promise<LocalFileComposerRoute> => {
       if (!api) {
         return 'reference';
       }
@@ -2588,7 +2591,7 @@ export function useDesktopRuntime() {
     }
   }, [api, applySnapshot]);
 
-  const setApprovalLevel = useCallback(async (approvalLevel: import('@spiritagent/host-internal').ApprovalLevel): Promise<boolean> => {
+  const setApprovalLevel = useCallback(async (approvalLevel: ApprovalLevel): Promise<boolean> => {
     if (!api) {
       return false;
     }
@@ -2622,7 +2625,7 @@ export function useDesktopRuntime() {
   }, [api, applySnapshot]);
 
   const setWorkLocation = useCallback(async (
-    workLocation: import('@spiritagent/host-internal').WorkLocationKind,
+    workLocation: WorkLocationKind,
   ): Promise<boolean> => {
     if (!api) {
       return false;

--- a/apps/desktop/src/hooks/useDesktopRuntime.ts
+++ b/apps/desktop/src/hooks/useDesktopRuntime.ts
@@ -1028,13 +1028,13 @@ export function useDesktopRuntime() {
   );
 
   const switchPaneModel = useCallback(
-    async (sessionPath: string, modelName: string): Promise<boolean> => {
+    async (sessionPath: string, modelRef: ModelRef): Promise<boolean> => {
       if (!api?.switchPaneModel) {
         return false;
       }
 
       try {
-        const next = await api.switchPaneModel({ sessionPath, modelName });
+        const next = await api.switchPaneModel({ sessionPath, modelRef });
         applySnapshot(next);
         setQuestionError("");
         setRuntimeError("");

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -38,6 +38,7 @@ import type {
   SaveHookEntryRequest,
   UpdateExtensionSecretRequest,
   UpdateExtensionSettingsRequest,
+  RemoveProviderGroupRequest,
   PreviewModelsRequest,
   PreviewModelsResponse,
   QueryWorkspaceFileReferenceSuggestionsRequest,
@@ -114,6 +115,7 @@ export interface HostApi {
   previewModels(request: PreviewModelsRequest): Promise<PreviewModelsResponse>;
   removeModel(name: string): Promise<DesktopSnapshot>;
   removeProviderModels(provider: DesktopModelProvider): Promise<DesktopSnapshot>;
+  removeProviderGroup(request: RemoveProviderGroupRequest): Promise<DesktopSnapshot>;
   addMcpServer(request: AddMcpServerRequest): Promise<DesktopSnapshot>;
   deleteMcpServer(request: DeleteMcpServerRequest): Promise<DesktopSnapshot>;
   saveHookEntry(request: SaveHookEntryRequest): Promise<DesktopSnapshot>;

--- a/apps/desktop/src/host-api.ts
+++ b/apps/desktop/src/host-api.ts
@@ -97,6 +97,9 @@ import type {
   SubmitSkillSlashRequest,
   UpdateConfigRequest,
   InstallLspProviderRequest,
+  ApprovalLevel,
+  LocalFileComposerRoute,
+  WorkLocationKind,
 } from './types';
 
 import { createElectronHostApi } from './adapters/electron';
@@ -144,9 +147,9 @@ export interface HostApi {
   compactHistory(): Promise<DesktopSnapshot>;
   submitUserTurn(request: SubmitUserTurnRequest): Promise<DesktopSnapshot>;
   setLoopEnabled(enabled: boolean): Promise<DesktopSnapshot>;
-  setApprovalLevel(approvalLevel: import('@spiritagent/host-internal').ApprovalLevel): Promise<DesktopSnapshot>;
+  setApprovalLevel(approvalLevel: ApprovalLevel): Promise<DesktopSnapshot>;
   setPendingGitBranch(branch: string): Promise<DesktopSnapshot>;
-  setWorkLocation(workLocation: import('@spiritagent/host-internal').WorkLocationKind): Promise<DesktopSnapshot>;
+  setWorkLocation(workLocation: WorkLocationKind): Promise<DesktopSnapshot>;
   checkoutGitBranch(request: CheckoutGitBranchRequest): Promise<DesktopSnapshot>;
   mergeWorktreeToMain(): Promise<DesktopSnapshot>;
   pushGitBranch(): Promise<DesktopSnapshot>;
@@ -266,7 +269,7 @@ export interface HostApi {
   readHostTextFile(absolutePath: string): Promise<WorkspaceReadTextFileResult>;
   writeHostTextFile(request: WriteHostTextFileRequest): Promise<void>;
   statHostTextFile(absolutePath: string): Promise<HostTextFileStatResult>;
-  classifyLocalFileComposerRoute(absolutePath: string): Promise<import('@spiritagent/host-internal').LocalFileComposerRoute>;
+  classifyLocalFileComposerRoute(absolutePath: string): Promise<LocalFileComposerRoute>;
   pickWorkspaceDirectory?(): Promise<string | null>;
   pickLocalFile?(): Promise<string | null>;
   getPathForDroppedFile?(file: File): string;

--- a/apps/desktop/src/host/active-model-sync.ts
+++ b/apps/desktop/src/host/active-model-sync.ts
@@ -1,18 +1,20 @@
+import { modelRefsEqual } from '@spiritagent/host-internal';
+
+import type { ModelRef } from '../types.js';
+import type { DesktopConfigFile } from './storage.js';
+import { resolvePaneModelRef } from './model-config-access.js';
 import type { SessionBundle } from './session-bundle.js';
 
 export interface HostActiveModelState {
-  config: {
-    activeModel: string;
-    models: Array<{ name: string }>;
-  };
+  config: Pick<DesktopConfigFile, 'activeModel' | 'providerGroups'>;
 }
 
 export function resolveEffectivePaneActiveModel(
   bundle: Pick<SessionBundle, 'activeModel'>,
   state: HostActiveModelState,
-): string {
-  const fromBundle = bundle.activeModel?.trim();
-  if (fromBundle && state.config.models.some((model) => model.name === fromBundle)) {
+): ModelRef {
+  const fromBundle = resolvePaneModelRef(state.config, bundle.activeModel);
+  if (fromBundle) {
     return fromBundle;
   }
   return state.config.activeModel;
@@ -23,14 +25,14 @@ export function needsHostActiveModelSync(
   state: HostActiveModelState,
 ): boolean {
   const effective = resolveEffectivePaneActiveModel(bundle, state);
-  return effective !== state.config.activeModel;
+  return !modelRefsEqual(effective, state.config.activeModel);
 }
 
 export function resolvePaneModelProjection(input: {
   bundle: SessionBundle;
   state: HostActiveModelState;
   isForegroundActive: boolean;
-}): { activeModel: string } | undefined {
+}): { activeModel: ModelRef } | undefined {
   if (input.isForegroundActive) {
     return undefined;
   }
@@ -45,8 +47,8 @@ export function freezePaneActiveModelIfNeeded(
   bundle: SessionBundle,
   state: HostActiveModelState,
 ): void {
-  if (!bundle.activeModel?.trim()) {
-    bundle.activeModel = state.config.activeModel;
+  if (!resolvePaneModelRef(state.config, bundle.activeModel)) {
+    bundle.activeModel = { ...state.config.activeModel };
   }
 }
 

--- a/apps/desktop/src/host/auto-approval-review.ts
+++ b/apps/desktop/src/host/auto-approval-review.ts
@@ -22,7 +22,7 @@ export function createDesktopAutoApprovalReviewer(input: {
       return undefined;
     }
 
-    const apiKey = await resolveApiKeyForConfigModel(input.config, resolved.name);
+    const apiKey = await resolveApiKeyForConfigModel(input.config, resolved.profile.ref);
     if (!apiKey) {
       return undefined;
     }

--- a/apps/desktop/src/host/automation-runner.ts
+++ b/apps/desktop/src/host/automation-runner.ts
@@ -24,7 +24,15 @@ import {
 import { createDesktopRewindMetadata } from './rewind.js';
 import { buildStoredDesktopSession } from './sessions.js';
 import { buildPrimaryTransportConfig, resolveDesktopTransportKind } from './model-config.js';
+import {
+  findProviderGroup,
+  flattenProviderGroups,
+  modelExistsInGroup,
+  resolveModelProfile,
+  type ResolvedModelProfile,
+} from './model-config-access.js';
 import { modelProviderKeyScope } from './provider-api-key.js';
+import { findModelRefByName } from './model-config-access.js';
 import {
   chatsDirPath,
   loadHostMetadata,
@@ -80,12 +88,16 @@ export async function runDesktopAutomationOnce(
   deps.onRunUpdated?.(input.definition.id);
 
   try {
-    const apiKey = await resolveApiKeyForConfigModel(input.config, input.definition.modelName);
+    const modelRef = findModelRefByName(input.config, input.definition.modelName);
+    if (!modelRef) {
+      throw new Error(`Model not found: ${input.definition.modelName}`);
+    }
+    const apiKey = await resolveApiKeyForConfigModel(input.config, modelRef);
     if (!apiKey) {
       throw new Error(`Missing API key for model: ${input.definition.modelName}`);
     }
 
-    const profile = input.config.models.find((model) => model.name === input.definition.modelName);
+    const profile = resolveModelProfile(input.config, modelRef);
     const workspaceBinding = isNoWorkspaceSessionRoot(input.definition.workspaceRoot)
       ? 'none'
       : 'project';
@@ -104,7 +116,7 @@ export async function runDesktopAutomationOnce(
       model: input.definition.modelName,
       baseUrl: profile?.apiBase ?? currentApiBase(input.config),
       workspaceRoot: input.definition.workspaceRoot,
-      profile,
+      profile: profile ?? undefined,
       reasoningEffort: input.definition.reasoningEffort ?? profile?.reasoningEffort,
     });
 
@@ -310,8 +322,8 @@ function buildAutomationTransportConfig(input: {
   model: string;
   baseUrl: string;
   workspaceRoot: string;
-  profile?: DesktopConfigFile['models'][number];
-  reasoningEffort?: DesktopConfigFile['models'][number]['reasoningEffort'];
+  profile?: ResolvedModelProfile;
+  reasoningEffort?: ResolvedModelProfile['reasoningEffort'];
 }): LlmTransportConfig {
   const transportKind = resolveDesktopTransportKind(input.profile);
   const bedrockCredentials = transportKind === 'bedrock' && input.profile?.provider

--- a/apps/desktop/src/host/automation-runner.ts
+++ b/apps/desktop/src/host/automation-runner.ts
@@ -31,8 +31,8 @@ import {
   resolveModelProfile,
   type ResolvedModelProfile,
 } from './model-config-access.js';
+import { modelRefKey } from '@spiritagent/host-internal/config-v2';
 import { modelProviderKeyScope } from './provider-api-key.js';
-import { findModelRefByName } from './model-config-access.js';
 import {
   chatsDirPath,
   loadHostMetadata,
@@ -88,13 +88,13 @@ export async function runDesktopAutomationOnce(
   deps.onRunUpdated?.(input.definition.id);
 
   try {
-    const modelRef = findModelRefByName(input.config, input.definition.modelName);
-    if (!modelRef) {
-      throw new Error(`Model not found: ${input.definition.modelName}`);
+    const modelRef = input.definition.modelRef;
+    if (!modelExistsInGroup(input.config, modelRef.groupId, modelRef.name)) {
+      throw new Error(`Model not found: ${modelRefKey(modelRef)}`);
     }
     const apiKey = await resolveApiKeyForConfigModel(input.config, modelRef);
     if (!apiKey) {
-      throw new Error(`Missing API key for model: ${input.definition.modelName}`);
+      throw new Error(`Missing API key for model: ${modelRefKey(modelRef)}`);
     }
 
     const profile = resolveModelProfile(input.config, modelRef);
@@ -113,7 +113,7 @@ export async function runDesktopAutomationOnce(
 
     const transportConfig = buildAutomationTransportConfig({
       apiKey,
-      model: input.definition.modelName,
+      model: modelRef.name,
       baseUrl: profile?.apiBase ?? currentApiBase(input.config),
       workspaceRoot: input.definition.workspaceRoot,
       profile: profile ?? undefined,

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -16,7 +16,7 @@ import {
 } from '@spiritagent/host-internal';
 
 import { cloneDesktopConfig } from './service-utils.js';
-import { findModelRefByName } from './model-config-access.js';
+import { modelExistsInGroup } from './model-config-access.js';
 import { loadGitHubAccessToken } from './github-auth-storage.js';
 import { spiritAgentDataDir, type DesktopConfigFile } from './storage.js';
 import { runDesktopAutomationOnce } from './automation-runner.js';
@@ -347,5 +347,9 @@ export function automationDefinitionNeedsApiKey(
   definition: HostAutomationDefinition,
   config: DesktopConfigFile,
 ): boolean {
-  return findModelRefByName(config, definition.modelName) !== undefined;
+  return modelExistsInGroup(
+    config,
+    definition.modelRef.groupId,
+    definition.modelRef.name,
+  );
 }

--- a/apps/desktop/src/host/automation-scheduler-service.ts
+++ b/apps/desktop/src/host/automation-scheduler-service.ts
@@ -16,6 +16,7 @@ import {
 } from '@spiritagent/host-internal';
 
 import { cloneDesktopConfig } from './service-utils.js';
+import { findModelRefByName } from './model-config-access.js';
 import { loadGitHubAccessToken } from './github-auth-storage.js';
 import { spiritAgentDataDir, type DesktopConfigFile } from './storage.js';
 import { runDesktopAutomationOnce } from './automation-runner.js';
@@ -346,5 +347,5 @@ export function automationDefinitionNeedsApiKey(
   definition: HostAutomationDefinition,
   config: DesktopConfigFile,
 ): boolean {
-  return config.models.some((model) => model.name === definition.modelName);
+  return findModelRefByName(config, definition.modelName) !== undefined;
 }

--- a/apps/desktop/src/host/code-completion-commands.ts
+++ b/apps/desktop/src/host/code-completion-commands.ts
@@ -75,7 +75,7 @@ export async function requestCodeCompletionCommand(
       return { operations: [] };
     }
 
-    const apiKey = await resolveApiKeyForConfigModel(context.config, resolved.name);
+    const apiKey = await resolveApiKeyForConfigModel(context.config, resolved.profile.ref);
     if (!apiKey) {
       return { operations: [] };
     }

--- a/apps/desktop/src/host/contracts.ts
+++ b/apps/desktop/src/host/contracts.ts
@@ -22,6 +22,7 @@ export type HostCommandName =
   | 'previewModels'
   | 'removeModel'
   | 'removeProviderModels'
+  | 'removeProviderGroup'
   | 'addMcpServer'
   | 'deleteMcpServer'
   | 'saveHookEntry'

--- a/apps/desktop/src/host/direct-media-turn.ts
+++ b/apps/desktop/src/host/direct-media-turn.ts
@@ -27,6 +27,11 @@ import { isWorktreeBootstrapInFlight } from './worktree-bootstrap-card.js';
 import { syncRuntimeHistoryFromBundleArchive } from './conversation-continuation.js';
 import type { SessionTurnOrchestratorContext } from './session-turn-orchestrator.js';
 import type { DesktopConfigFile } from './storage.js';
+import type { ModelRef } from '../types.js';
+import {
+  flattenProviderGroups,
+  resolveModelProfile,
+} from './model-config-access.js';
 import type { DesktopToolExecutor } from './tool-executor.js';
 
 export interface DirectMediaTurnInput {
@@ -148,12 +153,12 @@ async function validateDirectMediaTurnSetup(
   input: DirectMediaTurnInput,
 ): Promise<void> {
   const config = ctx.requireConfig();
-  const profile = config.models.find((model) => model.name === config.activeModel);
+  const profile = resolveModelProfile(config, config.activeModel);
   if (!profile) {
-    throw new Error(i18n.t('error.modelNotFound', { model: config.activeModel }));
+    throw new Error(i18n.t('error.modelNotFound', { model: config.activeModel.name }));
   }
 
-  const apiKey = await ctx.resolveApiKeyForConfigModel(profile.name);
+  const apiKey = await ctx.resolveApiKeyForConfigModel(profile.ref);
   if (!apiKey) {
     throw new Error(i18n.t('error.apiKeyNotConfigured'));
   }
@@ -168,12 +173,12 @@ async function runDirectMediaGeneration(
   request: DesktopToolRequest,
 ): Promise<void> {
   const config = ctx.requireConfig();
-  const profile = config.models.find((model) => model.name === config.activeModel);
+  const profile = resolveModelProfile(config, config.activeModel);
   if (!profile) {
-    throw new Error(i18n.t('error.modelNotFound', { model: config.activeModel }));
+    throw new Error(i18n.t('error.modelNotFound', { model: config.activeModel.name }));
   }
 
-  const apiKey = await ctx.resolveApiKeyForConfigModel(profile.name);
+  const apiKey = await ctx.resolveApiKeyForConfigModel(profile.ref);
   if (!apiKey) {
     throw new Error(i18n.t('error.apiKeyNotConfigured'));
   }
@@ -298,17 +303,28 @@ export async function startComposerDirectMediaTurn(
 
 export function shouldUseComposerDirectMediaTurn(
   config: DesktopConfigFile,
-  activeModel: string,
+  activeModel: ModelRef,
   explicitWorkspaceFileCount: number,
 ): DirectMediaTool | null {
-  const directMediaTool = resolveComposerDirectMediaTool(activeModel, config);
+  const activeProfile = resolveModelProfile(config, activeModel);
+  if (!activeProfile) {
+    return null;
+  }
+  const directMediaTool = resolveComposerDirectMediaTool(activeModel, {
+    models: flattenProviderGroups(config).map((model) => ({
+      name: model.name,
+      capabilities: model.capabilities,
+    })),
+    imageGenerationModel: config.imageGenerationModel,
+    videoGenerationModel: config.videoGenerationModel,
+  });
   if (!directMediaTool) {
     return null;
   }
   if (explicitWorkspaceFileCount > 0) {
     console.debug(
       '[desktop][composer-direct-media] attachments present; falling back to chat',
-      { activeModel, tool: directMediaTool },
+      { activeModel: activeProfile.name, tool: directMediaTool },
     );
     return null;
   }

--- a/apps/desktop/src/host/dream-collector-service.ts
+++ b/apps/desktop/src/host/dream-collector-service.ts
@@ -103,7 +103,7 @@ export function startDreamCollectorIfNeeded(ctx: DreamCollectorServiceContext): 
   const collectorInput = {
     workspaceRoot: state.workspaceRoot,
     gitBranch: state.git.branch,
-    collectorModel: lightweightModel.name,
+    collectorModel: lightweightModel.profile.ref,
     config: cloneDesktopConfig(state.config),
     planMetadata: buildDreamCollectorPlanMetadata(state.metadata.planMetadata),
   };

--- a/apps/desktop/src/host/dreams.ts
+++ b/apps/desktop/src/host/dreams.ts
@@ -24,10 +24,12 @@ import {
 import type {
   ConversationMessageSnapshot,
   DesktopDreamCollectorSnapshot,
+  ModelRef,
   SessionListItem,
 } from '../types.js';
 import type { DesktopToolRequest, StoredDesktopSession } from './contracts.js';
 import { buildPrimaryTransportConfig, resolveDesktopTransportKind } from './model-config.js';
+import { resolveModelProfile, type ResolvedModelProfile } from './model-config-access.js';
 import { modelProviderKeyScope } from './provider-api-key.js';
 import {
   chatsDirPath,
@@ -144,7 +146,7 @@ export function buildDreamCollectorPlanMetadata(
 export interface RunDesktopDreamCollectorOnceInput {
   workspaceRoot: string;
   gitBranch: string;
-  collectorModel: string;
+  collectorModel: ModelRef;
   config: DesktopConfigFile;
   planMetadata: LlmPlanMetadata;
 }
@@ -210,12 +212,14 @@ export async function runDesktopDreamCollectorOnce(
       pendingCount: pendingSessions.length,
     }));
 
+    const activeProfile = resolveModelProfile(input.config, input.collectorModel);
+    if (!activeProfile) {
+      throw new Error(i18n.t('error.dreamCollectorApiKeyMissing'));
+    }
     const apiKey = await resolveApiKeyForConfigModel(input.config, input.collectorModel);
     if (!apiKey) {
       throw new Error(i18n.t('error.dreamCollectorApiKeyMissing'));
     }
-
-    const activeProfile = input.config.models.find((model) => model.name === input.collectorModel);
     const archive = await loadStoredSession(sourceSession.path);
     const sessionProgress = sessionProgressMap.get(sourceSession.path);
     const sourceContext = buildDreamCollectorSourceContext(archive, sessionProgress);
@@ -252,7 +256,7 @@ export async function runDesktopDreamCollectorOnce(
     const runtime = deps.createRuntime(
       buildDreamCollectorTransportConfig({
         apiKey,
-        model: input.collectorModel,
+        model: activeProfile.name,
         baseUrl: activeProfile?.apiBase ?? currentApiBase(input.config),
         workspaceRoot: input.workspaceRoot,
         profile: activeProfile,
@@ -298,7 +302,7 @@ export async function runDesktopDreamCollectorOnce(
         runId,
         workspaceRoot: input.workspaceRoot,
         gitBranch: input.gitBranch,
-        collectorModel: input.collectorModel,
+        collectorModel: input.collectorModel.name,
         sourceSession,
         prompt: promptForDebug,
         assistantText: result.assistantText,
@@ -329,7 +333,7 @@ export async function runDesktopDreamCollectorOnce(
       finishedAtUnixMs: Date.now(),
       workspaceRoot: input.workspaceRoot,
       gitBranch: input.gitBranch,
-      collectorModel: input.collectorModel,
+      collectorModel: input.collectorModel.name,
       sourceSessionPath: sourceSession.path,
       decision: 'processed',
       ...(sourceContextMode ? { sourceContextMode } : {}),
@@ -344,7 +348,7 @@ export async function runDesktopDreamCollectorOnce(
         runId,
         workspaceRoot: input.workspaceRoot,
         gitBranch: input.gitBranch,
-        collectorModel: input.collectorModel,
+        collectorModel: input.collectorModel.name,
         sourceSession,
         prompt: promptForDebug,
         assistantText: error instanceof Error ? error.message : String(error),
@@ -357,7 +361,7 @@ export async function runDesktopDreamCollectorOnce(
       finishedAtUnixMs: Date.now(),
       workspaceRoot: input.workspaceRoot,
       gitBranch: input.gitBranch,
-      collectorModel: input.collectorModel,
+      collectorModel: input.collectorModel.name,
       ...(sourceSession ? { sourceSessionPath: sourceSession.path } : {}),
       decision: 'failed',
       ...(sourceContextMode ? { sourceContextMode } : {}),
@@ -657,7 +661,7 @@ function buildDreamCollectorTransportConfig(input: {
   model: string;
   baseUrl: string;
   workspaceRoot: string;
-  profile?: DesktopConfigFile['models'][number];
+  profile?: ResolvedModelProfile;
 }): LlmTransportConfig {
   const transportKind = resolveDesktopTransportKind(input.profile);
   const bedrockCredentials = transportKind === 'bedrock' && input.profile?.provider

--- a/apps/desktop/src/host/host-command-payloads.ts
+++ b/apps/desktop/src/host/host-command-payloads.ts
@@ -26,6 +26,7 @@ import type {
   InstallMarketplaceExtensionRequest,
   PrepareMarketplaceExtensionInstallRequest,
   PreviewModelsRequest,
+  RemoveProviderGroupRequest,
   QueryWorkspaceFileReferenceSuggestionsRequest,
   RecordCodeCompletionFileStateRequest,
   RequestCodeCompletionRequest,
@@ -109,6 +110,7 @@ export type CommandPayloads = {
   previewModels: { request: PreviewModelsRequest };
   removeModel: { request: RemoveModelRequest };
   removeProviderModels: { request: RemoveProviderModelsRequest };
+  removeProviderGroup: { request: RemoveProviderGroupRequest };
   addMcpServer: { request: AddMcpServerRequest };
   deleteMcpServer: { request: DeleteMcpServerRequest };
   saveHookEntry: { request: SaveHookEntryRequest };

--- a/apps/desktop/src/host/host-invoke-dispatch.ts
+++ b/apps/desktop/src/host/host-invoke-dispatch.ts
@@ -14,6 +14,7 @@ export interface HostCommandDelegate {
   previewModels(request: CommandPayloads['previewModels']['request']): Promise<unknown>;
   removeModel(request: CommandPayloads['removeModel']['request']): Promise<unknown>;
   removeProviderModels(request: CommandPayloads['removeProviderModels']['request']): Promise<unknown>;
+  removeProviderGroup(request: CommandPayloads['removeProviderGroup']['request']): Promise<unknown>;
   addMcpServer(request: CommandPayloads['addMcpServer']['request']): Promise<unknown>;
   deleteMcpServer(request: CommandPayloads['deleteMcpServer']['request']): Promise<unknown>;
   saveHookEntry(request: CommandPayloads['saveHookEntry']['request']): Promise<unknown>;
@@ -191,6 +192,7 @@ const hostCommandDispatch = {
   previewModels: (host, payload) => host.previewModels(payload.request),
   removeModel: (host, payload) => host.removeModel(payload.request),
   removeProviderModels: (host, payload) => host.removeProviderModels(payload.request),
+  removeProviderGroup: (host, payload) => host.removeProviderGroup(payload.request),
   addMcpServer: (host, payload) => host.addMcpServer(payload.request),
   deleteMcpServer: (host, payload) => host.deleteMcpServer(payload.request),
   saveHookEntry: (host, payload) => host.saveHookEntry(payload.request),

--- a/apps/desktop/src/host/host-model-commands.ts
+++ b/apps/desktop/src/host/host-model-commands.ts
@@ -1,7 +1,14 @@
 import {
+  defaultPresetProviderGroupId,
+  isEmptyModelRef,
+  modelRefKey,
+  modelRefsEqual,
   parseModelProviderId,
   parsePresetModelProviderId,
-  partitionModelsByProvider,
+  slugifyProviderGroupLabel,
+  type ModelEntryV2,
+  type ModelRef,
+  type ProviderGroupV2,
 } from '@spiritagent/host-internal';
 import {
   defaultModelReasoningEffort,
@@ -27,6 +34,7 @@ import type {
   PreviewModelsRequest,
   PreviewModelsResponse,
   RemoveModelRequest,
+  RemoveProviderGroupRequest,
   RemoveProviderModelsRequest,
   UpdateConfigRequest,
 } from '../types.js';
@@ -40,8 +48,6 @@ import {
   resolveAddedModelCapabilities,
   resolveDesktopTransportKind,
   resolveProfileApiBase,
-  supportsImageGeneration,
-  supportsVideoGeneration,
 } from './model-config.js';
 import {
   bedrockApiBaseFromRegion,
@@ -56,13 +62,21 @@ import {
 import { bedrockMantleApiBaseFromRegion, isBedrockMantleOpenAiModel } from '@spiritagent/host-internal/bedrock-mantle';
 import { modelSupportsChat } from './lightweight-chat-model.js';
 import {
-  modelExistsInProviderScope,
   applyModelsRemovalToConfig,
+  filterNewGroupModelIds,
   type ModelRemovalTarget,
 } from './provider-api-key.js';
 import {
+  flattenProviderGroups,
+  findProviderGroup,
+  modelExistsInGroup,
+  modelSupportsImageGeneration,
+  modelSupportsVideoGeneration,
+  normalizeSlotModelRef,
+  resolveModelProfile,
+} from './model-config-access.js';
+import {
   loadHostMetadata,
-  modelProviderKeyScope,
   normalizeDreamConfig,
   normalizeAgentsConfig,
   normalizeNetworksConfig,
@@ -70,6 +84,8 @@ import {
   applyLlmHttpVersionFromConfig,
   normalizeModelCapabilities,
   normalizeWebHostConfig,
+  removeBedrockProviderCredentials,
+  removeGoogleVertexProviderCredentials,
   removeModelApiKey,
   removeProviderApiKey,
   saveApiKeyForModel,
@@ -77,7 +93,6 @@ import {
   saveBedrockProviderCredentialsForProvider,
   saveGoogleVertexProviderCredentialsForProvider,
   saveConfig,
-  readBedrockProviderCredentialsFromKeyring,
   type DesktopConfigFile,
   type DesktopWorkspaceBinding,
   type HostMetadataSummary,
@@ -99,7 +114,7 @@ interface HostModelState {
 
 interface HostModelBundle {
   activePlanPath?: string;
-  activeModel?: string;
+  activeModel?: ModelRef;
   deferredRuntimeRefreshWhileBusy: boolean;
 }
 
@@ -122,6 +137,214 @@ export interface HostModelCommandContext {
   refreshLspSnapshot(): Promise<void>;
 }
 
+interface ConnectRequestFields {
+  groupId: string;
+  provider?: DesktopModelProvider;
+  customGroupLabel?: string;
+  transportKind?: DesktopTransportKind;
+  apiBase: string;
+  awsRegion?: string;
+  providerSite?: DesktopProviderConnectSiteId;
+  alibabaWorkspaceId?: string;
+  alibabaBillingMode?: DesktopAlibabaBillingMode;
+  vertexProject?: string;
+  vertexLocation?: string;
+  azureResourceName?: string;
+}
+
+interface ModelEntryLocation {
+  group: ProviderGroupV2;
+  model: ModelEntryV2;
+}
+
+function asModelEntryReasoningEffort(
+  value: ModelReasoningEffort,
+): ModelEntryV2['reasoningEffort'] {
+  return value as ModelEntryV2['reasoningEffort'];
+}
+
+function asModelEntrySupportedReasoningEfforts(
+  value: DesktopModelReasoningEffort[],
+): NonNullable<ModelEntryV2['supportedReasoningEfforts']> {
+  return value as NonNullable<ModelEntryV2['supportedReasoningEfforts']>;
+}
+
+function resolveConnectGroupId(input: ConnectRequestFields): string {
+  const provider = input.provider;
+  if (provider === 'custom') {
+    const label = input.customGroupLabel?.trim();
+    if (label) {
+      return slugifyProviderGroupLabel(label);
+    }
+    const groupId = input.groupId.trim();
+    if (groupId) {
+      return groupId;
+    }
+    throw new Error(i18n.t('error.modelNameRequired'));
+  }
+  const explicitGroupId = input.groupId.trim();
+  if (explicitGroupId) {
+    return explicitGroupId;
+  }
+  if (provider) {
+    return defaultPresetProviderGroupId(provider);
+  }
+  throw new Error(i18n.t('error.modelNameRequired'));
+}
+
+function findModelEntryInConfig(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  ref: ModelRef,
+): ModelEntryLocation | null {
+  const group = findProviderGroup(config, ref.groupId);
+  if (!group) {
+    return null;
+  }
+  const model = group.models.find((entry) => entry.name === ref.name.trim());
+  if (!model) {
+    return null;
+  }
+  return { group, model };
+}
+
+function buildProviderGroupConnect(
+  input: ConnectRequestFields & { modelName?: string },
+): Omit<ProviderGroupV2, 'id' | 'models'> {
+  const provider = input.provider ?? 'custom';
+  const transportKind = resolveDesktopTransportKind({
+    provider,
+    transportKind: input.transportKind,
+  });
+  const apiBase = resolveManagedConnectApiBase(
+    provider,
+    transportKind,
+    input.apiBase,
+    input.awsRegion,
+    input.modelName,
+    input.vertexProject,
+    input.vertexLocation,
+    input.azureResourceName,
+    input.providerSite,
+    input.alibabaWorkspaceId,
+    input.alibabaBillingMode,
+  );
+  const group: Omit<ProviderGroupV2, 'id' | 'models'> = {
+    provider,
+    apiBase,
+  };
+  const label = input.customGroupLabel?.trim();
+  if (provider === 'custom' && label) {
+    group.label = label;
+  }
+  if (transportKind === 'anthropic' || transportKind === 'open-responses' || transportKind === 'bedrock') {
+    group.transportKind = transportKind;
+  }
+  if (provider === 'amazon-bedrock' && input.awsRegion?.trim()) {
+    group.awsRegion = input.awsRegion.trim();
+  }
+  if (provider === 'azure' && input.azureResourceName?.trim()) {
+    group.azureResourceName = input.azureResourceName.trim();
+  }
+  if (provider === 'google-vertex-ai') {
+    if (input.vertexProject?.trim()) {
+      group.vertexProject = input.vertexProject.trim();
+    }
+    if (input.vertexLocation?.trim()) {
+      group.vertexLocation = input.vertexLocation.trim();
+    }
+  }
+  applyManagedProviderConnectFields(group, {
+    provider,
+    providerSite: input.providerSite,
+    alibabaWorkspaceId: input.alibabaWorkspaceId,
+    alibabaBillingMode: input.alibabaBillingMode,
+  });
+  return group;
+}
+
+function findOrCreateProviderGroup(
+  config: DesktopConfigFile,
+  groupId: string,
+  connect: Omit<ProviderGroupV2, 'id' | 'models'>,
+): ProviderGroupV2 {
+  const existing = findProviderGroup(config, groupId);
+  if (existing) {
+    Object.assign(existing, connect);
+    return existing;
+  }
+  const created: ProviderGroupV2 = {
+    id: groupId,
+    ...connect,
+    models: [],
+  };
+  config.providerGroups.push(created);
+  return created;
+}
+
+function existingModelsForGroupAdd(config: DesktopConfigFile) {
+  return flattenProviderGroups(config).map((profile) => ({
+    groupId: profile.groupId,
+    name: profile.name,
+    provider: profile.provider,
+    ...(profile.vertexProject ? { vertexProject: profile.vertexProject } : {}),
+    ...(profile.vertexLocation ? { vertexLocation: profile.vertexLocation } : {}),
+  }));
+}
+
+async function saveGroupCredentials(
+  groupId: string,
+  provider: DesktopModelProvider,
+  input: {
+    apiKey: string;
+    accessKeyId?: string;
+    secretAccessKey?: string;
+    vertexClientEmail?: string;
+    vertexPrivateKey?: string;
+  },
+): Promise<void> {
+  if (provider === 'amazon-bedrock') {
+    await saveBedrockProviderCredentialsForProvider(groupId, {
+      apiKey: input.apiKey,
+      accessKeyId: input.accessKeyId,
+      secretAccessKey: input.secretAccessKey,
+    });
+    return;
+  }
+  if (provider === 'google-vertex-ai') {
+    await saveGoogleVertexProviderCredentialsForProvider(groupId, {
+      apiKey: input.apiKey,
+      clientEmail: input.vertexClientEmail,
+      privateKey: input.vertexPrivateKey,
+    });
+    return;
+  }
+  await saveApiKeyForProvider(groupId, input.apiKey);
+}
+
+async function clearGroupCredentials(groupId: string, provider: DesktopModelProvider): Promise<void> {
+  if (provider === 'amazon-bedrock') {
+    await saveBedrockProviderCredentialsForProvider(groupId, {});
+    return;
+  }
+  if (provider === 'google-vertex-ai') {
+    await saveGoogleVertexProviderCredentialsForProvider(groupId, {});
+    return;
+  }
+  await removeProviderApiKey(groupId);
+}
+
+async function removeGroupKeyring(groupId: string, provider: DesktopModelProvider): Promise<void> {
+  if (provider === 'amazon-bedrock') {
+    await removeBedrockProviderCredentials(groupId);
+    return;
+  }
+  if (provider === 'google-vertex-ai') {
+    await removeGoogleVertexProviderCredentials(groupId);
+    return;
+  }
+  await removeProviderApiKey(groupId);
+}
+
 export async function updateConfigCommand(
   ctx: HostModelCommandContext,
   request: UpdateConfigRequest,
@@ -136,9 +359,7 @@ export async function updateConfigCommand(
     const prevApiBase = currentApiBase(state.config);
     const prevAgentMode = resolveDesktopAgentMode(state.config);
     const prevLspEnabled = state.config.agents.lsp.enabled;
-    const prevActiveModelProfile = state.config.models.find(
-      (model) => model.name === state.config.activeModel,
-    );
+    const prevActiveModelProfile = resolveModelProfile(state.config, state.config.activeModel);
     const prevActiveModelInference = prevActiveModelProfile
       ? {
           thinkingEnabled: prevActiveModelProfile.thinkingEnabled,
@@ -150,112 +371,119 @@ export async function updateConfigCommand(
       throw new Error(i18n.t('error.runtimeBusy'));
     }
 
-    const activeModel = request.activeModel.trim();
+    const activeRef = request.activeModel;
     const apiBase = request.apiBase.trim();
     const reasoningEffort = request.reasoningEffort;
     const thinkingEnabled = request.thinkingEnabled;
-    let existing = activeModel
-      ? state.config.models.find((model) => model.name === activeModel)
-      : undefined;
-    if (activeModel) {
-      if (existing) {
-        if (existing.provider && existing.provider !== 'custom') {
-          // 仅切换 activeModel 时归一化 apiBase；agentMode 等无关 patch 不得把已存 endpoint 打回 provider 默认站点
-          if (state.config.activeModel !== activeModel) {
-            existing.apiBase = resolveProfileApiBase(existing);
-          }
-        } else {
-          existing.apiBase = apiBase;
-        }
-        if (reasoningEffort !== undefined) {
-          existing.reasoningEffort = resolveModelReasoningEffortForContext(reasoningEffort, {
-            ...(existing.provider ? { provider: existing.provider } : {}),
-            model: existing.name,
-            ...(existing.transportKind ? { transportKind: existing.transportKind } : {}),
-            ...(existing.supportedReasoningEfforts !== undefined
-              ? { supportedEfforts: existing.supportedReasoningEfforts }
-              : {}),
-          });
-        }
-        if (thinkingEnabled !== undefined) {
-          const modelContext = {
-            ...(existing.provider ? { provider: existing.provider } : {}),
-            model: existing.name,
-            ...(existing.transportKind ? { transportKind: existing.transportKind } : {}),
-            ...(existing.supportedReasoningEfforts !== undefined
-              ? { supportedEfforts: existing.supportedReasoningEfforts }
-              : {}),
-            ...(existing.supportsThinkingType
-              ? { supportsThinkingType: existing.supportsThinkingType }
-              : {}),
-          };
-          if (thinkingEnabled) {
-            delete existing.thinkingEnabled;
-          } else {
-            existing.thinkingEnabled = false;
-          }
-          if (shouldPinReasoningEffortToDefault(thinkingEnabled, modelContext)) {
-            existing.reasoningEffort = resolveModelReasoningEffortForContext('default', modelContext);
-          }
+    let activeEntry: ModelEntryLocation | null = null;
+    if (!isEmptyModelRef(activeRef)) {
+      activeEntry = findModelEntryInConfig(state.config, activeRef);
+      if (!activeEntry) {
+        throw new Error(i18n.t('error.modelNotFound', { name: activeRef.name }));
+      }
+      const { group, model } = activeEntry;
+      const resolved = resolveModelProfile(state.config, activeRef);
+      if (!resolved) {
+        throw new Error(i18n.t('error.modelNotFound', { name: activeRef.name }));
+      }
+      if (resolved.provider && resolved.provider !== 'custom') {
+        if (!modelRefsEqual(state.config.activeModel, activeRef)) {
+          group.apiBase = resolveProfileApiBase(resolved);
         }
       } else {
-        state.config.models.push({
-          name: activeModel,
-          apiBase,
-          reasoningEffort: resolveModelReasoningEffortForContext(reasoningEffort, {
-            model: activeModel,
-          }),
-        });
+        group.apiBase = apiBase;
       }
-      state.config.activeModel = activeModel;
+      if (reasoningEffort !== undefined) {
+        model.reasoningEffort = asModelEntryReasoningEffort(resolveModelReasoningEffortForContext(reasoningEffort, {
+          ...(resolved.provider ? { provider: resolved.provider } : {}),
+          model: model.name,
+          ...(resolved.transportKind ? { transportKind: resolved.transportKind } : {}),
+          ...(resolved.supportedReasoningEfforts !== undefined
+            ? { supportedEfforts: resolved.supportedReasoningEfforts }
+            : {}),
+        }));
+      }
+      if (thinkingEnabled !== undefined) {
+        const modelContext = {
+          ...(resolved.provider ? { provider: resolved.provider } : {}),
+          model: model.name,
+          ...(resolved.transportKind ? { transportKind: resolved.transportKind } : {}),
+          ...(resolved.supportedReasoningEfforts !== undefined
+            ? { supportedEfforts: resolved.supportedReasoningEfforts }
+            : {}),
+          ...(resolved.supportsThinkingType
+            ? { supportsThinkingType: resolved.supportsThinkingType }
+            : {}),
+        };
+        if (thinkingEnabled) {
+          delete model.thinkingEnabled;
+        } else {
+          model.thinkingEnabled = false;
+        }
+        if (shouldPinReasoningEffortToDefault(thinkingEnabled, modelContext)) {
+          model.reasoningEffort = asModelEntryReasoningEffort(
+            resolveModelReasoningEffortForContext('default', modelContext),
+          );
+        }
+      }
+      state.config.activeModel = {
+        groupId: activeRef.groupId.trim(),
+        name: activeRef.name.trim(),
+      };
     } else {
-      state.config.activeModel = '';
-      existing = undefined;
+      state.config.activeModel = { groupId: '', name: '' };
+      activeEntry = null;
     }
     state.config.uiLocale = request.uiLocale?.trim() || undefined;
     if (request.imageGenerationModel !== undefined) {
-      const imageGenerationModel = request.imageGenerationModel.trim();
-      if (!imageGenerationModel) {
+      if (isEmptyModelRef(request.imageGenerationModel)) {
         delete state.config.imageGenerationModel;
       } else {
-        const imageProfile = state.config.models.find((model) => model.name === imageGenerationModel);
-        if (!imageProfile) {
-          throw new Error(i18n.t('error.imageGenModelNotFound', { model: imageGenerationModel }));
+        const imageRef = normalizeSlotModelRef(
+          request.imageGenerationModel,
+          state.config,
+          modelSupportsImageGeneration,
+        );
+        if (!imageRef) {
+          throw new Error(i18n.t('error.imageGenModelNotFound', {
+            model: request.imageGenerationModel.name,
+          }));
         }
-        if (!supportsImageGeneration(imageProfile)) {
-          throw new Error(i18n.t('error.modelNoImageGenCapability', { model: imageGenerationModel }));
-        }
-        state.config.imageGenerationModel = imageProfile.name;
+        state.config.imageGenerationModel = imageRef;
       }
     }
     if (request.videoGenerationModel !== undefined) {
-      const videoGenerationModel = request.videoGenerationModel.trim();
-      if (!videoGenerationModel) {
+      if (isEmptyModelRef(request.videoGenerationModel)) {
         delete state.config.videoGenerationModel;
       } else {
-        const videoProfile = state.config.models.find((model) => model.name === videoGenerationModel);
-        if (!videoProfile) {
-          throw new Error(i18n.t('error.videoGenModelNotFound', { model: videoGenerationModel }));
+        const videoRef = normalizeSlotModelRef(
+          request.videoGenerationModel,
+          state.config,
+          modelSupportsVideoGeneration,
+        );
+        if (!videoRef) {
+          throw new Error(i18n.t('error.videoGenModelNotFound', {
+            model: request.videoGenerationModel.name,
+          }));
         }
-        if (!supportsVideoGeneration(videoProfile)) {
-          throw new Error(i18n.t('error.modelNoVideoGenCapability', { model: videoGenerationModel }));
-        }
-        state.config.videoGenerationModel = videoProfile.name;
+        state.config.videoGenerationModel = videoRef;
       }
     }
     if (request.lightweightChatModel !== undefined) {
-      const lightweightChatModel = request.lightweightChatModel.trim();
-      if (!lightweightChatModel) {
+      if (isEmptyModelRef(request.lightweightChatModel)) {
         delete state.config.lightweightChatModel;
       } else {
-        const chatProfile = state.config.models.find((model) => model.name === lightweightChatModel);
-        if (!chatProfile) {
-          throw new Error(i18n.t('error.lightweightChatModelNotFound', { model: lightweightChatModel }));
+        const chatRef = normalizeSlotModelRef(
+          request.lightweightChatModel,
+          state.config,
+          modelSupportsChat,
+        );
+        if (!chatRef) {
+          throw new Error(i18n.t('error.lightweightChatModelNotFound', {
+            model: request.lightweightChatModel.name,
+          }));
         }
-        if (!modelSupportsChat(chatProfile)) {
-          throw new Error(i18n.t('error.modelNoChatCapability', { model: lightweightChatModel }));
-        }
-        state.config.lightweightChatModel = chatProfile.name;
+        state.config.lightweightChatModel = chatRef;
       }
     }
     state.config.windowsMica = request.windowsMica !== false;
@@ -314,18 +542,23 @@ export async function updateConfigCommand(
       applyLlmClientVersionFromApp();
     }
     await saveConfig(state.config);
-    if (request.apiKey?.trim()) {
-      const keyScope = modelProviderKeyScope(existing?.provider);
-      await saveApiKeyForProvider(keyScope, request.apiKey);
+    if (request.apiKey?.trim() && activeEntry) {
+      await saveApiKeyForProvider(activeEntry.group.id, request.apiKey);
     }
 
     const agentModeNow = resolveDesktopAgentMode(state.config);
     const lspEnabledChanged = state.config.agents.lsp.enabled !== prevLspEnabled;
     const modelOrEndpointChanged =
-      state.config.activeModel !== prevActiveModel ||
-      currentApiBase(state.config) !== prevApiBase;
-    const imageGenerationModelChanged = state.config.imageGenerationModel !== prevImageGenerationModel;
-    const videoGenerationModelChanged = state.config.videoGenerationModel !== prevVideoGenerationModel;
+      !modelRefsEqual(state.config.activeModel, prevActiveModel)
+      || currentApiBase(state.config) !== prevApiBase;
+    const imageGenerationModelChanged = !modelRefsEqual(
+      state.config.imageGenerationModel,
+      prevImageGenerationModel,
+    );
+    const videoGenerationModelChanged = !modelRefsEqual(
+      state.config.videoGenerationModel,
+      prevVideoGenerationModel,
+    );
 
     if (agentModeNow !== prevAgentMode) {
       state.metadata = await loadHostMetadata(state.workspaceRoot, agentModeNow, {
@@ -339,7 +572,7 @@ export async function updateConfigCommand(
       ctx.invalidateToolExecutors();
     }
 
-    if (state.config.activeModel !== prevActiveModel) {
+    if (!modelRefsEqual(state.config.activeModel, prevActiveModel)) {
       ctx.clearActiveContextUsage();
       ctx.activeBundle().activeModel = state.config.activeModel;
     }
@@ -349,25 +582,23 @@ export async function updateConfigCommand(
       || modelOrEndpointChanged
       || imageGenerationModelChanged
       || videoGenerationModelChanged;
-    const activeModelProfile = state.config.models.find(
-      (model) => model.name === state.config.activeModel,
-    );
+    const activeModelProfile = resolveModelProfile(state.config, state.config.activeModel);
     const inferencePreferenceOnlyUpdate =
       !transportOrPlanChanged
       && !lspEnabledChanged
       && agentModeNow === prevAgentMode
       && !Boolean(request.apiKey?.trim())
-      && activeModelProfile !== undefined
+      && activeModelProfile !== null
       && prevActiveModelInference !== undefined
-      && state.config.activeModel === prevActiveModel
+      && modelRefsEqual(state.config.activeModel, prevActiveModel)
       && (
         activeModelProfile.thinkingEnabled !== prevActiveModelInference.thinkingEnabled
         || activeModelProfile.reasoningEffort !== prevActiveModelInference.reasoningEffort
       );
     const deferRuntimeRefresh =
-      wasBusy &&
-      transportOrPlanChanged &&
-      !Boolean(request.apiKey?.trim());
+      wasBusy
+      && transportOrPlanChanged
+      && !Boolean(request.apiKey?.trim());
 
     if (deferRuntimeRefresh) {
       ctx.activeBundle().deferredRuntimeRefreshWhileBusy = true;
@@ -384,7 +615,6 @@ export async function updateConfigCommand(
     }
 
     ctx.setLastRuntimeError('');
-    // 勿在此处 persist：仅改 config（如 agentMode）不应刷新 savedAtUnixMs，否则会话在侧栏会误排到首位
     await ctx.flushDeferredRuntimeRefreshIfIdle();
     return ctx.buildSnapshot();
   });
@@ -662,19 +892,21 @@ export async function addProviderModelsCommand(
       throw new Error(i18n.t('error.bedrockRegionRequired'));
     }
     assertAlibabaConnectWorkspace({ provider, providerSite, alibabaWorkspaceId, alibabaBillingMode });
-    const apiBase = resolveManagedConnectApiBase(
-      provider,
+    const connectInput: ConnectRequestFields = {
+      groupId: request.groupId,
+      ...(provider !== undefined ? { provider } : {}),
       transportKind,
-      request.apiBase,
-      awsRegion,
-      undefined,
-      vertexProject,
-      vertexLocation,
-      undefined,
-      providerSite,
-      alibabaWorkspaceId,
-      alibabaBillingMode,
-    );
+      apiBase: request.apiBase,
+      ...(awsRegion ? { awsRegion } : {}),
+      ...(providerSite ? { providerSite } : {}),
+      ...(alibabaWorkspaceId ? { alibabaWorkspaceId } : {}),
+      ...(alibabaBillingMode ? { alibabaBillingMode } : {}),
+      ...(vertexProject ? { vertexProject } : {}),
+      ...(vertexLocation ? { vertexLocation } : {}),
+    };
+    const groupId = resolveConnectGroupId(connectInput);
+    const groupConnect = buildProviderGroupConnect(connectInput);
+    const apiBase = groupConnect.apiBase;
     const apiKey = request.apiKey.trim();
     const accessKeyId = request.accessKeyId?.trim();
     const secretAccessKey = request.secretAccessKey?.trim();
@@ -700,34 +932,15 @@ export async function addProviderModelsCommand(
       throw new Error(i18n.t('error.emptyModelList'));
     }
 
-    type NewProfile = {
-      name: string;
-      apiBase: string;
-      reasoningEffort: ModelReasoningEffort;
-      supportedReasoningEfforts?: DesktopModelReasoningEffort[];
-      capabilities?: DesktopModelCapability[];
-      contextLength?: number;
-      supportsThinkingType?: 'only';
-      provider?: DesktopModelProvider;
-      transportKind?: DesktopTransportKind;
-      awsRegion?: string;
-      providerSite?: DesktopProviderConnectSiteId;
-      alibabaWorkspaceId?: string;
-      alibabaBillingMode?: DesktopAlibabaBillingMode;
-      vertexProject?: string;
-      vertexLocation?: string;
-    };
+    const existingModels = existingModelsForGroupAdd(state.config);
+    const newIds = filterNewGroupModelIds(existingModels, uniqueIds, groupId);
     const catalogEntries = previewCatalogMapForAddProviderRequest(request, provider, transportKind);
-    const toAdd: NewProfile[] = [];
-    for (const name of uniqueIds) {
-      if (modelExistsInProviderScope(state.config.models, name, provider)) {
-        continue;
-      }
+    const toAdd: ModelEntryV2[] = [];
+    for (const name of newIds) {
       const catalogEntry = catalogEntries.get(name);
-      const profile: NewProfile = {
+      const entry: ModelEntryV2 = {
         name,
-        apiBase,
-        reasoningEffort: defaultModelReasoningEffort({
+        reasoningEffort: asModelEntryReasoningEffort(defaultModelReasoningEffort({
           ...(reasoningProviderForTransport(provider, transportKind)
             ? { provider: reasoningProviderForTransport(provider, transportKind) }
             : {}),
@@ -738,50 +951,30 @@ export async function addProviderModelsCommand(
           ...(catalogEntry?.supportsThinkingType
             ? { supportsThinkingType: catalogEntry.supportsThinkingType }
             : {}),
-        }),
+        })),
       };
       if (catalogEntry?.supportedReasoningEfforts !== undefined) {
-        profile.supportedReasoningEfforts = catalogEntry.supportedReasoningEfforts;
+        entry.supportedReasoningEfforts = asModelEntrySupportedReasoningEfforts(
+          catalogEntry.supportedReasoningEfforts,
+        );
       }
       if (catalogEntry?.capabilities) {
-        profile.capabilities = catalogEntry.capabilities;
+        entry.capabilities = catalogEntry.capabilities;
       }
       if (catalogEntry?.contextLength !== undefined) {
         const contextLength = parseModelContextLength(catalogEntry.contextLength);
         if (contextLength !== undefined) {
-          profile.contextLength = contextLength;
+          entry.contextLength = contextLength;
         }
       }
       if (catalogEntry?.supportsThinkingType !== undefined) {
-        profile.supportsThinkingType = catalogEntry.supportsThinkingType;
+        entry.supportsThinkingType = catalogEntry.supportsThinkingType;
       }
-      if (provider !== undefined) {
-        profile.provider = provider;
-        if (transportKind === 'anthropic' || transportKind === 'open-responses' || transportKind === 'bedrock') {
-          profile.transportKind = transportKind;
-        }
-        if (provider === 'amazon-bedrock' && awsRegion) {
-          profile.awsRegion = awsRegion;
-        }
-        applyManagedProviderConnectFields(profile, {
-          provider,
-          providerSite,
-          alibabaWorkspaceId,
-          alibabaBillingMode,
-        });
-        if (provider === 'google-vertex-ai') {
-          if (vertexProject) {
-            profile.vertexProject = vertexProject;
-          }
-          if (vertexLocation) {
-            profile.vertexLocation = vertexLocation;
-          }
-        }
-      }
-      toAdd.push(profile);
+      toAdd.push(entry);
     }
 
     const scopeProfile: ModelProfileSnapshot = {
+      groupId,
       name: uniqueIds[0] ?? '',
       apiBase,
       provider,
@@ -823,59 +1016,50 @@ export async function addProviderModelsCommand(
       throw new Error(i18n.t('error.modelsAlreadyExist'));
     }
 
-    const providerKeyScope = modelProviderKeyScope(provider);
+    const resolvedProvider = provider ?? 'custom';
     try {
-      if (provider === 'amazon-bedrock') {
-        await saveBedrockProviderCredentialsForProvider(providerKeyScope, {
-          apiKey,
-          accessKeyId,
-          secretAccessKey,
-        });
-      } else if (provider === 'google-vertex-ai') {
-        await saveGoogleVertexProviderCredentialsForProvider(providerKeyScope, {
-          apiKey,
-          clientEmail: vertexClientEmail,
-          privateKey: vertexPrivateKey,
-        });
-      } else {
-        await saveApiKeyForProvider(providerKeyScope, apiKey);
-      }
+      await saveGroupCredentials(groupId, resolvedProvider, {
+        apiKey,
+        accessKeyId,
+        secretAccessKey,
+        vertexClientEmail,
+        vertexPrivateKey,
+      });
     } catch (err) {
-      if (provider === 'amazon-bedrock') {
-        await saveBedrockProviderCredentialsForProvider(providerKeyScope, {});
-      } else if (provider === 'google-vertex-ai') {
-        await saveGoogleVertexProviderCredentialsForProvider(providerKeyScope, {});
-      } else {
-        await removeProviderApiKey(providerKeyScope);
-      }
+      await clearGroupCredentials(groupId, resolvedProvider);
       throw err;
     }
 
+    const group = findOrCreateProviderGroup(state.config, groupId, groupConnect);
     const pruned = removeDelistedModelsFromCatalog(state.config, scopeProfile, catalogRefreshResult);
     if (request.modelCatalog?.length) {
       syncExistingModelsFromCatalog(state.config, scopeProfile, catalogRefreshResult);
     }
 
-    const firstNew = toAdd[0]?.name;
-    for (const profile of toAdd) {
-      state.config.models.push(profile);
+    for (const entry of toAdd) {
+      group.models.push(entry);
     }
 
-    state.config.activeModel = firstNew ?? state.config.activeModel;
+    const firstNewRef: ModelRef = toAdd[0]
+      ? { groupId, name: toAdd[0].name }
+      : state.config.activeModel;
+    if (toAdd.length > 0) {
+      state.config.activeModel = firstNewRef;
+    }
     if (!state.config.imageGenerationModel) {
-      const imageGenerationProfile = toAdd.find((profile) => supportsImageGeneration(profile));
-      if (imageGenerationProfile) {
-        state.config.imageGenerationModel = imageGenerationProfile.name;
+      const imageEntry = toAdd.find((entry) => modelSupportsImageGeneration(entry));
+      if (imageEntry) {
+        state.config.imageGenerationModel = { groupId, name: imageEntry.name };
       }
     }
     if (!state.config.videoGenerationModel) {
-      const videoGenerationProfile = toAdd.find((profile) => supportsVideoGeneration(profile));
-      if (videoGenerationProfile) {
-        state.config.videoGenerationModel = videoGenerationProfile.name;
+      const videoEntry = toAdd.find((entry) => modelSupportsVideoGeneration(entry));
+      if (videoEntry) {
+        state.config.videoGenerationModel = { groupId, name: videoEntry.name };
       }
     }
     for (const name of pruned) {
-      await removeModelApiKey(name);
+      await removeModelApiKey(modelRefKey({ groupId, name }));
     }
     await saveConfig(state.config);
     await ctx.refreshRuntime();
@@ -898,7 +1082,7 @@ export async function addModelCommand(
     }
 
     const name = request.name.trim();
-    const provider = parseModelProviderId(request.provider);
+    const provider = parseModelProviderId(request.provider) ?? 'custom';
     if (
       provider === 'azure'
       && request.transportKind !== undefined
@@ -927,19 +1111,23 @@ export async function addModelCommand(
       throw new Error(i18n.t('error.azureResourceNameInvalid'));
     }
     assertAlibabaConnectWorkspace({ provider, providerSite, alibabaWorkspaceId, alibabaBillingMode });
-    const apiBase = resolveManagedConnectApiBase(
+    const connectInput: ConnectRequestFields = {
+      groupId: request.groupId,
       provider,
+      customGroupLabel: request.customGroupLabel,
       transportKind,
-      request.apiBase,
-      awsRegion,
-      name,
-      vertexProject,
-      vertexLocation,
-      azureResourceName,
-      providerSite,
-      alibabaWorkspaceId,
-      alibabaBillingMode,
-    );
+      apiBase: request.apiBase,
+      ...(awsRegion ? { awsRegion } : {}),
+      ...(providerSite ? { providerSite } : {}),
+      ...(alibabaWorkspaceId ? { alibabaWorkspaceId } : {}),
+      ...(alibabaBillingMode ? { alibabaBillingMode } : {}),
+      ...(vertexProject ? { vertexProject } : {}),
+      ...(vertexLocation ? { vertexLocation } : {}),
+      ...(azureResourceName ? { azureResourceName } : {}),
+    };
+    const groupId = resolveConnectGroupId(connectInput);
+    const groupConnect = buildProviderGroupConnect({ ...connectInput, modelName: name });
+    const apiBase = groupConnect.apiBase;
     const apiKey = request.apiKey.trim();
 
     if (!name) {
@@ -956,7 +1144,7 @@ export async function addModelCommand(
     } else if (!apiKey) {
       throw new Error(i18n.t('error.apiKeyRequired'));
     }
-    if (state.config.models.some((model) => model.name === name)) {
+    if (modelExistsInGroup(state.config, groupId, name)) {
       throw new Error(i18n.t('error.modelExists', { name }));
     }
 
@@ -969,27 +1157,9 @@ export async function addModelCommand(
     });
     const requestedCapabilities = normalizeModelCapabilities(request.capabilities);
 
-    const profile: {
-      name: string;
-      apiBase: string;
-      reasoningEffort: ModelReasoningEffort;
-      supportedReasoningEfforts?: DesktopModelReasoningEffort[];
-      provider?: DesktopModelProvider;
-      transportKind?: DesktopTransportKind;
-      capabilities?: DesktopModelCapability[];
-      contextLength?: number;
-      supportsThinkingType?: 'only';
-      awsRegion?: string;
-      providerSite?: DesktopProviderConnectSiteId;
-      alibabaWorkspaceId?: string;
-      alibabaBillingMode?: DesktopAlibabaBillingMode;
-      vertexProject?: string;
-      vertexLocation?: string;
-      azureResourceName?: string;
-    } = {
+    const modelEntry: ModelEntryV2 = {
       name,
-      apiBase,
-      reasoningEffort: defaultModelReasoningEffort({
+      reasoningEffort: asModelEntryReasoningEffort(defaultModelReasoningEffort({
         ...(reasoningProviderForTransport(provider, transportKind)
           ? { provider: reasoningProviderForTransport(provider, transportKind) }
           : {}),
@@ -1000,36 +1170,12 @@ export async function addModelCommand(
         ...(catalogEntry?.supportsThinkingType
           ? { supportsThinkingType: catalogEntry.supportsThinkingType }
           : {}),
-      }),
+      })),
     };
     if (catalogEntry?.supportedReasoningEfforts !== undefined) {
-      profile.supportedReasoningEfforts = catalogEntry.supportedReasoningEfforts;
-    }
-    if (provider !== undefined) {
-      profile.provider = provider;
-      if (transportKind === 'anthropic' || transportKind === 'open-responses' || transportKind === 'bedrock') {
-        profile.transportKind = transportKind;
-      }
-      if (provider === 'amazon-bedrock' && awsRegion) {
-        profile.awsRegion = awsRegion;
-      }
-      applyManagedProviderConnectFields(profile, {
-        provider,
-        providerSite,
-        alibabaWorkspaceId,
-        alibabaBillingMode,
-      });
-      if (provider === 'google-vertex-ai') {
-        if (vertexProject) {
-          profile.vertexProject = vertexProject;
-        }
-        if (vertexLocation) {
-          profile.vertexLocation = vertexLocation;
-        }
-      }
-      if (provider === 'azure' && azureResourceName) {
-        profile.azureResourceName = azureResourceName;
-      }
+      modelEntry.supportedReasoningEfforts = asModelEntrySupportedReasoningEfforts(
+        catalogEntry.supportedReasoningEfforts,
+      );
     }
     const capabilities = resolveAddedModelCapabilities({
       provider,
@@ -1037,42 +1183,41 @@ export async function addModelCommand(
       catalogEntry,
     });
     if (capabilities) {
-      profile.capabilities = capabilities;
+      modelEntry.capabilities = capabilities;
     }
     if (catalogEntry?.contextLength !== undefined && request.contextLength === undefined) {
       const contextLength = parseModelContextLength(catalogEntry.contextLength);
       if (contextLength !== undefined) {
-        profile.contextLength = contextLength;
+        modelEntry.contextLength = contextLength;
       }
     }
     if (catalogEntry?.supportsThinkingType !== undefined) {
-      profile.supportsThinkingType = catalogEntry.supportsThinkingType;
+      modelEntry.supportsThinkingType = catalogEntry.supportsThinkingType;
     }
     if (request.contextLength !== undefined) {
       const contextLength = parseModelContextLength(request.contextLength);
       if (contextLength === undefined) {
         throw new Error(i18n.t('error.contextLengthInvalid'));
       }
-      profile.contextLength = contextLength;
+      modelEntry.contextLength = contextLength;
     }
-    state.config.models.push(profile);
-    state.config.activeModel = name;
+
+    const group = findOrCreateProviderGroup(state.config, groupId, groupConnect);
+    group.models.push(modelEntry);
+    const modelRef: ModelRef = { groupId, name };
+    state.config.activeModel = modelRef;
     ctx.clearActiveContextUsage();
-    if (!state.config.imageGenerationModel && supportsImageGeneration(profile)) {
-      state.config.imageGenerationModel = name;
+    if (!state.config.imageGenerationModel && modelSupportsImageGeneration(modelEntry)) {
+      state.config.imageGenerationModel = modelRef;
     }
-    if (!state.config.videoGenerationModel && supportsVideoGeneration(profile)) {
-      state.config.videoGenerationModel = name;
+    if (!state.config.videoGenerationModel && modelSupportsVideoGeneration(modelEntry)) {
+      state.config.videoGenerationModel = modelRef;
     }
     await saveConfig(state.config);
-    if (provider === 'amazon-bedrock') {
-      await saveBedrockProviderCredentialsForProvider(modelProviderKeyScope(provider), { apiKey });
-    } else if (provider === 'google-vertex-ai') {
-      await saveGoogleVertexProviderCredentialsForProvider(modelProviderKeyScope(provider), { apiKey });
-    } else if (provider !== undefined) {
-      await saveApiKeyForProvider(modelProviderKeyScope(provider), apiKey);
+    if (provider === 'custom' && !request.provider) {
+      await saveApiKeyForModel(modelRefKey(modelRef), apiKey);
     } else {
-      await saveApiKeyForModel(name, apiKey);
+      await saveGroupCredentials(groupId, provider, { apiKey });
     }
 
     await ctx.refreshRuntime();
@@ -1090,44 +1235,62 @@ export async function removeModelCommand(
     await ctx.ensureInitialized();
     const state = ctx.requireState();
 
-    const name = request.name.trim();
-    if (!name) {
+    const ref = request.ref;
+    if (isEmptyModelRef(ref)) {
       throw new Error(i18n.t('error.modelNameRequired'));
     }
-    const targetsToRemove: ModelRemovalTarget[] = state.config.models
-      .filter((model) => model.name === name)
-      .map((model) => ({ name: model.name, provider: model.provider }));
-    if (targetsToRemove.length === 0) {
-      throw new Error(i18n.t('error.modelNotFound', { name }));
+    if (!resolveModelProfile(state.config, ref)) {
+      throw new Error(i18n.t('error.modelNotFound', { name: ref.name }));
     }
-
+    const targetsToRemove: ModelRemovalTarget[] = [{ ref: { groupId: ref.groupId.trim(), name: ref.name.trim() } }];
     return finalizeModelRemoval(ctx, state, targetsToRemove, { removeLegacyModelKeys: true });
   });
 }
 
-export async function removeProviderModelsCommand(
+export async function removeProviderGroupCommand(
   ctx: HostModelCommandContext,
-  request: RemoveProviderModelsRequest,
+  request: RemoveProviderGroupRequest,
 ): Promise<DesktopSnapshot> {
   return ctx.runSerialized(async () => {
     await ctx.ensureInitialized();
     const state = ctx.requireState();
 
-    const provider = parsePresetModelProviderId(request.provider);
-    if (!provider) {
-      throw new Error(i18n.t('error.providerDeleteOnly'));
+    const groupId = request.groupId.trim();
+    if (!groupId) {
+      throw new Error(i18n.t('error.modelNameRequired'));
     }
-
-    const { matched: targets } = partitionModelsByProvider(state.config.models, provider);
-    if (targets.length === 0) {
+    const group = findProviderGroup(state.config, groupId);
+    if (!group || group.models.length === 0) {
       throw new Error(i18n.t('error.noModelsInProvider'));
     }
 
-    const targetsToRemove: ModelRemovalTarget[] = targets.map((model) => ({
-      name: model.name,
-      provider: model.provider,
+    const targetsToRemove: ModelRemovalTarget[] = group.models.map((model) => ({
+      ref: { groupId, name: model.name },
     }));
-    return finalizeModelRemoval(ctx, state, targetsToRemove, { removeProviderKey: provider });
+    const provider = group.provider as DesktopModelProvider;
+    applyModelsRemovalToConfig(state.config, targetsToRemove);
+    state.config.providerGroups = state.config.providerGroups.filter((entry) => entry.id !== groupId);
+    await saveConfig(state.config);
+    await removeGroupKeyring(groupId, provider);
+    await ctx.refreshModelKeyPresence();
+    await ctx.refreshRuntime();
+    ctx.setLastRuntimeError('');
+    await ctx.persistCurrentSessionIfNeeded();
+    return ctx.buildSnapshot();
+  });
+}
+
+/** @deprecated 使用 {@link removeProviderGroupCommand} */
+export async function removeProviderModelsCommand(
+  ctx: HostModelCommandContext,
+  request: RemoveProviderModelsRequest,
+): Promise<DesktopSnapshot> {
+  const provider = parsePresetModelProviderId(request.provider);
+  if (!provider) {
+    throw new Error(i18n.t('error.providerDeleteOnly'));
+  }
+  return removeProviderGroupCommand(ctx, {
+    groupId: defaultPresetProviderGroupId(provider),
   });
 }
 
@@ -1136,18 +1299,15 @@ async function finalizeModelRemoval(
   state: HostModelState,
   targetsToRemove: readonly ModelRemovalTarget[],
   options?: {
-    removeProviderKey?: DesktopModelProvider;
     removeLegacyModelKeys?: boolean;
   },
 ): Promise<DesktopSnapshot> {
   applyModelsRemovalToConfig(state.config, targetsToRemove);
+  state.config.providerGroups = state.config.providerGroups.filter((group) => group.models.length > 0);
   await saveConfig(state.config);
-  if (options?.removeProviderKey) {
-    await removeProviderApiKey(options.removeProviderKey);
-  }
   if (options?.removeLegacyModelKeys) {
     for (const target of targetsToRemove) {
-      await removeModelApiKey(target.name);
+      await removeModelApiKey(modelRefKey(target.ref));
     }
   }
   await ctx.refreshModelKeyPresence();

--- a/apps/desktop/src/host/host-pane-model.ts
+++ b/apps/desktop/src/host/host-pane-model.ts
@@ -4,10 +4,11 @@ import type { DesktopSnapshot, SwitchPaneModelRequest } from '../types.js';
 import type { SessionBundle } from './session-bundle.js';
 import type { SessionSplitHostContext } from './session-split.js';
 import { freezePaneActiveModelIfNeeded } from './active-model-sync.js';
+import { findModelRefByName } from './model-config-access.js';
 import { saveConfig } from './storage.js';
 
 export interface PaneModelHostContext extends SessionSplitHostContext {
-  adoptActiveModelForForeground(modelName: string): Promise<void>;
+  adoptActiveModelForForeground(modelRef: import('../types.js').ModelRef): Promise<void>;
   refreshRuntimeForBundle(bundle: SessionBundle): Promise<void>;
   invalidatePaneSessionSliceCache(sessionPath: string): void;
   invalidateAllPaneSessionSliceCache(): void;
@@ -38,7 +39,8 @@ export async function switchPaneModelCommand(
     }
 
     const state = ctx.requireState();
-    if (!state.config.models.some((model) => model.name === modelName)) {
+    const modelRef = findModelRefByName(state.config, modelName);
+    if (!modelRef) {
       throw new Error(`Model not found: ${modelName}`);
     }
 
@@ -50,10 +52,10 @@ export async function switchPaneModelCommand(
       }
       freezePaneActiveModelIfNeeded(bundle, state);
     }
-    bundle.activeModel = modelName;
+    bundle.activeModel = modelRef;
 
     if (isForeground) {
-      await ctx.adoptActiveModelForForeground(modelName);
+      await ctx.adoptActiveModelForForeground(modelRef);
     } else if (bundle.runtime && !bundle.runtime.isBusy()) {
       await ctx.refreshRuntimeForBundle(bundle);
       await ctx.persistCurrentSessionIfNeeded();

--- a/apps/desktop/src/host/host-pane-model.ts
+++ b/apps/desktop/src/host/host-pane-model.ts
@@ -4,8 +4,7 @@ import type { DesktopSnapshot, SwitchPaneModelRequest } from '../types.js';
 import type { SessionBundle } from './session-bundle.js';
 import type { SessionSplitHostContext } from './session-split.js';
 import { freezePaneActiveModelIfNeeded } from './active-model-sync.js';
-import { findModelRefByName } from './model-config-access.js';
-import { saveConfig } from './storage.js';
+import { modelExistsInGroup } from './model-config-access.js';
 
 export interface PaneModelHostContext extends SessionSplitHostContext {
   adoptActiveModelForForeground(modelRef: import('../types.js').ModelRef): Promise<void>;
@@ -27,9 +26,9 @@ export async function switchPaneModelCommand(
       throw new Error('Split pane session path is required.');
     }
 
-    const modelName = request.modelName.trim();
-    if (!modelName) {
-      throw new Error('Model name is required.');
+    const modelRef = request.modelRef;
+    if (!modelRef.groupId.trim() || !modelRef.name.trim()) {
+      throw new Error('Model ref is required.');
     }
 
     const registry = ctx.sessionRegistry();
@@ -39,9 +38,8 @@ export async function switchPaneModelCommand(
     }
 
     const state = ctx.requireState();
-    const modelRef = findModelRefByName(state.config, modelName);
-    if (!modelRef) {
-      throw new Error(`Model not found: ${modelName}`);
+    if (!modelExistsInGroup(state.config, modelRef.groupId, modelRef.name)) {
+      throw new Error(`Model not found: ${modelRef.groupId}::${modelRef.name}`);
     }
 
     const isForeground = registry.getActive() === bundle;

--- a/apps/desktop/src/host/lightweight-chat-model.ts
+++ b/apps/desktop/src/host/lightweight-chat-model.ts
@@ -1,43 +1,45 @@
-import type { ModelProfileSnapshot } from '../types.js';
+import type { ModelRef } from '../types.js';
+import type { DesktopConfigFile } from './storage.js';
+import {
+  flattenProviderGroups,
+  modelSupportsChat,
+  resolveModelProfile,
+  type ResolvedModelProfile,
+} from './model-config-access.js';
 
-export type LightweightChatModelResolveInput = {
-  activeModel: string;
-  lightweightChatModel?: string;
-  models: ModelProfileSnapshot[];
-};
+export type LightweightChatModelResolveInput = Pick<
+  DesktopConfigFile,
+  'activeModel' | 'lightweightChatModel' | 'providerGroups'
+>;
+
+export { modelSupportsChat };
 
 export const LIGHTWEIGHT_CHAT_MODEL_FALLBACK_PATTERNS = ['deepseek-v4-flash'] as const;
 
-export function modelSupportsChat(model: ModelProfileSnapshot): boolean {
-  return model.capabilities === undefined || model.capabilities.includes('chat');
-}
-
 export function normalizeLightweightChatModel(
-  value: unknown,
-  models: readonly ModelProfileSnapshot[],
-): string | undefined {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    return undefined;
-  }
-
-  const modelName = value.trim();
-  const profile = models.find((model) => model.name === modelName);
-  return profile && modelSupportsChat(profile) ? profile.name : undefined;
+  value: ModelRef | undefined,
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+): ModelRef | undefined {
+  const profile = resolveModelProfile(config, value);
+  return profile && modelSupportsChat(profile) ? profile.ref : undefined;
 }
 
-export function resolveLightweightChatModelName(config: LightweightChatModelResolveInput): string {
-  const explicit = normalizeLightweightChatModel(config.lightweightChatModel, config.models);
+export function resolveLightweightChatModelName(
+  config: LightweightChatModelResolveInput,
+): ModelRef {
+  const explicit = normalizeLightweightChatModel(config.lightweightChatModel, config);
   if (explicit) {
     return explicit;
   }
 
+  const models = flattenProviderGroups(config);
   for (const pattern of LIGHTWEIGHT_CHAT_MODEL_FALLBACK_PATTERNS) {
     const lowerPattern = pattern.toLowerCase();
-    const match = config.models.find(
+    const match = models.find(
       (model) => modelSupportsChat(model) && model.name.toLowerCase().includes(lowerPattern),
     );
     if (match) {
-      return match.name;
+      return match.ref;
     }
   }
 
@@ -46,16 +48,12 @@ export function resolveLightweightChatModelName(config: LightweightChatModelReso
 
 export function resolveLightweightChatModelProfile(
   config: LightweightChatModelResolveInput,
-): { name: string; profile: ModelProfileSnapshot } | null {
-  const name = resolveLightweightChatModelName(config).trim();
-  if (!name) {
-    return null;
-  }
-
-  const profile = config.models.find((model) => model.name === name);
+): { name: string; profile: ResolvedModelProfile } | null {
+  const ref = resolveLightweightChatModelName(config);
+  const profile = resolveModelProfile(config, ref);
   if (!profile || !modelSupportsChat(profile)) {
     return null;
   }
 
-  return { name, profile };
+  return { name: profile.name, profile };
 }

--- a/apps/desktop/src/host/model-catalog-startup-refresh.ts
+++ b/apps/desktop/src/host/model-catalog-startup-refresh.ts
@@ -23,11 +23,17 @@ import {
   type LoadedPreviewModelsResult,
 } from './model-config.js';
 import {
+  findProviderGroup,
+  flattenProviderGroups,
+  modelExistsInGroup,
+  resolveModelProfileFromParts,
+} from './model-config-access.js';
+import {
   hasBedrockRuntimeCredentials,
   hasGoogleVertexRuntimeCredentials,
-  modelExistsInProviderScope,
   modelProviderKeyScope,
   applyModelsRemovalToConfig,
+  type ModelRemovalTarget,
 } from './provider-api-key.js';
 import {
   DEFAULT_API_BASE,
@@ -65,7 +71,7 @@ export function collectModelCatalogRefreshTargets(
 }
 
 export async function loadModelCatalogForProfile(
-  config: Pick<DesktopConfigFile, 'models'>,
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
   profile: ModelProfileSnapshot,
   options?: { forceRefresh?: boolean },
 ): Promise<LoadedPreviewModelsResult | undefined> {
@@ -77,7 +83,10 @@ export async function loadModelCatalogForProfile(
 
   const transportKind = resolveDesktopTransportKind(profile);
   const apiBase = profile.apiBase.trim() || DEFAULT_API_BASE;
-  const apiKey = await resolveApiKeyForConfigModel(config, profile.name);
+  const modelRef = profile.ref ?? (profile.groupId
+    ? { groupId: profile.groupId, name: profile.name }
+    : undefined);
+  const apiKey = modelRef ? await resolveApiKeyForConfigModel(config, modelRef) : undefined;
 
   if (transportKind === 'bedrock') {
     const bedrockCredentials = readBedrockProviderCredentialsFromKeyring(modelProviderKeyScope(provider));
@@ -143,7 +152,7 @@ export async function loadModelCatalogForProfile(
 }
 
 export async function forceRefreshModelCatalogForProfile(
-  config: Pick<DesktopConfigFile, 'models'>,
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
   profile: ModelProfileSnapshot,
 ): Promise<LoadedPreviewModelsResult | undefined> {
   return loadModelCatalogForProfile(config, profile, { forceRefresh: true });
@@ -171,7 +180,12 @@ export function mergeNewCatalogModelsIntoConfig(
   result: LoadedPreviewModelsResult,
 ): number {
   const provider = profile.provider;
-  if (!provider) {
+  const groupId = profile.groupId?.trim();
+  if (!provider || !groupId) {
+    return 0;
+  }
+  const group = findProviderGroup(config, groupId);
+  if (!group) {
     return 0;
   }
 
@@ -186,7 +200,7 @@ export function mergeNewCatalogModelsIntoConfig(
   const toAdd: StartupMergedProfile[] = [];
   for (const name of result.modelIds) {
     const trimmed = name.trim();
-    if (!trimmed || modelExistsInProviderScope(config.models, trimmed, provider)) {
+    if (!trimmed || modelExistsInGroup(config, groupId, trimmed)) {
       continue;
     }
     const catalogEntry = catalogEntries.get(trimmed);
@@ -241,19 +255,26 @@ export function mergeNewCatalogModelsIntoConfig(
   }
 
   for (const merged of toAdd) {
-    config.models.push(merged);
+    group.models.push({
+      name: merged.name,
+      reasoningEffort: merged.reasoningEffort as import('@spiritagent/host-internal').ModelEntryV2['reasoningEffort'],
+      ...(merged.supportedReasoningEfforts !== undefined
+        ? { supportedReasoningEfforts: merged.supportedReasoningEfforts as import('@spiritagent/host-internal').ModelEntryV2['supportedReasoningEfforts'] }
+        : {}),
+      ...(merged.capabilities !== undefined ? { capabilities: merged.capabilities } : {}),
+    });
   }
 
   if (!config.imageGenerationModel) {
     const imageGenerationProfile = toAdd.find((entry) => supportsImageGeneration(entry));
     if (imageGenerationProfile) {
-      config.imageGenerationModel = imageGenerationProfile.name;
+      config.imageGenerationModel = { groupId, name: imageGenerationProfile.name };
     }
   }
   if (!config.videoGenerationModel) {
     const videoGenerationProfile = toAdd.find((entry) => supportsVideoGeneration(entry));
     if (videoGenerationProfile) {
-      config.videoGenerationModel = videoGenerationProfile.name;
+      config.videoGenerationModel = { groupId, name: videoGenerationProfile.name };
     }
   }
 
@@ -380,16 +401,33 @@ export function syncExistingModelsFromCatalog(
   }
 
   let updated = 0;
-  for (const model of config.models) {
-    if (!modelMatchesCatalogRefreshScope(model, provider, transportKind, apiBase)) {
-      continue;
-    }
-    const catalogEntry = catalogEntries.get(model.name);
-    if (!catalogEntry) {
-      continue;
-    }
-    if (applyCatalogEntryToStoredModel(model, catalogEntry)) {
-      updated += 1;
+  for (const group of config.providerGroups) {
+    for (const model of group.models) {
+      const resolved = resolveModelProfileFromParts(group, model);
+      if (!resolved || !modelMatchesCatalogRefreshScope(resolved, provider, transportKind, apiBase)) {
+        continue;
+      }
+      const catalogEntry = catalogEntries.get(model.name);
+      if (!catalogEntry) {
+        continue;
+      }
+      if (applyCatalogEntryToStoredModel(resolved, catalogEntry)) {
+        if (resolved.capabilities !== undefined) {
+          model.capabilities = resolved.capabilities;
+        }
+        if (resolved.supportedReasoningEfforts !== undefined) {
+          model.supportedReasoningEfforts = resolved.supportedReasoningEfforts as import('@spiritagent/host-internal').ModelEntryV2['supportedReasoningEfforts'];
+        } else {
+          delete model.supportedReasoningEfforts;
+        }
+        if (resolved.contextLength !== undefined) {
+          model.contextLength = resolved.contextLength;
+        }
+        if (resolved.supportsThinkingType !== undefined) {
+          model.supportsThinkingType = resolved.supportsThinkingType;
+        }
+        updated += 1;
+      }
     }
   }
   return updated;
@@ -414,20 +452,23 @@ export function removeDelistedModelsFromCatalog(
 
   const transportKind = resolveDesktopTransportKind(profile);
   const apiBase = profile.apiBase.trim() || DEFAULT_API_BASE;
-  const targetsToRemove: Array<{ name: string; provider?: typeof provider }> = [];
-  for (const model of config.models) {
-    if (!modelMatchesCatalogRefreshScope(model, provider, transportKind, apiBase)) {
-      continue;
-    }
-    if (!catalogIds.has(model.name)) {
-      targetsToRemove.push({ name: model.name, provider: model.provider });
+  const targetsToRemove: ModelRemovalTarget[] = [];
+  for (const group of config.providerGroups) {
+    for (const model of group.models) {
+      const resolved = resolveModelProfileFromParts(group, model);
+      if (!resolved || !modelMatchesCatalogRefreshScope(resolved, provider, transportKind, apiBase)) {
+        continue;
+      }
+      if (!catalogIds.has(model.name)) {
+        targetsToRemove.push({ ref: { groupId: group.id, name: model.name } });
+      }
     }
   }
   if (targetsToRemove.length === 0) {
     return [];
   }
   applyModelsRemovalToConfig(config, targetsToRemove);
-  return targetsToRemove.map((target) => target.name);
+  return targetsToRemove.map((target) => target.ref.name);
 }
 
 export type ModelCatalogRefreshFetchResult = {
@@ -456,7 +497,7 @@ export async function fetchConfiguredModelCatalogsOnStartup(
   config: DesktopConfigFile,
   options?: { forceRefresh?: boolean },
 ): Promise<ModelCatalogStartupFetchSummary> {
-  const targets = collectModelCatalogRefreshTargets(config.models);
+  const targets = collectModelCatalogRefreshTargets(flattenProviderGroups(config));
   const forceRefresh = options?.forceRefresh === true;
   const fetched: ModelCatalogRefreshFetchResult[] = [];
   let skipped = 0;

--- a/apps/desktop/src/host/model-config-access.ts
+++ b/apps/desktop/src/host/model-config-access.ts
@@ -1,18 +1,19 @@
-import type {
-  ModelEntryV2,
-  ModelRef,
-  ProviderGroupV2,
+import {
+  modelRefsEqual,
+  type ModelEntryV2,
+  type ModelRef,
+  type ProviderGroupV2,
 } from '@spiritagent/host-internal';
 
 import type {
   DesktopAlibabaBillingMode,
-  DesktopConfigFile,
   DesktopModelCapability,
   DesktopModelProvider,
   DesktopModelReasoningEffort,
   DesktopTransportKind,
   ModelProfileSnapshot,
 } from '../types.js';
+import type { DesktopConfigFile } from './storage.js';
 
 export interface ResolvedModelProfile extends ModelProfileSnapshot {
   groupId: string;
@@ -156,6 +157,40 @@ export function modelSupportsVideoGeneration(model: Pick<ModelProfileSnapshot, '
 
 export function modelSupportsChat(model: Pick<ModelProfileSnapshot, 'capabilities'>): boolean {
   return model.capabilities === undefined || model.capabilities.includes('chat');
+}
+
+export function findModelRefByName(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  name: string,
+): ModelRef | undefined {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  for (const group of config.providerGroups) {
+    const model = group.models.find((entry) => entry.name === trimmed);
+    if (model) {
+      return { groupId: group.id, name: model.name };
+    }
+  }
+  return undefined;
+}
+
+export function resolvePaneModelRef(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  ref: ModelRef | undefined,
+): ModelRef | undefined {
+  if (!ref?.name?.trim()) {
+    return undefined;
+  }
+  const profile = resolveModelProfile(config, ref);
+  if (profile) {
+    return profile.ref;
+  }
+  if (!ref.groupId?.trim()) {
+    return findModelRefByName(config, ref.name);
+  }
+  return undefined;
 }
 
 export function normalizeSlotModelRef(

--- a/apps/desktop/src/host/model-config-access.ts
+++ b/apps/desktop/src/host/model-config-access.ts
@@ -1,0 +1,177 @@
+import type {
+  ModelEntryV2,
+  ModelRef,
+  ProviderGroupV2,
+} from '@spiritagent/host-internal';
+
+import type {
+  DesktopAlibabaBillingMode,
+  DesktopConfigFile,
+  DesktopModelCapability,
+  DesktopModelProvider,
+  DesktopModelReasoningEffort,
+  DesktopTransportKind,
+  ModelProfileSnapshot,
+} from '../types.js';
+
+export interface ResolvedModelProfile extends ModelProfileSnapshot {
+  groupId: string;
+  ref: ModelRef;
+}
+
+export function flattenProviderGroups(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+): ResolvedModelProfile[] {
+  const resolved: ResolvedModelProfile[] = [];
+  for (const group of config.providerGroups) {
+    for (const model of group.models) {
+      const profile = resolveModelProfileFromParts(group, model);
+      if (profile) {
+        resolved.push(profile);
+      }
+    }
+  }
+  return resolved;
+}
+
+export function resolveModelProfileFromParts(
+  group: ProviderGroupV2,
+  model: ModelEntryV2,
+): ResolvedModelProfile | null {
+  if (!group.id.trim() || !model.name.trim()) {
+    return null;
+  }
+  const ref: ModelRef = { groupId: group.id, name: model.name };
+  return {
+    ref,
+    groupId: group.id,
+    name: model.name,
+    apiBase: group.apiBase,
+    reasoningEffort: model.reasoningEffort as DesktopModelReasoningEffort,
+    ...(model.thinkingEnabled === false ? { thinkingEnabled: false } : {}),
+    ...(model.supportedReasoningEfforts !== undefined
+      ? { supportedReasoningEfforts: model.supportedReasoningEfforts as DesktopModelReasoningEffort[] }
+      : {}),
+    ...(model.capabilities !== undefined
+      ? { capabilities: model.capabilities as DesktopModelCapability[] }
+      : {}),
+    provider: group.provider as DesktopModelProvider,
+    ...(group.transportKind ? { transportKind: group.transportKind as DesktopTransportKind } : {}),
+    ...(group.providerSite ? { providerSite: group.providerSite as ResolvedModelProfile['providerSite'] } : {}),
+    ...(group.alibabaWorkspaceId ? { alibabaWorkspaceId: group.alibabaWorkspaceId } : {}),
+    ...(group.alibabaBillingMode
+      ? { alibabaBillingMode: group.alibabaBillingMode as DesktopAlibabaBillingMode }
+      : {}),
+    ...(group.awsRegion ? { awsRegion: group.awsRegion } : {}),
+    ...(group.azureResourceName ? { azureResourceName: group.azureResourceName } : {}),
+    ...(group.cloudflareAccountId ? { cloudflareAccountId: group.cloudflareAccountId } : {}),
+    ...(group.cloudflareGatewayId ? { cloudflareGatewayId: group.cloudflareGatewayId } : {}),
+    ...(group.vertexProject ? { vertexProject: group.vertexProject } : {}),
+    ...(group.vertexLocation ? { vertexLocation: group.vertexLocation } : {}),
+    ...(model.contextLength !== undefined ? { contextLength: model.contextLength } : {}),
+    ...(model.supportsThinkingType ? { supportsThinkingType: model.supportsThinkingType } : {}),
+  };
+}
+
+export function resolveModelProfile(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  ref: ModelRef | undefined,
+): ResolvedModelProfile | null {
+  if (!ref?.groupId?.trim() || !ref?.name?.trim()) {
+    return null;
+  }
+  const group = config.providerGroups.find((entry) => entry.id === ref.groupId.trim());
+  if (!group) {
+    return null;
+  }
+  const model = group.models.find((entry) => entry.name === ref.name.trim());
+  if (!model) {
+    return null;
+  }
+  return resolveModelProfileFromParts(group, model);
+}
+
+export function findProviderGroup(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  groupId: string,
+): ProviderGroupV2 | undefined {
+  const normalized = groupId.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return config.providerGroups.find((group) => group.id === normalized);
+}
+
+export function modelExistsInGroup(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  groupId: string,
+  name: string,
+): boolean {
+  const group = findProviderGroup(config, groupId);
+  if (!group) {
+    return false;
+  }
+  return group.models.some((model) => model.name === name.trim());
+}
+
+export function listAllModelRefs(config: Pick<DesktopConfigFile, 'providerGroups'>): ModelRef[] {
+  const refs: ModelRef[] = [];
+  for (const group of config.providerGroups) {
+    for (const model of group.models) {
+      refs.push({ groupId: group.id, name: model.name });
+    }
+  }
+  return refs;
+}
+
+export function firstModelRef(config: Pick<DesktopConfigFile, 'providerGroups'>): ModelRef {
+  const firstGroup = config.providerGroups[0];
+  const firstModel = firstGroup?.models[0];
+  if (!firstGroup || !firstModel) {
+    return { groupId: '', name: '' };
+  }
+  return { groupId: firstGroup.id, name: firstModel.name };
+}
+
+export function modelRefExists(
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  ref: ModelRef | undefined,
+): boolean {
+  return resolveModelProfile(config, ref) !== null;
+}
+
+export function resolveActiveModelProfile(
+  config: DesktopConfigFile,
+): ResolvedModelProfile | null {
+  return resolveModelProfile(config, config.activeModel);
+}
+
+export function modelSupportsImageGeneration(model: Pick<ModelProfileSnapshot, 'capabilities'>): boolean {
+  return model.capabilities?.includes('imageGeneration') === true;
+}
+
+export function modelSupportsVideoGeneration(model: Pick<ModelProfileSnapshot, 'capabilities'>): boolean {
+  return model.capabilities?.includes('videoGeneration') === true;
+}
+
+export function modelSupportsChat(model: Pick<ModelProfileSnapshot, 'capabilities'>): boolean {
+  return model.capabilities === undefined || model.capabilities.includes('chat');
+}
+
+export function normalizeSlotModelRef(
+  value: unknown,
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  predicate: (profile: ResolvedModelProfile) => boolean,
+): ModelRef | undefined {
+  const ref = typeof value === 'object' && value !== null
+    ? {
+        groupId: typeof (value as ModelRef).groupId === 'string' ? (value as ModelRef).groupId.trim() : '',
+        name: typeof (value as ModelRef).name === 'string' ? (value as ModelRef).name.trim() : '',
+      }
+    : undefined;
+  if (!ref?.groupId || !ref?.name) {
+    return undefined;
+  }
+  const profile = resolveModelProfile(config, ref);
+  return profile && predicate(profile) ? ref : undefined;
+}

--- a/apps/desktop/src/host/pane-snapshot.ts
+++ b/apps/desktop/src/host/pane-snapshot.ts
@@ -2,11 +2,13 @@ import { appendQueuedUserTurnSnapshots } from './message-queue.js';
 import { isSessionBundleBusy } from './direct-media-turn.js';
 import type { DesktopConversationSnapshotView } from './conversation-snapshot.js';
 import type { SessionBundle } from './session-bundle.js';
+
 import type {
   ActiveSessionSnapshot,
   ConversationSnapshot,
   DesktopGitSnapshot,
   DesktopWorkspaceBinding,
+  ModelRef,
   PaneSessionSlice,
   PendingAssistantAux,
 } from '../types.js';
@@ -41,7 +43,7 @@ export function buildPaneSessionSlice(input: {
     git: DesktopGitSnapshot;
   };
   paneModel?: {
-    activeModel: string;
+    activeModel: ModelRef;
   };
 }): PaneSessionSlice {
   const { bundle } = input;

--- a/apps/desktop/src/host/provider-api-key.ts
+++ b/apps/desktop/src/host/provider-api-key.ts
@@ -1,4 +1,14 @@
 import {
+  hasBedrockIamCredentials,
+  hasGoogleVertexServiceAccountCredentials,
+} from '../lib/provider-runtime-credentials.js';
+
+export {
+  hasBedrockIamCredentials,
+  hasGoogleVertexServiceAccountCredentials,
+} from '../lib/provider-runtime-credentials.js';
+
+import {
   emptyModelRef,
   findModelByRef,
   listAllModelRefs,
@@ -60,22 +70,10 @@ export function hasBedrockRuntimeCredentials(credentials: BedrockProviderCredent
   return hasBedrockIamCredentials(credentials);
 }
 
-export function hasBedrockIamCredentials(
-  credentials: Pick<BedrockProviderCredentials, 'accessKeyId' | 'secretAccessKey'>,
-): boolean {
-  return Boolean(credentials.accessKeyId?.trim() && credentials.secretAccessKey?.trim());
-}
-
 export interface GoogleVertexProviderCredentials {
   apiKey?: string;
   clientEmail?: string;
   privateKey?: string;
-}
-
-export function hasGoogleVertexServiceAccountCredentials(
-  credentials: Pick<GoogleVertexProviderCredentials, 'clientEmail' | 'privateKey'>,
-): boolean {
-  return Boolean(credentials.clientEmail?.trim() && credentials.privateKey?.trim());
 }
 
 export function hasGoogleVertexRuntimeCredentials(input: {

--- a/apps/desktop/src/host/provider-api-key.ts
+++ b/apps/desktop/src/host/provider-api-key.ts
@@ -1,25 +1,50 @@
+import {
+  emptyModelRef,
+  findModelByRef,
+  listAllModelRefs,
+  modelRefKey,
+  modelRefsEqual,
+  type ModelRef,
+  type ProviderGroupV2,
+} from '@spiritagent/host-internal';
+
 import type { DesktopModelProvider } from '../types.js';
 
-/** Keyring account for a provider-scoped API key (`SpiritAgent` / `provider::{id}`). */
-export function providerKeyAccount(providerId: string): string {
-  return `provider::${providerId}`;
+/** Keyring account for a provider-group-scoped API key (`SpiritAgent` / `group::{id}`). */
+export function groupKeyAccount(groupId: string): string {
+  return `group::${groupId}`;
 }
 
-export function providerAccessKeyIdAccount(providerId: string): string {
-  return `provider::${providerId}::access-key-id`;
+export function groupAccessKeyIdAccount(groupId: string): string {
+  return `group::${groupId}::access-key-id`;
 }
 
-export function providerSecretAccessKeyAccount(providerId: string): string {
-  return `provider::${providerId}::secret-access-key`;
+export function groupSecretAccessKeyAccount(groupId: string): string {
+  return `group::${groupId}::secret-access-key`;
 }
 
-export function providerVertexClientEmailAccount(providerId: string): string {
-  return `provider::${providerId}::client-email`;
+export function groupVertexClientEmailAccount(groupId: string): string {
+  return `group::${groupId}::client-email`;
 }
 
-export function providerVertexPrivateKeyAccount(providerId: string): string {
-  return `provider::${providerId}::private-key`;
+export function groupVertexPrivateKeyAccount(groupId: string): string {
+  return `group::${groupId}::private-key`;
 }
+
+/** @deprecated Use {@link groupKeyAccount} */
+export const providerKeyAccount = groupKeyAccount;
+
+/** @deprecated Use {@link groupAccessKeyIdAccount} */
+export const providerAccessKeyIdAccount = groupAccessKeyIdAccount;
+
+/** @deprecated Use {@link groupSecretAccessKeyAccount} */
+export const providerSecretAccessKeyAccount = groupSecretAccessKeyAccount;
+
+/** @deprecated Use {@link groupVertexClientEmailAccount} */
+export const providerVertexClientEmailAccount = groupVertexClientEmailAccount;
+
+/** @deprecated Use {@link groupVertexPrivateKeyAccount} */
+export const providerVertexPrivateKeyAccount = groupVertexPrivateKeyAccount;
 
 export interface BedrockProviderCredentials {
   apiKey?: string;
@@ -75,15 +100,32 @@ export function modelProviderKeyScope(provider?: DesktopModelProvider): DesktopM
 }
 
 export interface ModelKeyPresenceProfile {
+  groupId: string;
   name: string;
   provider?: DesktopModelProvider;
   vertexProject?: string;
   vertexLocation?: string;
 }
 
-export type ExistingModelForProviderAdd = ModelKeyPresenceProfile;
+export type ExistingModelForGroupAdd = ModelKeyPresenceProfile;
 
-/** True when the same model id is already configured under this provider scope. */
+/** @deprecated Use {@link ExistingModelForGroupAdd} */
+export type ExistingModelForProviderAdd = ExistingModelForGroupAdd;
+
+/** True when the same model id is already configured under this provider group. */
+export function modelExistsInGroupScope(
+  existingModels: readonly ExistingModelForGroupAdd[],
+  groupId: string,
+  name: string,
+): boolean {
+  const normalizedGroupId = groupId.trim();
+  const normalizedName = name.trim();
+  return existingModels.some(
+    (model) => model.groupId === normalizedGroupId && model.name === normalizedName,
+  );
+}
+
+/** @deprecated Use {@link modelExistsInGroupScope} */
 export function modelExistsInProviderScope(
   existingModels: readonly ExistingModelForProviderAdd[],
   name: string,
@@ -97,40 +139,33 @@ export function modelExistsInProviderScope(
 
 /** After removing models, keep active if still valid; else first remaining or empty. */
 export function resolveActiveModelAfterRemoval(
-  currentActive: string,
-  remainingModels: readonly Pick<ModelKeyPresenceProfile, 'name'>[],
-  removedNames: readonly string[],
-): string {
-  if (!removedNames.some((name) => name === currentActive)) {
+  currentActive: ModelRef,
+  remainingModels: readonly ModelRef[],
+  removedRefs: readonly ModelRef[],
+): ModelRef {
+  if (!removedRefs.some((ref) => modelRefsEqual(ref, currentActive))) {
     return currentActive;
   }
-  return remainingModels[0]?.name ?? '';
+  return remainingModels[0] ? { ...remainingModels[0] } : emptyModelRef();
 }
 
 type ModelRemovalConfigTarget = {
-  models: Array<{ name: string; provider?: DesktopModelProvider }>;
-  activeModel: string;
-  imageGenerationModel?: string;
-  videoGenerationModel?: string;
-  lightweightChatModel?: string;
+  providerGroups: ProviderGroupV2[];
+  activeModel: ModelRef;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
+  lightweightChatModel?: ModelRef;
 };
 
 export type ModelRemovalTarget = {
-  name: string;
-  provider?: DesktopModelProvider;
+  ref: ModelRef;
 };
 
-function modelMatchesRemovalTarget(
-  model: { name: string; provider?: DesktopModelProvider },
-  target: ModelRemovalTarget,
+function modelRefStillExists(
+  groups: readonly ProviderGroupV2[],
+  ref: ModelRef | undefined,
 ): boolean {
-  if (model.name !== target.name) {
-    return false;
-  }
-  if (target.provider === undefined) {
-    return true;
-  }
-  return modelProviderKeyScope(model.provider) === modelProviderKeyScope(target.provider);
+  return findModelByRef(groups, ref) !== undefined;
 }
 
 function clearDefaultSlotIfNoRemainingModel(
@@ -138,7 +173,7 @@ function clearDefaultSlotIfNoRemainingModel(
   slot: 'imageGenerationModel' | 'videoGenerationModel' | 'lightweightChatModel',
 ): void {
   const value = config[slot];
-  if (value && !config.models.some((model) => model.name === value)) {
+  if (value && !modelRefStillExists(config.providerGroups, value)) {
     delete config[slot];
   }
 }
@@ -151,14 +186,21 @@ export function applyModelsRemovalToConfig(
   if (targetsToRemove.length === 0) {
     return 0;
   }
-  const before = config.models.length;
-  config.models = config.models.filter(
-    (model) => !targetsToRemove.some((target) => modelMatchesRemovalTarget(model, target)),
-  );
-  const removed = before - config.models.length;
+  let removed = 0;
+  for (const group of config.providerGroups) {
+    const before = group.models.length;
+    group.models = group.models.filter(
+      (model) =>
+        !targetsToRemove.some(
+          (target) => target.ref.groupId === group.id && target.ref.name === model.name,
+        ),
+    );
+    removed += before - group.models.length;
+  }
 
-  if (!config.models.some((model) => model.name === config.activeModel)) {
-    config.activeModel = config.models[0]?.name ?? '';
+  if (!modelRefStillExists(config.providerGroups, config.activeModel)) {
+    const remaining = listAllModelRefs(config.providerGroups);
+    config.activeModel = remaining[0] ? { ...remaining[0] } : emptyModelRef();
   }
   clearDefaultSlotIfNoRemainingModel(config, 'imageGenerationModel');
   clearDefaultSlotIfNoRemainingModel(config, 'videoGenerationModel');
@@ -166,37 +208,41 @@ export function applyModelsRemovalToConfig(
   return removed;
 }
 
-/** Model ids from `modelIds` that are not already present under the target provider scope. */
-export function filterNewProviderModelIds(
-  existingModels: readonly ExistingModelForProviderAdd[],
+/** Model ids from `modelIds` that are not already present under the target group. */
+export function filterNewGroupModelIds(
+  existingModels: readonly ExistingModelForGroupAdd[],
   modelIds: readonly string[],
-  provider?: DesktopModelProvider,
+  groupId: string,
 ): string[] {
-  return modelIds.filter((name) => !modelExistsInProviderScope(existingModels, name, provider));
+  return modelIds.filter((name) => !modelExistsInGroupScope(existingModels, groupId, name));
 }
 
+/** @deprecated Use {@link filterNewGroupModelIds} */
+export const filterNewProviderModelIds = filterNewGroupModelIds;
+
 /**
- * Per-model keyring presence: provider-level entry OR legacy per-model entry.
+ * Per-model keyring presence: group-level entry OR legacy per-model entry.
  * Does not include env vars or global fallback (snapshot `keyConfigured` semantics).
  */
 export function buildModelSecretKeyPresence(
   profiles: ModelKeyPresenceProfile[],
-  hasProviderKey: (providerId: string, profile: ModelKeyPresenceProfile) => boolean,
-  hasModelKey: (modelName: string) => boolean,
+  hasGroupKey: (groupId: string, profile: ModelKeyPresenceProfile) => boolean,
+  hasModelKey: (refKey: string) => boolean,
 ): Record<string, boolean> {
-  const providerCache = new Map<string, boolean>();
+  const groupCache = new Map<string, boolean>();
   const out: Record<string, boolean> = {};
   for (const profile of profiles) {
-    const scope = modelProviderKeyScope(profile.provider);
+    const ref: ModelRef = { groupId: profile.groupId, name: profile.name };
+    const refKey = modelRefKey(ref);
     const cacheKey = profile.provider === 'google-vertex-ai'
-      ? `${scope}::${profile.vertexProject?.trim() ?? ''}::${profile.vertexLocation?.trim() ?? ''}`
-      : scope;
-    let providerPresent = providerCache.get(cacheKey);
-    if (providerPresent === undefined) {
-      providerPresent = hasProviderKey(scope, profile);
-      providerCache.set(cacheKey, providerPresent);
+      ? `${profile.groupId}::${profile.vertexProject?.trim() ?? ''}::${profile.vertexLocation?.trim() ?? ''}`
+      : profile.groupId;
+    let groupPresent = groupCache.get(cacheKey);
+    if (groupPresent === undefined) {
+      groupPresent = hasGroupKey(profile.groupId, profile);
+      groupCache.set(cacheKey, groupPresent);
     }
-    out[profile.name] = providerPresent ? true : hasModelKey(profile.name);
+    out[refKey] = groupPresent ? true : hasModelKey(refKey);
   }
   return out;
 }

--- a/apps/desktop/src/host/service-utils.ts
+++ b/apps/desktop/src/host/service-utils.ts
@@ -29,7 +29,12 @@ import {
   mergeRecentWorkspaceRoots,
   resolveDesktopHomeDirectory,
 } from './storage.js';
+import type { DesktopModelReasoningEffort } from '../types.js';
 import { resolveProfileApiBase } from './model-config.js';
+import {
+  flattenProviderGroups,
+  resolveActiveModelProfile,
+} from './model-config-access.js';
 import {
   DESKTOP_WEB_HOST_POLICY,
   getDesktopWebHostRuntimeStatus,
@@ -205,8 +210,7 @@ export function buildWebHostSnapshot(config: DesktopWebHostConfigFile): DesktopW
 }
 
 export function currentApiBase(config: DesktopConfigFile): string {
-  const profile =
-    config.models.find((model) => model.name === config.activeModel) ?? config.models[0];
+  const profile = resolveActiveModelProfile(config) ?? flattenProviderGroups(config)[0];
   if (!profile) {
     return '';
   }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -120,6 +120,7 @@ import type {
   RememberWorkspaceRequest,
   ForgetWorkspaceRequest,
   RemoveModelRequest,
+  RemoveProviderGroupRequest,
   RemoveProviderModelsRequest,
   QueryWorkspaceFileReferenceSuggestionsRequest,
   RecordCodeCompletionFileStateRequest,
@@ -160,6 +161,7 @@ import {
   addProviderModelsCommand,
   previewModelsCommand,
   removeModelCommand,
+  removeProviderGroupCommand,
   removeProviderModelsCommand,
   updateConfigCommand,
   type HostModelCommandContext,
@@ -314,7 +316,13 @@ import {
   freezePaneActiveModelIfNeeded,
   ensureVisiblePaneActiveModels,
 } from './active-model-sync.js';
+import {
+  findModelRefByName,
+  resolveModelProfile,
+} from './model-config-access.js';
 import { deleteSessionCommand, type SessionDeleteContext } from './session-delete.js';
+import { modelRefKey, modelRefsEqual } from '@spiritagent/host-internal';
+import type { ModelRef } from '../types.js';
 import { renameSessionCommand, type SessionRenameContext } from './session-rename.js';
 import {
   finishSessionActivationCommand,
@@ -915,7 +923,7 @@ class DesktopHostService {
     const state = this.state;
     const workspaceRoot = bundle.workspaceRoot || state?.workspaceRoot || '';
     const hookRunner = this.getHookRunner(workspaceRoot);
-    const context = buildDesktopHookSessionContext(bundle, state?.config.activeModel);
+    const context = buildDesktopHookSessionContext(bundle, state?.config.activeModel.name);
     await runDesktopSessionEndHook(hookRunner, context, reason);
   }
 
@@ -926,7 +934,7 @@ class DesktopHostService {
     const state = this.state;
     const workspaceRoot = bundle.workspaceRoot || state?.workspaceRoot || '';
     const hookRunner = this.getHookRunner(workspaceRoot);
-    const context = buildDesktopHookSessionContext(bundle, state?.config.activeModel);
+    const context = buildDesktopHookSessionContext(bundle, state?.config.activeModel.name);
     await runDesktopSessionStartHook(bundle.runtime, hookRunner, context, source);
   }
 
@@ -1025,7 +1033,7 @@ class DesktopHostService {
   private paneModelContext(): PaneModelHostContext {
     return {
       ...this.sessionSplitContext(),
-      adoptActiveModelForForeground: (modelName) => this.adoptActiveModelForForeground(modelName),
+      adoptActiveModelForForeground: (modelRef) => this.adoptActiveModelForForeground(modelRef),
       refreshRuntimeForBundle: (bundle) => this.refreshRuntimeForBundle(bundle),
       invalidatePaneSessionSliceCache: (sessionPath) => {
         this.paneSessionSliceCache.delete(path.resolve(sessionPath));
@@ -1037,19 +1045,17 @@ class DesktopHostService {
     };
   }
 
-  private async adoptActiveModelForForeground(modelName: string): Promise<void> {
+  private async adoptActiveModelForForeground(modelRef: ModelRef): Promise<void> {
     const state = this.requireState();
     const bundle = this.activeBundle();
-    const normalized = modelName.trim();
-    if (!normalized) {
-      throw new Error(i18n.t('error.modelNameRequired'));
+    const activeProfile = resolveModelProfile(state.config, modelRef);
+    if (!activeProfile) {
+      throw new Error(i18n.t('error.modelNotFound', { model: modelRef.name }));
     }
-    if (!state.config.models.some((model) => model.name === normalized)) {
-      throw new Error(i18n.t('error.modelNotFound', { model: normalized }));
-    }
+    const resolvedRef = activeProfile.ref;
 
-    const modelChanged = state.config.activeModel !== normalized;
-    bundle.activeModel = normalized;
+    const modelChanged = !modelRefsEqual(state.config.activeModel, resolvedRef);
+    bundle.activeModel = resolvedRef;
     const runtimeBusy = bundle.runtime?.isBusy() === true;
     if (!modelChanged) {
       if (!runtimeBusy) {
@@ -1059,7 +1065,7 @@ class DesktopHostService {
       return;
     }
 
-    state.config.activeModel = normalized;
+    state.config.activeModel = resolvedRef;
     await saveConfig(state.config);
     this.clearActiveBundleContextUsage();
     if (runtimeBusy) {
@@ -1288,8 +1294,8 @@ class DesktopHostService {
         if (!state) {
           return undefined;
         }
-        const activeModelName = resolveEffectivePaneActiveModel(bundle, state).trim();
-        return state.config.models.find((model) => model.name === activeModelName);
+        const activeModelRef = resolveEffectivePaneActiveModel(bundle, state);
+        return resolveModelProfile(state.config, activeModelRef) ?? undefined;
       },
       resolveCatalogHints: () => buildModelCatalogHints(this.requireState().config),
       setContextUsage: (usage) => {
@@ -1446,6 +1452,10 @@ class DesktopHostService {
 
   async removeProviderModels(request: RemoveProviderModelsRequest): Promise<DesktopSnapshot> {
     return removeProviderModelsCommand(this.modelCommandContext(), request);
+  }
+
+  async removeProviderGroup(request: RemoveProviderGroupRequest): Promise<DesktopSnapshot> {
+    return removeProviderGroupCommand(this.modelCommandContext(), request);
   }
 
   async createSkill(request: CreateSkillRequest): Promise<DesktopSnapshot> {
@@ -1643,12 +1653,12 @@ class DesktopHostService {
       const exportPayload = {
         export_version: 2,
         exported_at_unix_secs: exportedAtUnixSecs,
-        active_model: state.config.activeModel,
+        active_model: modelRefKey(state.config.activeModel),
         api_base: currentApiBase(state.config),
         working_directory: state.workspaceRoot,
         system_prompts: {
           ...(this.runtimeTransport.llmSystemPromptsForExport() as Record<string, unknown>),
-          tool_agent: buildToolAgentHostPrompt(state.config.activeModel),
+          tool_agent: buildToolAgentHostPrompt(state.config.activeModel.name),
           ...(rulesSystemPrompt === undefined ? {} : { rules: rulesSystemPrompt }),
           ...(skillsCatalogSystemPrompt === undefined
             ? {}
@@ -2621,8 +2631,8 @@ class DesktopHostService {
     }
     // 保留 bundle.currentTurnSkills：斜杠激活的 turn skill 须在 startUserTurnStreaming 时注入用户消息 meta
     const effectiveActiveModel = resolveEffectivePaneActiveModel(bundle, state);
-    const activeProfile = state.config.models.find((m) => m.name === effectiveActiveModel);
-    const activeTransportKind = resolveDesktopTransportKind(activeProfile);
+    const activeProfile = resolveModelProfile(state.config, effectiveActiveModel);
+    const activeTransportKind = resolveDesktopTransportKind(activeProfile ?? undefined);
     const bedrockCredentials = activeTransportKind === 'bedrock' && activeProfile?.provider
       ? readBedrockProviderCredentialsFromKeyring(modelProviderKeyScope(activeProfile.provider))
       : undefined;
@@ -2653,16 +2663,16 @@ class DesktopHostService {
     this.activeApiKeyConfigured = runtimeAuthReady;
     const extensionSystemPrompts = this.extensionWarmup.systemPromptsCache;
     const imageGenerationProfile = state.config.imageGenerationModel
-      ? state.config.models.find((model) => model.name === state.config.imageGenerationModel)
+      ? resolveModelProfile(state.config, state.config.imageGenerationModel) ?? undefined
       : undefined;
     const videoGenerationProfile = state.config.videoGenerationModel
-      ? state.config.models.find((model) => model.name === state.config.videoGenerationModel)
+      ? resolveModelProfile(state.config, state.config.videoGenerationModel) ?? undefined
       : undefined;
     const imageGenerationApiKey = imageGenerationProfile
-      ? await resolveApiKeyForConfigModel(state.config, imageGenerationProfile.name)
+      ? await resolveApiKeyForConfigModel(state.config, imageGenerationProfile.ref)
       : undefined;
     const videoGenerationApiKey = videoGenerationProfile
-      ? await resolveApiKeyForConfigModel(state.config, videoGenerationProfile.name)
+      ? await resolveApiKeyForConfigModel(state.config, videoGenerationProfile.ref)
       : undefined;
     bundle.runtimeTransport = createLlmTransport();
     if (!runtimeAuthReady) {
@@ -2679,10 +2689,10 @@ class DesktopHostService {
 
     let runtimeTransportConfig = buildPrimaryTransportConfig({
       apiKey: apiKey ?? bedrockCredentials?.apiKey ?? '',
-      model: effectiveActiveModel,
+      model: activeProfile?.name ?? effectiveActiveModel.name,
       baseUrl: currentApiBase(state.config),
       workspaceRoot: bundle.workspaceRoot || state.workspaceRoot,
-      profile: activeProfile,
+      profile: activeProfile ?? undefined,
       agentMode: resolveDesktopAgentMode(state.config),
       ...(activeTransportKind === 'bedrock' && bedrockCredentials
         ? { bedrockCredentials: { ...bedrockCredentials, apiKey: apiKey ?? bedrockCredentials.apiKey } }
@@ -3266,7 +3276,7 @@ class DesktopHostService {
       this.modelKeyPresence = {};
       return;
     }
-    this.modelKeyPresence = await modelSecretKeyPresence(state.config.models);
+    this.modelKeyPresence = await modelSecretKeyPresence(state.config);
   }
 
   private clearActiveBundleContextUsage(): void {
@@ -3321,7 +3331,8 @@ class DesktopHostService {
     if (!state || !activeModel.provider) {
       return;
     }
-    const profile = state.config.models.find((model) => model.name === activeModel.name);
+    const activeRef = findModelRefByName(state.config, activeModel.name);
+    const profile = activeRef ? resolveModelProfile(state.config, activeRef) : undefined;
     if (!profile) {
       return;
     }
@@ -3694,7 +3705,9 @@ class DesktopHostService {
         paneWorkspace?.git?.revision ?? 0,
         paneWorkspace?.git?.selectedBranch ?? paneWorkspace?.git?.branch ?? '',
         bundle.approvalLevel,
-        paneModel?.activeModel ?? resolveEffectivePaneActiveModel(bundle, this.requireState()),
+        paneModel?.activeModel
+          ? modelRefKey(paneModel.activeModel)
+          : modelRefKey(resolveEffectivePaneActiveModel(bundle, this.requireState())),
       ].join('\0');
       const cached = this.paneSessionSliceCache.get(resolved);
       // 流式回合中 messageTimeline 内容会变但 revision/msgCount 签名常不变；忙碌时禁用缓存（19a224c6 回归）。
@@ -3934,7 +3947,7 @@ class DesktopHostService {
     if (!lightweightModel) {
       throw new Error(i18n.t('error.lightweightChatModelNotConfigured'));
     }
-    const apiKey = await resolveApiKeyForConfigModel(state.config, lightweightModel.name);
+    const apiKey = await resolveApiKeyForConfigModel(state.config, lightweightModel.profile.ref);
     if (!apiKey) {
       throw new Error(i18n.t('error.autoWorktreeNameFailedNoKey'));
     }

--- a/apps/desktop/src/host/service.ts
+++ b/apps/desktop/src/host/service.ts
@@ -2901,7 +2901,7 @@ class DesktopHostService {
         }
         return {
           workspaceRoot,
-          modelName: lightweightModel.name,
+          modelRef: lightweightModel.profile.ref,
           ...(lightweightModel.profile.reasoningEffort
             ? { reasoningEffort: lightweightModel.profile.reasoningEffort }
             : {}),

--- a/apps/desktop/src/host/session-bundle.ts
+++ b/apps/desktop/src/host/session-bundle.ts
@@ -7,6 +7,8 @@ import type {
 import type { DesktopToolRequest, SessionTitleSource } from './contracts.js';
 import type { ApprovalLevel, WorkLocationKind } from '@spiritagent/host-internal';
 
+import type { ModelRef } from '../types.js';
+
 import type { DesktopRuntime } from './runtime.js';
 import type { DesktopToolExecutor } from './tool-executor.js';
 
@@ -41,7 +43,7 @@ export interface SessionBundle {
   archiveSubagentSessions: NonNullable<ChatArchive['subagentSessions']>;
   loopEnabled: boolean;
   approvalLevel: ApprovalLevel;
-  activeModel?: string;
+  activeModel?: ModelRef;
   pendingGitBranch?: string;
   workLocation: WorkLocationKind;
   rewind: StoredDesktopRewindMetadata;

--- a/apps/desktop/src/host/session-title-generation.ts
+++ b/apps/desktop/src/host/session-title-generation.ts
@@ -32,7 +32,7 @@ export async function generateSessionTitleFromModelTask(
     throw new Error('Lightweight chat model is not available.');
   }
 
-  const apiKey = await resolveApiKeyForConfigModel(context.config, resolved.name);
+  const apiKey = await resolveApiKeyForConfigModel(context.config, resolved.profile.ref);
   if (!apiKey) {
     throw new Error(`API key is not configured for lightweight chat model: ${resolved.name}`);
   }

--- a/apps/desktop/src/host/session-turn-orchestrator.ts
+++ b/apps/desktop/src/host/session-turn-orchestrator.ts
@@ -84,7 +84,7 @@ export interface SessionTurnOrchestratorContext {
   requireRuntime(): DesktopRuntime;
   requireState(): { workspaceRoot: string };
   requireConfig(): import('./storage.js').DesktopConfigFile;
-  resolveApiKeyForConfigModel(model: string): Promise<string | undefined>;
+  resolveApiKeyForConfigModel(model: import('../types.js').ModelRef): Promise<string | undefined>;
   activeBundle(): SessionBundle;
   allBundles(): Iterable<SessionBundle>;
   getActiveBundle(): SessionBundle | undefined;

--- a/apps/desktop/src/host/sessions.ts
+++ b/apps/desktop/src/host/sessions.ts
@@ -19,8 +19,14 @@ import type {
   ConversationMessageSnapshot,
   SessionListItem,
 } from '../types.js';
-import { extractActivePlanPathFromLlmHistory, normalizeApprovalLevel } from '@spiritagent/host-internal';
-import type { ApprovalLevel } from '@spiritagent/host-internal';
+import {
+  extractActivePlanPathFromLlmHistory,
+  modelRefKey,
+  normalizeApprovalLevel,
+  parseModelRef,
+  type ApprovalLevel,
+  type ModelRef,
+} from '@spiritagent/host-internal';
 import type { QueuedUserTurn } from './message-queue.js';
 import type { SessionTitleSource } from './contracts.js';
 import type { DesktopTimelineTurnSnapshot } from './message-timeline.js';
@@ -41,6 +47,33 @@ export const EPHEMERAL_WORKTREE_SESSION_PREFIX = 'ephemeral://worktree-naming/';
 export const EPHEMERAL_SESSION_TITLE_PREFIX = 'ephemeral://session-title/';
 const MAX_EPHEMERAL_COMMIT_SESSIONS = 8;
 
+function parseStoredSessionActiveModel(value: unknown): ModelRef | undefined {
+  const asRef = parseModelRef(value);
+  if (asRef) {
+    return asRef;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    const separatorIndex = trimmed.lastIndexOf('::');
+    if (separatorIndex > 0) {
+      const groupId = trimmed.slice(0, separatorIndex).trim();
+      const name = trimmed.slice(separatorIndex + 2).trim();
+      if (groupId && name) {
+        return { groupId, name };
+      }
+    }
+    return { groupId: '', name: trimmed };
+  }
+  return undefined;
+}
+
+export function serializeSessionActiveModel(ref: ModelRef): string {
+  return modelRefKey(ref);
+}
+
 export interface EphemeralSessionRecord {
   path: string;
   displayName: string;
@@ -60,7 +93,7 @@ export interface RestoredSessionState {
   rewind: StoredDesktopRewindMetadata;
   loopEnabled: boolean;
   approvalLevel: ApprovalLevel;
-  activeModel?: string;
+  activeModel?: ModelRef;
   activePlanPath?: string;
   sessionTitleSource?: SessionTitleSource;
   contextUsage?: ConversationContextUsageSnapshot;
@@ -175,9 +208,10 @@ export function restoreStoredSessionState(input: {
     rewind: input.loaded.rewind ?? createDesktopRewindMetadata(),
     loopEnabled: input.loaded.loopEnabled === true,
     approvalLevel: normalizeApprovalLevel(input.loaded.approvalLevel),
-    ...(typeof input.loaded.activeModel === 'string' && input.loaded.activeModel.trim()
-      ? { activeModel: input.loaded.activeModel.trim() }
-      : {}),
+    ...((): { activeModel?: ModelRef } => {
+      const activeModel = parseStoredSessionActiveModel(input.loaded.activeModel);
+      return activeModel ? { activeModel } : {};
+    })(),
     ...(activePlanPath ? { activePlanPath } : {}),
     ...(input.loaded.sessionTitleSource === 'seed'
       || input.loaded.sessionTitleSource === 'llm'
@@ -211,7 +245,7 @@ export function buildStoredDesktopSession(input: {
   rewind: StoredDesktopRewindMetadata;
   loopEnabled: boolean;
   approvalLevel: ApprovalLevel;
-  activeModel?: string;
+  activeModel?: ModelRef;
   contextUsage?: ConversationContextUsageSnapshot;
   subagentDesktopTimelines?: Record<string, PersistedDesktopTimelineTurnSnapshot[]>;
   queuedUserTurns?: QueuedUserTurn[];
@@ -226,7 +260,7 @@ export function buildStoredDesktopSession(input: {
     ...(input.subagentSessions?.length ? { subagentSessions: input.subagentSessions } : {}),
     loopEnabled: input.loopEnabled,
     approvalLevel: input.approvalLevel,
-    ...(input.activeModel ? { activeModel: input.activeModel } : {}),
+    ...(input.activeModel ? { activeModel: serializeSessionActiveModel(input.activeModel) } : {}),
     desktopMessageTimeline,
     savedAtUnixMs: input.savedAtUnixMs ?? Date.now(),
     sessionDisplayName: input.sessionDisplayName,

--- a/apps/desktop/src/host/snapshot.ts
+++ b/apps/desktop/src/host/snapshot.ts
@@ -13,6 +13,7 @@ import type {
   McpStatusSnapshot,
 } from '../types.js';
 import { readModelCatalogCacheSync } from './model-catalog-cache.js';
+import { flattenProviderGroups } from './model-config-access.js';
 import {
   DEFAULT_API_BASE,
   normalizeAgentsConfig,
@@ -53,7 +54,16 @@ export interface BuildDesktopSnapshotInput {
   paneSessions?: DesktopSnapshot['paneSessions'];
 }
 
+function snapshotProviderGroups(config: DesktopConfigFile): DesktopConfigFile['providerGroups'] {
+  return config.providerGroups.map((group) => ({
+    ...group,
+    models: group.models.map((model) => ({ ...model })),
+  }));
+}
+
 export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopSnapshot {
+  const flattenedModels = flattenProviderGroups(input.config);
+
   return {
     workspaceRoot: input.workspaceRoot,
     userHomeDirectory: resolveDesktopHomeDirectory(),
@@ -74,17 +84,9 @@ export function buildDesktopSnapshot(input: BuildDesktopSnapshotInput): DesktopS
     runtimeReady: input.runtimeReady,
     ...(input.runtimeError ? { runtimeError: input.runtimeError } : {}),
     config: {
-      models: input.config.models.map((model) => ({
-        name: model.name,
-        apiBase: model.apiBase,
-        reasoningEffort: model.reasoningEffort,
-        ...(model.thinkingEnabled === false ? { thinkingEnabled: false } : {}),
-        ...(model.supportedReasoningEfforts !== undefined
-          ? { supportedReasoningEfforts: [...model.supportedReasoningEfforts] }
-          : {}),
-        ...(model.capabilities ? { capabilities: [...model.capabilities] } : {}),
-        ...(model.provider ? { provider: model.provider } : {}),
-        ...(model.transportKind ? { transportKind: model.transportKind } : {}),
+      providerGroups: snapshotProviderGroups(input.config),
+      models: flattenedModels.map((model) => ({
+        ...model,
         keyConfigured: input.modelKeyPresence[model.name] ?? false,
       })),
       activeModel: input.config.activeModel,
@@ -163,24 +165,24 @@ export function invalidateModelCatalogHintsMemo(): void {
 
 export function buildModelCatalogHints(config: DesktopConfigFile): DesktopModelCatalogHint[] {
   const seen = new Set<string>();
-  for (const model of config.models) {
-    const base = model.apiBase.trim() || DEFAULT_API_BASE;
-    const transportKind = model.transportKind ?? (model.provider === 'anthropic' ? 'anthropic' : 'openai-compatible');
-    seen.add(`${model.provider ?? 'custom'}::${transportKind}::${base}`);
+  for (const group of config.providerGroups) {
+    const base = group.apiBase.trim() || DEFAULT_API_BASE;
+    const transportKind = group.transportKind ?? (group.provider === 'anthropic' ? 'anthropic' : 'openai-compatible');
+    seen.add(`${group.provider ?? 'custom'}::${transportKind}::${base}`);
   }
   const memoKey = [...seen].join('\n');
   if (modelCatalogHintsMemo?.key === memoKey) {
     return modelCatalogHintsMemo.hints;
   }
   const hints: DesktopModelCatalogHint[] = [];
-  for (const model of config.models) {
-    const base = model.apiBase.trim() || DEFAULT_API_BASE;
-    const transportKind = model.transportKind ?? (model.provider === 'anthropic' ? 'anthropic' : 'openai-compatible');
-    const cacheKey = `${model.provider ?? 'custom'}::${transportKind}::${base}`;
+  for (const group of config.providerGroups) {
+    const base = group.apiBase.trim() || DEFAULT_API_BASE;
+    const transportKind = group.transportKind ?? (group.provider === 'anthropic' ? 'anthropic' : 'openai-compatible');
+    const cacheKey = `${group.provider ?? 'custom'}::${transportKind}::${base}`;
     if (!seen.delete(cacheKey)) {
       continue;
     }
-    const hit = readModelCatalogCacheSync(base, model.provider, transportKind);
+    const hit = readModelCatalogCacheSync(base, group.provider, transportKind);
     if (hit && hit.modelIds.length > 0) {
       hints.push({
         ...(hit.provider ? { provider: hit.provider } : {}),

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -32,7 +32,6 @@ import {
 import {
   assertSpiritConfigSchemaVersion,
   createFileExtensionStateStore,
-  defaultPresetProviderGroupId,
   emptyModelRef,
   findModelByRef,
   listAllModelRefs,
@@ -53,6 +52,7 @@ import {
 } from '@spiritagent/host-internal';
 
 import { resolveDesktopAgentMode, type DesktopAgentMode } from '../lib/agent-mode.js';
+import { flattenProviderGroups, resolveModelProfile } from './model-config-access.js';
 import { normalizeContextUsageSnapshot } from '../lib/context-usage.js';
 import { parseModelContextLength } from '../lib/model-context-length.js';
 
@@ -76,14 +76,13 @@ import {
 } from './chat-schema.js';
 import {
   buildModelSecretKeyPresence,
+  groupAccessKeyIdAccount,
+  groupKeyAccount,
+  groupSecretAccessKeyAccount,
+  groupVertexClientEmailAccount,
+  groupVertexPrivateKeyAccount,
   hasBedrockRuntimeCredentials,
   hasGoogleVertexRuntimeCredentials,
-  modelProviderKeyScope,
-  providerAccessKeyIdAccount,
-  providerKeyAccount,
-  providerSecretAccessKeyAccount,
-  providerVertexClientEmailAccount,
-  providerVertexPrivateKeyAccount,
   type BedrockProviderCredentials,
   type GoogleVertexProviderCredentials,
   type ModelKeyPresenceProfile,
@@ -93,10 +92,9 @@ import { normalizeDesktopRewindMetadata } from './rewind.js';
 export { SpiritConfigSchemaError as ConfigSchemaError } from '@spiritagent/host-internal';
 export {
   buildModelSecretKeyPresence,
+  groupKeyAccount,
   hasBedrockRuntimeCredentials,
   hasGoogleVertexRuntimeCredentials,
-  modelProviderKeyScope,
-  providerKeyAccount,
 } from './provider-api-key.js';
 
 export const DEFAULT_API_BASE = 'https://api.openai.com/v1';
@@ -269,118 +267,118 @@ function readGlobalKeyFromKeyring(): string | undefined {
   return trimmed || undefined;
 }
 
-export function readProviderAccessKeyIdFromKeyring(providerId: string): string | undefined {
-  const value = getKeyringPassword(KEYRING_SERVICE, providerAccessKeyIdAccount(providerId));
+export function readProviderAccessKeyIdFromKeyring(groupId: string): string | undefined {
+  const value = getKeyringPassword(KEYRING_SERVICE, groupAccessKeyIdAccount(groupId));
   const trimmed = value?.trim();
   return trimmed || undefined;
 }
 
-export function readProviderSecretAccessKeyFromKeyring(providerId: string): string | undefined {
-  const value = getKeyringPassword(KEYRING_SERVICE, providerSecretAccessKeyAccount(providerId));
+export function readProviderSecretAccessKeyFromKeyring(groupId: string): string | undefined {
+  const value = getKeyringPassword(KEYRING_SERVICE, groupSecretAccessKeyAccount(groupId));
   const trimmed = value?.trim();
   return trimmed || undefined;
 }
 
-export function readProviderVertexClientEmailFromKeyring(providerId: string): string | undefined {
-  const value = getKeyringPassword(KEYRING_SERVICE, providerVertexClientEmailAccount(providerId));
+export function readProviderVertexClientEmailFromKeyring(groupId: string): string | undefined {
+  const value = getKeyringPassword(KEYRING_SERVICE, groupVertexClientEmailAccount(groupId));
   const trimmed = value?.trim();
   return trimmed || undefined;
 }
 
-export function readProviderVertexPrivateKeyFromKeyring(providerId: string): string | undefined {
-  const value = getKeyringPassword(KEYRING_SERVICE, providerVertexPrivateKeyAccount(providerId));
+export function readProviderVertexPrivateKeyFromKeyring(groupId: string): string | undefined {
+  const value = getKeyringPassword(KEYRING_SERVICE, groupVertexPrivateKeyAccount(groupId));
   const trimmed = value?.trim();
   return trimmed || undefined;
 }
 
 export function readBedrockProviderCredentialsFromKeyring(
-  providerId: DesktopModelProvider,
+  groupId: string,
 ): BedrockProviderCredentials {
   return {
-    apiKey: readProviderKeyFromKeyring(providerId),
-    accessKeyId: readProviderAccessKeyIdFromKeyring(providerId),
-    secretAccessKey: readProviderSecretAccessKeyFromKeyring(providerId),
+    apiKey: readProviderKeyFromKeyring(groupId),
+    accessKeyId: readProviderAccessKeyIdFromKeyring(groupId),
+    secretAccessKey: readProviderSecretAccessKeyFromKeyring(groupId),
   };
 }
 
 export async function saveBedrockProviderCredentialsForProvider(
-  providerId: DesktopModelProvider,
+  groupId: string,
   credentials: BedrockProviderCredentials,
 ): Promise<void> {
   const apiKey = credentials.apiKey?.trim();
   if (apiKey) {
-    await saveApiKeyForProvider(providerId, apiKey);
+    await saveApiKeyForProvider(groupId, apiKey);
   } else {
-    await removeProviderApiKey(providerId);
+    await removeProviderApiKey(groupId);
   }
 
   const accessKeyId = credentials.accessKeyId?.trim();
   if (accessKeyId) {
-    setKeyringPassword(KEYRING_SERVICE, providerAccessKeyIdAccount(providerId), accessKeyId);
+    setKeyringPassword(KEYRING_SERVICE, groupAccessKeyIdAccount(groupId), accessKeyId);
   } else {
-    deleteKeyringPassword(KEYRING_SERVICE, providerAccessKeyIdAccount(providerId));
+    deleteKeyringPassword(KEYRING_SERVICE, groupAccessKeyIdAccount(groupId));
   }
 
   const secretAccessKey = credentials.secretAccessKey?.trim();
   if (secretAccessKey) {
-    setKeyringPassword(KEYRING_SERVICE, providerSecretAccessKeyAccount(providerId), secretAccessKey);
+    setKeyringPassword(KEYRING_SERVICE, groupSecretAccessKeyAccount(groupId), secretAccessKey);
   } else {
-    deleteKeyringPassword(KEYRING_SERVICE, providerSecretAccessKeyAccount(providerId));
+    deleteKeyringPassword(KEYRING_SERVICE, groupSecretAccessKeyAccount(groupId));
   }
 }
 
-export async function removeBedrockProviderCredentials(providerId: DesktopModelProvider): Promise<void> {
-  await removeProviderApiKey(providerId);
-  deleteKeyringPassword(KEYRING_SERVICE, providerAccessKeyIdAccount(providerId));
-  deleteKeyringPassword(KEYRING_SERVICE, providerSecretAccessKeyAccount(providerId));
+export async function removeBedrockProviderCredentials(groupId: string): Promise<void> {
+  await removeProviderApiKey(groupId);
+  deleteKeyringPassword(KEYRING_SERVICE, groupAccessKeyIdAccount(groupId));
+  deleteKeyringPassword(KEYRING_SERVICE, groupSecretAccessKeyAccount(groupId));
 }
 
 export function readGoogleVertexProviderCredentialsFromKeyring(
-  providerId: DesktopModelProvider,
+  groupId: string,
 ): GoogleVertexProviderCredentials {
   return {
-    apiKey: readProviderKeyFromKeyring(providerId),
-    clientEmail: readProviderVertexClientEmailFromKeyring(providerId),
-    privateKey: readProviderVertexPrivateKeyFromKeyring(providerId),
+    apiKey: readProviderKeyFromKeyring(groupId),
+    clientEmail: readProviderVertexClientEmailFromKeyring(groupId),
+    privateKey: readProviderVertexPrivateKeyFromKeyring(groupId),
   };
 }
 
 export async function saveGoogleVertexProviderCredentialsForProvider(
-  providerId: DesktopModelProvider,
+  groupId: string,
   credentials: GoogleVertexProviderCredentials,
 ): Promise<void> {
   const apiKey = credentials.apiKey?.trim();
   if (apiKey) {
-    await saveApiKeyForProvider(providerId, apiKey);
+    await saveApiKeyForProvider(groupId, apiKey);
   } else {
-    await removeProviderApiKey(providerId);
+    await removeProviderApiKey(groupId);
   }
 
   const clientEmail = credentials.clientEmail?.trim();
   if (clientEmail) {
-    setKeyringPassword(KEYRING_SERVICE, providerVertexClientEmailAccount(providerId), clientEmail);
+    setKeyringPassword(KEYRING_SERVICE, groupVertexClientEmailAccount(groupId), clientEmail);
   } else {
-    deleteKeyringPassword(KEYRING_SERVICE, providerVertexClientEmailAccount(providerId));
+    deleteKeyringPassword(KEYRING_SERVICE, groupVertexClientEmailAccount(groupId));
   }
 
   const privateKey = credentials.privateKey?.trim();
   if (privateKey) {
-    setKeyringPassword(KEYRING_SERVICE, providerVertexPrivateKeyAccount(providerId), privateKey);
+    setKeyringPassword(KEYRING_SERVICE, groupVertexPrivateKeyAccount(groupId), privateKey);
   } else {
-    deleteKeyringPassword(KEYRING_SERVICE, providerVertexPrivateKeyAccount(providerId));
+    deleteKeyringPassword(KEYRING_SERVICE, groupVertexPrivateKeyAccount(groupId));
   }
 }
 
 export async function removeGoogleVertexProviderCredentials(
-  providerId: DesktopModelProvider,
+  groupId: string,
 ): Promise<void> {
-  await removeProviderApiKey(providerId);
-  deleteKeyringPassword(KEYRING_SERVICE, providerVertexClientEmailAccount(providerId));
-  deleteKeyringPassword(KEYRING_SERVICE, providerVertexPrivateKeyAccount(providerId));
+  await removeProviderApiKey(groupId);
+  deleteKeyringPassword(KEYRING_SERVICE, groupVertexClientEmailAccount(groupId));
+  deleteKeyringPassword(KEYRING_SERVICE, groupVertexPrivateKeyAccount(groupId));
 }
 
-export function readProviderKeyFromKeyring(providerId: string): string | undefined {
-  const value = getKeyringPassword(KEYRING_SERVICE, providerKeyAccount(providerId));
+export function readProviderKeyFromKeyring(groupId: string): string | undefined {
+  const value = getKeyringPassword(KEYRING_SERVICE, groupKeyAccount(groupId));
   const trimmed = value?.trim();
   return trimmed || undefined;
 }
@@ -486,67 +484,69 @@ export async function saveConfig(config: DesktopConfigFile): Promise<void> {
 }
 
 export async function resolveApiKeyForModel(
-  modelName: string,
-  provider?: DesktopModelProvider,
+  groupId: string,
+  modelName?: string,
 ): Promise<string | undefined> {
   const envKey = process.env.SPIRIT_API_KEY?.trim();
   if (envKey) {
     return envKey;
   }
 
-  const providerKey = readProviderKeyFromKeyring(modelProviderKeyScope(provider));
-  if (providerKey) {
-    return providerKey;
+  const groupKey = readProviderKeyFromKeyring(groupId);
+  if (groupKey) {
+    return groupKey;
   }
 
-  const modelKey = readModelKeyFromKeyring(modelName);
-  if (modelKey) {
-    return modelKey;
+  if (modelName) {
+    const modelKey = readModelKeyFromKeyring(modelName);
+    if (modelKey) {
+      return modelKey;
+    }
   }
 
   return readGlobalKeyFromKeyring();
 }
 
 export async function hasApiKeyForModel(
-  modelName: string,
-  provider?: DesktopModelProvider,
+  groupId: string,
+  modelName?: string,
 ): Promise<boolean> {
-  return Boolean(await resolveApiKeyForModel(modelName, provider));
+  return Boolean(await resolveApiKeyForModel(groupId, modelName));
 }
 
 export async function resolveApiKeyForConfigModel(
-  config: Pick<DesktopConfigFile, 'models'>,
-  modelName: string,
+  config: Pick<DesktopConfigFile, 'providerGroups'>,
+  ref: ModelRef,
 ): Promise<string | undefined> {
-  const profile = config.models.find((model) => model.name === modelName);
-  return resolveApiKeyForModel(modelName, profile?.provider);
+  const profile = resolveModelProfile(config, ref);
+  if (!profile) {
+    return undefined;
+  }
+  return resolveApiKeyForModel(profile.groupId, profile.name);
 }
 
 function normalizePresenceProfiles(
-  profilesOrNames: string[] | ModelKeyPresenceProfile[] | ModelProfileSnapshot[],
+  profiles: ModelKeyPresenceProfile[] | ModelProfileSnapshot[],
 ): ModelKeyPresenceProfile[] {
-  if (profilesOrNames.length === 0) {
+  if (profiles.length === 0) {
     return [];
   }
-  const first = profilesOrNames[0];
-  if (typeof first === 'string') {
-    return (profilesOrNames as string[]).map((name) => ({ name }));
-  }
+  const first = profiles[0];
   if ('apiBase' in first && typeof first === 'object' && first !== null) {
-    return (profilesOrNames as ModelProfileSnapshot[]).map(toModelKeyPresenceProfile);
+    return (profiles as ModelProfileSnapshot[]).map(toModelKeyPresenceProfile);
   }
-  return profilesOrNames as ModelKeyPresenceProfile[];
+  return profiles as ModelKeyPresenceProfile[];
 }
 
-function hasProviderSecretInKeyring(providerId: string, profile: ModelKeyPresenceProfile): boolean {
-  if (readProviderKeyFromKeyring(providerId)) {
+function hasGroupSecretInKeyring(groupId: string, profile: ModelKeyPresenceProfile): boolean {
+  if (readProviderKeyFromKeyring(groupId)) {
     return true;
   }
-  if (providerId === 'amazon-bedrock') {
-    return hasBedrockRuntimeCredentials(readBedrockProviderCredentialsFromKeyring('amazon-bedrock'));
+  if (profile.provider === 'amazon-bedrock') {
+    return hasBedrockRuntimeCredentials(readBedrockProviderCredentialsFromKeyring(groupId));
   }
-  if (providerId === 'google-vertex-ai') {
-    const credentials = readGoogleVertexProviderCredentialsFromKeyring('google-vertex-ai');
+  if (profile.provider === 'google-vertex-ai') {
+    const credentials = readGoogleVertexProviderCredentialsFromKeyring(groupId);
     return hasGoogleVertexRuntimeCredentials({
       apiKey: credentials.apiKey,
       clientEmail: credentials.clientEmail,
@@ -559,7 +559,12 @@ function hasProviderSecretInKeyring(providerId: string, profile: ModelKeyPresenc
 }
 
 function toModelKeyPresenceProfile(model: ModelProfileSnapshot): ModelKeyPresenceProfile {
+  const groupId = model.groupId?.trim() ?? model.ref?.groupId?.trim() ?? '';
+  if (!groupId) {
+    throw new Error(`model profile "${model.name}" is missing groupId`);
+  }
   return {
+    groupId,
     name: model.name,
     provider: model.provider,
     ...(model.vertexProject ? { vertexProject: model.vertexProject } : {}),
@@ -567,15 +572,23 @@ function toModelKeyPresenceProfile(model: ModelProfileSnapshot): ModelKeyPresenc
   };
 }
 
-/** 各模型是否在钥匙串中有提供商级或遗留模型级条目（不含环境变量与全局回退）。 */
+function legacyModelKeyPresent(refKey: string): boolean {
+  const separatorIndex = refKey.lastIndexOf('::');
+  const modelName = separatorIndex >= 0 ? refKey.slice(separatorIndex + 2) : refKey;
+  return Boolean(readModelKeyFromKeyring(modelName));
+}
+
+/** 各模型是否在钥匙串中有提供商组级或遗留模型级条目（不含环境变量与全局回退）。 */
 export async function modelSecretKeyPresence(
-  profilesOrNames: string[] | ModelKeyPresenceProfile[] | ModelProfileSnapshot[],
+  input: Pick<DesktopConfigFile, 'providerGroups'> | ModelKeyPresenceProfile[] | ModelProfileSnapshot[],
 ): Promise<Record<string, boolean>> {
-  const profiles = normalizePresenceProfiles(profilesOrNames);
+  const profiles = 'providerGroups' in input
+    ? flattenProviderGroups(input).map(toModelKeyPresenceProfile)
+    : normalizePresenceProfiles(input);
   return buildModelSecretKeyPresence(
     profiles,
-    hasProviderSecretInKeyring,
-    (modelName) => Boolean(readModelKeyFromKeyring(modelName)),
+    hasGroupSecretInKeyring,
+    legacyModelKeyPresent,
   );
 }
 
@@ -584,15 +597,15 @@ export async function saveApiKeyForModel(modelName: string, apiKey: string): Pro
 }
 
 export async function saveApiKeyForProvider(
-  providerId: DesktopModelProvider,
+  groupId: string,
   apiKey: string,
 ): Promise<void> {
-  setKeyringPassword(KEYRING_SERVICE, providerKeyAccount(providerId), apiKey.trim());
+  setKeyringPassword(KEYRING_SERVICE, groupKeyAccount(groupId), apiKey.trim());
 }
 
-/** 删除提供商在钥匙串中的共享 API Key 条目。 */
-export async function removeProviderApiKey(providerId: DesktopModelProvider): Promise<void> {
-  deleteKeyringPassword(KEYRING_SERVICE, providerKeyAccount(providerId));
+/** 删除提供商组在钥匙串中的共享 API Key 条目。 */
+export async function removeProviderApiKey(groupId: string): Promise<void> {
+  deleteKeyringPassword(KEYRING_SERVICE, groupKeyAccount(groupId));
 }
 
 /** 与 CLI `remove_model_api_key` 一致：删除该模型在钥匙串中的专属条目。 */
@@ -1018,8 +1031,10 @@ function normalizeModelEntry(
       ...(transportKind ? { transportKind } : {}),
       ...(supportedReasoningEfforts !== undefined ? { supportedEfforts: supportedReasoningEfforts } : {}),
       ...(supportsThinkingType ? { supportsThinkingType } : {}),
-    }),
-    ...(supportedReasoningEfforts !== undefined ? { supportedReasoningEfforts } : {}),
+    }) as ModelEntryV2['reasoningEffort'],
+    ...(supportedReasoningEfforts !== undefined
+      ? { supportedReasoningEfforts: supportedReasoningEfforts as ModelEntryV2['supportedReasoningEfforts'] }
+      : {}),
     ...(capabilities ? { capabilities } : {}),
     ...(contextLength !== undefined ? { contextLength } : {}),
     ...(supportsThinkingType ? { supportsThinkingType } : {}),

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -19,7 +19,6 @@ import {
   getKeyringPassword,
   setKeyringPassword,
 } from './keyring-secret.js';
-import { normalizeLightweightChatModel } from './lightweight-chat-model.js';
 import {
   configureLlmClientVersion,
   configureLlmHttpVersion,
@@ -31,15 +30,26 @@ import {
   resolveModelReasoningEffortForContext,
 } from '@spiritagent/agent-core/reasoning-effort';
 import {
+  assertSpiritConfigSchemaVersion,
   createFileExtensionStateStore,
+  defaultPresetProviderGroupId,
+  emptyModelRef,
+  findModelByRef,
+  listAllModelRefs,
+  parseModelProviderId,
+  parseModelRef,
+  SPIRIT_CONFIG_SCHEMA_VERSION,
+  SpiritConfigSchemaError,
   type ExtensionManagementContext,
   type ExtensionSettingValue,
   type ExtensionStateStore,
   loadHostInstructionMetadata,
-  parseModelProviderId,
   type HostInstructionMetadataSummary,
   type HostRuleDiscoveryResult,
   type HostSkillDiscoveryResult,
+  type ModelEntryV2,
+  type ModelRef,
+  type ProviderGroupV2,
 } from '@spiritagent/host-internal';
 
 import { resolveDesktopAgentMode, type DesktopAgentMode } from '../lib/agent-mode.js';
@@ -80,7 +90,7 @@ import {
 } from './provider-api-key.js';
 import { normalizeDesktopRewindMetadata } from './rewind.js';
 
-export type { ModelKeyPresenceProfile } from './provider-api-key.js';
+export { SpiritConfigSchemaError as ConfigSchemaError } from '@spiritagent/host-internal';
 export {
   buildModelSecretKeyPresence,
   hasBedrockRuntimeCredentials,
@@ -104,7 +114,7 @@ export type DesktopWorkspaceBinding = 'project' | 'none';
 
 export interface DesktopDreamConfigFile {
   enabled: boolean;
-  collectorModel?: string;
+  collectorModel?: ModelRef;
   debugMode: boolean;
 }
 
@@ -126,11 +136,12 @@ export interface DesktopNetworksConfigFile {
 }
 
 export interface DesktopConfigFile {
-  models: ModelProfileSnapshot[];
-  activeModel: string;
-  imageGenerationModel?: string;
-  videoGenerationModel?: string;
-  lightweightChatModel?: string;
+  schemaVersion: typeof SPIRIT_CONFIG_SCHEMA_VERSION;
+  providerGroups: ProviderGroupV2[];
+  activeModel: ModelRef;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
+  lightweightChatModel?: ModelRef;
   recentWorkspaces?: string[];
   /** When `none`, cwd is the user home directory and workspace-scoped instructions/MCP are skipped. */
   workspaceBinding?: DesktopWorkspaceBinding;
@@ -463,9 +474,9 @@ export async function loadConfig(): Promise<DesktopConfigFile> {
     return initial;
   }
 
-  const raw = await readFile(filePath, 'utf8');
-  const parsed = JSON.parse(raw) as Partial<DesktopConfigFile>;
-  return normalizeConfig(parsed);
+  const raw = JSON.parse(await readFile(filePath, 'utf8')) as Record<string, unknown>;
+  assertSpiritConfigSchemaVersion(raw);
+  return normalizeConfig(raw as Partial<DesktopConfigFile>);
 }
 
 export async function saveConfig(config: DesktopConfigFile): Promise<void> {
@@ -784,8 +795,9 @@ export async function deleteStoredSession(filePath: string): Promise<void> {
 
 function defaultConfig(): DesktopConfigFile {
   return {
-    models: [],
-    activeModel: '',
+    schemaVersion: SPIRIT_CONFIG_SCHEMA_VERSION,
+    providerGroups: [],
+    activeModel: emptyModelRef(),
     recentWorkspaces: [],
     windowsMica: true,
     systemNotifications: true,
@@ -891,96 +903,165 @@ export function normalizeAgentsConfig(raw: unknown): DesktopAgentsConfigFile {
   };
 }
 
-function normalizeConfig(raw: Partial<DesktopConfigFile>): DesktopConfigFile {
-  const models = Array.isArray(raw.models)
-    ? raw.models
-        .filter(
-          (model): model is ModelProfileSnapshot =>
-            typeof model?.name === 'string' && model.name.trim().length > 0,
-        )
-        .map((model) => {
-          const provider = parseModelProviderId(model.provider);
-          const transportKind = normalizeDesktopTransportKind(model.transportKind, provider);
-          const capabilities = normalizeModelCapabilities(model.capabilities);
-          const supportedReasoningEfforts = normalizeSupportedReasoningEfforts(model.supportedReasoningEfforts);
-          const contextLength = parseModelContextLength(model.contextLength);
-          const supportsThinkingType = model.supportsThinkingType === 'only' ? 'only' as const : undefined;
-          const awsRegion =
-            typeof model.awsRegion === 'string' && model.awsRegion.trim().length > 0
-              ? model.awsRegion.trim()
-              : undefined;
-          const providerSite =
-            typeof model.providerSite === 'string' && model.providerSite.trim().length > 0
-              ? model.providerSite.trim()
-              : undefined;
-          const alibabaWorkspaceId =
-            typeof model.alibabaWorkspaceId === 'string' && model.alibabaWorkspaceId.trim().length > 0
-              ? model.alibabaWorkspaceId.trim()
-              : undefined;
-          const alibabaBillingMode =
-            model.alibabaBillingMode === 'token-plan' ? 'token-plan' as const : undefined;
-          const vertexProject =
-            typeof model.vertexProject === 'string' && model.vertexProject.trim().length > 0
-              ? model.vertexProject.trim()
-              : undefined;
-          const vertexLocation =
-            typeof model.vertexLocation === 'string' && model.vertexLocation.trim().length > 0
-              ? model.vertexLocation.trim()
-              : undefined;
-          const azureResourceName =
-            typeof model.azureResourceName === 'string' && model.azureResourceName.trim().length > 0
-              ? model.azureResourceName.trim()
-              : undefined;
-          if (provider === 'azure' && !azureResourceName) {
-            return null;
-          }
-          return {
-            name: model.name.trim(),
-            apiBase: model.apiBase?.trim() || DEFAULT_API_BASE,
-            reasoningEffort: resolveModelReasoningEffortForContext(model.reasoningEffort, {
-              ...(provider ? { provider } : {}),
-              model: model.name,
-              ...(transportKind ? { transportKind } : {}),
-              ...(supportedReasoningEfforts !== undefined ? { supportedEfforts: supportedReasoningEfforts } : {}),
-              ...(supportsThinkingType ? { supportsThinkingType } : {}),
-            }),
-            ...(supportedReasoningEfforts !== undefined ? { supportedReasoningEfforts } : {}),
-            ...(capabilities ? { capabilities } : {}),
-            ...(provider ? { provider } : {}),
-            ...(transportKind ? { transportKind } : {}),
-            ...(providerSite ? { providerSite } : {}),
-            ...(alibabaWorkspaceId ? { alibabaWorkspaceId } : {}),
-            ...(alibabaBillingMode ? { alibabaBillingMode } : {}),
-            ...(awsRegion ? { awsRegion } : {}),
-            ...(vertexProject ? { vertexProject } : {}),
-            ...(vertexLocation ? { vertexLocation } : {}),
-            ...(azureResourceName ? { azureResourceName } : {}),
-            ...(contextLength !== undefined ? { contextLength } : {}),
-            ...(supportsThinkingType ? { supportsThinkingType } : {}),
-            ...(model.thinkingEnabled === false ? { thinkingEnabled: false } : {}),
-          };
-        })
-        .filter((model): model is ModelProfileSnapshot => model !== null)
+function normalizeProviderGroup(raw: unknown): ProviderGroupV2 | null {
+  if (typeof raw !== 'object' || raw === null) {
+    return null;
+  }
+  const record = raw as Partial<ProviderGroupV2>;
+  const id = typeof record.id === 'string' ? record.id.trim() : '';
+  const provider = parseModelProviderId(record.provider);
+  if (!id || !provider) {
+    return null;
+  }
+  const label = typeof record.label === 'string' && record.label.trim() ? record.label.trim() : undefined;
+  if (provider === 'custom' && !label) {
+    return null;
+  }
+  const apiBase = typeof record.apiBase === 'string' && record.apiBase.trim()
+    ? record.apiBase.trim()
+    : DEFAULT_API_BASE;
+  const transportKind = normalizeDesktopTransportKind(record.transportKind, provider);
+  const providerSite =
+    typeof record.providerSite === 'string' && record.providerSite.trim().length > 0
+      ? record.providerSite.trim()
+      : undefined;
+  const alibabaWorkspaceId =
+    typeof record.alibabaWorkspaceId === 'string' && record.alibabaWorkspaceId.trim().length > 0
+      ? record.alibabaWorkspaceId.trim()
+      : undefined;
+  const alibabaBillingMode =
+    record.alibabaBillingMode === 'token-plan' ? 'token-plan' as const : undefined;
+  const awsRegion =
+    typeof record.awsRegion === 'string' && record.awsRegion.trim().length > 0
+      ? record.awsRegion.trim()
+      : undefined;
+  const vertexProject =
+    typeof record.vertexProject === 'string' && record.vertexProject.trim().length > 0
+      ? record.vertexProject.trim()
+      : undefined;
+  const vertexLocation =
+    typeof record.vertexLocation === 'string' && record.vertexLocation.trim().length > 0
+      ? record.vertexLocation.trim()
+      : undefined;
+  const azureResourceName =
+    typeof record.azureResourceName === 'string' && record.azureResourceName.trim().length > 0
+      ? record.azureResourceName.trim()
+      : undefined;
+  const cloudflareAccountId =
+    typeof record.cloudflareAccountId === 'string' && record.cloudflareAccountId.trim().length > 0
+      ? record.cloudflareAccountId.trim()
+      : undefined;
+  const cloudflareGatewayId =
+    typeof record.cloudflareGatewayId === 'string' && record.cloudflareGatewayId.trim().length > 0
+      ? record.cloudflareGatewayId.trim()
+      : undefined;
+  if (provider === 'azure' && !azureResourceName) {
+    return null;
+  }
+
+  const models = Array.isArray(record.models)
+    ? record.models
+        .map((model) => normalizeModelEntry(model, provider, transportKind))
+        .filter((model): model is ModelEntryV2 => model !== null)
     : [];
 
-  const normalizedModels = models;
-  const activeModel =
-    normalizedModels.length === 0
-      ? (typeof raw.activeModel === 'string' ? raw.activeModel.trim() : '')
-      : normalizedModels.some((model) => model.name === raw.activeModel?.trim())
-        ? raw.activeModel!.trim()
-        : normalizedModels[0]!.name;
-  const imageGenerationModel = normalizeImageGenerationModel(raw.imageGenerationModel, normalizedModels);
-  const videoGenerationModel = normalizeVideoGenerationModel(raw.videoGenerationModel, normalizedModels);
-  const dreams = normalizeDreamConfig(raw.dreams);
-  const lightweightChatModel = normalizeLightweightChatModel(
+  const seenNames = new Set<string>();
+  const dedupedModels = models.filter((model) => {
+    if (seenNames.has(model.name)) {
+      return false;
+    }
+    seenNames.add(model.name);
+    return true;
+  });
+
+  return {
+    id,
+    provider,
+    ...(label ? { label } : {}),
+    apiBase,
+    ...(transportKind ? { transportKind } : {}),
+    ...(providerSite ? { providerSite } : {}),
+    ...(alibabaWorkspaceId ? { alibabaWorkspaceId } : {}),
+    ...(alibabaBillingMode ? { alibabaBillingMode } : {}),
+    ...(awsRegion ? { awsRegion } : {}),
+    ...(vertexProject ? { vertexProject } : {}),
+    ...(vertexLocation ? { vertexLocation } : {}),
+    ...(azureResourceName ? { azureResourceName } : {}),
+    ...(cloudflareAccountId ? { cloudflareAccountId } : {}),
+    ...(cloudflareGatewayId ? { cloudflareGatewayId } : {}),
+    models: dedupedModels,
+  };
+}
+
+function normalizeModelEntry(
+  raw: unknown,
+  provider: DesktopModelProvider,
+  transportKind: DesktopTransportKind | undefined,
+): ModelEntryV2 | null {
+  if (typeof raw !== 'object' || raw === null) {
+    return null;
+  }
+  const record = raw as Partial<ModelEntryV2>;
+  const name = typeof record.name === 'string' ? record.name.trim() : '';
+  if (!name) {
+    return null;
+  }
+  const capabilities = normalizeModelCapabilities(record.capabilities);
+  const supportedReasoningEfforts = normalizeSupportedReasoningEfforts(record.supportedReasoningEfforts);
+  const contextLength = parseModelContextLength(record.contextLength);
+  const supportsThinkingType = record.supportsThinkingType === 'only' ? 'only' as const : undefined;
+  return {
+    name,
+    reasoningEffort: resolveModelReasoningEffortForContext(record.reasoningEffort, {
+      provider,
+      model: name,
+      ...(transportKind ? { transportKind } : {}),
+      ...(supportedReasoningEfforts !== undefined ? { supportedEfforts: supportedReasoningEfforts } : {}),
+      ...(supportsThinkingType ? { supportsThinkingType } : {}),
+    }),
+    ...(supportedReasoningEfforts !== undefined ? { supportedReasoningEfforts } : {}),
+    ...(capabilities ? { capabilities } : {}),
+    ...(contextLength !== undefined ? { contextLength } : {}),
+    ...(supportsThinkingType ? { supportsThinkingType } : {}),
+    ...(record.thinkingEnabled === false ? { thinkingEnabled: false } : {}),
+  };
+}
+
+function normalizeConfig(raw: Partial<DesktopConfigFile>): DesktopConfigFile {
+  const providerGroups = Array.isArray(raw.providerGroups)
+    ? raw.providerGroups
+        .map((group) => normalizeProviderGroup(group))
+        .filter((group): group is ProviderGroupV2 => group !== null)
+    : [];
+
+  const seenGroupIds = new Set<string>();
+  const normalizedGroups = providerGroups.filter((group) => {
+    if (seenGroupIds.has(group.id)) {
+      return false;
+    }
+    seenGroupIds.add(group.id);
+    return true;
+  });
+
+  const allRefs = listAllModelRefs(normalizedGroups);
+  const activeModel = parseModelRef(raw.activeModel)
+    ?? (allRefs[0] ? { ...allRefs[0] } : emptyModelRef());
+  const resolvedActive = findModelByRef(normalizedGroups, activeModel)
+    ? activeModel
+    : (allRefs[0] ? { ...allRefs[0] } : emptyModelRef());
+
+  const imageGenerationModel = normalizeImageGenerationModelRef(raw.imageGenerationModel, normalizedGroups);
+  const videoGenerationModel = normalizeVideoGenerationModelRef(raw.videoGenerationModel, normalizedGroups);
+  const dreams = normalizeDreamConfig(raw.dreams, normalizedGroups);
+  const lightweightChatModel = normalizeLightweightChatModelRef(
     raw.lightweightChatModel ?? dreams.collectorModel,
-    normalizedModels,
+    normalizedGroups,
   );
 
   return {
-    models: normalizedModels,
-    activeModel,
+    schemaVersion: SPIRIT_CONFIG_SCHEMA_VERSION,
+    providerGroups: normalizedGroups,
+    activeModel: resolvedActive,
     ...(imageGenerationModel ? { imageGenerationModel } : {}),
     ...(videoGenerationModel ? { videoGenerationModel } : {}),
     ...(lightweightChatModel ? { lightweightChatModel } : {}),
@@ -1002,38 +1083,55 @@ function normalizeConfig(raw: Partial<DesktopConfigFile>): DesktopConfigFile {
   };
 }
 
-function normalizeImageGenerationModel(
+function normalizeImageGenerationModelRef(
   value: unknown,
-  models: readonly ModelProfileSnapshot[],
-): string | undefined {
-  if (typeof value !== 'string' || value.trim().length === 0) {
+  groups: readonly ProviderGroupV2[],
+): ModelRef | undefined {
+  const ref = parseModelRef(value);
+  if (!ref) {
     return undefined;
   }
-
-  const modelName = value.trim();
-  const profile = models.find((model) => model.name === modelName);
-  return profile && modelSupportsImageGeneration(profile) ? profile.name : undefined;
-}
-
-function modelSupportsImageGeneration(model: ModelProfileSnapshot): boolean {
-  return model.capabilities?.includes('imageGeneration') === true;
-}
-
-function normalizeVideoGenerationModel(
-  value: unknown,
-  models: readonly ModelProfileSnapshot[],
-): string | undefined {
-  if (typeof value !== 'string' || value.trim().length === 0) {
+  const resolved = findModelByRef(groups, ref);
+  if (!resolved) {
     return undefined;
   }
-
-  const modelName = value.trim();
-  const profile = models.find((model) => model.name === modelName);
-  return profile && modelSupportsVideoGeneration(profile) ? profile.name : undefined;
+  const capabilities = normalizeModelCapabilities(resolved.model.capabilities);
+  return capabilities?.includes('imageGeneration') ? ref : undefined;
 }
 
-function modelSupportsVideoGeneration(model: ModelProfileSnapshot): boolean {
-  return model.capabilities?.includes('videoGeneration') === true;
+function normalizeVideoGenerationModelRef(
+  value: unknown,
+  groups: readonly ProviderGroupV2[],
+): ModelRef | undefined {
+  const ref = parseModelRef(value);
+  if (!ref) {
+    return undefined;
+  }
+  const resolved = findModelByRef(groups, ref);
+  if (!resolved) {
+    return undefined;
+  }
+  const capabilities = normalizeModelCapabilities(resolved.model.capabilities);
+  return capabilities?.includes('videoGeneration') ? ref : undefined;
+}
+
+function normalizeLightweightChatModelRef(
+  value: unknown,
+  groups: readonly ProviderGroupV2[],
+): ModelRef | undefined {
+  const ref = parseModelRef(value);
+  if (!ref) {
+    return undefined;
+  }
+  const resolved = findModelByRef(groups, ref);
+  if (!resolved) {
+    return undefined;
+  }
+  const capabilities = normalizeModelCapabilities(resolved.model.capabilities);
+  if (capabilities && !capabilities.includes('chat')) {
+    return undefined;
+  }
+  return ref;
 }
 
 function normalizeDesktopTransportKind(
@@ -1119,10 +1217,9 @@ export function normalizeSupportedReasoningEfforts(
 
 export function normalizeDreamConfig(
   raw?: Partial<DesktopDreamConfigFile>,
+  groups: readonly ProviderGroupV2[] = [],
 ): DesktopDreamConfigFile {
-  const collectorModel = typeof raw?.collectorModel === 'string' && raw.collectorModel.trim()
-    ? raw.collectorModel.trim()
-    : undefined;
+  const collectorModel = normalizeLightweightChatModelRef(raw?.collectorModel, groups);
   return {
     enabled: raw?.enabled === true,
     ...(collectorModel ? { collectorModel } : {}),

--- a/apps/desktop/src/lib/composer-direct-media.ts
+++ b/apps/desktop/src/lib/composer-direct-media.ts
@@ -1,3 +1,6 @@
+import type { ModelRef } from '@/types';
+import { isEmptyModelRef, modelRefsEqual } from '@spiritagent/host-internal';
+
 export type DirectMediaTool = 'generate_image' | 'generate_video';
 
 type ModelWithCapabilities = {
@@ -7,8 +10,8 @@ type ModelWithCapabilities = {
 
 type ComposerDirectMediaConfig = {
   models: readonly ModelWithCapabilities[];
-  imageGenerationModel?: string;
-  videoGenerationModel?: string;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
 };
 
 function supportsImageGeneration(model: ModelWithCapabilities): boolean {
@@ -24,39 +27,42 @@ function supportsChat(model: ModelWithCapabilities): boolean {
 }
 
 export function resolveComposerDirectMediaTool(
-  activeModel: string,
+  activeModel: ModelRef,
   config: ComposerDirectMediaConfig,
 ): DirectMediaTool | null {
-  const trimmedActive = activeModel.trim();
-  if (!trimmedActive) {
+  if (isEmptyModelRef(activeModel)) {
     return null;
   }
 
-  const matchesVideoSlot = config.videoGenerationModel?.trim() === trimmedActive;
-  const matchesImageSlot = config.imageGenerationModel?.trim() === trimmedActive;
+  const matchesVideoSlot =
+    config.videoGenerationModel !== undefined
+    && modelRefsEqual(config.videoGenerationModel, activeModel);
+  const matchesImageSlot =
+    config.imageGenerationModel !== undefined
+    && modelRefsEqual(config.imageGenerationModel, activeModel);
 
   if (matchesVideoSlot && matchesImageSlot) {
     console.debug(
       '[desktop][composer-direct-media] active model matches both image and video default slots; preferring generate_video',
-      { activeModel: trimmedActive },
+      { activeModel },
     );
   }
 
   if (matchesVideoSlot) {
-    const profile = config.models.find((model) => model.name === trimmedActive);
+    const profile = config.models.find((model) => model.name === activeModel.name);
     if (profile && supportsVideoGeneration(profile)) {
       return 'generate_video';
     }
   }
 
   if (matchesImageSlot) {
-    const profile = config.models.find((model) => model.name === trimmedActive);
+    const profile = config.models.find((model) => model.name === activeModel.name);
     if (profile && supportsImageGeneration(profile)) {
       return 'generate_image';
     }
   }
 
-  const profile = config.models.find((model) => model.name === trimmedActive);
+  const profile = config.models.find((model) => model.name === activeModel.name);
   if (profile && !supportsChat(profile)) {
     if (supportsVideoGeneration(profile)) {
       return 'generate_video';

--- a/apps/desktop/src/lib/composer-direct-media.ts
+++ b/apps/desktop/src/lib/composer-direct-media.ts
@@ -1,5 +1,5 @@
-import type { ModelRef } from '@/types';
-import { isEmptyModelRef, modelRefsEqual } from '@spiritagent/host-internal';
+import type { ModelRef } from '../types.js';
+import { isEmptyModelRef, modelRefsEqual } from '@spiritagent/host-internal/config-v2';
 
 export type DirectMediaTool = 'generate_image' | 'generate_video';
 

--- a/apps/desktop/src/lib/context-usage.ts
+++ b/apps/desktop/src/lib/context-usage.ts
@@ -1,13 +1,15 @@
 import { normalizeOpenAiApiBase } from '@spiritagent/host-internal/openai-api-base';
 
 import { parseModelContextLength } from './model-context-length.js';
-import { DEFAULT_API_BASE } from '../host/storage.js';
 import type {
   ConversationContextUsageSnapshot,
   DesktopModelCatalogHint,
   DesktopModelProvider,
   DesktopTransportKind,
 } from '../types.js';
+
+/** 与 `apps/desktop/src/host/storage.ts` 中 `DEFAULT_API_BASE` 保持一致。 */
+const DEFAULT_API_BASE = 'https://api.openai.com/v1';
 
 export interface ContextUsageModelProfile {
   name: string;

--- a/apps/desktop/src/lib/model-picker-groups.ts
+++ b/apps/desktop/src/lib/model-picker-groups.ts
@@ -1,13 +1,15 @@
 import {
   MODEL_PROVIDER_PICKER_ORDER,
   PROVIDER_PICKER_ROWS,
-} from "@spiritagent/host-internal/model-provider-presets";
+  defaultPresetProviderGroupId,
+} from "@spiritagent/host-internal";
 import { normalizeOpenAiApiBase } from "@spiritagent/host-internal/openai-api-base";
 import type {
   DesktopModelCatalogHint,
   DesktopModelProvider,
   DesktopTransportKind,
   ModelProfileSnapshot,
+  ProviderGroupV2,
 } from "@/types";
 
 const PROVIDER_ORDER: DesktopModelProvider[] = [...MODEL_PROVIDER_PICKER_ORDER];
@@ -47,60 +49,71 @@ function catalogOrderIndex(
 }
 
 export type ModelPickerGroup = {
+  groupId: string;
   provider: DesktopModelProvider;
   labelKey: string;
   fallbackLabel: string;
+  customLabel?: string;
   items: ModelProfileSnapshot[];
 };
 
 /**
- * 主界面模型下拉：按提供商分组；组内顺序优先对齐 `modelCatalogHints` 中的上游列表顺序。
+ * 主界面模型下拉：按 provider group（groupId）分组；组内顺序优先对齐 `modelCatalogHints` 中的上游列表顺序。
  */
 export function groupModelsForPicker(
   models: ModelProfileSnapshot[],
   catalogHints: DesktopModelCatalogHint[] | undefined,
+  providerGroups?: readonly ProviderGroupV2[],
 ): ModelPickerGroup[] {
-  const buckets = new Map<DesktopModelProvider, ModelProfileSnapshot[]>();
-  for (const m of models) {
-    const p: DesktopModelProvider = m.provider ?? "custom";
-    const list = buckets.get(p) ?? [];
-    list.push(m);
-    buckets.set(p, list);
+  const groupMeta = new Map(
+    (providerGroups ?? []).map((group) => [group.id, group] as const),
+  );
+  const buckets = new Map<string, ModelProfileSnapshot[]>();
+  for (const model of models) {
+    const groupId =
+      model.groupId
+      ?? model.ref?.groupId
+      ?? defaultPresetProviderGroupId(model.provider ?? "custom");
+    const list = buckets.get(groupId) ?? [];
+    list.push(model);
+    buckets.set(groupId, list);
   }
 
-  const keys = [...buckets.keys()].sort((a, b) => {
-    const ia = PROVIDER_ORDER.indexOf(a);
-    const ib = PROVIDER_ORDER.indexOf(b);
-    if (ia !== ib) {
-      return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+  const keys = [...buckets.keys()].sort((leftId, rightId) => {
+    const leftGroup = groupMeta.get(leftId);
+    const rightGroup = groupMeta.get(rightId);
+    const leftProvider = leftGroup?.provider ?? buckets.get(leftId)?.[0]?.provider ?? "custom";
+    const rightProvider = rightGroup?.provider ?? buckets.get(rightId)?.[0]?.provider ?? "custom";
+    const leftIndex = PROVIDER_ORDER.indexOf(leftProvider);
+    const rightIndex = PROVIDER_ORDER.indexOf(rightProvider);
+    if (leftIndex !== rightIndex) {
+      return (leftIndex === -1 ? 99 : leftIndex) - (rightIndex === -1 ? 99 : rightIndex);
     }
-    return a.localeCompare(b);
+    const leftLabel = leftGroup?.label?.trim() ?? leftId;
+    const rightLabel = rightGroup?.label?.trim() ?? rightId;
+    return leftLabel.localeCompare(rightLabel);
   });
 
-  return keys.map((provider) => {
-    const items = (buckets.get(provider) ?? []).slice().sort((a, b) => {
-      const filteredHints = catalogHints?.filter((hint) => (hint.provider ?? 'custom') === provider);
+  return keys.map((groupId) => {
+    const meta = groupMeta.get(groupId);
+    const provider = meta?.provider ?? buckets.get(groupId)?.[0]?.provider ?? "custom";
+    const items = (buckets.get(groupId) ?? []).slice().sort((a, b) => {
+      const filteredHints = catalogHints?.filter(
+        (hint) => (hint.provider ?? "custom") === provider,
+      );
       const aTransportKind = normalizeTransportKind(a.transportKind, a.provider);
       const bTransportKind = normalizeTransportKind(b.transportKind, b.provider);
-      const oa = catalogOrderIndex(
-        a.name,
-        a.apiBase,
-        aTransportKind,
-        filteredHints,
-      );
-      const ob = catalogOrderIndex(
-        b.name,
-        b.apiBase,
-        bTransportKind,
-        filteredHints,
-      );
-      if (oa !== ob) {
-        return oa - ob;
+      const orderA = catalogOrderIndex(a.name, a.apiBase, aTransportKind, filteredHints);
+      const orderB = catalogOrderIndex(b.name, b.apiBase, bTransportKind, filteredHints);
+      if (orderA !== orderB) {
+        return orderA - orderB;
       }
       return a.name.localeCompare(b.name);
     });
     return {
+      groupId,
       provider,
+      customLabel: meta?.label?.trim() || undefined,
       ...providerLabelMetadata(provider),
       items,
     };

--- a/apps/desktop/src/lib/model-picker-groups.ts
+++ b/apps/desktop/src/lib/model-picker-groups.ts
@@ -1,8 +1,8 @@
 import {
   MODEL_PROVIDER_PICKER_ORDER,
   PROVIDER_PICKER_ROWS,
-  defaultPresetProviderGroupId,
-} from "@spiritagent/host-internal";
+} from "@spiritagent/host-internal/model-provider-presets";
+import { defaultPresetProviderGroupId } from "@spiritagent/host-internal/config-v2";
 import { normalizeOpenAiApiBase } from "@spiritagent/host-internal/openai-api-base";
 import type {
   DesktopModelCatalogHint,

--- a/apps/desktop/src/lib/provider-runtime-credentials.ts
+++ b/apps/desktop/src/lib/provider-runtime-credentials.ts
@@ -1,0 +1,15 @@
+/** Renderer-safe provider credential predicates（无 keyring / host 依赖）。 */
+
+export function hasBedrockIamCredentials(credentials: {
+  accessKeyId?: string;
+  secretAccessKey?: string;
+}): boolean {
+  return Boolean(credentials.accessKeyId?.trim() && credentials.secretAccessKey?.trim());
+}
+
+export function hasGoogleVertexServiceAccountCredentials(credentials: {
+  clientEmail?: string;
+  privateKey?: string;
+}): boolean {
+  return Boolean(credentials.clientEmail?.trim() && credentials.privateKey?.trim());
+}

--- a/apps/desktop/src/lib/shell-tool-display.ts
+++ b/apps/desktop/src/lib/shell-tool-display.ts
@@ -17,6 +17,13 @@ export function parseShellToolResult(
 
 const COMMAND_LINE_PREFIX = i18n.t('tool.commandPrefix');
 
+/** 展开区优先用完整 command（argsExcerpt / detailLines），摘要 headlineDetail 仅作回退。 */
+export function resolveShellToolExpandedCommand(
+  tool: Pick<ToolBlockSnapshot, "argsExcerpt" | "detailLines" | "headlineDetail">,
+): string | undefined {
+  return parseShellToolCommand(tool) || tool.headlineDetail?.trim() || undefined;
+}
+
 export function parseShellToolCommand(
   tool: Pick<ToolBlockSnapshot, "argsExcerpt" | "detailLines">,
 ): string | undefined {

--- a/apps/desktop/src/lib/spirit-message-code-highlight.tsx
+++ b/apps/desktop/src/lib/spirit-message-code-highlight.tsx
@@ -88,25 +88,45 @@ export function renderHighlightToken(token: HighlightToken, key: string | number
   );
 }
 
-export function renderHighlightedCodeBody(result: HighlightResult) {
-  const preStyle =
-    typeof result.rootStyle === "string"
-      ? (Object.fromEntries(
-          result.rootStyle
-            .split(";")
-            .filter(Boolean)
-            .map((rule) => {
-              const colon = rule.indexOf(":");
-              if (colon === -1) {
-                return null;
-              }
-              return [rule.slice(0, colon).trim(), rule.slice(colon + 1).trim()] as const;
-            })
-            .filter((entry): entry is readonly [string, string] => entry !== null),
-        ) as CSSProperties)
-      : undefined;
+function parseRootStyle(rootStyle: HighlightResult["rootStyle"]): CSSProperties | undefined {
+  if (typeof rootStyle !== "string") {
+    return undefined;
+  }
+  return Object.fromEntries(
+    rootStyle
+      .split(";")
+      .filter(Boolean)
+      .map((rule) => {
+        const colon = rule.indexOf(":");
+        if (colon === -1) {
+          return null;
+        }
+        return [rule.slice(0, colon).trim(), rule.slice(colon + 1).trim()] as const;
+      })
+      .filter((entry): entry is readonly [string, string] => entry !== null),
+  ) as CSSProperties;
+}
 
+export function renderHighlightedCodeLines(
+  result: HighlightResult,
+  options?: { firstLineInline?: boolean },
+) {
   const lines = dropTrailingEmptyTokenLines(result.tokens);
+
+  return lines.map((line, lineIndex) => (
+    <span
+      key={lineIndex}
+      className={options?.firstLineInline && lineIndex === 0 ? undefined : "block"}
+    >
+      {isEmptyTokenLine(line)
+        ? null
+        : line.map((token, tokenIndex) => renderHighlightToken(token, tokenIndex))}
+    </span>
+  ));
+}
+
+export function renderHighlightedCodeBody(result: HighlightResult) {
+  const preStyle = parseRootStyle(result.rootStyle);
 
   return (
     <div data-language="" data-streamdown="code-block-body">
@@ -114,15 +134,7 @@ export function renderHighlightedCodeBody(result: HighlightResult) {
         className="bg-[var(--sdm-bg,inherit)] dark:bg-[var(--shiki-dark-bg,var(--sdm-bg,inherit))]"
         style={preStyle}
       >
-        <code>
-          {lines.map((line, lineIndex) => (
-            <span key={lineIndex} className="block">
-              {isEmptyTokenLine(line)
-                ? null
-                : line.map((token, tokenIndex) => renderHighlightToken(token, tokenIndex))}
-            </span>
-          ))}
-        </code>
+        <code>{renderHighlightedCodeLines(result)}</code>
       </pre>
     </div>
   );

--- a/apps/desktop/src/lib/spirit-shiki-code-plugin.ts
+++ b/apps/desktop/src/lib/spirit-shiki-code-plugin.ts
@@ -1,0 +1,8 @@
+import { createCodePlugin } from "@streamdown/code";
+
+import { SPIRIT_SHIKI_PLUS_THEMES } from "@/lib/spirit-shiki-themes";
+
+/** Streamdown 与工具卡等 UI 共用的 Shiki 高亮插件。 */
+export const spiritShikiCodePlugin = createCodePlugin({
+  themes: [...SPIRIT_SHIKI_PLUS_THEMES],
+});

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1,4 +1,10 @@
 import type { ModelProviderId, ProviderConnectSiteId } from '@spiritagent/host-internal/model-provider-presets';
+import type {
+  ModelEntryV2,
+  ModelRef,
+  ProviderGroupV2,
+  SpiritConfigSchemaVersion,
+} from '@spiritagent/host-internal';
 import type { ModelReasoningEffort } from '@spiritagent/agent-core/reasoning-effort';
 import type { LspWriteDiagnosticsUi } from '@spiritagent/agent-core';
 
@@ -14,7 +20,7 @@ import type { BrowserElementAttachment } from './lib/browser-element-attachment.
 import type { RichSegment } from './lib/composer-segment-model.js';
 import type { ComposerLocalFileAttachmentView } from './lib/local-file-attachments.js';
 
-export type DesktopWorkspaceBinding = 'project' | 'none';
+export type { ModelRef, ModelEntryV2, ProviderGroupV2, SpiritConfigSchemaVersion };
 
 export interface BootstrapRequest {
   workspaceRoot?: string;
@@ -41,10 +47,10 @@ export interface CheckoutGitBranchRequest {
 }
 
 export interface UpdateConfigRequest {
-  activeModel: string;
-  imageGenerationModel?: string;
-  videoGenerationModel?: string;
-  lightweightChatModel?: string;
+  activeModel: ModelRef;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
+  lightweightChatModel?: ModelRef;
   apiBase: string;
   reasoningEffort?: DesktopModelReasoningEffort;
   /** 厂商 extended thinking；false 关闭。缺省不修改。 */
@@ -117,7 +123,7 @@ export interface DesktopWebHostConfigUpdate {
 
 export interface DesktopDreamConfigUpdate {
   enabled?: boolean;
-  collectorModel?: string;
+  collectorModel?: ModelRef;
   clearCollectorModel?: boolean;
   debugMode?: boolean;
 }
@@ -191,6 +197,7 @@ export interface PreviewModelsResponse {
 
 /** 批量写入同一端点下的多个模型 id（共享 API Key），用于提供商连接批量导入。 */
 export interface AddProviderModelsRequest {
+  groupId: string;
   apiBase: string;
   apiKey: string;
   modelIds: string[];
@@ -224,6 +231,7 @@ export interface DesktopModelCatalogHint {
 
 /** 与 CLI `model add` 一致：新增模型、写入密钥，并将当前模型切到新模型。 */
 export interface AddModelRequest {
+  groupId: string;
   name: string;
   apiBase: string;
   apiKey: string;
@@ -248,9 +256,14 @@ export interface AddModelRequest {
 }
 
 export interface RemoveModelRequest {
-  name: string;
+  ref: ModelRef;
 }
 
+export interface RemoveProviderGroupRequest {
+  groupId: string;
+}
+
+/** @deprecated 使用 RemoveProviderGroupRequest */
 export interface RemoveProviderModelsRequest {
   provider: DesktopModelProvider;
 }
@@ -943,11 +956,12 @@ export interface DesktopExtensionCssLayer {
 }
 
 export interface DesktopConfigSnapshot {
+  providerGroups: ProviderGroupV2[];
   models: ModelProfileSnapshot[];
-  activeModel: string;
-  imageGenerationModel?: string;
-  videoGenerationModel?: string;
-  lightweightChatModel?: string;
+  activeModel: ModelRef;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
+  lightweightChatModel?: ModelRef;
   uiLocale?: string;
   activeApiKeyConfigured: boolean;
   /** 桌面宿主在 Windows 上是否使用 Mica 风格；无字段时按 true 处理。 */
@@ -965,7 +979,7 @@ export interface DesktopConfigSnapshot {
 
 export interface DesktopDreamSettingsSnapshot {
   enabled: boolean;
-  collectorModel?: string;
+  collectorModel?: ModelRef;
   debugMode: boolean;
 }
 
@@ -1262,6 +1276,8 @@ export type {
 } from '@spiritagent/host-internal';
 
 export interface ModelProfileSnapshot {
+  groupId?: string;
+  ref?: ModelRef;
   name: string;
   apiBase: string;
   reasoningEffort: DesktopModelReasoningEffort;

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -709,7 +709,7 @@ export interface SwitchPaneWorkspaceRequest {
 
 export interface SwitchPaneModelRequest {
   sessionPath: string;
-  modelName: string;
+  modelRef: ModelRef;
 }
 
 export interface SetPanePendingGitBranchRequest {

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -4,7 +4,7 @@ import type {
   ModelRef,
   ProviderGroupV2,
   SpiritConfigSchemaVersion,
-} from '@spiritagent/host-internal';
+} from '@spiritagent/host-internal/config-v2';
 import type { ModelReasoningEffort } from '@spiritagent/agent-core/reasoning-effort';
 import type { LspWriteDiagnosticsUi } from '@spiritagent/agent-core';
 
@@ -12,9 +12,13 @@ import type { DesktopAgentMode } from './lib/agent-mode.js';
 import type { DesktopAutomationTrigger } from './lib/automation-trigger.js';
 
 export type { DesktopAgentMode };
-import type { WorkspaceFileReferenceSuggestionsResult as HostWorkspaceFileReferenceSuggestionsResult, ApprovalLevel, GitHubPullRequestCommit } from '@spiritagent/host-internal';
+import type { WorkspaceFileReferenceSuggestionsResult as HostWorkspaceFileReferenceSuggestionsResult } from '@spiritagent/host-internal/workspace-file-reference-query';
+import type { ApprovalLevel } from '@spiritagent/host-internal/approval-level';
+import type { WorkLocationKind } from '@spiritagent/host-internal/work-location';
+import type { LocalFileComposerRoute } from '@spiritagent/host-internal/local-file-composer-route';
+import type { GitHubPullRequestCommit, GitHubPullRequestMergeMethod } from '@spiritagent/host-internal/github/types';
 
-export type { ApprovalLevel };
+export type { ApprovalLevel, WorkLocationKind, LocalFileComposerRoute };
 
 import type { BrowserElementAttachment } from './lib/browser-element-attachment.js';
 import type { RichSegment } from './lib/composer-segment-model.js';
@@ -715,7 +719,7 @@ export interface SetPanePendingGitBranchRequest {
 
 export interface SetPaneWorkLocationRequest {
   sessionPath: string;
-  workLocation: import('@spiritagent/host-internal').WorkLocationKind;
+  workLocation: WorkLocationKind;
 }
 
 export interface CheckoutPaneGitBranchRequest {
@@ -1140,7 +1144,7 @@ export interface DesktopGitSnapshot {
   /** User-selected branch for the next send; defaults to `branch` when unset. */
   selectedBranch?: string;
   /** Session work-location preference; populated on client snapshots. */
-  workLocation?: import('@spiritagent/host-internal').WorkLocationKind;
+  workLocation?: WorkLocationKind;
   /** True when the active workspace path is a linked Git worktree. */
   isWorktreeSession?: boolean;
   /** Primary repository root for the active worktree session. */
@@ -1240,7 +1244,7 @@ export type {
   GitHubPullRequestTabCounts,
   GitHubPullRequestTaskListProgress,
   GitHubRepositoryRef,
-} from '@spiritagent/host-internal';
+} from '@spiritagent/host-internal/github/types';
 
 export interface ListGitHubPullRequestsRequest {
   owner: string;
@@ -1271,13 +1275,13 @@ export interface GetGitHubPullRequestDetailRequest {
 }
 
 export interface MergeGitHubPullRequestRequest extends GetGitHubPullRequestDetailRequest {
-  mergeMethod: import('@spiritagent/host-internal').GitHubPullRequestMergeMethod;
+  mergeMethod: GitHubPullRequestMergeMethod;
 }
 
 export type {
   GitHubPullRequestMergeMethod,
   GitHubPullRequestMergeResult,
-} from '@spiritagent/host-internal';
+} from '@spiritagent/host-internal/github/types';
 
 export interface ModelProfileSnapshot {
   groupId?: string;

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -1091,7 +1091,7 @@ export interface DesktopAutomationDefinition {
   overview: string;
   trigger: import('./lib/automation-trigger.js').DesktopAutomationTrigger;
   workspaceRoot: string;
-  modelName: string;
+  modelRef: ModelRef;
   reasoningEffort?: DesktopModelReasoningEffort;
   approvalLevel: ApprovalLevel;
   enabled: boolean;
@@ -1110,7 +1110,7 @@ export interface DesktopCreateAutomationRequest {
   overview: string;
   trigger: import('./lib/automation-trigger.js').DesktopAutomationTrigger;
   workspaceRoot: string;
-  modelName: string;
+  modelRef: ModelRef;
   reasoningEffort?: DesktopModelReasoningEffort;
   approvalLevel: ApprovalLevel;
   enabled?: boolean;
@@ -1121,7 +1121,7 @@ export interface DesktopUpdateAutomationRequest {
   overview?: string;
   trigger?: import('./lib/automation-trigger.js').DesktopAutomationTrigger;
   workspaceRoot?: string;
-  modelName?: string;
+  modelRef?: ModelRef;
   reasoningEffort?: DesktopModelReasoningEffort;
   approvalLevel?: ApprovalLevel;
   enabled?: boolean;

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -22,6 +22,8 @@ import type { ComposerLocalFileAttachmentView } from './lib/local-file-attachmen
 
 export type { ModelRef, ModelEntryV2, ProviderGroupV2, SpiritConfigSchemaVersion };
 
+export type DesktopWorkspaceBinding = 'project' | 'none';
+
 export interface BootstrapRequest {
   workspaceRoot?: string;
   workspaceBinding?: DesktopWorkspaceBinding;
@@ -253,6 +255,8 @@ export interface AddModelRequest {
   vertexProject?: string;
   /** Google Vertex 区域（如 `us-central1`）。 */
   vertexLocation?: string;
+  /** 自定义提供商连接显示名；`custom` 时用于生成 groupId（`slugifyProviderGroupLabel`）。 */
+  customGroupLabel?: string;
 }
 
 export interface RemoveModelRequest {
@@ -728,7 +732,7 @@ export interface PaneSessionSlice {
   workspaceRoot?: string;
   workspaceBinding?: DesktopWorkspaceBinding;
   git?: DesktopGitSnapshot;
-  activeModel?: string;
+  activeModel?: ModelRef;
 }
 
 export interface QueuedUserTurnRequest {

--- a/apps/desktop/test/host/automation-scheduler-service.test.mjs
+++ b/apps/desktop/test/host/automation-scheduler-service.test.mjs
@@ -19,7 +19,7 @@ test('groupGitHubPollMatchesByAutomation groups matches by automation id', () =>
     overview: 'A',
     trigger: { kind: 'github', owner: 'o', repo: 'r', event: 'issue_created' },
     workspaceRoot: '/tmp',
-    modelName: 'm',
+    modelRef: { groupId: 'openai', name: 'm' },
     approvalLevel: 'default',
     enabled: true,
     createdAtUnixMs: 1,
@@ -105,7 +105,7 @@ test('failDanglingAutomationRuns marks crash-leftover running runs as failed', a
       overview: 'Crash recovery',
       trigger: { kind: 'time', schedule: { kind: 'hourly' } },
       workspaceRoot: spiritDataDir,
-      modelName: 'gpt-test',
+      modelRef: { groupId: 'openai', name: 'gpt-test' },
       approvalLevel: 'default',
     });
     await store.addRun(created.id, {

--- a/apps/desktop/test/host/config-schema.test.mjs
+++ b/apps/desktop/test/host/config-schema.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  assertSpiritConfigSchemaVersion,
+  SPIRIT_CONFIG_SCHEMA_VERSION,
+} from '@spiritagent/host-internal';
+import { ConfigSchemaError } from '../../dist-electron/src/host/storage.js';
+
+test('assertSpiritConfigSchemaVersion rejects legacy schemaVersion 1', () => {
+  assert.throws(
+    () => assertSpiritConfigSchemaVersion({ schemaVersion: 1 }),
+    ConfigSchemaError,
+  );
+});
+
+test('assertSpiritConfigSchemaVersion accepts schemaVersion 2', () => {
+  assert.doesNotThrow(() => assertSpiritConfigSchemaVersion({ schemaVersion: SPIRIT_CONFIG_SCHEMA_VERSION }));
+});

--- a/apps/desktop/test/host/lightweight-chat-model.test.mjs
+++ b/apps/desktop/test/host/lightweight-chat-model.test.mjs
@@ -7,95 +7,117 @@ import {
   resolveLightweightChatModelProfile,
 } from '../../dist-electron/src/host/lightweight-chat-model.js';
 
+const openAiGroupId = 'openai';
+const exampleGroupId = 'example';
+
 const chatModel = {
   name: 'gpt-4o-mini',
-  apiBase: 'https://api.openai.com/v1',
-  reasoningEffort: 'default',
+  reasoningEffort: 'medium',
   capabilities: ['chat'],
 };
 
 const flashModel = {
   name: 'deepseek/deepseek-v4-flash',
-  apiBase: 'https://api.example.com/v1',
-  reasoningEffort: 'default',
+  reasoningEffort: 'medium',
   capabilities: ['chat'],
 };
 
 const imageOnlyModel = {
   name: 'dall-e-3',
-  apiBase: 'https://api.openai.com/v1',
-  reasoningEffort: 'default',
+  reasoningEffort: 'medium',
   capabilities: ['imageGeneration'],
+};
+
+const config = {
+  providerGroups: [
+    {
+      id: openAiGroupId,
+      provider: 'openai',
+      apiBase: 'https://api.openai.com/v1',
+      models: [chatModel, imageOnlyModel],
+    },
+    {
+      id: exampleGroupId,
+      provider: 'custom',
+      apiBase: 'https://api.example.com/v1',
+      models: [flashModel],
+    },
+  ],
+  activeModel: { groupId: openAiGroupId, name: 'gpt-4o-mini' },
 };
 
 test('resolveLightweightChatModelName prefers explicit lightweightChatModel', () => {
   const name = resolveLightweightChatModelName({
-    activeModel: 'gpt-4o-mini',
-    lightweightChatModel: 'deepseek/deepseek-v4-flash',
-    models: [chatModel, flashModel],
+    ...config,
+    lightweightChatModel: { groupId: exampleGroupId, name: 'deepseek/deepseek-v4-flash' },
   });
 
-  assert.equal(name, 'deepseek/deepseek-v4-flash');
+  assert.deepEqual(name, { groupId: exampleGroupId, name: 'deepseek/deepseek-v4-flash' });
 });
 
 test('resolveLightweightChatModelName ignores invalid explicit config', () => {
   const name = resolveLightweightChatModelName({
-    activeModel: 'gpt-4o-mini',
-    lightweightChatModel: 'missing-model',
-    models: [chatModel, flashModel],
+    ...config,
+    lightweightChatModel: { groupId: openAiGroupId, name: 'missing-model' },
   });
 
-  assert.equal(name, 'deepseek/deepseek-v4-flash');
+  assert.deepEqual(name, { groupId: exampleGroupId, name: 'deepseek/deepseek-v4-flash' });
 });
 
 test('resolveLightweightChatModelName ignores non-chat explicit config', () => {
   const name = resolveLightweightChatModelName({
-    activeModel: 'gpt-4o-mini',
-    lightweightChatModel: 'dall-e-3',
-    models: [chatModel, imageOnlyModel],
+    providerGroups: [{
+      id: openAiGroupId,
+      provider: 'openai',
+      apiBase: 'https://api.openai.com/v1',
+      models: [chatModel, imageOnlyModel],
+    }],
+    activeModel: { groupId: openAiGroupId, name: 'gpt-4o-mini' },
+    lightweightChatModel: { groupId: openAiGroupId, name: 'dall-e-3' },
   });
 
-  assert.equal(name, 'gpt-4o-mini');
+  assert.deepEqual(name, { groupId: openAiGroupId, name: 'gpt-4o-mini' });
 });
 
 test('resolveLightweightChatModelName falls back to pattern match before activeModel', () => {
-  const name = resolveLightweightChatModelName({
-    activeModel: 'gpt-4o-mini',
-    models: [chatModel, flashModel],
-  });
+  const name = resolveLightweightChatModelName(config);
 
-  assert.equal(name, 'deepseek/deepseek-v4-flash');
+  assert.deepEqual(name, { groupId: exampleGroupId, name: 'deepseek/deepseek-v4-flash' });
 });
 
 test('resolveLightweightChatModelName falls back to activeModel when no pattern matches', () => {
   const name = resolveLightweightChatModelName({
-    activeModel: 'gpt-4o-mini',
-    models: [chatModel],
+    providerGroups: [config.providerGroups[0]],
+    activeModel: { groupId: openAiGroupId, name: 'gpt-4o-mini' },
   });
 
-  assert.equal(name, 'gpt-4o-mini');
+  assert.deepEqual(name, { groupId: openAiGroupId, name: 'gpt-4o-mini' });
 });
 
 test('normalizeLightweightChatModel only keeps chat-capable models', () => {
   assert.equal(
-    normalizeLightweightChatModel('dall-e-3', [imageOnlyModel]),
+    normalizeLightweightChatModel(
+      { groupId: openAiGroupId, name: 'dall-e-3' },
+      { providerGroups: [config.providerGroups[0]] },
+    ),
     undefined,
   );
-  assert.equal(
-    normalizeLightweightChatModel('gpt-4o-mini', [chatModel]),
-    'gpt-4o-mini',
+  assert.deepEqual(
+    normalizeLightweightChatModel(
+      { groupId: openAiGroupId, name: 'gpt-4o-mini' },
+      { providerGroups: [config.providerGroups[0]] },
+    ),
+    { groupId: openAiGroupId, name: 'gpt-4o-mini' },
   );
 });
 
 test('resolveLightweightChatModelProfile returns profile for resolved model', () => {
   const resolved = resolveLightweightChatModelProfile({
-    activeModel: 'gpt-4o-mini',
-    lightweightChatModel: 'deepseek/deepseek-v4-flash',
-    models: [chatModel, flashModel],
+    ...config,
+    lightweightChatModel: { groupId: exampleGroupId, name: 'deepseek/deepseek-v4-flash' },
   });
 
-  assert.deepEqual(resolved, {
-    name: 'deepseek/deepseek-v4-flash',
-    profile: flashModel,
-  });
+  assert.equal(resolved?.name, 'deepseek/deepseek-v4-flash');
+  assert.equal(resolved?.profile.groupId, exampleGroupId);
+  assert.equal(resolved?.profile.name, 'deepseek/deepseek-v4-flash');
 });

--- a/apps/desktop/test/host/model-catalog-startup-refresh.test.mjs
+++ b/apps/desktop/test/host/model-catalog-startup-refresh.test.mjs
@@ -11,13 +11,56 @@ import {
   syncExistingModelsFromCatalog,
 } from '../../dist-electron/src/host/model-catalog-startup-refresh.js';
 
+const gatewayGroupId = 'vercel-ai-gateway';
+const openAiGroupId = 'openai';
+const customGroupId = 'custom-local';
+const minimaxGroupId = 'minimax';
+
 const gatewayScopeProfile = {
+  groupId: gatewayGroupId,
   name: 'anthropic/claude-sonnet-4',
   apiBase: 'https://ai-gateway.vercel.sh/v1',
   provider: 'vercel-ai-gateway',
   transportKind: 'open-responses',
   reasoningEffort: 'default',
 };
+
+function gatewayGroup(models) {
+  return {
+    id: gatewayGroupId,
+    provider: 'vercel-ai-gateway',
+    apiBase: 'https://ai-gateway.vercel.sh/v1',
+    transportKind: 'open-responses',
+    models,
+  };
+}
+
+function openAiGroup(models) {
+  return {
+    id: openAiGroupId,
+    provider: 'openai',
+    apiBase: 'https://api.openai.com/v1',
+    models,
+  };
+}
+
+function customGroup(models) {
+  return {
+    id: customGroupId,
+    provider: 'custom',
+    apiBase: 'http://127.0.0.1:8080/v1',
+    models,
+  };
+}
+
+function minimaxGroup(models) {
+  return {
+    id: minimaxGroupId,
+    provider: 'minimax',
+    apiBase: 'https://api.minimaxi.com/v1',
+    models,
+  };
+}
 
 test('providerSupportsModelCatalogListing includes OpenAI and excludes Azure', () => {
   assert.equal(
@@ -76,21 +119,21 @@ test('modelCatalogScopeKey normalizes api base', () => {
 
 test('mergeNewCatalogModelsIntoConfig appends only new provider-scoped models', () => {
   const config = {
-    models: [
-      {
-        name: 'zai/glm-5.1',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'zai/glm-5.1',
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+        },
+      ]),
     ],
-    activeModel: 'zai/glm-5.1',
+    activeModel: { groupId: gatewayGroupId, name: 'zai/glm-5.1' },
   };
 
   const merged = mergeNewCatalogModelsIntoConfig(
     config,
-    config.models[0],
+    { ...gatewayScopeProfile, name: 'zai/glm-5.1' },
     {
       modelIds: ['zai/glm-5.1', 'zai/glm-5.2'],
       fromCache: false,
@@ -103,36 +146,41 @@ test('mergeNewCatalogModelsIntoConfig appends only new provider-scoped models', 
 
   assert.equal(merged, 1);
   assert.deepEqual(
-    config.models.map((model) => model.name),
+    config.providerGroups[0].models.map((model) => model.name),
     ['zai/glm-5.1', 'zai/glm-5.2'],
   );
-  assert.equal(config.activeModel, 'zai/glm-5.1');
+  assert.deepEqual(config.activeModel, { groupId: gatewayGroupId, name: 'zai/glm-5.1' });
 });
 
 test('syncExistingModelsFromCatalog upgrades chat-only profiles from catalog', () => {
   const config = {
-    models: [
-      {
-        name: 'MiniMax-M3',
-        apiBase: 'https://api.minimaxi.com/v1',
-        provider: 'minimax',
-        capabilities: ['chat'],
-        reasoningEffort: 'medium',
-      },
-      {
-        name: 'MiniMax-M2.5',
-        apiBase: 'https://api.minimaxi.com/v1',
-        provider: 'minimax',
-        capabilities: ['chat'],
-        reasoningEffort: 'medium',
-      },
+    providerGroups: [
+      minimaxGroup([
+        {
+          name: 'MiniMax-M3',
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+        },
+        {
+          name: 'MiniMax-M2.5',
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+        },
+      ]),
     ],
-    activeModel: 'MiniMax-M3',
+    activeModel: { groupId: minimaxGroupId, name: 'MiniMax-M3' },
   };
 
   const synced = syncExistingModelsFromCatalog(
     config,
-    config.models[0],
+    {
+      groupId: minimaxGroupId,
+      name: 'MiniMax-M3',
+      apiBase: 'https://api.minimaxi.com/v1',
+      provider: 'minimax',
+      capabilities: ['chat'],
+      reasoningEffort: 'medium',
+    },
     {
       modelIds: ['MiniMax-M3', 'MiniMax-M2.5'],
       fromCache: false,
@@ -144,20 +192,19 @@ test('syncExistingModelsFromCatalog upgrades chat-only profiles from catalog', (
   );
 
   assert.equal(synced, 1);
-  assert.deepEqual(config.models[0].capabilities, ['chat', 'image', 'video']);
-  assert.deepEqual(config.models[1].capabilities, ['chat']);
+  assert.deepEqual(config.providerGroups[0].models[0].capabilities, ['chat', 'image', 'video']);
+  assert.deepEqual(config.providerGroups[0].models[1].capabilities, ['chat']);
 });
 
 test('syncExistingModelsFromCatalog writes videoGeneration when capabilities are missing', () => {
   const config = {
-    models: [
-      {
-        name: 'alibaba/wan-v2.6-t2v',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'alibaba/wan-v2.6-t2v',
+          reasoningEffort: 'medium',
+        },
+      ]),
     ],
   };
 
@@ -168,20 +215,19 @@ test('syncExistingModelsFromCatalog writes videoGeneration when capabilities are
   });
 
   assert.equal(synced, 1);
-  assert.deepEqual(config.models[0].capabilities, ['videoGeneration']);
+  assert.deepEqual(config.providerGroups[0].models[0].capabilities, ['videoGeneration']);
 });
 
 test('syncExistingModelsFromCatalog corrects stale video input to videoGeneration', () => {
   const config = {
-    models: [
-      {
-        name: 'alibaba/wan-v2.6-t2v',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-        capabilities: ['chat', 'video'],
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'alibaba/wan-v2.6-t2v',
+          reasoningEffort: 'medium',
+          capabilities: ['chat', 'video'],
+        },
+      ]),
     ],
   };
 
@@ -192,20 +238,19 @@ test('syncExistingModelsFromCatalog corrects stale video input to videoGeneratio
   });
 
   assert.equal(synced, 1);
-  assert.deepEqual(config.models[0].capabilities, ['videoGeneration']);
+  assert.deepEqual(config.providerGroups[0].models[0].capabilities, ['videoGeneration']);
 });
 
 test('syncExistingModelsFromCatalog syncs supportedReasoningEfforts from catalog', () => {
   const config = {
-    models: [
-      {
-        name: 'anthropic/claude-sonnet-4',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-        capabilities: ['chat'],
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'anthropic/claude-sonnet-4',
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+        },
+      ]),
     ],
   };
 
@@ -222,22 +267,21 @@ test('syncExistingModelsFromCatalog syncs supportedReasoningEfforts from catalog
   });
 
   assert.equal(synced, 1);
-  assert.deepEqual(config.models[0].supportedReasoningEfforts, ['low', 'high']);
+  assert.deepEqual(config.providerGroups[0].models[0].supportedReasoningEfforts, ['low', 'high']);
 });
 
 test('syncExistingModelsFromCatalog returns zero when catalog matches stored profile', () => {
   const config = {
-    models: [
-      {
-        name: 'openai/gpt-4.1',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-        capabilities: ['chat'],
-        supportedReasoningEfforts: ['low', 'high'],
-        contextLength: 128000,
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'openai/gpt-4.1',
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+          supportedReasoningEfforts: ['low', 'high'],
+          contextLength: 128000,
+        },
+      ]),
     ],
   };
 
@@ -255,7 +299,7 @@ test('syncExistingModelsFromCatalog returns zero when catalog matches stored pro
   });
 
   assert.equal(synced, 0);
-  assert.equal(config.models[0].contextLength, 128000);
+  assert.equal(config.providerGroups[0].models[0].contextLength, 128000);
 });
 
 test('applyCatalogEntryToStoredModel backfills contextLength only when unset', () => {
@@ -304,32 +348,28 @@ test('applyCatalogEntryToStoredModel syncs supportsThinkingType', () => {
 
 test('removeDelistedModelsFromCatalog drops scope models missing from upstream ids', () => {
   const config = {
-    models: [
-      {
-        name: 'alibaba/wan-v2.6-t2v',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-        capabilities: ['videoGeneration'],
-      },
-      {
-        name: 'openai/gpt-4.1',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-        capabilities: ['chat'],
-      },
-      {
-        name: 'legacy-local',
-        apiBase: 'http://127.0.0.1:8080/v1',
-        provider: 'custom',
-        reasoningEffort: 'default',
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'alibaba/wan-v2.6-t2v',
+          reasoningEffort: 'medium',
+          capabilities: ['videoGeneration'],
+        },
+        {
+          name: 'openai/gpt-4.1',
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+        },
+      ]),
+      customGroup([
+        {
+          name: 'legacy-local',
+          reasoningEffort: 'medium',
+        },
+      ]),
     ],
-    activeModel: 'alibaba/wan-v2.6-t2v',
-    videoGenerationModel: 'alibaba/wan-v2.6-t2v',
+    activeModel: { groupId: gatewayGroupId, name: 'alibaba/wan-v2.6-t2v' },
+    videoGenerationModel: { groupId: gatewayGroupId, name: 'alibaba/wan-v2.6-t2v' },
   };
 
   const pruned = removeDelistedModelsFromCatalog(config, gatewayScopeProfile, {
@@ -340,56 +380,25 @@ test('removeDelistedModelsFromCatalog drops scope models missing from upstream i
 
   assert.deepEqual(pruned, ['alibaba/wan-v2.6-t2v']);
   assert.deepEqual(
-    config.models.map((model) => model.name),
-    ['openai/gpt-4.1', 'legacy-local'],
+    config.providerGroups[0].models.map((model) => model.name),
+    ['openai/gpt-4.1'],
   );
-  assert.equal(config.activeModel, 'openai/gpt-4.1');
+  assert.deepEqual(config.providerGroups[1].models.map((model) => model.name), ['legacy-local']);
+  assert.deepEqual(config.activeModel, { groupId: gatewayGroupId, name: 'openai/gpt-4.1' });
   assert.equal(config.videoGenerationModel, undefined);
 });
 
 test('removeDelistedModelsFromCatalog clears activeModel when last scope model is removed', () => {
   const config = {
-    models: [
-      {
-        name: 'alibaba/wan-v2.6-t2v',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'alibaba/wan-v2.6-t2v',
+          reasoningEffort: 'medium',
+        },
+      ]),
     ],
-    activeModel: 'alibaba/wan-v2.6-t2v',
-  };
-
-  const pruned = removeDelistedModelsFromCatalog(config, gatewayScopeProfile, {
-    modelIds: [],
-    fromCache: false,
-    modelCatalog: [],
-  });
-
-  assert.deepEqual(pruned, []);
-  assert.deepEqual(config.models.map((model) => model.name), ['alibaba/wan-v2.6-t2v']);
-  assert.equal(config.activeModel, 'alibaba/wan-v2.6-t2v');
-});
-
-test('removeDelistedModelsFromCatalog keeps same-named models in other provider scopes', () => {
-  const config = {
-    models: [
-      {
-        name: 'shared-id',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-      },
-      {
-        name: 'shared-id',
-        apiBase: 'https://api.openai.com/v1',
-        provider: 'openai',
-        reasoningEffort: 'default',
-      },
-    ],
-    activeModel: 'shared-id',
+    activeModel: { groupId: gatewayGroupId, name: 'alibaba/wan-v2.6-t2v' },
   };
 
   const pruned = removeDelistedModelsFromCatalog(config, gatewayScopeProfile, {
@@ -400,29 +409,61 @@ test('removeDelistedModelsFromCatalog keeps same-named models in other provider 
 
   assert.deepEqual(pruned, []);
   assert.deepEqual(
-    config.models.map((model) => model.provider),
+    config.providerGroups[0].models.map((model) => model.name),
+    ['alibaba/wan-v2.6-t2v'],
+  );
+  assert.deepEqual(config.activeModel, { groupId: gatewayGroupId, name: 'alibaba/wan-v2.6-t2v' });
+});
+
+test('removeDelistedModelsFromCatalog keeps same-named models in other provider scopes', () => {
+  const config = {
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'shared-id',
+          reasoningEffort: 'medium',
+        },
+      ]),
+      openAiGroup([
+        {
+          name: 'shared-id',
+          reasoningEffort: 'medium',
+        },
+      ]),
+    ],
+    activeModel: { groupId: gatewayGroupId, name: 'shared-id' },
+  };
+
+  const pruned = removeDelistedModelsFromCatalog(config, gatewayScopeProfile, {
+    modelIds: [],
+    fromCache: false,
+    modelCatalog: [],
+  });
+
+  assert.deepEqual(pruned, []);
+  assert.deepEqual(
+    config.providerGroups.map((group) => group.provider),
     ['vercel-ai-gateway', 'openai'],
   );
 });
 
 test('removeDelistedModelsFromCatalog prunes delisted gateway model but keeps openai same name', () => {
   const config = {
-    models: [
-      {
-        name: 'shared-id',
-        apiBase: 'https://ai-gateway.vercel.sh/v1',
-        provider: 'vercel-ai-gateway',
-        transportKind: 'open-responses',
-        reasoningEffort: 'default',
-      },
-      {
-        name: 'shared-id',
-        apiBase: 'https://api.openai.com/v1',
-        provider: 'openai',
-        reasoningEffort: 'default',
-      },
+    providerGroups: [
+      gatewayGroup([
+        {
+          name: 'shared-id',
+          reasoningEffort: 'medium',
+        },
+      ]),
+      openAiGroup([
+        {
+          name: 'shared-id',
+          reasoningEffort: 'medium',
+        },
+      ]),
     ],
-    activeModel: 'shared-id',
+    activeModel: { groupId: gatewayGroupId, name: 'shared-id' },
   };
 
   const pruned = removeDelistedModelsFromCatalog(config, gatewayScopeProfile, {
@@ -433,8 +474,8 @@ test('removeDelistedModelsFromCatalog prunes delisted gateway model but keeps op
 
   assert.deepEqual(pruned, ['shared-id']);
   assert.deepEqual(
-    config.models.map((model) => model.provider),
+    config.providerGroups.flatMap((group) => group.models.map(() => group.provider)),
     ['openai'],
   );
-  assert.equal(config.activeModel, 'shared-id');
+  assert.deepEqual(config.activeModel, { groupId: openAiGroupId, name: 'shared-id' });
 });

--- a/apps/desktop/test/host/provider-api-key.test.mjs
+++ b/apps/desktop/test/host/provider-api-key.test.mjs
@@ -11,10 +11,14 @@ import {
   resolveActiveModelAfterRemoval,
 } from '../../dist-electron/src/host/provider-api-key.js';
 
-test('providerKeyAccount uses provider namespace', () => {
-  assert.equal(providerKeyAccount('vercel-ai-gateway'), 'provider::vercel-ai-gateway');
-  assert.equal(providerKeyAccount('openrouter'), 'provider::openrouter');
-  assert.equal(providerKeyAccount('custom'), 'provider::custom');
+const openAiGroupId = 'openai';
+const anthropicGroupId = 'anthropic';
+const gatewayGroupId = 'vercel-ai-gateway';
+
+test('providerKeyAccount uses group namespace', () => {
+  assert.equal(providerKeyAccount('vercel-ai-gateway'), 'group::vercel-ai-gateway');
+  assert.equal(providerKeyAccount('openrouter'), 'group::openrouter');
+  assert.equal(providerKeyAccount('custom'), 'group::custom');
 });
 
 test('modelProviderKeyScope defaults missing provider to custom', () => {
@@ -23,47 +27,47 @@ test('modelProviderKeyScope defaults missing provider to custom', () => {
 });
 
 test('buildModelSecretKeyPresence reads each provider once', () => {
-  const providerReads = [];
+  const groupReads = [];
   const modelReads = [];
 
   const presence = buildModelSecretKeyPresence(
     [
-      { name: 'a', provider: 'openai' },
-      { name: 'b', provider: 'openai' },
-      { name: 'c', provider: 'anthropic' },
-      { name: 'legacy-only' },
+      { groupId: openAiGroupId, name: 'a', provider: 'openai' },
+      { groupId: openAiGroupId, name: 'b', provider: 'openai' },
+      { groupId: anthropicGroupId, name: 'c', provider: 'anthropic' },
+      { groupId: 'custom', name: 'legacy-only' },
     ],
-    (providerId, _profile) => {
-      providerReads.push(providerId);
-      return providerId === 'openai';
+    (groupId, _profile) => {
+      groupReads.push(groupId);
+      return groupId === openAiGroupId;
     },
-    (modelName) => {
-      modelReads.push(modelName);
-      return modelName === 'legacy-only';
+    (refKey) => {
+      modelReads.push(refKey);
+      return refKey === 'custom::legacy-only';
     },
   );
 
-  assert.deepEqual(providerReads, ['openai', 'anthropic', 'custom']);
-  assert.deepEqual(modelReads, ['c', 'legacy-only']);
-  assert.equal(presence.a, true);
-  assert.equal(presence.b, true);
-  assert.equal(presence.c, false);
-  assert.equal(presence['legacy-only'], true);
+  assert.deepEqual(groupReads, [openAiGroupId, anthropicGroupId, 'custom']);
+  assert.deepEqual(modelReads, ['anthropic::c', 'custom::legacy-only']);
+  assert.equal(presence['openai::a'], true);
+  assert.equal(presence['openai::b'], true);
+  assert.equal(presence['anthropic::c'], false);
+  assert.equal(presence['custom::legacy-only'], true);
 });
 
 test('buildModelSecretKeyPresence prefers provider key over per-model key', () => {
   const presence = buildModelSecretKeyPresence(
-    [{ name: 'gpt-4', provider: 'openai' }],
+    [{ groupId: openAiGroupId, name: 'gpt-4', provider: 'openai' }],
     () => true,
     () => false,
   );
-  assert.equal(presence['gpt-4'], true);
+  assert.equal(presence['openai::gpt-4'], true);
 });
 
 test('modelExistsInProviderScope only matches same provider scope', () => {
   const existing = [
-    { name: 'gpt-4', provider: 'openai' },
-    { name: 'gpt-4', provider: 'vercel-ai-gateway' },
+    { groupId: openAiGroupId, name: 'gpt-4', provider: 'openai' },
+    { groupId: gatewayGroupId, name: 'gpt-4', provider: 'vercel-ai-gateway' },
   ];
   assert.equal(modelExistsInProviderScope(existing, 'gpt-4', 'openai'), true);
   assert.equal(modelExistsInProviderScope(existing, 'gpt-4', 'anthropic'), false);
@@ -71,76 +75,110 @@ test('modelExistsInProviderScope only matches same provider scope', () => {
 });
 
 test('resolveActiveModelAfterRemoval switches to another model or clears active', () => {
-  const remaining = [{ name: 'b' }, { name: 'c' }];
-  assert.equal(
-    resolveActiveModelAfterRemoval('a', remaining, ['a']),
-    'b',
+  const remaining = [
+    { groupId: openAiGroupId, name: 'b' },
+    { groupId: openAiGroupId, name: 'c' },
+  ];
+  assert.deepEqual(
+    resolveActiveModelAfterRemoval(
+      { groupId: openAiGroupId, name: 'a' },
+      remaining,
+      [{ groupId: openAiGroupId, name: 'a' }],
+    ),
+    { groupId: openAiGroupId, name: 'b' },
   );
-  assert.equal(
-    resolveActiveModelAfterRemoval('a', [], ['a']),
-    '',
+  assert.deepEqual(
+    resolveActiveModelAfterRemoval(
+      { groupId: openAiGroupId, name: 'a' },
+      [],
+      [{ groupId: openAiGroupId, name: 'a' }],
+    ),
+    { groupId: '', name: '' },
   );
-  assert.equal(
-    resolveActiveModelAfterRemoval('b', remaining, ['a']),
-    'b',
+  assert.deepEqual(
+    resolveActiveModelAfterRemoval(
+      { groupId: openAiGroupId, name: 'b' },
+      remaining,
+      [{ groupId: openAiGroupId, name: 'a' }],
+    ),
+    { groupId: openAiGroupId, name: 'b' },
   );
 });
 
 test('applyModelsRemovalToConfig clears default slots when active model is removed', () => {
   const config = {
-    models: [
-      { name: 'a', provider: 'openai' },
-      { name: 'b', provider: 'openai' },
-    ],
-    activeModel: 'a',
-    imageGenerationModel: 'a',
-    videoGenerationModel: 'b',
-    lightweightChatModel: 'a',
+    providerGroups: [{
+      id: openAiGroupId,
+      provider: 'openai',
+      apiBase: 'https://api.openai.com/v1',
+      models: [
+        { name: 'a', reasoningEffort: 'medium', capabilities: ['chat'] },
+        { name: 'b', reasoningEffort: 'medium', capabilities: ['chat'] },
+      ],
+    }],
+    activeModel: { groupId: openAiGroupId, name: 'a' },
+    imageGenerationModel: { groupId: openAiGroupId, name: 'a' },
+    videoGenerationModel: { groupId: openAiGroupId, name: 'b' },
+    lightweightChatModel: { groupId: openAiGroupId, name: 'a' },
   };
 
-  assert.equal(applyModelsRemovalToConfig(config, [{ name: 'a', provider: 'openai' }]), 1);
+  assert.equal(
+    applyModelsRemovalToConfig(config, [{ ref: { groupId: openAiGroupId, name: 'a' } }]),
+    1,
+  );
   assert.deepEqual(
-    config.models.map((model) => model.name),
+    config.providerGroups[0].models.map((model) => model.name),
     ['b'],
   );
-  assert.equal(config.activeModel, 'b');
+  assert.deepEqual(config.activeModel, { groupId: openAiGroupId, name: 'b' });
   assert.equal(config.imageGenerationModel, undefined);
-  assert.equal(config.videoGenerationModel, 'b');
+  assert.deepEqual(config.videoGenerationModel, { groupId: openAiGroupId, name: 'b' });
   assert.equal(config.lightweightChatModel, undefined);
 });
 
 test('applyModelsRemovalToConfig only removes models in the same provider scope', () => {
   const config = {
-    models: [
-      { name: 'shared-id', provider: 'openai' },
-      { name: 'shared-id', provider: 'vercel-ai-gateway' },
+    providerGroups: [
+      {
+        id: openAiGroupId,
+        provider: 'openai',
+        apiBase: 'https://api.openai.com/v1',
+        models: [{ name: 'shared-id', reasoningEffort: 'medium', capabilities: ['chat'] }],
+      },
+      {
+        id: gatewayGroupId,
+        provider: 'vercel-ai-gateway',
+        apiBase: 'https://ai-gateway.vercel.sh/v1',
+        transportKind: 'open-responses',
+        models: [{ name: 'shared-id', reasoningEffort: 'medium', capabilities: ['chat'] }],
+      },
     ],
-    activeModel: 'shared-id',
-    videoGenerationModel: 'shared-id',
+    activeModel: { groupId: openAiGroupId, name: 'shared-id' },
+    videoGenerationModel: { groupId: openAiGroupId, name: 'shared-id' },
   };
 
   assert.equal(
-    applyModelsRemovalToConfig(config, [{ name: 'shared-id', provider: 'openai' }]),
+    applyModelsRemovalToConfig(config, [{ ref: { groupId: openAiGroupId, name: 'shared-id' } }]),
     1,
   );
   assert.deepEqual(
-    config.models.map((model) => model.provider),
+    config.providerGroups.flatMap((group) => group.models.map(() => group.provider)),
     ['vercel-ai-gateway'],
   );
-  assert.equal(config.activeModel, 'shared-id');
-  assert.equal(config.videoGenerationModel, 'shared-id');
+  assert.deepEqual(config.activeModel, { groupId: gatewayGroupId, name: 'shared-id' });
+  assert.equal(config.videoGenerationModel, undefined);
 });
 
 test('filterNewProviderModelIds skips only duplicates within provider scope', () => {
-  const existing = [{ name: 'shared-id', provider: 'openai' }];
+  const existing = [{ groupId: openAiGroupId, name: 'shared-id', provider: 'openai' }];
   const filtered = filterNewProviderModelIds(
     existing,
     ['shared-id', 'new-id'],
-    'vercel-ai-gateway',
+    gatewayGroupId,
   );
   assert.deepEqual(filtered, ['shared-id', 'new-id']);
   assert.deepEqual(
-    filterNewProviderModelIds(existing, ['shared-id', 'new-id'], 'openai'),
+    filterNewProviderModelIds(existing, ['shared-id', 'new-id'], openAiGroupId),
     ['new-id'],
   );
 });

--- a/apps/desktop/test/host/tool-executor-lazy.test.mjs
+++ b/apps/desktop/test/host/tool-executor-lazy.test.mjs
@@ -24,7 +24,7 @@ test('DesktopToolExecutor exposes lazy gateway for built-in create_automation wi
     hostContributedToolsEnabled: true,
     getAutomationCreateDefaults: () => ({
       workspaceRoot: process.cwd(),
-      model: 'demo-model',
+      modelRef: { groupId: 'openai', name: 'demo-model' },
     }),
   });
 
@@ -47,7 +47,7 @@ test('DesktopToolExecutor exposes lazy gateway when MCP only provides fetch_mcp_
     hostContributedToolsEnabled: true,
     getAutomationCreateDefaults: () => ({
       workspaceRoot: process.cwd(),
-      model: 'demo-model',
+      modelRef: { groupId: 'openai', name: 'demo-model' },
     }),
   });
 
@@ -63,7 +63,7 @@ test('DesktopToolExecutor hides built-in create_automation in plan mode', () => 
     hostContributedToolsEnabled: true,
     getAutomationCreateDefaults: () => ({
       workspaceRoot: process.cwd(),
-      model: 'demo-model',
+      modelRef: { groupId: 'openai', name: 'demo-model' },
     }),
   });
   toolExecutor.setAgentModeToolExposure('plan');

--- a/packages/acp-server/src/credentials/credentials.ts
+++ b/packages/acp-server/src/credentials/credentials.ts
@@ -1,4 +1,7 @@
-import type { ModelProviderId } from '@spiritagent/host-internal';
+import {
+  SPIRIT_CONFIG_SCHEMA_VERSION,
+  type ModelProviderId,
+} from '@spiritagent/host-internal';
 
 import { keyringStore } from './keyring-store.js';
 import {
@@ -238,13 +241,33 @@ export async function saveProviderSetup(
   }
 
   const existing = loadSpiritConfig(spiritDataDir);
-  const models = existing?.models.filter((model) => model.name !== setup.profile.name) ?? [];
-  models.push(setup.profile);
+  const providerGroups = [...(existing?.providerGroups ?? [])];
+  const groupIndex = providerGroups.findIndex((group) => group.id === setup.groupId);
+  const activeModel = { groupId: setup.groupId, name: setup.model.name };
+
+  if (groupIndex >= 0) {
+    const currentGroup = providerGroups[groupIndex]!;
+    const models = currentGroup.models.filter((model) => model.name !== setup.model.name);
+    models.push(setup.model);
+    providerGroups[groupIndex] = {
+      ...currentGroup,
+      ...setup.group,
+      id: setup.groupId,
+      models,
+    };
+  } else {
+    providerGroups.push({
+      ...setup.group,
+      id: setup.groupId,
+      models: [setup.model],
+    });
+  }
 
   const config: SpiritConfigFile = {
-    ...(existing ?? { models: [], activeModel: '' }),
-    models,
-    activeModel: setup.profile.name,
+    ...(existing ?? {}),
+    schemaVersion: SPIRIT_CONFIG_SCHEMA_VERSION,
+    providerGroups,
+    activeModel,
   };
   await saveSpiritConfig(spiritDataDir, config);
 }

--- a/packages/acp-server/src/credentials/spirit-config.ts
+++ b/packages/acp-server/src/credentials/spirit-config.ts
@@ -3,10 +3,23 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import {
+  assertSpiritConfigSchemaVersion,
+  findModelByRef,
+  parseModelRef,
+  SPIRIT_CONFIG_SCHEMA_VERSION,
+  SpiritConfigSchemaError,
+  type ModelEntryV2,
+  type ModelRef,
+  type ProviderGroupV2,
+} from '@spiritagent/host-internal';
+
 import type { SpiritConfigFile, SpiritModelProfile } from './types.js';
 
 const CONFIG_FILE_NAME = 'config.json';
 const APP_DATA_DIR_NAME = 'SpiritAgent';
+
+export { SpiritConfigSchemaError };
 
 export function resolveSpiritDataDir(): string {
   const envOverride = process.env['SPIRIT_ACP_DATA_DIR']?.trim()
@@ -47,62 +60,59 @@ export function configFilePath(spiritDataDir: string): string {
   return join(spiritDataDir, CONFIG_FILE_NAME);
 }
 
-function normalizeModelProfile(raw: unknown): SpiritModelProfile | undefined {
-  if (typeof raw !== 'object' || raw === null) {
-    return undefined;
-  }
-  const record = raw as Record<string, unknown>;
-  const name = typeof record['name'] === 'string' ? record['name'].trim() : '';
-  const apiBase = typeof record['apiBase'] === 'string' ? record['apiBase'].trim() : '';
-  if (!name || !apiBase) {
-    return undefined;
-  }
+function resolveSpiritModelProfile(
+  group: ProviderGroupV2,
+  model: ModelEntryV2,
+): SpiritModelProfile {
+  const ref: ModelRef = { groupId: group.id, name: model.name };
+  return {
+    groupId: group.id,
+    ref,
+    name: model.name,
+    apiBase: group.apiBase,
+    reasoningEffort: model.reasoningEffort,
+    ...(model.supportedReasoningEfforts !== undefined
+      ? { supportedReasoningEfforts: model.supportedReasoningEfforts }
+      : {}),
+    ...(model.capabilities !== undefined ? { capabilities: model.capabilities } : {}),
+    provider: group.provider,
+    ...(group.transportKind ? { transportKind: group.transportKind } : {}),
+    ...(group.providerSite ? { providerSite: group.providerSite } : {}),
+    ...(group.alibabaWorkspaceId ? { alibabaWorkspaceId: group.alibabaWorkspaceId } : {}),
+    ...(group.awsRegion ? { awsRegion: group.awsRegion } : {}),
+    ...(group.azureResourceName ? { azureResourceName: group.azureResourceName } : {}),
+    ...(group.cloudflareAccountId ? { cloudflareAccountId: group.cloudflareAccountId } : {}),
+    ...(group.cloudflareGatewayId ? { cloudflareGatewayId: group.cloudflareGatewayId } : {}),
+    ...(group.vertexProject ? { vertexProject: group.vertexProject } : {}),
+    ...(group.vertexLocation ? { vertexLocation: group.vertexLocation } : {}),
+    ...(model.contextLength !== undefined ? { contextLength: model.contextLength } : {}),
+  };
+}
 
-  const profile: SpiritModelProfile = { name, apiBase };
-  if (typeof record['provider'] === 'string') {
-    profile.provider = record['provider'] as NonNullable<SpiritModelProfile['provider']>;
+function normalizeProviderGroups(raw: unknown): ProviderGroupV2[] {
+  if (!Array.isArray(raw)) {
+    return [];
   }
-  if (typeof record['transportKind'] === 'string') {
-    profile.transportKind = record['transportKind'] as NonNullable<SpiritModelProfile['transportKind']>;
-  }
-  if (typeof record['reasoningEffort'] === 'string') {
-    profile.reasoningEffort = record['reasoningEffort'] as NonNullable<SpiritModelProfile['reasoningEffort']>;
-  }
-  if (typeof record['providerSite'] === 'string') {
-    profile.providerSite = record['providerSite'];
-  }
-  if (typeof record['alibabaWorkspaceId'] === 'string') {
-    profile.alibabaWorkspaceId = record['alibabaWorkspaceId'];
-  }
-  if (typeof record['awsRegion'] === 'string') {
-    profile.awsRegion = record['awsRegion'];
-  }
-  if (typeof record['azureResourceName'] === 'string') {
-    profile.azureResourceName = record['azureResourceName'];
-  }
-  if (typeof record['vertexProject'] === 'string') {
-    profile.vertexProject = record['vertexProject'];
-  }
-  if (typeof record['vertexLocation'] === 'string') {
-    profile.vertexLocation = record['vertexLocation'];
-  }
-  if (Array.isArray(record['capabilities'])) {
-    profile.capabilities = record['capabilities'] as NonNullable<SpiritModelProfile['capabilities']>;
-  }
-  return profile;
+  return raw as ProviderGroupV2[];
 }
 
 function normalizeConfig(raw: Record<string, unknown>): SpiritConfigFile {
-  const modelsRaw = Array.isArray(raw['models']) ? raw['models'] : [];
-  const models = modelsRaw
-    .map(normalizeModelProfile)
-    .filter((model): model is SpiritModelProfile => model !== undefined);
+  assertSpiritConfigSchemaVersion(raw);
 
-  const activeModel = typeof raw['activeModel'] === 'string' ? raw['activeModel'].trim() : '';
+  const providerGroups = normalizeProviderGroups(raw['providerGroups']);
+  const activeModel = parseModelRef(raw['activeModel']) ?? { groupId: '', name: '' };
+  const imageGenerationModel = parseModelRef(raw['imageGenerationModel']);
+  const videoGenerationModel = parseModelRef(raw['videoGenerationModel']);
+  const lightweightChatModel = parseModelRef(raw['lightweightChatModel']);
+
   return {
     ...raw,
-    models,
-    activeModel: activeModel || models[0]?.name || '',
+    schemaVersion: SPIRIT_CONFIG_SCHEMA_VERSION,
+    providerGroups,
+    activeModel,
+    ...(imageGenerationModel ? { imageGenerationModel } : {}),
+    ...(videoGenerationModel ? { videoGenerationModel } : {}),
+    ...(lightweightChatModel ? { lightweightChatModel } : {}),
   };
 }
 
@@ -117,7 +127,10 @@ export function loadSpiritConfig(spiritDataDir: string): SpiritConfigFile | unde
       return undefined;
     }
     return normalizeConfig(parsed as Record<string, unknown>);
-  } catch {
+  } catch (err) {
+    if (err instanceof SpiritConfigSchemaError) {
+      return undefined;
+    }
     return undefined;
   }
 }
@@ -128,13 +141,21 @@ export async function saveSpiritConfig(
 ): Promise<void> {
   const filePath = configFilePath(spiritDataDir);
   await mkdir(spiritDataDir, { recursive: true });
-  await writeFile(filePath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+  const payload: SpiritConfigFile = {
+    ...config,
+    schemaVersion: SPIRIT_CONFIG_SCHEMA_VERSION,
+  };
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
 }
 
 export function loadActiveModelProfile(spiritDataDir: string): SpiritModelProfile | undefined {
   const config = loadSpiritConfig(spiritDataDir);
-  if (!config?.activeModel.trim()) {
+  if (!config) {
     return undefined;
   }
-  return config.models.find((model) => model.name === config.activeModel);
+  const resolved = findModelByRef(config.providerGroups, config.activeModel);
+  if (!resolved) {
+    return undefined;
+  }
+  return resolveSpiritModelProfile(resolved.group, resolved.model);
 }

--- a/packages/acp-server/src/credentials/types.ts
+++ b/packages/acp-server/src/credentials/types.ts
@@ -1,11 +1,21 @@
-import type { ModelProviderId, ProviderModelTransportKind } from '@spiritagent/host-internal';
+import type {
+  ModelEntryV2,
+  ModelProviderId,
+  ModelRef,
+  ProviderGroupV2,
+  ProviderModelTransportKind,
+  SpiritConfigSchemaVersion,
+  SpiritModelCapabilityV2,
+  SpiritModelReasoningEffortV2,
+} from '@spiritagent/host-internal';
 
-export type SpiritModelCapability = 'chat' | 'image' | 'video' | 'imageGeneration' | 'videoGeneration';
+export type SpiritModelCapability = SpiritModelCapabilityV2;
+export type SpiritModelReasoningEffort = SpiritModelReasoningEffortV2;
 
-export type SpiritModelReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
-
-/** Subset of Desktop `ModelProfileSnapshot` used by ACP setup and transport resolution. */
+/** Resolved profile for ACP transport (group connect fields + model entry). */
 export interface SpiritModelProfile {
+  groupId: string;
+  ref: ModelRef;
   name: string;
   apiBase: string;
   reasoningEffort?: SpiritModelReasoningEffort;
@@ -17,6 +27,8 @@ export interface SpiritModelProfile {
   alibabaWorkspaceId?: string;
   awsRegion?: string;
   azureResourceName?: string;
+  cloudflareAccountId?: string;
+  cloudflareGatewayId?: string;
   vertexProject?: string;
   vertexLocation?: string;
   contextLength?: number;
@@ -24,10 +36,16 @@ export interface SpiritModelProfile {
 
 /** Minimal `config.json` fields read/written by ACP; other Desktop fields are preserved on merge. */
 export interface SpiritConfigFile {
-  models: SpiritModelProfile[];
-  activeModel: string;
+  schemaVersion: SpiritConfigSchemaVersion;
+  providerGroups: ProviderGroupV2[];
+  activeModel: ModelRef;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
+  lightweightChatModel?: ModelRef;
   [key: string]: unknown;
 }
+
+export type { ModelEntryV2, ModelRef, ProviderGroupV2 };
 
 export interface BedrockSetupCredentials {
   apiKey?: string;
@@ -43,8 +61,10 @@ export interface GoogleVertexSetupCredentials {
 
 /** Result collected by the setup wizard before persistence. */
 export interface ProviderSetupResult {
-  profile: SpiritModelProfile;
+  groupId: string;
+  model: ModelEntryV2;
   providerScope: ModelProviderId;
+  group: Omit<ProviderGroupV2, 'models'>;
   apiKey?: string;
   bedrock?: BedrockSetupCredentials;
   vertex?: GoogleVertexSetupCredentials;

--- a/packages/acp-server/src/setup/provider-wizard.ts
+++ b/packages/acp-server/src/setup/provider-wizard.ts
@@ -1,12 +1,18 @@
-import type { ModelProviderId, ProviderModelTransportKind } from '@spiritagent/host-internal';
+import type {
+  ModelEntryV2,
+  ModelProviderId,
+  ProviderGroupV2,
+  ProviderModelTransportKind,
+} from '@spiritagent/host-internal';
 import {
+  defaultPresetProviderGroupId,
   listProviderConnectSiteOptions,
   providerConnectSiteRequiresWorkspaceId,
   providerSupportsSiteSelection,
   resolveProviderConnectApiBase,
 } from '@spiritagent/host-internal';
 
-import type { SpiritModelProfile } from '../credentials/types.js';
+import type { ProviderSetupResult, SpiritModelProfile } from '../credentials/types.js';
 
 const DEFAULT_API_BASE = 'https://api.openai.com/v1';
 
@@ -182,6 +188,7 @@ export function validateCustomSetup(input: { apiBase?: string; apiKey?: string; 
 export function buildSetupProfile(input: {
   provider: ModelProviderId;
   modelName: string;
+  groupId?: string;
   transportKind?: ProviderModelTransportKind;
   providerSite?: string;
   alibabaWorkspaceId?: string;
@@ -191,9 +198,14 @@ export function buildSetupProfile(input: {
   vertexLocation?: string;
   apiBaseOverride?: string;
 }): SpiritModelProfile {
+  const groupId = input.groupId?.trim() || defaultPresetProviderGroupId(input.provider);
+  const name = input.modelName.trim();
+  const ref = { groupId, name };
   const transportKind = resolveSetupTransportKind(input.provider, input.transportKind);
   const profile: SpiritModelProfile = {
-    name: input.modelName.trim(),
+    groupId,
+    ref,
+    name,
     apiBase: input.apiBaseOverride?.trim() || '',
     reasoningEffort: 'medium',
     capabilities: ['chat', 'image'],
@@ -224,6 +236,49 @@ export function buildSetupProfile(input: {
     profile.apiBase = resolveProfileApiBase(profile);
   }
   return profile;
+}
+
+export function buildProviderSetupResult(input: {
+  provider: ModelProviderId;
+  modelName: string;
+  groupId?: string;
+  transportKind?: ProviderModelTransportKind;
+  providerSite?: string;
+  alibabaWorkspaceId?: string;
+  awsRegion?: string;
+  azureResourceName?: string;
+  vertexProject?: string;
+  vertexLocation?: string;
+  apiBaseOverride?: string;
+}): Pick<ProviderSetupResult, 'groupId' | 'group' | 'model' | 'providerScope'> {
+  const profile = buildSetupProfile(input);
+  const group: Omit<ProviderGroupV2, 'models'> = {
+    id: profile.groupId,
+    provider: profile.provider ?? 'custom',
+    apiBase: profile.apiBase,
+    ...(profile.transportKind ? { transportKind: profile.transportKind } : {}),
+    ...(profile.providerSite ? { providerSite: profile.providerSite } : {}),
+    ...(profile.alibabaWorkspaceId ? { alibabaWorkspaceId: profile.alibabaWorkspaceId } : {}),
+    ...(profile.awsRegion ? { awsRegion: profile.awsRegion } : {}),
+    ...(profile.azureResourceName ? { azureResourceName: profile.azureResourceName } : {}),
+    ...(profile.vertexProject ? { vertexProject: profile.vertexProject } : {}),
+    ...(profile.vertexLocation ? { vertexLocation: profile.vertexLocation } : {}),
+  };
+  const model: ModelEntryV2 = {
+    name: profile.name,
+    reasoningEffort: profile.reasoningEffort ?? 'medium',
+    ...(profile.supportedReasoningEfforts !== undefined
+      ? { supportedReasoningEfforts: profile.supportedReasoningEfforts }
+      : {}),
+    ...(profile.capabilities !== undefined ? { capabilities: profile.capabilities } : {}),
+    ...(profile.contextLength !== undefined ? { contextLength: profile.contextLength } : {}),
+  };
+  return {
+    groupId: profile.groupId,
+    group,
+    model,
+    providerScope: input.provider,
+  };
 }
 
 export function providerNeedsSiteSelection(provider: ModelProviderId): boolean {

--- a/packages/acp-server/src/setup/run-interactive-setup.ts
+++ b/packages/acp-server/src/setup/run-interactive-setup.ts
@@ -10,6 +10,7 @@ import {
 import type { ProviderSetupResult } from '../credentials/types.js';
 import {
   buildSetupProfile,
+  buildProviderSetupResult,
   listSiteOptions,
   providerNeedsSiteSelection,
   resolveProfileApiBase,
@@ -346,7 +347,7 @@ export async function runProviderWizard(): Promise<ProviderSetupResult> {
     }
   }
 
-  const profile = buildSetupProfile({
+  const setupParts = buildProviderSetupResult({
     provider,
     modelName,
     ...(providerSite ? { providerSite } : {}),
@@ -359,7 +360,7 @@ export async function runProviderWizard(): Promise<ProviderSetupResult> {
   });
 
   const confirmed = await confirm({
-    message: `Save ${profile.name} (${provider}) as the active model?`,
+    message: `Save ${setupParts.model.name} (${provider}) as the active model?`,
     default: true,
   });
   if (!confirmed) {
@@ -367,8 +368,7 @@ export async function runProviderWizard(): Promise<ProviderSetupResult> {
   }
 
   const result: ProviderSetupResult = {
-    profile,
-    providerScope: provider,
+    ...setupParts,
   };
   if (apiKey.trim()) {
     result.apiKey = apiKey.trim();

--- a/packages/acp-server/src/setup/run-setup.ts
+++ b/packages/acp-server/src/setup/run-setup.ts
@@ -11,7 +11,7 @@ export async function runSetup(): Promise<void> {
   try {
     const setup = await runProviderWizard();
     await saveProviderSetup(resolveSpiritDataDir(), setup);
-    console.error(`\nSetup complete. Active model: ${setup.profile.name}`);
+    console.error(`\nSetup complete. Active model: ${setup.model.name}`);
     console.error('Return to your ACP client to authenticate and create a session.');
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/acp-server/test/credentials.test.ts
+++ b/packages/acp-server/test/credentials.test.ts
@@ -14,6 +14,19 @@ import {
   providerKeyAccount,
   providerSecretAccessKeyAccount,
 } from '../src/credentials/provider-accounts.js';
+import { buildProviderSetupResult } from '../src/setup/provider-wizard.js';
+
+function openAiSetup(overrides: Record<string, unknown> = {}) {
+  return {
+    ...buildProviderSetupResult({
+      provider: 'openai',
+      modelName: 'gpt-4o-mini',
+    }),
+    providerScope: 'openai' as const,
+    apiKey: 'secret-key',
+    ...overrides,
+  };
+}
 
 test('loadSpiritConfig returns undefined for invalid JSON', () => {
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-config-'));
@@ -21,17 +34,23 @@ test('loadSpiritConfig returns undefined for invalid JSON', () => {
   assert.equal(loadSpiritConfig(dir), undefined);
 });
 
+test('loadSpiritConfig rejects legacy schemaVersion 1 config', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-config-v1-'));
+  writeFileSync(
+    join(dir, 'config.json'),
+    JSON.stringify({
+      schemaVersion: 1,
+      models: [{ name: 'gpt-4o-mini', apiBase: 'https://api.openai.com/v1', provider: 'openai' }],
+      activeModel: 'gpt-4o-mini',
+    }),
+    'utf8',
+  );
+  assert.equal(loadSpiritConfig(dir), undefined);
+});
+
 test('saveProviderSetup writes keyring before config', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-save-'));
-  const setup = {
-    profile: {
-      name: 'gpt-4o-mini',
-      apiBase: 'https://api.openai.com/v1',
-      provider: 'openai' as const,
-    },
-    providerScope: 'openai' as const,
-    apiKey: 'secret-key',
-  };
+  const setup = openAiSetup();
 
   setKeyringStoreForTests({
     getPassword: () => undefined,
@@ -65,22 +84,17 @@ test('saveProviderSetup persists keyring and config together', async () => {
     },
   });
 
-  const setup = {
-    profile: {
-      name: 'gpt-4o-mini',
-      apiBase: 'https://api.openai.com/v1',
-      provider: 'openai' as const,
-    },
-    providerScope: 'openai' as const,
-    apiKey: 'secret-key',
-  };
+  const setup = openAiSetup();
 
   try {
     await saveProviderSetup(dir, setup);
     assert.equal(passwords.get(providerKeyAccount('openai')), 'secret-key');
     const config = loadSpiritConfig(dir);
-    assert.equal(config?.activeModel, 'gpt-4o-mini');
-    assert.equal(config?.models.length, 1);
+    assert.equal(config?.schemaVersion, 2);
+    assert.deepEqual(config?.activeModel, { groupId: 'openai', name: 'gpt-4o-mini' });
+    assert.equal(config?.providerGroups.length, 1);
+    assert.equal(config?.providerGroups[0]?.models.length, 1);
+    assert.equal(config?.providerGroups[0]?.models[0]?.name, 'gpt-4o-mini');
   } finally {
     setKeyringStoreForTests(undefined);
   }
@@ -100,13 +114,12 @@ test('saveProviderSetup persists bedrock IAM credentials', async () => {
   });
 
   const setup = {
-    profile: {
-      name: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-      apiBase: 'https://bedrock-runtime.us-east-1.amazonaws.com',
-      provider: 'amazon-bedrock' as const,
-      transportKind: 'bedrock' as const,
+    ...buildProviderSetupResult({
+      provider: 'amazon-bedrock',
+      modelName: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
       awsRegion: 'us-east-1',
-    },
+      transportKind: 'bedrock',
+    }),
     providerScope: 'amazon-bedrock' as const,
     bedrock: {
       accessKeyId: 'AKIAEXAMPLE',
@@ -119,7 +132,10 @@ test('saveProviderSetup persists bedrock IAM credentials', async () => {
     assert.equal(passwords.get(providerAccessKeyIdAccount('amazon-bedrock')), 'AKIAEXAMPLE');
     assert.equal(passwords.get(providerSecretAccessKeyAccount('amazon-bedrock')), 'secret-key');
     const config = loadSpiritConfig(dir);
-    assert.equal(config?.activeModel, setup.profile.name);
+    assert.deepEqual(config?.activeModel, {
+      groupId: 'amazon-bedrock',
+      name: setup.model.name,
+    });
   } finally {
     setKeyringStoreForTests(undefined);
   }

--- a/packages/acp-server/test/fixtures/v2-config.ts
+++ b/packages/acp-server/test/fixtures/v2-config.ts
@@ -1,0 +1,23 @@
+import type { ModelRef, ProviderGroupV2 } from '@spiritagent/host-internal';
+
+export function v2ConfigFixture(input: {
+  groups: ProviderGroupV2[];
+  activeModel: ModelRef;
+  extra?: Record<string, unknown>;
+}): Record<string, unknown> {
+  return {
+    schemaVersion: 2,
+    providerGroups: input.groups,
+    activeModel: input.activeModel,
+    ...input.extra,
+  };
+}
+
+export function openAiGroup(models: ProviderGroupV2['models']): ProviderGroupV2 {
+  return {
+    id: 'openai',
+    provider: 'openai',
+    apiBase: 'https://api.openai.com/v1',
+    models,
+  };
+}

--- a/packages/acp-server/test/resolve-transport.test.ts
+++ b/packages/acp-server/test/resolve-transport.test.ts
@@ -13,21 +13,28 @@ import {
 } from '../src/credentials/provider-accounts.js';
 import { setKeyringStoreForTests } from '../src/credentials/index.js';
 import { resolveTransportConfig } from '../src/transport/resolve-transport.js';
+import { v2ConfigFixture } from './fixtures/v2-config.js';
 
 test('resolveTransportConfig builds bedrock transport from IAM credentials', () => {
+  const modelName = 'anthropic.claude-3-5-sonnet-20241022-v2:0';
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-bedrock-'));
   writeFileSync(
     join(dir, 'config.json'),
-    JSON.stringify({
-      models: [{
-        name: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-        apiBase: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+    JSON.stringify(v2ConfigFixture({
+      groups: [{
+        id: 'amazon-bedrock',
         provider: 'amazon-bedrock',
+        apiBase: 'https://bedrock-runtime.us-east-1.amazonaws.com',
         transportKind: 'bedrock',
         awsRegion: 'us-east-1',
+        models: [{
+          name: modelName,
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+        }],
       }],
-      activeModel: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
-    }),
+      activeModel: { groupId: 'amazon-bedrock', name: modelName },
+    })),
     'utf8',
   );
 
@@ -60,19 +67,25 @@ test('resolveTransportConfig builds bedrock transport from IAM credentials', () 
 });
 
 test('resolveTransportConfig builds vertex transport from service account credentials', () => {
+  const modelName = 'gemini-2.0-flash';
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-vertex-'));
   writeFileSync(
     join(dir, 'config.json'),
-    JSON.stringify({
-      models: [{
-        name: 'gemini-2.0-flash',
-        apiBase: 'https://us-central1-aiplatform.googleapis.com/v1',
+    JSON.stringify(v2ConfigFixture({
+      groups: [{
+        id: 'google-vertex-ai',
         provider: 'google-vertex-ai',
+        apiBase: 'https://us-central1-aiplatform.googleapis.com/v1',
         vertexProject: 'my-project',
         vertexLocation: 'us-central1',
+        models: [{
+          name: modelName,
+          reasoningEffort: 'medium',
+          capabilities: ['chat'],
+        }],
       }],
-      activeModel: 'gemini-2.0-flash',
-    }),
+      activeModel: { groupId: 'google-vertex-ai', name: modelName },
+    })),
     'utf8',
   );
 

--- a/packages/acp-server/test/terminal-auth.test.ts
+++ b/packages/acp-server/test/terminal-auth.test.ts
@@ -22,6 +22,7 @@ import {
   buildSetupProfile,
 } from '../src/setup/provider-wizard.js';
 import { resolveTransportConfig } from '../src/transport/resolve-transport.js';
+import { openAiGroup, v2ConfigFixture } from './fixtures/v2-config.js';
 
 test('buildTerminalAuthMethod declares terminal setup args', () => {
   const method = buildTerminalAuthMethod();
@@ -47,14 +48,10 @@ test('buildAuthMethods returns terminal auth even when shared credentials exist'
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
-    JSON.stringify({
-      models: [{
-        name: 'gpt-4o-mini',
-        apiBase: 'https://api.openai.com/v1',
-        provider: 'openai',
-      }],
-      activeModel: 'gpt-4o-mini',
-    }),
+    JSON.stringify(v2ConfigFixture({
+      groups: [openAiGroup([{ name: 'gpt-4o-mini', reasoningEffort: 'medium', capabilities: ['chat'] }])],
+      activeModel: { groupId: 'openai', name: 'gpt-4o-mini' },
+    })),
     'utf8',
   );
 
@@ -81,14 +78,10 @@ test('logout allows authenticate to restore session creation', () => {
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
-    JSON.stringify({
-      models: [{
-        name: 'gpt-4o-mini',
-        apiBase: 'https://api.openai.com/v1',
-        provider: 'openai',
-      }],
-      activeModel: 'gpt-4o-mini',
-    }),
+    JSON.stringify(v2ConfigFixture({
+      groups: [openAiGroup([{ name: 'gpt-4o-mini', reasoningEffort: 'medium', capabilities: ['chat'] }])],
+      activeModel: { groupId: 'openai', name: 'gpt-4o-mini' },
+    })),
     'utf8',
   );
 
@@ -124,14 +117,10 @@ test('createInitialAuthState pre-authenticates when shared credentials exist', (
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
-    JSON.stringify({
-      models: [{
-        name: 'gpt-4o-mini',
-        apiBase: 'https://api.openai.com/v1',
-        provider: 'openai',
-      }],
-      activeModel: 'gpt-4o-mini',
-    }),
+    JSON.stringify(v2ConfigFixture({
+      groups: [openAiGroup([{ name: 'gpt-4o-mini', reasoningEffort: 'medium', capabilities: ['chat'] }])],
+      activeModel: { groupId: 'openai', name: 'gpt-4o-mini' },
+    })),
     'utf8',
   );
 
@@ -162,14 +151,10 @@ test('canCreateSession requires authenticate when using shared credentials witho
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-auth-'));
   writeFileSync(
     join(dir, 'config.json'),
-    JSON.stringify({
-      models: [{
-        name: 'gpt-4o-mini',
-        apiBase: 'https://api.openai.com/v1',
-        provider: 'openai',
-      }],
-      activeModel: 'gpt-4o-mini',
-    }),
+    JSON.stringify(v2ConfigFixture({
+      groups: [openAiGroup([{ name: 'gpt-4o-mini', reasoningEffort: 'medium', capabilities: ['chat'] }])],
+      activeModel: { groupId: 'openai', name: 'gpt-4o-mini' },
+    })),
     'utf8',
   );
 
@@ -210,14 +195,10 @@ test('resolveTransportConfig reads shared config and keyring', () => {
   const dir = mkdtempSync(join(tmpdir(), 'spirit-acp-transport-'));
   writeFileSync(
     join(dir, 'config.json'),
-    JSON.stringify({
-      models: [{
-        name: 'gpt-4o-mini',
-        apiBase: 'https://api.openai.com/v1',
-        provider: 'openai',
-      }],
-      activeModel: 'gpt-4o-mini',
-    }),
+    JSON.stringify(v2ConfigFixture({
+      groups: [openAiGroup([{ name: 'gpt-4o-mini', reasoningEffort: 'medium', capabilities: ['chat'] }])],
+      activeModel: { groupId: 'openai', name: 'gpt-4o-mini' },
+    })),
     'utf8',
   );
 
@@ -262,6 +243,8 @@ test('buildSetupProfile resolves preset provider api base', () => {
     provider: 'openai',
     modelName: 'gpt-4o-mini',
   });
+  assert.equal(profile.groupId, 'openai');
+  assert.deepEqual(profile.ref, { groupId: 'openai', name: 'gpt-4o-mini' });
   assert.equal(profile.provider, 'openai');
   assert.ok(profile.apiBase.includes('openai.com'));
 });

--- a/packages/host-internal/package.json
+++ b/packages/host-internal/package.json
@@ -27,6 +27,26 @@
       "types": "./dist/discovery.d.ts",
       "default": "./dist/discovery.js"
     },
+    "./approval-level": {
+      "types": "./dist/approval-level.d.ts",
+      "default": "./dist/approval-level.js"
+    },
+    "./work-location": {
+      "types": "./dist/work-location.d.ts",
+      "default": "./dist/work-location.js"
+    },
+    "./local-file-composer-route": {
+      "types": "./dist/local-file-composer-route.d.ts",
+      "default": "./dist/local-file-composer-route.js"
+    },
+    "./github/types": {
+      "types": "./dist/github/types.d.ts",
+      "default": "./dist/github/types.js"
+    },
+    "./config-v2": {
+      "types": "./dist/config-v2.d.ts",
+      "default": "./dist/config-v2.js"
+    },
     "./model-provider-presets": {
       "types": "./dist/model-provider-presets.d.ts",
       "default": "./dist/model-provider-presets.js"

--- a/packages/host-internal/src/approval-level.ts
+++ b/packages/host-internal/src/approval-level.ts
@@ -1,0 +1,3 @@
+/** Renderer-safe approval level union (no Node / tool registry deps). */
+
+export type ApprovalLevel = 'default' | 'auto-approval' | 'full-approval';

--- a/packages/host-internal/src/automations.test.ts
+++ b/packages/host-internal/src/automations.test.ts
@@ -1,10 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-
-import { readdir, readFile } from 'node:fs/promises';
 
 import {
   computeNextRunAt,
@@ -27,7 +25,7 @@ test('automation store create list get update delete', async () => {
       overview: '收集 GitHub 新闻',
       trigger: { kind: 'time', schedule: { kind: 'daily', hour: 20, minute: 0 } },
       workspaceRoot: spiritDataDir,
-      modelName: 'gpt-test',
+      modelRef: { groupId: 'openai', name: 'gpt-test' },
       approvalLevel: 'default',
     });
     assert.equal(created.enabled, true);
@@ -63,7 +61,7 @@ test('automation store tracks runs and active run', async () => {
       overview: 'Do work',
       trigger: { kind: 'time', schedule: { kind: 'hourly' } },
       workspaceRoot: spiritDataDir,
-      modelName: 'gpt-test',
+      modelRef: { groupId: 'openai', name: 'gpt-test' },
       approvalLevel: 'full-approval',
     });
 
@@ -183,7 +181,7 @@ test('automation store serializes concurrent mutations and writes atomically', a
       overview: 'Concurrent writes',
       trigger: { kind: 'time', schedule: { kind: 'hourly' } },
       workspaceRoot: spiritDataDir,
-      modelName: 'gpt-test',
+      modelRef: { groupId: 'openai', name: 'gpt-test' },
       approvalLevel: 'default',
     });
 
@@ -273,4 +271,52 @@ test('reconcileGitHubTriggerPollState clears poll when repo identity changes', (
     repo: 'd',
     event: 'issue_created',
   });
+});
+
+test('automation store persists modelRef and rejects legacy modelName-only files', async () => {
+  const spiritDataDir = await mkdtemp(join(tmpdir(), 'spirit-host-automations-modelref-'));
+
+  try {
+    const store = createHostAutomationStore(spiritDataDir);
+    const created = await store.create({
+      title: 'Model ref task',
+      overview: 'Uses group-scoped model',
+      trigger: { kind: 'time', schedule: { kind: 'hourly' } },
+      workspaceRoot: spiritDataDir,
+      modelRef: { groupId: 'custom-openai', name: 'gpt-test' },
+      approvalLevel: 'default',
+    });
+    assert.deepEqual(created.modelRef, { groupId: 'custom-openai', name: 'gpt-test' });
+
+    const raw = await readFile(join(spiritDataDir, 'automations', `${created.id}.json`), 'utf8');
+    const parsed = JSON.parse(raw) as { definition: { modelRef?: { groupId: string; name: string }; modelName?: string } };
+    assert.deepEqual(parsed.definition.modelRef, { groupId: 'custom-openai', name: 'gpt-test' });
+    assert.equal(parsed.definition.modelName, undefined);
+
+    const legacyId = 'legacy-automation-id';
+    await mkdir(join(spiritDataDir, 'automations'), { recursive: true });
+    await writeFile(
+      join(spiritDataDir, 'automations', `${legacyId}.json`),
+      `${JSON.stringify({
+        version: 1,
+        definition: {
+          id: legacyId,
+          title: 'Legacy',
+          overview: 'Old format',
+          trigger: { kind: 'time', schedule: { kind: 'hourly' } },
+          workspaceRoot: spiritDataDir,
+          modelName: 'gpt-test',
+          approvalLevel: 'default',
+          enabled: true,
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 1,
+        },
+        runs: [],
+      }, null, 2)}\n`,
+      'utf8',
+    );
+    assert.equal(await store.get(legacyId), undefined);
+  } finally {
+    await rm(spiritDataDir, { recursive: true, force: true });
+  }
 });

--- a/packages/host-internal/src/automations.ts
+++ b/packages/host-internal/src/automations.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { parseModelRef, type ModelRef } from './config-v2.js';
 import type { ModelReasoningEffort } from './reasoning-effort.js';
 import { normalizeApprovalLevel, type ApprovalLevel } from './tools.js';
 
@@ -34,7 +35,7 @@ export interface HostAutomationDefinition {
   overview: string;
   trigger: HostAutomationTrigger;
   workspaceRoot: string;
-  modelName: string;
+  modelRef: ModelRef;
   reasoningEffort?: ModelReasoningEffort;
   approvalLevel: ApprovalLevel;
   enabled: boolean;
@@ -73,7 +74,7 @@ export interface HostAutomationCreateInput {
   overview: string;
   trigger: HostAutomationTrigger;
   workspaceRoot: string;
-  modelName: string;
+  modelRef: ModelRef;
   reasoningEffort?: ModelReasoningEffort;
   approvalLevel: ApprovalLevel;
   enabled?: boolean;
@@ -84,7 +85,7 @@ export interface HostAutomationUpdateInput {
   overview?: string;
   trigger?: HostAutomationTrigger;
   workspaceRoot?: string;
-  modelName?: string;
+  modelRef?: ModelRef;
   reasoningEffort?: ModelReasoningEffort;
   approvalLevel?: ApprovalLevel;
   enabled?: boolean;
@@ -403,7 +404,7 @@ export class HostAutomationStore {
       overview: normalizeNonEmpty(input.overview, 'overview'),
       trigger,
       workspaceRoot: path.resolve(normalizeNonEmpty(input.workspaceRoot, 'workspaceRoot')),
-      modelName: normalizeNonEmpty(input.modelName, 'modelName'),
+      modelRef: normalizeAutomationModelRef(input.modelRef, 'modelRef'),
       ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
       approvalLevel: normalizeApprovalLevel(input.approvalLevel),
       enabled: input.enabled !== false,
@@ -454,8 +455,8 @@ export class HostAutomationStore {
       if (patch.workspaceRoot !== undefined) {
         file.definition.workspaceRoot = path.resolve(normalizeNonEmpty(patch.workspaceRoot, 'workspaceRoot'));
       }
-      if (patch.modelName !== undefined) {
-        file.definition.modelName = normalizeNonEmpty(patch.modelName, 'modelName');
+      if (patch.modelRef !== undefined) {
+        file.definition.modelRef = normalizeAutomationModelRef(patch.modelRef, 'modelRef');
       }
       if (patch.reasoningEffort !== undefined) {
         file.definition.reasoningEffort = patch.reasoningEffort;
@@ -679,7 +680,8 @@ function normalizeAutomationDefinition(value: unknown): HostAutomationDefinition
   if (typeof record.workspaceRoot !== 'string' || !record.workspaceRoot.trim()) {
     return undefined;
   }
-  if (typeof record.modelName !== 'string' || !record.modelName.trim()) {
+  const modelRef = parseModelRef(record.modelRef);
+  if (!modelRef) {
     return undefined;
   }
   const createdAtUnixMs =
@@ -692,7 +694,7 @@ function normalizeAutomationDefinition(value: unknown): HostAutomationDefinition
     overview: record.overview.trim(),
     trigger,
     workspaceRoot: path.resolve(record.workspaceRoot.trim()),
-    modelName: record.modelName.trim(),
+    modelRef,
     ...(record.reasoningEffort ? { reasoningEffort: record.reasoningEffort } : {}),
     approvalLevel: normalizeApprovalLevel(record.approvalLevel),
     enabled: record.enabled !== false,
@@ -747,6 +749,14 @@ function normalizeAutomationRun(value: unknown): HostAutomationRun | undefined {
       ? { error: record.error.trim() }
       : {}),
   };
+}
+
+function normalizeAutomationModelRef(value: ModelRef, field: string): ModelRef {
+  const modelRef = parseModelRef(value);
+  if (!modelRef) {
+    throw new Error(`${field} must be a valid modelRef.`);
+  }
+  return modelRef;
 }
 
 function normalizeNonEmpty(value: string, field: string): string {

--- a/packages/host-internal/src/config-v2.test.ts
+++ b/packages/host-internal/src/config-v2.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  assertSpiritConfigSchemaVersion,
+  emptyModelRef,
+  findModelByRef,
+  isEmptyModelRef,
+  modelExistsInGroup,
+  modelRefKey,
+  modelRefsEqual,
+  parseModelRef,
+  slugifyProviderGroupLabel,
+  SpiritConfigSchemaError,
+  SPIRIT_CONFIG_SCHEMA_VERSION,
+} from './config-v2.js';
+import type { ProviderGroupV2 } from './config-v2.js';
+
+test('assertSpiritConfigSchemaVersion rejects missing or wrong version', () => {
+  assert.throws(
+    () => assertSpiritConfigSchemaVersion({}),
+    SpiritConfigSchemaError,
+  );
+  assert.throws(
+    () => assertSpiritConfigSchemaVersion({ schemaVersion: 1 }),
+    SpiritConfigSchemaError,
+  );
+  assert.doesNotThrow(() => assertSpiritConfigSchemaVersion({ schemaVersion: SPIRIT_CONFIG_SCHEMA_VERSION }));
+});
+
+test('parseModelRef requires groupId and name', () => {
+  assert.deepEqual(parseModelRef({ groupId: 'openai', name: 'gpt-4.1' }), {
+    groupId: 'openai',
+    name: 'gpt-4.1',
+  });
+  assert.equal(parseModelRef({ groupId: 'openai', name: '' }), undefined);
+});
+
+test('modelExistsInGroup is scoped to group', () => {
+  const groups: ProviderGroupV2[] = [
+    {
+      id: 'vercel-ai-gateway',
+      provider: 'vercel-ai-gateway',
+      apiBase: 'https://example.com/v1',
+      models: [{ name: 'openai/gpt-4.1', reasoningEffort: 'medium' }],
+    },
+    {
+      id: 'openrouter',
+      provider: 'openrouter',
+      apiBase: 'https://openrouter.ai/api/v1',
+      models: [{ name: 'openai/gpt-4.1', reasoningEffort: 'medium' }],
+    },
+  ];
+  assert.equal(modelExistsInGroup(groups, 'vercel-ai-gateway', 'openai/gpt-4.1'), true);
+  assert.equal(modelExistsInGroup(groups, 'openrouter', 'openai/gpt-4.1'), true);
+  assert.equal(modelExistsInGroup(groups, 'vercel-ai-gateway', 'missing'), false);
+  assert.equal(findModelByRef(groups, { groupId: 'openrouter', name: 'openai/gpt-4.1' })?.model.name, 'openai/gpt-4.1');
+});
+
+test('slugifyProviderGroupLabel normalizes custom group names', () => {
+  assert.equal(slugifyProviderGroupLabel('My Local Ollama'), 'my-local-ollama');
+  assert.equal(slugifyProviderGroupLabel('---'), 'custom-group');
+});
+
+test('modelRef helpers', () => {
+  const ref = { groupId: 'openai', name: 'gpt-4.1' };
+  assert.equal(modelRefKey(ref), 'openai::gpt-4.1');
+  assert.equal(modelRefsEqual(ref, { ...ref }), true);
+  assert.equal(isEmptyModelRef(emptyModelRef()), true);
+});

--- a/packages/host-internal/src/config-v2.ts
+++ b/packages/host-internal/src/config-v2.ts
@@ -1,0 +1,199 @@
+import type { ModelProviderId } from './model-provider-presets.js';
+
+export const SPIRIT_CONFIG_SCHEMA_VERSION = 2 as const;
+
+export type SpiritConfigSchemaVersion = typeof SPIRIT_CONFIG_SCHEMA_VERSION;
+
+export interface ModelRef {
+  groupId: string;
+  name: string;
+}
+
+export type SpiritModelCapabilityV2 =
+  | 'chat'
+  | 'image'
+  | 'video'
+  | 'imageGeneration'
+  | 'videoGeneration';
+
+export type SpiritModelReasoningEffortV2 =
+  | 'none'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh';
+
+export type SpiritTransportKindV2 =
+  | 'openai-compatible'
+  | 'open-responses'
+  | 'anthropic'
+  | 'bedrock';
+
+export type SpiritAlibabaBillingModeV2 = 'token-plan';
+
+export interface ModelEntryV2 {
+  name: string;
+  reasoningEffort: SpiritModelReasoningEffortV2;
+  thinkingEnabled?: boolean;
+  supportedReasoningEfforts?: SpiritModelReasoningEffortV2[];
+  capabilities?: SpiritModelCapabilityV2[];
+  contextLength?: number;
+  supportsThinkingType?: 'only';
+}
+
+export interface ProviderGroupV2 {
+  id: string;
+  provider: ModelProviderId;
+  label?: string;
+  apiBase: string;
+  transportKind?: SpiritTransportKindV2;
+  providerSite?: string;
+  alibabaWorkspaceId?: string;
+  alibabaBillingMode?: SpiritAlibabaBillingModeV2;
+  awsRegion?: string;
+  azureResourceName?: string;
+  cloudflareAccountId?: string;
+  cloudflareGatewayId?: string;
+  vertexProject?: string;
+  vertexLocation?: string;
+  models: ModelEntryV2[];
+}
+
+export interface SpiritConfigV2Core {
+  schemaVersion: SpiritConfigSchemaVersion;
+  providerGroups: ProviderGroupV2[];
+  activeModel: ModelRef;
+  imageGenerationModel?: ModelRef;
+  videoGenerationModel?: ModelRef;
+  lightweightChatModel?: ModelRef;
+}
+
+export class SpiritConfigSchemaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SpiritConfigSchemaError';
+  }
+}
+
+export function emptyModelRef(): ModelRef {
+  return { groupId: '', name: '' };
+}
+
+export function modelRefKey(ref: ModelRef): string {
+  return `${ref.groupId}::${ref.name}`;
+}
+
+export function modelRefsEqual(a: ModelRef | undefined, b: ModelRef | undefined): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return a.groupId === b.groupId && a.name === b.name;
+}
+
+export function isEmptyModelRef(ref: ModelRef | undefined): boolean {
+  return !ref?.groupId?.trim() || !ref?.name?.trim();
+}
+
+export function assertSpiritConfigSchemaVersion(raw: unknown): void {
+  const version =
+    typeof raw === 'object' && raw !== null && 'schemaVersion' in raw
+      ? (raw as { schemaVersion?: unknown }).schemaVersion
+      : undefined;
+  if (version !== SPIRIT_CONFIG_SCHEMA_VERSION) {
+    throw new SpiritConfigSchemaError(
+      `config.json 须为 schemaVersion ${SPIRIT_CONFIG_SCHEMA_VERSION}；请删除旧版配置后重新连接提供商。`,
+    );
+  }
+}
+
+export function parseModelRef(value: unknown): ModelRef | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+  const groupId = typeof (value as ModelRef).groupId === 'string'
+    ? (value as ModelRef).groupId.trim()
+    : '';
+  const name = typeof (value as ModelRef).name === 'string'
+    ? (value as ModelRef).name.trim()
+    : '';
+  if (!groupId || !name) {
+    return undefined;
+  }
+  return { groupId, name };
+}
+
+export function slugifyProviderGroupLabel(label: string): string {
+  const trimmed = label.trim().toLowerCase();
+  const slug = trimmed
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return slug || 'custom-group';
+}
+
+export function findProviderGroup(
+  groups: readonly ProviderGroupV2[],
+  groupId: string,
+): ProviderGroupV2 | undefined {
+  const normalized = groupId.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return groups.find((group) => group.id === normalized);
+}
+
+export function findModelEntryInGroup(
+  group: ProviderGroupV2,
+  name: string,
+): ModelEntryV2 | undefined {
+  const normalized = name.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return group.models.find((model) => model.name === normalized);
+}
+
+export function findModelByRef(
+  groups: readonly ProviderGroupV2[],
+  ref: ModelRef | undefined,
+): { group: ProviderGroupV2; model: ModelEntryV2 } | undefined {
+  if (!ref || isEmptyModelRef(ref)) {
+    return undefined;
+  }
+  const group = findProviderGroup(groups, ref.groupId);
+  if (!group) {
+    return undefined;
+  }
+  const model = findModelEntryInGroup(group, ref.name);
+  if (!model) {
+    return undefined;
+  }
+  return { group, model };
+}
+
+export function modelExistsInGroup(
+  groups: readonly ProviderGroupV2[],
+  groupId: string,
+  name: string,
+): boolean {
+  const group = findProviderGroup(groups, groupId);
+  if (!group) {
+    return false;
+  }
+  return findModelEntryInGroup(group, name) !== undefined;
+}
+
+export function listAllModelRefs(groups: readonly ProviderGroupV2[]): ModelRef[] {
+  const refs: ModelRef[] = [];
+  for (const group of groups) {
+    for (const model of group.models) {
+      refs.push({ groupId: group.id, name: model.name });
+    }
+  }
+  return refs;
+}
+
+export function defaultPresetProviderGroupId(provider: ModelProviderId): string {
+  return provider;
+}

--- a/packages/host-internal/src/git-workspace.ts
+++ b/packages/host-internal/src/git-workspace.ts
@@ -6,7 +6,8 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 const GIT_MAX_BUFFER = 4 * 1024 * 1024;
 
-export type WorkLocationKind = 'local' | 'worktree';
+export type { WorkLocationKind } from './work-location.js';
+import type { WorkLocationKind } from './work-location.js';
 
 export interface GitCheckoutOptions {
   discardLocalChanges?: boolean;

--- a/packages/host-internal/src/github/automation-poller.test.ts
+++ b/packages/host-internal/src/github/automation-poller.test.ts
@@ -14,7 +14,7 @@ const baseDefinition = {
   title: 'Test',
   overview: 'Do work',
   workspaceRoot: '/tmp',
-  modelName: 'gpt-test',
+  modelRef: { groupId: 'openai', name: 'gpt-test' },
   approvalLevel: 'default' as const,
   enabled: true,
   createdAtUnixMs: 1,

--- a/packages/host-internal/src/index.ts
+++ b/packages/host-internal/src/index.ts
@@ -25,6 +25,7 @@ export * from './bedrock-region.js';
 export * from './azure-resource.js';
 export * from './bedrock-mantle.js';
 export * from './model-provider-presets.js';
+export * from './config-v2.js';
 export * from './model-display-name.js';
 export * from './openai-api-base.js';
 export * from './openai-models.js';

--- a/packages/host-internal/src/local-file-composer-route.ts
+++ b/packages/host-internal/src/local-file-composer-route.ts
@@ -1,0 +1,3 @@
+/** Renderer-safe local file composer routing label. */
+
+export type LocalFileComposerRoute = 'media' | 'reference';

--- a/packages/host-internal/src/tools.test.ts
+++ b/packages/host-internal/src/tools.test.ts
@@ -911,7 +911,7 @@ test('create_automation writes automation file when defaults are provided', asyn
       {
         getAutomationCreateDefaults: () => ({
           workspaceRoot,
-          modelName: 'test-model',
+          modelRef: { groupId: 'openai', name: 'test-model' },
         }),
         onAutomationCreated: (definition) => {
           createdId = definition.id;

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -387,7 +387,9 @@ export interface HostExtensionRuntimeBinding<THostApi> {
   logger?: Pick<Console, 'error' | 'log'>;
 }
 
-export type ApprovalLevel = 'default' | 'auto-approval' | 'full-approval';
+import type { ApprovalLevel } from './approval-level.js';
+
+export type { ApprovalLevel } from './approval-level.js';
 
 export function normalizeApprovalLevel(value: unknown): ApprovalLevel {
   if (value === 'full-approval' || value === 'full-access') {

--- a/packages/host-internal/src/tools.ts
+++ b/packages/host-internal/src/tools.ts
@@ -63,6 +63,7 @@ import {
   type HostAutomationTrigger,
 } from './automations.js';
 import type { ModelReasoningEffort } from './reasoning-effort.js';
+import type { ModelRef } from './config-v2.js';
 import { resolveInstructionPaths, type InstructionDiscoveryContext } from './storage.js';
 import { isPathUnderPlansDir, resolvePlanFilePath } from './plans.js';
 import {
@@ -403,7 +404,7 @@ export function normalizeApprovalLevel(value: unknown): ApprovalLevel {
 
 export interface HostAutomationCreateDefaults {
   workspaceRoot: string;
-  modelName: string;
+  modelRef: ModelRef;
   reasoningEffort?: ModelReasoningEffort;
 }
 
@@ -1853,7 +1854,7 @@ export class NodeHostToolService<QuestionSpec = HostAskQuestionsQuestionSpec>
       overview: request.overview,
       trigger: request.trigger,
       workspaceRoot: defaults.workspaceRoot,
-      modelName: defaults.modelName,
+      modelRef: defaults.modelRef,
       ...(defaults.reasoningEffort ? { reasoningEffort: defaults.reasoningEffort } : {}),
       approvalLevel: request.approval_level,
       enabled: true,

--- a/packages/host-internal/src/work-location.ts
+++ b/packages/host-internal/src/work-location.ts
@@ -1,0 +1,3 @@
+/** Renderer-safe work location union (no git / Node deps). */
+
+export type WorkLocationKind = 'local' | 'worktree';

--- a/packages/host-internal/src/workspace-file-references.ts
+++ b/packages/host-internal/src/workspace-file-references.ts
@@ -210,7 +210,9 @@ export async function workspaceFileReferenceAttachmentFromPath(
   return localFileAttachmentFromAbsolutePath(absolutePath, relativePath, options);
 }
 
-export type LocalFileComposerRoute = 'media' | 'reference';
+import type { LocalFileComposerRoute } from './local-file-composer-route.js';
+
+export type { LocalFileComposerRoute } from './local-file-composer-route.js';
 
 export async function classifyLocalFileComposerRoute(
   absolutePath: string,


### PR DESCRIPTION
## Summary

- 将扁平 `models[]` 迁移为 `schemaVersion: 2` 的 `providerGroups[]`，模型槽位统一为 `ModelRef`（`groupId` + `name`）
- Desktop / CLI / ACP 读写、钥匙串与模型选择 UI 全链路适配 providerGroups，拒绝加载 v1 配置
- Renderer 仅通过 host-internal renderer-safe 子路径导入，避免 Vite 拉入 Node 依赖
- 自动化定义与运行改为持久化 `modelRef`，运行时按组定位模型，避免跨组同名误匹配

## Test plan

- [x] `npm run build -w @spiritagent/host-internal`
- [x] `apps/desktop` 下 `npm run build:electron`
- [x] `node --test` 跑通 host-internal 自动化与 create_automation 相关用例
- [x] `apps/desktop` 下 automation-scheduler-service / tool-executor-lazy 测试
- [x] CLI `model_registry` 与 ts_bridge 集成测试（config v2）
- [x] ACP credentials / resolve-transport v2 用例