### PR TITLE
refactor: OpenAI 主对话固定为 Responses API

### DIFF
--- a/.github/instructions/agent-core-host-boundary.instructions.md
+++ b/.github/instructions/agent-core-host-boundary.instructions.md
@@ -192,7 +192,7 @@ apps 必须尽量薄，避免 CLI 与 Desktop 再次分叉。
 | `open-responses` | Responses / Open Responses | OpenAI 官方：`@ai-sdk/openai` 的 `responses`；xAI：`@ai-sdk/xai` 的 `responses`；Azure：`@ai-sdk/azure` 默认 Responses callable（`provider=azure` 固定此 transport，须 `azureResourceName` + 部署名，本版仅 API Key）；其它兼容 endpoint：`@ai-sdk/open-responses` |
 | `anthropic` | Anthropic Messages | `@ai-sdk/anthropic` |
 
-- 现有 `provider=openai` 配置默认仍为 `openai-compatible`；切换到 Responses 须由用户显式选择 `open-responses`。
+- `provider=openai` **固定** `open-responses`（存量缺省或显式 `openai-compatible` 静默升级），不提供 Chat Completions transport 选择。
 - `provider=azure` **固定** `open-responses`，不提供 transport 选择；Azure 无 `/models` 端点，部署名写入 `ModelProfile.name`。
 - OpenAI / Azure 官方 Responses 默认 `store: true`，并通过 `previous_response_id` 做增量续聊；`agent-core` 在支持远端存储的 provider 上仅发送 delta input
 - Open Responses 兼容 endpoint 是否支持服务端存储取决于用户配置的上游；未支持时 transport 回退为全量 input

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -594,7 +594,7 @@ fn parse_model_transport_kind(
         None => match provider {
             Some(ModelProvider::Anthropic) => ModelTransportKind::Anthropic,
             Some(ModelProvider::AmazonBedrock) => ModelTransportKind::Bedrock,
-            Some(ModelProvider::Azure) => ModelTransportKind::OpenResponses,
+            Some(ModelProvider::Azure | ModelProvider::Openai) => ModelTransportKind::OpenResponses,
             _ => ModelTransportKind::OpenAiCompatible,
         },
     };
@@ -614,6 +614,9 @@ fn parse_model_transport_kind(
         }
         (Some(ModelProvider::Openai), ModelTransportKind::Anthropic) => {
             Err(anyhow!("provider=openai 时 transport-kind 不能是 anthropic"))
+        }
+        (Some(ModelProvider::Openai), ModelTransportKind::OpenAiCompatible) => {
+            Err(anyhow!("provider=openai 仅支持 open-responses transport-kind"))
         }
         (Some(ModelProvider::Google), ModelTransportKind::OpenResponses | ModelTransportKind::Anthropic) => {
             Err(anyhow!("provider=google 仅支持 openai-compatible transport-kind"))

--- a/apps/cli/src/model_registry.rs
+++ b/apps/cli/src/model_registry.rs
@@ -344,17 +344,23 @@ pub struct ModelProfile {
 
 impl ModelProfile {
     pub fn transport_kind(&self) -> ModelTransportKind {
-        self.extra
+        let parsed = self
+            .extra
             .get("transportKind")
             .and_then(Value::as_str)
             .or_else(|| self.extra.get("transport_kind").and_then(Value::as_str))
-            .and_then(|value| value.parse().ok())
-            .unwrap_or_else(|| match self.provider {
-                Some(ModelProvider::Anthropic) => ModelTransportKind::Anthropic,
-                Some(ModelProvider::AmazonBedrock) => ModelTransportKind::Bedrock,
-                Some(ModelProvider::Azure) => ModelTransportKind::OpenResponses,
-                _ => ModelTransportKind::OpenAiCompatible,
-            })
+            .and_then(|value| value.parse().ok());
+        match self.provider {
+            Some(ModelProvider::Openai) => ModelTransportKind::OpenResponses,
+            Some(ModelProvider::Azure) => ModelTransportKind::OpenResponses,
+            Some(ModelProvider::Anthropic) => {
+                parsed.unwrap_or(ModelTransportKind::Anthropic)
+            }
+            Some(ModelProvider::AmazonBedrock) => {
+                parsed.unwrap_or(ModelTransportKind::Bedrock)
+            }
+            _ => parsed.unwrap_or(ModelTransportKind::OpenAiCompatible),
+        }
     }
 
     pub fn supports_image_input(&self) -> bool {
@@ -1234,7 +1240,7 @@ fn normalize_config(cfg: &mut AppConfig) {
             .unwrap_or_else(|| match provider {
                 ModelProvider::Anthropic => ModelTransportKind::Anthropic,
                 ModelProvider::AmazonBedrock => ModelTransportKind::Bedrock,
-                ModelProvider::Azure => ModelTransportKind::OpenResponses,
+                ModelProvider::Azure | ModelProvider::Openai => ModelTransportKind::OpenResponses,
                 _ => ModelTransportKind::OpenAiCompatible,
             });
         let normalized_transport = normalize_group_transport_kind(provider, transport_kind);
@@ -1260,6 +1266,9 @@ fn normalize_group_transport_kind(
     provider: ModelProvider,
     transport_kind: ModelTransportKind,
 ) -> ModelTransportKind {
+    if matches!(provider, ModelProvider::Openai | ModelProvider::Azure) {
+        return ModelTransportKind::OpenResponses;
+    }
     let mut transport_kind = transport_kind;
     if matches!(
         provider,
@@ -1920,6 +1929,50 @@ mod tests {
         let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
         let active = parsed.active_model_profile().expect("active model");
         assert_eq!(active.transport_kind(), ModelTransportKind::OpenAiCompatible);
+    }
+
+    #[test]
+    fn openai_transport_kind_forces_open_responses() {
+        let config = r#"
+{
+  "schemaVersion": 2,
+  "providerGroups": [
+    {
+      "id": "openai",
+      "provider": "openai",
+      "apiBase": "https://api.openai.com/v1",
+      "models": [{ "name": "gpt-4o-mini" }]
+    }
+  ],
+  "activeModel": { "groupId": "openai", "name": "gpt-4o-mini" }
+}
+"#;
+        let parsed = deserialize_config(config, Path::new("config.json")).expect("parse config");
+        let active = parsed.active_model_profile().expect("active model");
+        assert_eq!(active.transport_kind(), ModelTransportKind::OpenResponses);
+
+        let legacy = r#"
+{
+  "schemaVersion": 2,
+  "providerGroups": [
+    {
+      "id": "openai",
+      "provider": "openai",
+      "apiBase": "https://api.openai.com/v1",
+      "transportKind": "openai-compatible",
+      "models": [{ "name": "gpt-4o-mini" }]
+    }
+  ],
+  "activeModel": { "groupId": "openai", "name": "gpt-4o-mini" }
+}
+"#;
+        let legacy_parsed =
+            deserialize_config(legacy, Path::new("config.json")).expect("parse legacy config");
+        let legacy_active = legacy_parsed.active_model_profile().expect("active model");
+        assert_eq!(
+            legacy_active.transport_kind(),
+            ModelTransportKind::OpenResponses
+        );
     }
 
     #[test]

--- a/apps/cli/src/shell/bottom_form.rs
+++ b/apps/cli/src/shell/bottom_form.rs
@@ -666,7 +666,7 @@ fn model_add_transport_kind(form: &BottomFormView, provider: ModelProvider) -> M
             }
             _ => ModelTransportKind::OpenAiCompatible,
         },
-        ModelProvider::Azure => ModelTransportKind::OpenResponses,
+        ModelProvider::Azure | ModelProvider::Openai => ModelTransportKind::OpenResponses,
         _ => ModelTransportKind::OpenAiCompatible,
     }
 }

--- a/apps/desktop/src/components/settings/models/connect-transport.ts
+++ b/apps/desktop/src/components/settings/models/connect-transport.ts
@@ -33,6 +33,7 @@ export const connectTransportOptionCatalog = {
 export function connectTransportOptionsForProvider(provider: DesktopModelProvider): ConnectTransportOption[] {
   switch (provider) {
     case "openai":
+      return [];
     case "xai":
       return [connectTransportOptionCatalog.chatCompletions, connectTransportOptionCatalog.responsesApi];
     case "google":
@@ -102,7 +103,7 @@ export function defaultConnectTransportKind(provider: DesktopModelProvider): Des
   if (provider === "amazon-bedrock") {
     return "bedrock";
   }
-  if (provider === "azure") {
+  if (provider === "azure" || provider === "openai") {
     return "open-responses";
   }
 
@@ -113,7 +114,6 @@ export function providerSupportsConnectTransportPicker(
   provider: DesktopModelProvider | null,
 ): provider is DesktopModelProvider {
   return (
-    provider === "openai" ||
     provider === "xai" ||
     provider === "minimax" ||
     provider === "deepseek" ||
@@ -147,7 +147,7 @@ export function resolveConnectTransportKindForProvider(
   if (provider === "amazon-bedrock") {
     return "bedrock";
   }
-  if (provider === "azure") {
+  if (provider === "azure" || provider === "openai") {
     return "open-responses";
   }
 

--- a/apps/desktop/src/host/model-config.ts
+++ b/apps/desktop/src/host/model-config.ts
@@ -163,7 +163,7 @@ export function resolveDesktopTransportKind(
     ) {
       return 'openai-compatible';
     }
-    if (profile?.provider === 'azure') {
+    if (profile?.provider === 'azure' || profile?.provider === 'openai') {
       return 'open-responses';
     }
     return requested;
@@ -173,7 +173,7 @@ export function resolveDesktopTransportKind(
     ? 'anthropic'
     : profile?.provider === 'amazon-bedrock'
       ? 'bedrock'
-      : profile?.provider === 'azure'
+      : profile?.provider === 'azure' || profile?.provider === 'openai'
         ? 'open-responses'
         : 'openai-compatible';
 }

--- a/apps/desktop/src/host/storage.ts
+++ b/apps/desktop/src/host/storage.ts
@@ -1191,7 +1191,7 @@ function normalizeDesktopTransportKind(
   value: unknown,
   provider?: DesktopModelProvider,
 ): DesktopTransportKind | undefined {
-  if (provider === 'azure') {
+  if (provider === 'azure' || provider === 'openai') {
     return 'open-responses';
   }
 

--- a/apps/desktop/test/host/model-config-managed-endpoint.test.mjs
+++ b/apps/desktop/test/host/model-config-managed-endpoint.test.mjs
@@ -39,6 +39,22 @@ test('resolveDesktopTransportKind downgrades google open-responses to openai-com
   );
 });
 
+test('resolveDesktopTransportKind forces openai to open-responses', () => {
+  assert.equal(
+    resolveDesktopTransportKind({
+      provider: 'openai',
+    }),
+    'open-responses',
+  );
+  assert.equal(
+    resolveDesktopTransportKind({
+      provider: 'openai',
+      transportKind: 'openai-compatible',
+    }),
+    'open-responses',
+  );
+});
+
 test('resolveProfileApiBase routes Bedrock mantle OpenAI models to bedrock-mantle endpoint', () => {
   assert.equal(
     resolveProfileApiBase({

--- a/packages/acp-server/src/setup/provider-wizard.ts
+++ b/packages/acp-server/src/setup/provider-wizard.ts
@@ -30,7 +30,7 @@ export function resolveSetupTransportKind(
     ) {
       return 'openai-compatible';
     }
-    if (provider === 'azure') {
+    if (provider === 'azure' || provider === 'openai') {
       return 'open-responses';
     }
     return requested;
@@ -42,7 +42,7 @@ export function resolveSetupTransportKind(
   if (provider === 'amazon-bedrock') {
     return 'bedrock';
   }
-  if (provider === 'azure') {
+  if (provider === 'azure' || provider === 'openai') {
     return 'open-responses';
   }
   return 'openai-compatible';

--- a/packages/acp-server/test/terminal-auth.test.ts
+++ b/packages/acp-server/test/terminal-auth.test.ts
@@ -218,8 +218,8 @@ test('resolveTransportConfig reads shared config and keyring', () => {
     const config = loadBaseConfig();
     config.spiritDataDir = dir;
     const transport = resolveTransportConfig(config);
-    assert.equal(transport.transportKind, 'openai-compatible');
-    if (transport.transportKind === 'openai-compatible') {
+    assert.equal(transport.transportKind, 'open-responses');
+    if (transport.transportKind === 'open-responses') {
       assert.equal(transport.apiKey, 'stored-key');
       assert.equal(transport.model, 'gpt-4o-mini');
     }

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -23,7 +23,6 @@ import {
   createXai,
 } from '@ai-sdk/xai';
 import { createGateway } from '@ai-sdk/gateway';
-import { createOpenAI } from '@ai-sdk/openai';
 import {
   createOpenAICompatible,
   type OpenAICompatibleLanguageModelChatOptions,
@@ -676,14 +675,13 @@ function buildAiSdkRequestTrace(
 ): JsonValue[] {
   const requestTrace = buildOpenAiRequestTrace(config, stepIndex, messages, tools, stream);
   if (
-    !isDeepSeekOfficialAiSdkProvider(config) &&
-    !isXaiOfficialAiSdkProvider(config) &&
-    !isMoonshotOfficialAiSdkProvider(config) &&
-    !isAlibabaOfficialAiSdkProvider(config) &&
-    !isVercelAiGatewayProvider(config) &&
-    !isOpenAiOfficialAiSdkProvider(config) &&
-    !isGoogleOfficialAiSdkProvider(config) &&
-    !isGoogleVertexOfficialAiSdkProvider(config)
+    !isDeepSeekOfficialAiSdkProvider(config)
+    && !isXaiOfficialAiSdkProvider(config)
+    && !isMoonshotOfficialAiSdkProvider(config)
+    && !isAlibabaOfficialAiSdkProvider(config)
+    && !isVercelAiGatewayProvider(config)
+    && !isGoogleOfficialAiSdkProvider(config)
+    && !isGoogleVertexOfficialAiSdkProvider(config)
   ) {
     return requestTrace;
   }
@@ -705,9 +703,7 @@ function buildAiSdkRequestTrace(
             ? 'gateway_sdk_chat_completions'
             : isGoogleVertexOfficialAiSdkProvider(config)
               ? 'google_vertex_sdk_generate_content'
-              : isGoogleOfficialAiSdkProvider(config)
-                ? 'google_sdk_generate_content'
-                : 'openai_official_sdk_chat_completions';
+              : 'google_sdk_generate_content';
 
   const alibabaExtraBody = isAlibabaOfficialAiSdkProvider(config)
     && shouldUseAlibabaChatCompletionsBuiltInTools(config)
@@ -753,8 +749,10 @@ function createAiSdkLanguageModel(config: OpenAiTransportConfig): any {
     return createAiSdkGatewayProvider(config)(config.model);
   }
 
-  if (isOpenAiOfficialAiSdkProvider(config)) {
-    return createAiSdkOpenAiProvider(config).chat(config.model);
+  if (config.llmVendor === 'openai') {
+    throw new Error(
+      'OpenAI official Chat Completions is no longer supported; use transportKind open-responses.',
+    );
   }
 
   if (isGoogleOfficialAiSdkProvider(config)) {
@@ -1011,16 +1009,6 @@ function createAiSdkGatewayProvider(config: OpenAiTransportConfig) {
   });
 }
 
-function createAiSdkOpenAiProvider(config: OpenAiTransportConfig) {
-  return createOpenAI({
-    apiKey: config.apiKey,
-    ...(config.baseUrl ? { baseURL: config.baseUrl } : {}),
-    ...(config.organization ? { organization: config.organization } : {}),
-    ...(config.project ? { project: config.project } : {}),
-    fetch: getLlmFetch(),
-  });
-}
-
 function buildAiSdkProviderOptions(
   config: OpenAiTransportConfig,
 ): Record<string, JsonObject> {
@@ -1200,25 +1188,6 @@ function buildAiSdkProviderOptions(
 
     return {
       vertex: vertexOptions as JsonObject,
-    };
-  }
-
-  if (isOpenAiOfficialAiSdkProvider(config)) {
-    const reasoningEffort = openAiReasoningEffort(config) as
-      | OpenAICompatibleLanguageModelChatOptions['reasoningEffort']
-      | undefined;
-    const openaiOptions: JsonObject = {};
-    if (reasoningEffort !== undefined) {
-      openaiOptions.reasoningEffort = reasoningEffort;
-    }
-    if (isCodeCompletionTransportProfile(config) && reasoningEffort === 'none') {
-      openaiOptions.reasoningSummary = 'off';
-    }
-    if (Object.keys(openaiOptions).length === 0) {
-      return {};
-    }
-    return {
-      openai: openaiOptions as JsonObject,
     };
   }
 
@@ -1993,10 +1962,6 @@ function isVercelAiGatewayImageConfig(
   config: OpenAiImageGenerationConfig,
 ): boolean {
   return config.llmVendor === 'vercel-ai-gateway';
-}
-
-function isOpenAiOfficialAiSdkProvider(config: OpenAiTransportConfig): boolean {
-  return config.llmVendor === 'openai';
 }
 
 function isGoogleOfficialAiSdkProvider(config: OpenAiTransportConfig): boolean {

--- a/packages/agent-core/src/openai/openai-compat.ts
+++ b/packages/agent-core/src/openai/openai-compat.ts
@@ -141,12 +141,11 @@ export interface OpenAiRequestTrace extends JsonObject {
     | 'xai_sdk_chat_completions'
     | 'moonshot_sdk_chat_completions'
     | 'alibaba_sdk_chat_completions'
-    | 'gateway_sdk_chat_completions'
-    | 'openai_official_sdk_chat_completions';
+    | 'gateway_sdk_chat_completions';
   stepIndex: number;
   model: string;
   stream: boolean;
-  /** OpenAI 官方 chat.completions 请求字段。 */
+  /** OpenAI 兼容 chat.completions 请求字段。 */
   reasoning_effort?: JsonValue;
   toolChoice?: 'auto';
   messages: JsonValue[];


### PR DESCRIPTION
## Summary
- `provider=openai` 主对话固定 `open-responses`；存量缺省或显式 `openai-compatible` 静默升级
- Desktop 移除 OpenAI 的 API 类型 Select；CLI/ACP 同步强制 Responses
- agent-core 删除官方 Chat Completions 主对话路径；共享 `openai-compatible` 与 xAI 双选项保留

## Test plan
- [x] Desktop：连接 OpenAI 时无 API 类型 Select，对话走 Responses
- [x] 存量 openai 配置（省略/`openai-compatible`）加载后走 open-responses
- [x] CLI/ACP：openai 默认/强制 open-responses；拒绝 openai + openai-compatible
- [x] xAI 仍可选 Chat Completions 与 Responses
- [x] 其它厂商 Chat Completions 与 media-only openai-compatible 不受影响
- [x] 相关单测（Desktop transport / ACP / agent-core typecheck）通过