### PR TITLE
feat(agent-core, desktop): Kimi Code 接入托管 web_search

### DIFF
--- a/.github/instructions/agent-core-host-boundary.instructions.md
+++ b/.github/instructions/agent-core-host-boundary.instructions.md
@@ -29,6 +29,13 @@ applyTo: "**/*"
 - **不在** `host-internal` 注册可执行 `web_search`；Formula 执行留在 `agent-core` `moonshot/formula/`。
 - UI：`encrypted_output` 不可展示；Moonshot Formula `web_search` 卡片经 `_spiritUi.suppressExpand` 禁止展开。
 
+## Kimi Code / StepFun 托管 `web_search`（非 Formula）
+
+- **Kimi Code**（`llmVendor: kimi-code` 或 `api.kimi.com`）：`agent-core` 注入本地 `web_search` function schema，执行时 `POST https://api.kimi.com/coding/v1/search`（body `text_query`），结果写回 tool message。
+- **StepFun**（`llmVendor: stepfun` 或 `api.stepfun.com`）：同类托管工具，执行时打固定 `https://api.stepfun.com/v1/search`（可选 `n`）。
+- **不在** `host-internal` 注册可执行 `web_search`；执行留在 `agent-core`（`kimi-code/`、`stepfun/`），经 managed provider turn handler。
+- UI：可展开 preview（与 StepFun 共用 `_spiritUi`，无 `suppressExpand`）。
+
 ## 术语
 
 ### 工具定义

--- a/apps/desktop/src/host/tool-executor.ts
+++ b/apps/desktop/src/host/tool-executor.ts
@@ -56,6 +56,8 @@ import {
   executeGetDiagnostics,
   shouldUseStepfunWebSearch,
   buildStepfunWebSearchToolDefinition,
+  shouldUseKimiCodeWebSearch,
+  buildKimiCodeWebSearchToolDefinition,
 } from '@spiritagent/agent-core';
 import {
   LspService,
@@ -261,6 +263,10 @@ export class DesktopToolExecutor
         ...(this.activeTransportConfig !== undefined
           && shouldUseStepfunWebSearch(this.activeTransportConfig)
           ? [buildStepfunWebSearchToolDefinition()]
+          : []),
+        ...(this.activeTransportConfig !== undefined
+          && shouldUseKimiCodeWebSearch(this.activeTransportConfig)
+          ? [buildKimiCodeWebSearchToolDefinition()]
           : []),
       ],
       this.agentMode,

--- a/packages/agent-core/src/host-bridge/host-tool-executor.ts
+++ b/packages/agent-core/src/host-bridge/host-tool-executor.ts
@@ -30,6 +30,8 @@ import {
 import { enrichUnknownToolError, toolNamesFromDefinitions } from '../unknown-tool-error.js';
 import { shouldUseStepfunWebSearch } from '../stepfun/stepfun-eligibility.js';
 import { buildStepfunWebSearchToolDefinition } from '../stepfun/stepfun-web-search-tool.js';
+import { shouldUseKimiCodeWebSearch } from '../kimi-code/kimi-code-eligibility.js';
+import { buildKimiCodeWebSearchToolDefinition } from '../kimi-code/kimi-code-web-search-tool.js';
 import { buildLspHostToolDefinitions } from '../lsp/tool-definitions.js';
 import { executeGetDiagnostics } from '../lsp/execute-diagnostics.js';
 import {
@@ -572,6 +574,9 @@ export class HostToolExecutorProxy implements ToolExecutor<JsonValue, JsonValue>
             ...(shouldUseStepfunWebSearch(this.transportConfigForToolDefinitions)
               ? [buildStepfunWebSearchToolDefinition()]
               : []),
+            ...(shouldUseKimiCodeWebSearch(this.transportConfigForToolDefinitions)
+              ? [buildKimiCodeWebSearchToolDefinition()]
+              : []),
           ]
         : [
             ...this.loopToolDefinitionsCache,
@@ -579,6 +584,9 @@ export class HostToolExecutorProxy implements ToolExecutor<JsonValue, JsonValue>
             ...this.todoToolDefinitionsCache,
             ...(shouldUseStepfunWebSearch(this.transportConfigForToolDefinitions)
               ? [buildStepfunWebSearchToolDefinition()]
+              : []),
+            ...(shouldUseKimiCodeWebSearch(this.transportConfigForToolDefinitions)
+              ? [buildKimiCodeWebSearchToolDefinition()]
               : []),
           ],
       this.agentMode,

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -29,3 +29,5 @@ export * from './hooks/index.js';
 export * from './auto-approval/index.js';
 export { shouldUseStepfunWebSearch } from './stepfun/stepfun-eligibility.js';
 export { buildStepfunWebSearchToolDefinition } from './stepfun/stepfun-web-search-tool.js';
+export { shouldUseKimiCodeWebSearch } from './kimi-code/kimi-code-eligibility.js';
+export { buildKimiCodeWebSearchToolDefinition } from './kimi-code/kimi-code-web-search-tool.js';

--- a/packages/agent-core/src/kimi-code/kimi-code-eligibility.test.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-eligibility.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  isKimiCodeManagedWebSearchToolCall,
+  shouldUseKimiCodeWebSearch,
+} from './kimi-code-eligibility.js';
+import { buildKimiCodeWebSearchToolDefinition } from './kimi-code-web-search-tool.js';
+
+test('shouldUseKimiCodeWebSearch matches kimi-code vendor and api base', () => {
+  assert.equal(
+    shouldUseKimiCodeWebSearch({
+      apiKey: 'k',
+      model: 'kimi-for-coding',
+      llmVendor: 'kimi-code',
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseKimiCodeWebSearch({
+      transportKind: 'openai-compatible',
+      apiKey: 'k',
+      model: 'kimi-for-coding',
+      baseUrl: 'https://api.kimi.com/coding/v1',
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseKimiCodeWebSearch({
+      transportKind: 'openai-compatible',
+      apiKey: 'k',
+      model: 'kimi-k2.5',
+      llmVendor: 'moonshot-ai',
+    }),
+    false,
+  );
+});
+
+test('isKimiCodeManagedWebSearchToolCall matches web_search only when eligible', () => {
+  const config = {
+    apiKey: 'k',
+    model: 'kimi-for-coding',
+    llmVendor: 'kimi-code' as const,
+  };
+  assert.equal(isKimiCodeManagedWebSearchToolCall('web_search', config), true);
+  assert.equal(isKimiCodeManagedWebSearchToolCall('read_file', config), false);
+});
+
+test('buildKimiCodeWebSearchToolDefinition exposes query without n', () => {
+  const definition = buildKimiCodeWebSearchToolDefinition() as {
+    function: { name: string; parameters: { properties: Record<string, unknown>; required: string[] } };
+  };
+  assert.equal(definition.function.name, 'web_search');
+  assert.deepEqual(definition.function.parameters.required, ['query']);
+  assert.ok(definition.function.parameters.properties.query);
+  assert.equal(definition.function.parameters.properties.n, undefined);
+});

--- a/packages/agent-core/src/kimi-code/kimi-code-eligibility.test.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-eligibility.test.ts
@@ -34,6 +34,16 @@ test('shouldUseKimiCodeWebSearch matches kimi-code vendor and api base', () => {
     }),
     false,
   );
+  assert.equal(
+    shouldUseKimiCodeWebSearch({
+      transportKind: 'openai-compatible',
+      apiKey: 'k',
+      model: 'kimi-k2.5',
+      llmVendor: 'moonshot-ai',
+      baseUrl: 'https://api.kimi.com/coding/v1',
+    }),
+    false,
+  );
 });
 
 test('isKimiCodeManagedWebSearchToolCall matches web_search only when eligible', () => {

--- a/packages/agent-core/src/kimi-code/kimi-code-eligibility.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-eligibility.ts
@@ -22,6 +22,10 @@ export function shouldUseKimiCodeWebSearch(config: LlmTransportConfig | undefine
   if (vendor === 'kimi-code') {
     return true;
   }
+  // 与 Formula 排除 kimi-code 对称：moonshot-ai 即使 baseUrl 落在 api.kimi.com 也不走托管 search
+  if (vendor === 'moonshot-ai') {
+    return false;
+  }
 
   return isKimiCodeApiBase((config as { baseUrl?: string }).baseUrl);
 }

--- a/packages/agent-core/src/kimi-code/kimi-code-eligibility.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-eligibility.ts
@@ -1,0 +1,34 @@
+import type { LlmTransportConfig } from '../provider-config.js';
+
+function isKimiCodeApiBase(baseUrl: string | undefined): boolean {
+  const trimmed = baseUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  try {
+    return new URL(trimmed).hostname === 'api.kimi.com';
+  } catch {
+    return false;
+  }
+}
+
+export function shouldUseKimiCodeWebSearch(config: LlmTransportConfig | undefined): boolean {
+  if (!config) {
+    return false;
+  }
+
+  const vendor = (config as { llmVendor?: string }).llmVendor;
+  if (vendor === 'kimi-code') {
+    return true;
+  }
+
+  return isKimiCodeApiBase((config as { baseUrl?: string }).baseUrl);
+}
+
+export function isKimiCodeManagedWebSearchToolCall(
+  toolName: string,
+  config: unknown,
+): boolean {
+  return toolName === 'web_search' && shouldUseKimiCodeWebSearch(config as LlmTransportConfig);
+}

--- a/packages/agent-core/src/kimi-code/kimi-code-search-client.test.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-search-client.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  KIMI_CODE_SEARCH_URL,
+  formatKimiCodeSearchResults,
+  invokeKimiCodeSearch,
+} from './kimi-code-search-client.js';
+
+test('formatKimiCodeSearchResults serializes result fields', () => {
+  const formatted = formatKimiCodeSearchResults([
+    {
+      title: 'Example',
+      url: 'https://example.com',
+      site_name: 'example.com',
+      snippet: 'Snippet text',
+      content: 'Body text',
+      date: '2026-01-01',
+    },
+  ]);
+  assert.match(formatted, /Example/);
+  assert.match(formatted, /https:\/\/example.com/);
+  assert.match(formatted, /example.com/);
+  assert.match(formatted, /Snippet text/);
+  assert.match(formatted, /Body text/);
+  assert.match(formatted, /2026-01-01/);
+});
+
+test('invokeKimiCodeSearch posts text_query to coding/v1/search', async () => {
+  let capturedUrl = '';
+  let capturedBody: unknown;
+  let capturedAuth = '';
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    capturedUrl = typeof input === 'string' ? input : input.toString();
+    capturedBody = JSON.parse(String(init?.body));
+    const headers = new Headers(init?.headers);
+    capturedAuth = headers.get('Authorization') ?? '';
+    return new Response(
+      JSON.stringify({
+        search_results: [{ title: 'Hit', url: 'https://hit.example', snippet: 'Found it' }],
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as typeof fetch;
+
+  const result = await invokeKimiCodeSearch('sk-test', { query: 'latest news' }, fetchImpl);
+  assert.equal(result.kind, 'succeeded');
+  assert.equal(capturedUrl, KIMI_CODE_SEARCH_URL);
+  assert.equal(capturedAuth, 'Bearer sk-test');
+  assert.deepEqual(capturedBody, { text_query: 'latest news' });
+  if (result.kind === 'succeeded') {
+    assert.match(result.content, /Hit/);
+  }
+});
+
+test('invokeKimiCodeSearch rejects empty query', async () => {
+  const result = await invokeKimiCodeSearch('sk-test', { query: '   ' });
+  assert.equal(result.kind, 'failed');
+});

--- a/packages/agent-core/src/kimi-code/kimi-code-search-client.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-search-client.ts
@@ -1,0 +1,95 @@
+import { getLlmFetch } from '../llm-fetch.js';
+
+export const KIMI_CODE_SEARCH_URL = 'https://api.kimi.com/coding/v1/search';
+
+type KimiCodeSearchResult = {
+  url?: string;
+  title?: string;
+  date?: string;
+  snippet?: string;
+  content?: string;
+  site_name?: string;
+};
+
+type KimiCodeSearchResponse = {
+  search_results?: KimiCodeSearchResult[];
+};
+
+export type KimiCodeSearchInvokeResult =
+  | { kind: 'succeeded'; content: string }
+  | { kind: 'failed'; error: string };
+
+export function formatKimiCodeSearchResults(results: readonly KimiCodeSearchResult[]): string {
+  if (results.length === 0) {
+    return 'No search results.';
+  }
+
+  return results
+    .map((result, index) => {
+      const lines = [`## ${index + 1}. ${result.title?.trim() || 'Untitled'}`];
+      if (result.url?.trim()) {
+        lines.push(`URL: ${result.url.trim()}`);
+      }
+      if (result.site_name?.trim()) {
+        lines.push(`Site: ${result.site_name.trim()}`);
+      }
+      if (result.date?.trim()) {
+        lines.push(`Time: ${result.date.trim()}`);
+      }
+      if (result.snippet?.trim()) {
+        lines.push(`Snippet: ${result.snippet.trim()}`);
+      }
+      if (result.content?.trim()) {
+        lines.push(`Content: ${result.content.trim()}`);
+      }
+      return lines.join('\n');
+    })
+    .join('\n\n');
+}
+
+export async function invokeKimiCodeSearch(
+  apiKey: string,
+  body: { query: string },
+  fetchImpl: typeof fetch = getLlmFetch(),
+): Promise<KimiCodeSearchInvokeResult> {
+  const query = body.query.trim();
+  if (!query) {
+    return { kind: 'failed', error: 'web_search requires a non-empty query.' };
+  }
+
+  const trimmedKey = apiKey.trim();
+  if (!trimmedKey) {
+    return { kind: 'failed', error: 'Kimi Code search requires an API key.' };
+  }
+
+  try {
+    const response = await fetchImpl(KIMI_CODE_SEARCH_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${trimmedKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text_query: query }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      const suffix = text.trim() ? `: ${text.trim()}` : '';
+      return {
+        kind: 'failed',
+        error: `Kimi Code search failed (${response.status})${suffix}`,
+      };
+    }
+
+    const json = (await response.json()) as KimiCodeSearchResponse;
+    return {
+      kind: 'succeeded',
+      content: formatKimiCodeSearchResults(
+        Array.isArray(json.search_results) ? json.search_results : [],
+      ),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { kind: 'failed', error: message };
+  }
+}

--- a/packages/agent-core/src/kimi-code/kimi-code-web-search-tool-loop.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-web-search-tool-loop.ts
@@ -1,0 +1,63 @@
+import { getLlmFetch } from '../llm-fetch.js';
+import type { LlmTransportConfig } from '../provider-config.js';
+import type { ToolCallRequest } from '../ports.js';
+import { readWebSearchQuery } from '../web-search/read-web-search-query.js';
+import { buildStepfunWebSearchToolPreviewArgumentsJson } from '../stepfun/stepfun-spirit-ui.js';
+import { isKimiCodeManagedWebSearchToolCall } from './kimi-code-eligibility.js';
+import { invokeKimiCodeSearch } from './kimi-code-search-client.js';
+
+export function readKimiCodeWebSearchQuery(argumentsJson: string): string {
+  return readWebSearchQuery(argumentsJson);
+}
+
+export type KimiCodeWebSearchToolExecutionResult =
+  | { kind: 'succeeded'; content: string; previewArgumentsJson: string }
+  | { kind: 'failed'; error: string; previewArgumentsJson: string };
+
+export async function executeKimiCodeWebSearchToolCall(
+  config: LlmTransportConfig,
+  call: Pick<ToolCallRequest, 'name' | 'argumentsJson'>,
+  fetchImpl: typeof fetch = getLlmFetch(),
+): Promise<KimiCodeWebSearchToolExecutionResult> {
+  const query = readKimiCodeWebSearchQuery(call.argumentsJson);
+  const apiKey = (config as { apiKey?: string }).apiKey ?? '';
+
+  const searchResult = await invokeKimiCodeSearch(apiKey, { query }, fetchImpl);
+
+  if (searchResult.kind === 'failed') {
+    return {
+      kind: 'failed',
+      error: searchResult.error,
+      previewArgumentsJson: buildStepfunWebSearchToolPreviewArgumentsJson({
+        query,
+        failed: true,
+        status: 'failed',
+      }),
+    };
+  }
+
+  return {
+    kind: 'succeeded',
+    content: searchResult.content,
+    previewArgumentsJson: buildStepfunWebSearchToolPreviewArgumentsJson({
+      query,
+      status: 'completed',
+      outputExcerpt: searchResult.content,
+    }),
+  };
+}
+
+export function buildKimiCodeWebSearchStreamingPreviewArgumentsJson(
+  config: LlmTransportConfig,
+  toolName: string,
+  argumentsJson: string,
+): string | undefined {
+  if (!isKimiCodeManagedWebSearchToolCall(toolName, config)) {
+    return undefined;
+  }
+
+  return buildStepfunWebSearchToolPreviewArgumentsJson({
+    query: readKimiCodeWebSearchQuery(argumentsJson),
+    status: 'in_progress',
+  });
+}

--- a/packages/agent-core/src/kimi-code/kimi-code-web-search-tool.ts
+++ b/packages/agent-core/src/kimi-code/kimi-code-web-search-tool.ts
@@ -1,0 +1,11 @@
+import type { JsonObject } from '../ports.js';
+import {
+  WEB_SEARCH_TOOL_NAME,
+  buildWebSearchToolDefinition,
+} from '../web-search/web-search-tool-schema.js';
+
+export const KIMI_CODE_WEB_SEARCH_TOOL_NAME = WEB_SEARCH_TOOL_NAME;
+
+export function buildKimiCodeWebSearchToolDefinition(): JsonObject {
+  return buildWebSearchToolDefinition({ includeResultCountN: false });
+}

--- a/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
+++ b/packages/agent-core/src/moonshot/formula/moonshot-formula-turn-handler.ts
@@ -25,10 +25,23 @@ import {
   readStepfunWebSearchQuery,
 } from '../../stepfun/stepfun-web-search-tool-loop.js';
 import { isStepfunManagedWebSearchToolCall } from '../../stepfun/stepfun-eligibility.js';
+import {
+  executeKimiCodeWebSearchToolCall,
+  readKimiCodeWebSearchQuery,
+} from '../../kimi-code/kimi-code-web-search-tool-loop.js';
+import { isKimiCodeManagedWebSearchToolCall } from '../../kimi-code/kimi-code-eligibility.js';
+
+function isLocalManagedWebSearchToolCall(toolName: string, config: unknown): boolean {
+  return isStepfunManagedWebSearchToolCall(toolName, config)
+    || isKimiCodeManagedWebSearchToolCall(toolName, config);
+}
 
 function readPreviewQuery(argumentsJson: string, toolName: string, config: unknown): string {
   if (isStepfunManagedWebSearchToolCall(toolName, config)) {
     return readStepfunWebSearchQuery(argumentsJson);
+  }
+  if (isKimiCodeManagedWebSearchToolCall(toolName, config)) {
+    return readKimiCodeWebSearchQuery(argumentsJson);
   }
   return readMoonshotFormulaWebSearchQuery(argumentsJson);
 }
@@ -42,7 +55,7 @@ function buildManagedProviderWebSearchPreviewArgumentsJson(
     outputExcerpt?: string;
   },
 ): string {
-  if (isStepfunManagedWebSearchToolCall('web_search', config)) {
+  if (isLocalManagedWebSearchToolCall('web_search', config)) {
     return buildStepfunWebSearchToolPreviewArgumentsJson(input);
   }
   return buildMoonshotFormulaToolPreviewArgumentsJson(input);
@@ -57,7 +70,7 @@ function managedProviderToolSummaryText(
   if (failed) {
     return `[provider tool ${toolName}] failed`;
   }
-  if (isStepfunManagedWebSearchToolCall(toolName, config) && content?.trim()) {
+  if (isLocalManagedWebSearchToolCall(toolName, config) && content?.trim()) {
     return content;
   }
   return `[provider tool ${toolName}] completed`;
@@ -92,7 +105,9 @@ async function executeAndCommitManagedProviderToolCall<
 
   const execution = isStepfunManagedWebSearchToolCall(call.name, config)
     ? await executeStepfunWebSearchToolCall(config, call)
-    : await executeMoonshotFormulaToolCall(config as OpenAiTransportConfig, call);
+    : isKimiCodeManagedWebSearchToolCall(call.name, config)
+      ? await executeKimiCodeWebSearchToolCall(config, call)
+      : await executeMoonshotFormulaToolCall(config as OpenAiTransportConfig, call);
 
   runtime.emitEvent({
     kind: 'streaming-tool-preview',
@@ -151,7 +166,8 @@ async function executeAndCommitManagedProviderToolCall<
 
 function isManagedProviderToolCall(toolName: string, config: unknown): boolean {
   return isMoonshotFormulaManagedToolCall(toolName, config)
-    || isStepfunManagedWebSearchToolCall(toolName, config);
+    || isStepfunManagedWebSearchToolCall(toolName, config)
+    || isKimiCodeManagedWebSearchToolCall(toolName, config);
 }
 
 export type ManagedProviderToolCallOutcome<

--- a/packages/agent-core/src/openai/ai-sdk-transport.ts
+++ b/packages/agent-core/src/openai/ai-sdk-transport.ts
@@ -164,6 +164,7 @@ import {
 import { shouldUseMoonshotFormulaWebSearch } from '../moonshot/formula/formula-eligibility.js';
 import { buildMoonshotFormulaStreamingToolPreviewArgumentsJson } from '../moonshot/formula/moonshot-formula-tool-loop.js';
 import { buildStepfunWebSearchStreamingPreviewArgumentsJson } from '../stepfun/stepfun-web-search-tool-loop.js';
+import { buildKimiCodeWebSearchStreamingPreviewArgumentsJson } from '../kimi-code/kimi-code-web-search-tool-loop.js';
 import {
   buildJsonSchemaCompletionMessages,
   stringifyJsonSchemaCompletionOutput,
@@ -1616,6 +1617,7 @@ function resolveStreamingToolPreviewArgumentsJson(
 ): string {
   return buildMoonshotFormulaStreamingToolPreviewArgumentsJson(config, toolName, argumentsJson)
     ?? buildStepfunWebSearchStreamingPreviewArgumentsJson(config, toolName, argumentsJson)
+    ?? buildKimiCodeWebSearchStreamingPreviewArgumentsJson(config, toolName, argumentsJson)
     ?? argumentsJson;
 }
 

--- a/packages/agent-core/src/stepfun/stepfun-web-search-tool-loop.ts
+++ b/packages/agent-core/src/stepfun/stepfun-web-search-tool-loop.ts
@@ -3,22 +3,13 @@ import type { JsonObject } from '../ports.js';
 import { isJsonObject } from '../tool-agent.js';
 import type { LlmTransportConfig } from '../provider-config.js';
 import type { ToolCallRequest } from '../ports.js';
-import { tryExtractPartialWebSearchQuery } from '../tool-streaming-preview-gate.js';
+import { readWebSearchQuery } from '../web-search/read-web-search-query.js';
 import { buildStepfunWebSearchToolPreviewArgumentsJson } from './stepfun-spirit-ui.js';
 import { isStepfunManagedWebSearchToolCall } from './stepfun-eligibility.js';
 import { invokeStepfunSearch } from './stepfun-search-client.js';
 
 export function readStepfunWebSearchQuery(argumentsJson: string): string {
-  try {
-    const parsed = JSON.parse(argumentsJson) as JsonObject;
-    if (!isJsonObject(parsed)) {
-      return '';
-    }
-    const query = parsed.query;
-    return typeof query === 'string' ? query.trim() : '';
-  } catch {
-    return tryExtractPartialWebSearchQuery(argumentsJson) ?? '';
-  }
+  return readWebSearchQuery(argumentsJson);
 }
 
 function readStepfunWebSearchResultCount(argumentsJson: string): number | undefined {

--- a/packages/agent-core/src/stepfun/stepfun-web-search-tool.ts
+++ b/packages/agent-core/src/stepfun/stepfun-web-search-tool.ts
@@ -1,31 +1,11 @@
 import type { JsonObject } from '../ports.js';
+import {
+  WEB_SEARCH_TOOL_NAME,
+  buildWebSearchToolDefinition,
+} from '../web-search/web-search-tool-schema.js';
 
-export const STEPFUN_WEB_SEARCH_TOOL_NAME = 'web_search' as const;
+export const STEPFUN_WEB_SEARCH_TOOL_NAME = WEB_SEARCH_TOOL_NAME;
 
 export function buildStepfunWebSearchToolDefinition(): JsonObject {
-  return {
-    type: 'function',
-    function: {
-      name: STEPFUN_WEB_SEARCH_TOOL_NAME,
-      description:
-        'Search the web for up-to-date information. Returns page titles, URLs, snippets, and content.',
-      parameters: {
-        type: 'object',
-        properties: {
-          query: {
-            type: 'string',
-            description: 'Search query.',
-          },
-          n: {
-            type: 'integer',
-            minimum: 1,
-            maximum: 20,
-            description: 'Maximum number of results to return (default 10).',
-          },
-        },
-        required: ['query'],
-        additionalProperties: false,
-      },
-    },
-  };
+  return buildWebSearchToolDefinition({ includeResultCountN: true });
 }

--- a/packages/agent-core/src/web-search/read-web-search-query.ts
+++ b/packages/agent-core/src/web-search/read-web-search-query.ts
@@ -1,0 +1,17 @@
+import type { JsonObject } from '../ports.js';
+import { isJsonObject } from '../tool-agent.js';
+import { tryExtractPartialWebSearchQuery } from '../tool-streaming-preview-gate.js';
+
+/** Read `query` from complete or in-flight web_search argument JSON. */
+export function readWebSearchQuery(argumentsJson: string): string {
+  try {
+    const parsed = JSON.parse(argumentsJson) as JsonObject;
+    if (!isJsonObject(parsed)) {
+      return '';
+    }
+    const query = parsed.query;
+    return typeof query === 'string' ? query.trim() : '';
+  } catch {
+    return tryExtractPartialWebSearchQuery(argumentsJson) ?? '';
+  }
+}

--- a/packages/agent-core/src/web-search/web-search-tool-schema.ts
+++ b/packages/agent-core/src/web-search/web-search-tool-schema.ts
@@ -1,0 +1,43 @@
+import type { JsonObject } from '../ports.js';
+
+export const WEB_SEARCH_TOOL_NAME = 'web_search' as const;
+
+export const WEB_SEARCH_TOOL_DESCRIPTION =
+  'Search the web for up-to-date information. Returns page titles, URLs, snippets, and content.';
+
+export const WEB_SEARCH_QUERY_PARAMETER: JsonObject = {
+  type: 'string',
+  description: 'Search query.',
+};
+
+const WEB_SEARCH_RESULT_COUNT_N_PARAMETER: JsonObject = {
+  type: 'integer',
+  minimum: 1,
+  maximum: 20,
+  description: 'Maximum number of results to return (default 10).',
+};
+
+export function buildWebSearchToolDefinition(options: {
+  includeResultCountN: boolean;
+}): JsonObject {
+  const properties: JsonObject = {
+    query: WEB_SEARCH_QUERY_PARAMETER,
+  };
+  if (options.includeResultCountN) {
+    properties.n = WEB_SEARCH_RESULT_COUNT_N_PARAMETER;
+  }
+
+  return {
+    type: 'function',
+    function: {
+      name: WEB_SEARCH_TOOL_NAME,
+      description: WEB_SEARCH_TOOL_DESCRIPTION,
+      parameters: {
+        type: 'object',
+        properties,
+        required: ['query'],
+        additionalProperties: false,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- 抽取可复用的 `web_search` description / `query` schema，StepFun 改为复用并保留可选 `n`
- 为 Kimi Code 接入 agent-core 托管 `web_search`：固定 `POST https://api.kimi.com/coding/v1/search`（`text_query`），经 managed turn / streaming 执行
- Desktop `tool-executor` 同步注入 schema（与 StepFun 并列），避免仅 core 挂载而 Desktop 请求 `tools` 缺失

## Test plan
- [x] `packages/agent-core`：kimi-code / stepfun eligibility 与 search client 单测通过
- [x] 确认 Kimi Code schema 有 `query`、无 `n`；HTTP body 使用 `text_query`
- [x] Desktop 选 Kimi Code 模型后导出 LLM request，`tools` 含 `web_search`
- [x] 能力边界文档区分 Moonshot Formula（仍排除 kimi-code）与 Kimi/StepFun 托管 `web_search`