### PR TITLE
ci(release): 重构为手动纯版本号发版与审批门

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,9 +208,10 @@ jobs:
             apps/desktop/release/*.zip
           if-no-files-found: error
 
-  # Temporary publish path for Phase 2; Phase 3 inserts the approval gate before this job.
-  publish:
-    name: Publish GitHub Release
+  # prepare builds the English approval summary (changelog + per-channel asset tables).
+  # approve uses GitHub Environment "release" — configure Required reviewers in repo Settings.
+  prepare:
+    name: Prepare approval report
     needs:
       - cli
       - desktop
@@ -218,17 +219,76 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Download artifacts
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: release-assets
           merge-multiple: true
 
-      - name: Generate checksums
-        run: node scripts/release/checksums.mjs release-assets release-assets/SHA256SUMS.txt
+      - name: Prepare approval report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          npm run release:prepare-approval-report -- \
+            --input release-assets \
+            --output-dir release-assets/approval \
+            --version "$RELEASE_VERSION" \
+            --sha "${{ github.sha }}"
 
-      - name: Publish release
+      - name: Write job summary
+        run: cat release-assets/approval/approval-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-bundle
+          path: release-assets/
+          if-no-files-found: error
+
+  approve:
+    name: Approve release
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Download release bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: release-bundle
+          path: release-assets
+
+      - name: Show approval report
+        run: |
+          echo "Review the English approval report below (also in the prepare job summary), then approve this environment deployment."
+          echo
+          cat release-assets/approval/approval-report.md >> "$GITHUB_STEP_SUMMARY"
+          cat release-assets/approval/approval-report.md
+
+  publish-github:
+    name: Publish GitHub Release
+    needs: approve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download release bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: release-bundle
+          path: release-assets
+
+      - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -238,8 +298,41 @@ jobs:
             echo "No release assets found under release-assets" >&2
             exit 1
           fi
+          notes_file="release-assets/approval/release-notes.md"
+          if [ ! -f "$notes_file" ]; then
+            echo "Missing approval release notes: $notes_file" >&2
+            exit 1
+          fi
           if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
             gh release upload "$RELEASE_VERSION" "${assets[@]}" --clobber
           else
-            gh release create "$RELEASE_VERSION" "${assets[@]}" --title "$RELEASE_VERSION" --target "${{ github.sha }}" --generate-notes
+            gh release create "$RELEASE_VERSION" "${assets[@]}" \
+              --title "$RELEASE_VERSION" \
+              --target "${{ github.sha }}" \
+              --notes-file "$notes_file"
           fi
+
+  # Reserved publish channels: no-op placeholders so the parallel fan-out graph stays stable.
+  publish-selfhosted:
+    name: Publish self-hosted (reserved)
+    needs: approve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reserved
+        run: echo "Self-hosted publish to download.spirit.fast is reserved and not enabled in this run."
+
+  publish-msstore:
+    name: Publish MS Store (reserved)
+    needs: approve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reserved
+        run: echo "MS Store publish is reserved and not enabled in this run."
+
+  publish-homebrew:
+    name: Publish Homebrew (reserved)
+    needs: approve
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reserved
+        run: echo "Homebrew publish is reserved and not enabled in this run."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# Manual release pipeline: build HEAD → English approval gate → publish channels → tag X.Y.Z.
+# Configure GitHub Environment "release" with Required reviewers before using Approve release.
 name: Release
 
 on:
@@ -7,7 +9,6 @@ on:
         description: 'Release version (pure X.Y.Z, for example 0.1.0)'
         required: true
         type: string
-
 permissions:
   contents: write
 
@@ -293,6 +294,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo "::error::GitHub Release $RELEASE_VERSION already exists; refusing to overwrite."
+            exit 1
+          fi
           mapfile -d '' -t assets < <(find release-assets -maxdepth 1 -type f -print0)
           if [ "${#assets[@]}" -eq 0 ]; then
             echo "No release assets found under release-assets" >&2
@@ -303,14 +309,11 @@ jobs:
             echo "Missing approval release notes: $notes_file" >&2
             exit 1
           fi
-          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_VERSION" "${assets[@]}" --clobber
-          else
-            gh release create "$RELEASE_VERSION" "${assets[@]}" \
-              --title "$RELEASE_VERSION" \
-              --target "${{ github.sha }}" \
-              --notes-file "$notes_file"
-          fi
+          # Tag name is the pure version X.Y.Z (no "v" prefix).
+          gh release create "$RELEASE_VERSION" "${assets[@]}" \
+            --title "$RELEASE_VERSION" \
+            --target "${{ github.sha }}" \
+            --notes-file "$notes_file"
 
   # Reserved publish channels: no-op placeholders so the parallel fan-out graph stays stable.
   publish-selfhosted:
@@ -336,3 +339,42 @@ jobs:
     steps:
       - name: Reserved
         run: echo "Homebrew publish is reserved and not enabled in this run."
+
+  # After every publish channel finishes, ensure archival tag X.Y.Z points at the built SHA.
+  finalize-tag:
+    name: Finalize release tag
+    needs:
+      - publish-github
+      - publish-selfhosted
+      - publish-msstore
+      - publish-homebrew
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag at release SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="$RELEASE_VERSION"
+          EXPECTED_SHA="${{ github.sha }}"
+
+          git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" 2>/dev/null || true
+
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            ACTUAL_SHA="$(git rev-list -n 1 "refs/tags/${TAG}")"
+            if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+              echo "::error::Tag ${TAG} points to ${ACTUAL_SHA}, expected ${EXPECTED_SHA}"
+              exit 1
+            fi
+            echo "Tag ${TAG} already points at ${EXPECTED_SHA}"
+          else
+            git tag "$TAG" "$EXPECTED_SHA"
+            git push origin "refs/tags/${TAG}"
+            echo "Created and pushed tag ${TAG} at ${EXPECTED_SHA}"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,10 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Release tag, for example v0.1.0'
+      version:
+        description: 'Release version (pure X.Y.Z, for example 0.1.0)'
         required: true
         type: string
 
@@ -15,7 +12,7 @@ permissions:
   contents: write
 
 env:
-  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  RELEASE_VERSION: ${{ inputs.version }}
   NODE_VERSION: '22'
   SPIRIT_RELEASE_NODE_MAJOR: '22'
   CSC_IDENTITY_AUTO_DISCOVERY: 'false'
@@ -27,8 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -44,7 +39,7 @@ jobs:
           fi
 
       - name: Verify versions
-        run: npm run release:verify-version -- --version "$RELEASE_TAG"
+        run: npm run release:verify-version -- --version "$RELEASE_VERSION"
 
   cli:
     name: CLI ${{ matrix.package_target }}
@@ -85,8 +80,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -118,7 +111,7 @@ jobs:
         run: cross build -p spirit-agent --release --target ${{ matrix.rust_target }}
 
       - name: Bundle CLI
-        run: npm run release:cli:bundle -- --target ${{ matrix.rust_target }} --version ${RELEASE_TAG#v}
+        run: npm run release:cli:bundle -- --target ${{ matrix.rust_target }} --version "$RELEASE_VERSION"
         shell: bash
 
       - name: Upload CLI artifact
@@ -169,8 +162,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -217,6 +208,7 @@ jobs:
             apps/desktop/release/*.zip
           if-no-files-found: error
 
+  # Temporary publish path for Phase 2; Phase 3 inserts the approval gate before this job.
   publish:
     name: Publish GitHub Release
     needs:
@@ -226,8 +218,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_TAG }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -248,8 +238,8 @@ jobs:
             echo "No release assets found under release-assets" >&2
             exit 1
           fi
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" "${assets[@]}" --clobber
+          if gh release view "$RELEASE_VERSION" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_VERSION" "${assets[@]}" --clobber
           else
-            gh release create "$RELEASE_TAG" "${assets[@]}" --title "$RELEASE_TAG" --generate-notes
+            gh release create "$RELEASE_VERSION" "${assets[@]}" --title "$RELEASE_VERSION" --target "${{ github.sha }}" --generate-notes
           fi

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "release:verify-version": "node scripts/release/verify-version.mjs",
     "release:cli:bundle": "node scripts/release/bundle-cli.mjs",
     "release:checksums": "node scripts/release/checksums.mjs",
+    "release:prepare-approval-report": "node scripts/release/prepare-approval-report.mjs",
     "release:desktop": "npm --prefix apps/desktop run dist",
     "eval:compare": "npm run build:agent-core && npm run build:host-internal && node scripts/eval-compare.mjs",
     "eval:judge": "npm run build:agent-core && node scripts/eval-judge.mjs",

--- a/scripts/release/prepare-approval-report.mjs
+++ b/scripts/release/prepare-approval-report.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { mkdir, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const PURE_VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+function readArg(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function usage() {
+  console.error(
+    [
+      'Usage: node scripts/release/prepare-approval-report.mjs --input <dir> --output-dir <dir> --version <X.Y.Z> [--sha <commit>]',
+      'Env: RELEASE_VERSION, GITHUB_SHA, GITHUB_REPOSITORY, GH_TOKEN / GITHUB_TOKEN',
+    ].join('\n'),
+  );
+}
+
+function formatBytes(bytes) {
+  return new Intl.NumberFormat('en-US').format(bytes);
+}
+
+async function collectFiles(dir, { skipPaths, skipDirs }) {
+  const skipPathSet = new Set(skipPaths.map((item) => path.resolve(item)));
+  const skipDirSet = new Set(skipDirs.map((item) => path.resolve(item)));
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    const resolved = path.resolve(fullPath);
+    if (skipPathSet.has(resolved) || skipDirSet.has(resolved)) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await collectFiles(fullPath, { skipPaths, skipDirs })));
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function sha256(filePath) {
+  const hash = createHash('sha256');
+  await new Promise((resolve, reject) => {
+    createReadStream(filePath)
+      .on('data', (chunk) => hash.update(chunk))
+      .on('error', reject)
+      .on('end', resolve);
+  });
+  return hash.digest('hex');
+}
+
+function runCapture(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    cwd: repoRoot,
+    env: process.env,
+    ...options,
+  });
+  return result;
+}
+
+function generateNotesViaGh(version, sha) {
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!repository) {
+    return undefined;
+  }
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (!token) {
+    return undefined;
+  }
+
+  const args = [
+    'api',
+    '--method',
+    'POST',
+    `-H`,
+    'Accept: application/vnd.github+json',
+    `/repos/${repository}/releases/generate-notes`,
+    '-f',
+    `tag_name=${version}`,
+  ];
+  if (sha) {
+    args.push('-f', `target_commitish=${sha}`);
+  }
+
+  const result = runCapture('gh', args);
+  if (result.status !== 0) {
+    console.error(result.stderr?.trim() || 'gh releases/generate-notes failed');
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(result.stdout);
+    if (typeof parsed.body === 'string' && parsed.body.trim()) {
+      return parsed.body.trim();
+    }
+  } catch {
+    // fall through
+  }
+  return undefined;
+}
+
+function generateNotesViaGitLog(sha) {
+  const describe = runCapture('git', ['describe', '--tags', '--abbrev=0'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  const rangeArgs =
+    describe.status === 0 && describe.stdout.trim()
+      ? [`${describe.stdout.trim()}..${sha || 'HEAD'}`, '--']
+      : [sha || 'HEAD', '--max-count=30', '--'];
+
+  const log = runCapture('git', ['log', '--pretty=format:- %s (%h)', ...rangeArgs]);
+  if (log.status !== 0) {
+    return '- (changelog unavailable)';
+  }
+  const body = log.stdout.trim();
+  return body || '- (no commits in range)';
+}
+
+function renderAssetTable(assets) {
+  const lines = [
+    '| File | SHA256 | Size (bytes) |',
+    '| --- | --- | ---: |',
+  ];
+  for (const asset of assets) {
+    lines.push(`| \`${asset.file}\` | \`${asset.sha256}\` | ${formatBytes(asset.size)} |`);
+  }
+  return lines.join('\n');
+}
+
+const inputDir = path.resolve(readArg('--input') ?? path.join(repoRoot, 'dist', 'release'));
+const outputDir = path.resolve(readArg('--output-dir') ?? path.join(inputDir, 'approval'));
+const version = readArg('--version') ?? process.env.RELEASE_VERSION;
+const sha = readArg('--sha') ?? process.env.GITHUB_SHA ?? '';
+
+if (!version || !PURE_VERSION_RE.test(version)) {
+  usage();
+  console.error(`Invalid or missing --version. Expected pure X.Y.Z, got ${JSON.stringify(version)}`);
+  process.exit(1);
+}
+
+await mkdir(outputDir, { recursive: true });
+
+const reportPath = path.join(outputDir, 'approval-report.md');
+const manifestPath = path.join(outputDir, 'release-manifest.json');
+const notesPath = path.join(outputDir, 'release-notes.md');
+const sumsPath = path.join(inputDir, 'SHA256SUMS.txt');
+
+const files = (
+  await collectFiles(inputDir, {
+    skipPaths: [reportPath, manifestPath, notesPath, sumsPath, path.join(outputDir, 'SHA256SUMS.txt')],
+    skipDirs: [outputDir],
+  })
+).sort((left, right) => left.localeCompare(right));
+
+if (files.length === 0) {
+  console.error(`No release assets found under ${inputDir}`);
+  process.exit(1);
+}
+
+const assets = [];
+const sumLines = [];
+for (const filePath of files) {
+  const relativePath = path.relative(inputDir, filePath).replaceAll(path.sep, '/');
+  const digest = await sha256(filePath);
+  const size = (await stat(filePath)).size;
+  assets.push({ file: relativePath, sha256: digest, size });
+  sumLines.push(`${digest}  ${relativePath}`);
+}
+
+await writeFile(sumsPath, `${sumLines.join('\n')}\n`);
+
+const changelog = generateNotesViaGh(version, sha) ?? generateNotesViaGitLog(sha);
+await writeFile(notesPath, `${changelog}\n`);
+
+const table = renderAssetTable(assets);
+const report = [
+  `# Release approval — ${version}`,
+  '',
+  `Target commit: \`${sha || '(local)'}\``,
+  '',
+  '## Changelog',
+  '',
+  changelog,
+  '',
+  '## GitHub Release',
+  '',
+  'Channel status: **Will publish after approval**',
+  '',
+  table,
+  '',
+  '## Self-hosted (`download.spirit.fast`)',
+  '',
+  'Channel status: **Not publishing in this run** (architecture reserved)',
+  '',
+  table,
+  '',
+  '## Checksums',
+  '',
+  `Also written to \`SHA256SUMS.txt\` (${assets.length} files).`,
+  '',
+].join('\n');
+
+await writeFile(reportPath, report);
+
+const manifest = {
+  version,
+  sha: sha || null,
+  generatedAt: new Date().toISOString(),
+  channels: {
+    github: { publish: true },
+    selfhosted: { publish: false, host: 'download.spirit.fast' },
+    msstore: { publish: false },
+    homebrew: { publish: false },
+  },
+  assets,
+  files: {
+    report: 'approval-report.md',
+    notes: 'release-notes.md',
+    checksums: 'SHA256SUMS.txt',
+  },
+};
+
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+// Keep a copy of checksums next to the report for the release-bundle artifact layout.
+await writeFile(path.join(outputDir, 'SHA256SUMS.txt'), `${sumLines.join('\n')}\n`);
+
+console.log(`Wrote approval report: ${reportPath}`);
+console.log(`Wrote manifest: ${manifestPath}`);
+console.log(`Wrote notes: ${notesPath}`);
+console.log(`Wrote checksums: ${sumsPath}`);

--- a/scripts/release/verify-version.mjs
+++ b/scripts/release/verify-version.mjs
@@ -4,17 +4,24 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const PURE_VERSION_RE = /^\d+\.\d+\.\d+$/;
 
 function readArg(name) {
   const index = process.argv.indexOf(name);
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-function normalizeTagVersion(value) {
-  if (!value) {
+function resolveExpectedVersion(raw) {
+  if (!raw) {
     return undefined;
   }
-  return value.startsWith('v') ? value.slice(1) : value;
+  if (!PURE_VERSION_RE.test(raw)) {
+    console.error(
+      `Invalid release version ${JSON.stringify(raw)}. Expected a pure semver patch form X.Y.Z (no "v" prefix).`,
+    );
+    process.exit(1);
+  }
+  return raw;
 }
 
 async function readJsonVersion(relativePath) {
@@ -43,9 +50,14 @@ async function readMcpClientVersion(relativePath) {
   return match[1];
 }
 
-const expectedVersion = normalizeTagVersion(
-  readArg('--version') ?? process.env.RELEASE_VERSION ?? process.env.RELEASE_TAG ?? process.env.GITHUB_REF_NAME,
-);
+const explicitVersion = readArg('--version') ?? process.env.RELEASE_VERSION;
+const legacyVersion = process.env.RELEASE_TAG ?? process.env.GITHUB_REF_NAME;
+const expectedVersion =
+  explicitVersion !== undefined
+    ? resolveExpectedVersion(explicitVersion)
+    : legacyVersion && PURE_VERSION_RE.test(legacyVersion)
+      ? legacyVersion
+      : undefined;
 
 const versions = [
   ['desktop', 'apps/desktop/package.json', await readJsonVersion('apps/desktop/package.json')],
@@ -57,6 +69,13 @@ const versions = [
 ];
 
 const baseline = expectedVersion ?? versions[0][2];
+if (!PURE_VERSION_RE.test(baseline)) {
+  console.error(
+    `Invalid baseline version ${JSON.stringify(baseline)}. Package versions must use pure X.Y.Z (no "v" prefix).`,
+  );
+  process.exit(1);
+}
+
 const mismatches = versions.filter(([, , version]) => version !== baseline);
 
 if (mismatches.length > 0) {


### PR DESCRIPTION
## Summary
- 移除 `v*` Tag 触发，改为 `workflow_dispatch` 填入纯版本号 `X.Y.Z`，在 HEAD 构建并校验跨包版本
- 构建后生成英文审批报告（Changelog + GitHub / 自托管两表），经 Environment `release` 审批后再发布
- 仅 GitHub Release 实发；自托管 / MS Store / Homebrew 保留占位；全部完成后在 HEAD 留档 Tag（无 `v` 前缀）

## Test plan
- 仓库 Settings → Environments → `release` 已配置 Required reviewers
- 在 Actions 手动跑 Release，输入当前仓库版本（如 `0.3.0`），确认 verify/build 基于触发 SHA
- 确认 Approve release 前不会进入 publish；Job Summary 含英文 Changelog 与两张资产表
- Approve 后确认创建 GitHub Release（tag/title 为纯 `X.Y.Z`），已存在同名 Release 时应失败
- 确认 finalize-tag 后远程存在指向该 SHA 的 tag `X.Y.Z`；推送任意 `v*` tag 不再触发发版