### PR TITLE
ci(release): 审批通过后经 OIDC 发布 npm 包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,6 +315,39 @@ jobs:
             --target "${{ github.sha }}" \
             --notes-file "$notes_file"
 
+  # npm Trusted Publishing (OIDC): no NPM_TOKEN.
+  # Leave Environment name empty on the npm trusted publisher so this job does not
+  # re-trigger GitHub Environment "release" approval (approve is the single gate).
+  publish-npm:
+    name: Publish npm packages
+    needs: approve
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish packages
+        run: |
+          set -euo pipefail
+          # Dependency order: agent-core → host-internal → acp-server
+          npm --prefix packages/agent-core publish --access public
+          npm --prefix packages/host-internal publish --access public
+          npm --prefix packages/acp-server publish --access public
+
   # Reserved publish channels: no-op placeholders so the parallel fan-out graph stays stable.
   publish-selfhosted:
     name: Publish self-hosted (reserved)
@@ -345,6 +378,7 @@ jobs:
     name: Finalize release tag
     needs:
       - publish-github
+      - publish-npm
       - publish-selfhosted
       - publish-msstore
       - publish-homebrew

--- a/scripts/release/prepare-approval-report.mjs
+++ b/scripts/release/prepare-approval-report.mjs
@@ -180,6 +180,17 @@ const changelog = generateNotesViaGh(version, sha) ?? generateNotesViaGitLog(sha
 await writeFile(notesPath, `${changelog}\n`);
 
 const table = renderAssetTable(assets);
+const npmPackages = [
+  '@spiritagent/agent-core',
+  '@spiritagent/host-internal',
+  '@spiritagent/acp-server',
+];
+const npmTable = [
+  '| Package | Version |',
+  '| --- | --- |',
+  ...npmPackages.map((name) => `| \`${name}\` | \`${version}\` |`),
+].join('\n');
+
 const report = [
   `# Release approval — ${version}`,
   '',
@@ -194,6 +205,14 @@ const report = [
   'Channel status: **Will publish after approval**',
   '',
   table,
+  '',
+  '## npm',
+  '',
+  'Channel status: **Will publish after approval** (OIDC trusted publishing)',
+  '',
+  'Publish order: `agent-core` → `host-internal` → `acp-server`',
+  '',
+  npmTable,
   '',
   '## Self-hosted (`download.spirit.fast`)',
   '',
@@ -215,6 +234,7 @@ const manifest = {
   generatedAt: new Date().toISOString(),
   channels: {
     github: { publish: true },
+    npm: { publish: true, packages: npmPackages },
     selfhosted: { publish: false, host: 'download.spirit.fast' },
     msstore: { publish: false },
     homebrew: { publish: false },
@@ -226,7 +246,6 @@ const manifest = {
     checksums: 'SHA256SUMS.txt',
   },
 };
-
 await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
 
 // Keep a copy of checksums next to the report for the release-bundle artifact layout.


### PR DESCRIPTION
## Summary
- Release CI 在审批通过后新增 `publish-npm`：OIDC Trusted Publishing，按依赖顺序发布三个 `@spiritagent/*` 包
- 审批英文报告增加 npm 渠道表；`finalize-tag` 等待 npm 与 GitHub 发布均完成