### PR TITLE
fix(desktop): 柔化主区字色、恢复侧栏 Token 并增大 Markdown 标题

### DIFF
--- a/apps/desktop/src/components/automation-detail-view.tsx
+++ b/apps/desktop/src/components/automation-detail-view.tsx
@@ -70,7 +70,7 @@ function AutomationDetailTabs({
               "rounded-md px-3 py-2 text-sm",
               activeTab === id
                 ? "font-normal text-foreground underline decoration-foreground/80 underline-offset-[10px]"
-                : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                : "text-muted-foreground hover:bg-muted/60 hover:text-sidebar-foreground",
             )}
             onClick={() => onTabChange(id)}
           >
@@ -141,7 +141,7 @@ export function AutomationDetailView({
             <button
               type="button"
               onClick={onBack}
-              className="font-normal text-muted-foreground transition-colors hover:text-foreground"
+              className="font-normal text-muted-foreground transition-colors hover:text-sidebar-foreground"
             >
               {t("automations.detailBack")}
             </button>

--- a/apps/desktop/src/components/composer-insert-menu.tsx
+++ b/apps/desktop/src/components/composer-insert-menu.tsx
@@ -90,8 +90,8 @@ export function ComposerInsertMenu({
               aria-label={t('composer.openInsertPanel')}
               disabled={disabled}
               className={cn(
-                'size-7 shrink-0 rounded-full p-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground',
-                'aria-expanded:bg-muted/35 aria-expanded:text-foreground aria-expanded:hover:bg-muted/50',
+                'size-7 shrink-0 rounded-full p-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-sidebar-foreground',
+                'aria-expanded:bg-muted/35 aria-expanded:text-sidebar-foreground aria-expanded:hover:bg-muted/50',
                 instantHoverMotionClass,
               )}
             >

--- a/apps/desktop/src/components/desktop-title-bar.tsx
+++ b/apps/desktop/src/components/desktop-title-bar.tsx
@@ -45,9 +45,9 @@ const TITLE_BAR_ICON_PX = 14;
 /** 云母顶栏黑底标（`build/icon.png` 内图案更小，恢复迁移透明标前的 20px） */
 const TITLE_BAR_ICON_MICA_PX = 20;
 
-/** 与默认正文 / chrome 默认字色一致（`text-foreground`） */
+/** 与侧栏交互项默认字色一致（`text-sidebar-action-foreground`） */
 const TITLE_BAR_MENUBAR_TRIGGER_CLASS =
-  "px-2 py-1 text-[13px] text-foreground";
+  "px-2 py-1 text-[13px] text-sidebar-action-foreground";
 
 function execWindowAction(action: string): void {
   void window.spiritDesktop?.executeWindowAction(action);

--- a/apps/desktop/src/components/desktop-title-bar.tsx
+++ b/apps/desktop/src/components/desktop-title-bar.tsx
@@ -45,9 +45,9 @@ const TITLE_BAR_ICON_PX = 14;
 /** 云母顶栏黑底标（`build/icon.png` 内图案更小，恢复迁移透明标前的 20px） */
 const TITLE_BAR_ICON_MICA_PX = 20;
 
-/** 与侧栏交互项默认字色一致（`text-sidebar-action-foreground`） */
+/** 与默认正文 / chrome 默认字色一致（`text-foreground`） */
 const TITLE_BAR_MENUBAR_TRIGGER_CLASS =
-  "px-2 py-1 text-[13px] text-sidebar-action-foreground";
+  "px-2 py-1 text-[13px] text-foreground";
 
 function execWindowAction(action: string): void {
   void window.spiritDesktop?.executeWindowAction(action);

--- a/apps/desktop/src/components/detail-page-tabs.tsx
+++ b/apps/desktop/src/components/detail-page-tabs.tsx
@@ -102,7 +102,7 @@ export function DetailPageTabs<T extends string>({
                   tabButtonClassBySize[size],
                   selected
                     ? "font-normal text-foreground underline decoration-foreground/80"
-                    : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                    : "text-muted-foreground hover:bg-muted/60 hover:text-sidebar-foreground",
                 )}
                 onClick={() => onTabChange(id)}
               >

--- a/apps/desktop/src/components/github-sign-in-prompt.tsx
+++ b/apps/desktop/src/components/github-sign-in-prompt.tsx
@@ -21,7 +21,7 @@ export function GitHubSignInPrompt({
       <button
         type="button"
         className={cn(
-          "text-foreground underline underline-offset-2 hover:text-foreground/80",
+          "text-foreground underline underline-offset-2 hover:text-sidebar-foreground/80",
           linkClassName,
         )}
         onClick={onSignIn}

--- a/apps/desktop/src/components/marketplace-view.tsx
+++ b/apps/desktop/src/components/marketplace-view.tsx
@@ -535,7 +535,7 @@ export function MarketplaceView({
                 variant="ghost"
                 size="sm"
                 className={cn(
-                  "-ml-2 h-8 gap-1 text-muted-foreground hover:text-foreground",
+                  "-ml-2 h-8 gap-1 text-muted-foreground hover:text-sidebar-foreground",
                   instantHoverMotionClass,
                 )}
                 onClick={closeDetail}
@@ -635,7 +635,7 @@ export function MarketplaceView({
                           "rounded-md px-3 py-2 text-sm",
                           activeTab === tabId
                             ? "font-normal text-foreground underline decoration-foreground/80 underline-offset-[10px]"
-                            : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
+                            : "text-muted-foreground hover:bg-muted/60 hover:text-sidebar-foreground",
                         )}
                         onClick={() => setActiveTab(tabId)}
                       >

--- a/apps/desktop/src/components/pending-approval-card.tsx
+++ b/apps/desktop/src/components/pending-approval-card.tsx
@@ -104,7 +104,7 @@ export function PendingApprovalCard({
           <Button
             size="icon-sm"
             variant="outline"
-            className="h-auto w-9 self-stretch rounded-none border-0 border-l border-border/60 bg-transparent text-muted-foreground shadow-none hover:bg-muted/35 hover:text-foreground disabled:bg-transparent"
+            className="h-auto w-9 self-stretch rounded-none border-0 border-l border-border/60 bg-transparent text-muted-foreground shadow-none hover:bg-muted/35 hover:text-sidebar-foreground disabled:bg-transparent"
             onClick={() =>
               onSubmitApproval({
                 kind: "guidance",

--- a/apps/desktop/src/components/session-chrome-breadcrumb.tsx
+++ b/apps/desktop/src/components/session-chrome-breadcrumb.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/session-list-git-tooltip';
 import {
   DESKTOP_CHROME_ACTIVE_TEXT,
-  DESKTOP_CONTENT_TEXT,
+  DESKTOP_CHROME_MUTED_TEXT,
   DESKTOP_SESSION_TITLE_HOVER_CLASS,
   SESSION_TITLE_RENAME_INPUT_CLASS,
 } from '@/lib/desktop-chrome';
@@ -47,7 +47,7 @@ const sessionTitleButtonClass = (interactive: boolean) =>
   cn(
     "electron-no-drag min-w-0 w-full truncate rounded-sm p-0 text-left",
     DESKTOP_SIDEBAR_TEXT_CLASS,
-    DESKTOP_CONTENT_TEXT,
+    DESKTOP_CHROME_MUTED_TEXT,
     interactive && cn(DESKTOP_SESSION_TITLE_HOVER_CLASS, "cursor-pointer"),
   );
 

--- a/apps/desktop/src/components/session-chrome-breadcrumb.tsx
+++ b/apps/desktop/src/components/session-chrome-breadcrumb.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/components/session-list-git-tooltip';
 import {
   DESKTOP_CHROME_ACTIVE_TEXT,
-  DESKTOP_CHROME_MUTED_TEXT,
+  DESKTOP_CONTENT_TEXT,
   DESKTOP_SESSION_TITLE_HOVER_CLASS,
   SESSION_TITLE_RENAME_INPUT_CLASS,
 } from '@/lib/desktop-chrome';
@@ -47,7 +47,7 @@ const sessionTitleButtonClass = (interactive: boolean) =>
   cn(
     "electron-no-drag min-w-0 w-full truncate rounded-sm p-0 text-left",
     DESKTOP_SIDEBAR_TEXT_CLASS,
-    DESKTOP_CHROME_MUTED_TEXT,
+    DESKTOP_CONTENT_TEXT,
     interactive && cn(DESKTOP_SESSION_TITLE_HOVER_CLASS, "cursor-pointer"),
   );
 

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -1183,7 +1183,7 @@ const sidebarInteractionMotionClass =
   "!transition-[opacity,transform,box-shadow] duration-150 active:!translate-y-0";
 
 /** 侧栏交互项默认字色/图标色；hover 与选中回到 sidebar-foreground */
-const sidebarItemDefaultTextClass = "text-foreground";
+const sidebarItemDefaultTextClass = "text-sidebar-action-foreground";
 
 const sidebarItemActiveTextClass = "!text-sidebar-foreground";
 

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -1183,7 +1183,7 @@ const sidebarInteractionMotionClass =
   "!transition-[opacity,transform,box-shadow] duration-150 active:!translate-y-0";
 
 /** 侧栏交互项默认字色/图标色；hover 与选中回到 sidebar-foreground */
-const sidebarItemDefaultTextClass = "text-sidebar-action-foreground";
+const sidebarItemDefaultTextClass = "text-foreground";
 
 const sidebarItemActiveTextClass = "!text-sidebar-foreground";
 

--- a/apps/desktop/src/components/session-sidebar.tsx
+++ b/apps/desktop/src/components/session-sidebar.tsx
@@ -756,7 +756,7 @@ const SessionListRow = memo(function SessionListRow({
     <span className="flex w-3.5 shrink-0 items-center justify-center" aria-hidden>
       {isBusy && !isBlocked ? (
         <Spinner
-          className="size-3 shrink-0 text-primary"
+          className="size-3 shrink-0 text-foreground"
           aria-label={t('common.running')}
         />
       ) : !selected && isBlocked ? (

--- a/apps/desktop/src/components/settings/models/model-capabilities-combobox.tsx
+++ b/apps/desktop/src/components/settings/models/model-capabilities-combobox.tsx
@@ -65,7 +65,7 @@ export function ModelCapabilitiesCombobox({
                     role="button"
                     tabIndex={-1}
                     aria-label={t('settings.removeCapability', { label })}
-                    className="rounded-sm text-muted-foreground hover:text-foreground"
+                    className="rounded-sm text-muted-foreground hover:text-sidebar-foreground"
                     onPointerDown={(event) => {
                       event.preventDefault();
                       event.stopPropagation();

--- a/apps/desktop/src/components/settings/models/provider-connect-dialog.tsx
+++ b/apps/desktop/src/components/settings/models/provider-connect-dialog.tsx
@@ -771,7 +771,7 @@ export function ProviderConnectDialog({
                       DESKTOP_EDITOR_TAB_CLASS,
                       customConnectMode === value
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={busy || previewBusy}
                     onClick={() => setCustomConnectMode(value)}
@@ -862,7 +862,7 @@ export function ProviderConnectDialog({
                       DESKTOP_EDITOR_TAB_CLASS,
                       bedrockConnectMode === value
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={busy || previewBusy}
                     onClick={() => setBedrockConnectMode(value)}
@@ -1070,7 +1070,7 @@ export function ProviderConnectDialog({
                       DESKTOP_EDITOR_TAB_CLASS,
                       vertexConnectMode === value
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={busy || previewBusy}
                     onClick={() => setVertexConnectMode(value)}

--- a/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/hooks-settings-panel.tsx
@@ -336,7 +336,7 @@ export function HooksSettingsPanel({
                       DESKTOP_EDITOR_TAB_CLASS,
                       createScope === opt.scope
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={hooksBusy}
                     title={opt.hint}

--- a/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/mcps-settings-panel.tsx
@@ -408,7 +408,7 @@ export function McpsSettingsPanel({
                       DESKTOP_EDITOR_TAB_CLASS,
                       createScope === opt.scope
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={mcpsBusy}
                     title={opt.hint}
@@ -439,7 +439,7 @@ export function McpsSettingsPanel({
                       DESKTOP_EDITOR_TAB_CLASS,
                       transportType === value
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={mcpsBusy}
                     onClick={() => setTransportType(value)}

--- a/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/rules-settings-panel.tsx
@@ -271,7 +271,7 @@ export function RulesSettingsPanel({
                       DESKTOP_EDITOR_TAB_CLASS,
                       createRootKind === opt.kind
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={rulesBusy}
                     title={opt.hint}

--- a/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
+++ b/apps/desktop/src/components/settings/panels/skills-settings-panel.tsx
@@ -246,7 +246,7 @@ export function SkillsSettingsPanel({
                       DESKTOP_EDITOR_TAB_CLASS,
                       createRootKind === opt.kind
                         ? "bg-background text-foreground shadow-sm"
-                        : "text-muted-foreground hover:text-foreground",
+                        : "text-muted-foreground hover:text-sidebar-foreground",
                     )}
                     disabled={skillsBusy}
                     title={opt.hint}

--- a/apps/desktop/src/components/ui/badge.tsx
+++ b/apps/desktop/src/components/ui/badge.tsx
@@ -19,7 +19,7 @@ const badgeVariants = cva(
           "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost:
           "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-foreground underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {

--- a/apps/desktop/src/components/ui/breadcrumb.tsx
+++ b/apps/desktop/src/components/ui/breadcrumb.tsx
@@ -50,7 +50,7 @@ function BreadcrumbLink({
   return (
     <Comp
       data-slot="breadcrumb-link"
-      className={cn("transition-colors hover:text-foreground", className)}
+      className={cn("transition-colors hover:text-sidebar-foreground", className)}
       {...props}
     />
   )

--- a/apps/desktop/src/components/ui/button.tsx
+++ b/apps/desktop/src/components/ui/button.tsx
@@ -12,14 +12,14 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         outline:
-          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border-border bg-background hover:bg-muted hover:text-sidebar-foreground aria-expanded:bg-muted aria-expanded:text-sidebar-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
         ghost:
-          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+          "hover:bg-muted hover:text-sidebar-foreground aria-expanded:bg-muted aria-expanded:text-sidebar-foreground dark:hover:bg-muted/50",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-foreground underline-offset-4 hover:underline",
       },
       size: {
         default:

--- a/apps/desktop/src/components/ui/dialog.tsx
+++ b/apps/desktop/src/components/ui/dialog.tsx
@@ -223,7 +223,7 @@ function DialogDescription({
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-sidebar-foreground",
         className
       )}
       {...props}

--- a/apps/desktop/src/components/ui/toggle.tsx
+++ b/apps/desktop/src/components/ui/toggle.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 
 const toggleVariants = cva(
   cn(
-    `group/toggle inline-flex cursor-pointer items-center justify-center gap-1 rounded-lg text-sm ${FONT_WEIGHT_NORMAL} whitespace-nowrap outline-none hover:bg-muted/50 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted/35 data-[state=on]:bg-muted/35 data-[state=on]:hover:bg-muted/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
+    `group/toggle inline-flex cursor-pointer items-center justify-center gap-1 rounded-lg text-sm ${FONT_WEIGHT_NORMAL} whitespace-nowrap outline-none hover:bg-muted/50 hover:text-sidebar-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted/35 data-[state=on]:bg-muted/35 data-[state=on]:hover:bg-muted/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4`,
     instantHoverMotionClass,
   ),
   {

--- a/apps/desktop/src/components/workspace-files-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-panel.tsx
@@ -154,7 +154,7 @@ type CreatingEntryState = {
 
 const EXPLORER_ROOT_CREATE_BUTTON_CLASS = cn(
   "inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground",
-  "hover:bg-foreground/[0.08] hover:text-foreground dark:hover:bg-foreground/12",
+  "hover:bg-foreground/[0.08] hover:text-sidebar-foreground dark:hover:bg-foreground/12",
 );
 
 export type WorkspaceFilesPanelProps = {

--- a/apps/desktop/src/components/workspace-files-search-panel.tsx
+++ b/apps/desktop/src/components/workspace-files-search-panel.tsx
@@ -38,7 +38,7 @@ function pathBasename(rel: string): string {
 }
 
 const SEARCH_OPTION_TOGGLE_BTN = cn(
-  "electron-no-drag size-7 shrink-0 bg-transparent p-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground",
+  "electron-no-drag size-7 shrink-0 bg-transparent p-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-sidebar-foreground",
   "aria-pressed:bg-muted/35 aria-pressed:text-foreground aria-pressed:hover:bg-muted/50",
   "[&_svg]:size-3.5",
   instantHoverMotionClass,

--- a/apps/desktop/src/components/workspace-files-tab.tsx
+++ b/apps/desktop/src/components/workspace-files-tab.tsx
@@ -290,7 +290,7 @@ function WorkspaceFilesExplorerToolbar({
           {showStartImplementing ? (
             <button
               type="button"
-              className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground enabled:hover:bg-foreground/[0.06] enabled:hover:text-foreground disabled:opacity-50 dark:enabled:hover:bg-foreground/10"
+              className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground enabled:hover:bg-foreground/[0.06] enabled:hover:text-sidebar-foreground disabled:opacity-50 dark:enabled:hover:bg-foreground/10"
               disabled={startImplementingDisabled}
               aria-label={t("workspace.startImplementing")}
               title={t("workspace.startImplementing")}

--- a/apps/desktop/src/components/workspace-pr-changes-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-changes-view.tsx
@@ -359,7 +359,7 @@ function PrChangedFileCard({
                 {file.blobUrl && onOpenExternal ? (
                   <button
                     type="button"
-                    className="text-foreground underline underline-offset-2 hover:text-foreground/80"
+                    className="text-foreground underline underline-offset-2 hover:text-sidebar-foreground/80"
                     onClick={() => onOpenExternal(file.blobUrl!)}
                   >
                     {t("workspace.prChangesViewOnGitHub")}

--- a/apps/desktop/src/components/workspace-pr-checks-view.tsx
+++ b/apps/desktop/src/components/workspace-pr-checks-view.tsx
@@ -46,7 +46,7 @@ function CheckStateIcon({
     );
   }
 
-  return <Spinner className="size-3 shrink-0 text-primary" aria-label={label} />;
+  return <Spinner className="size-3 shrink-0 text-foreground" aria-label={label} />;
 }
 
 function PrCheckRow({

--- a/apps/desktop/src/components/workspace-pr-tab.tsx
+++ b/apps/desktop/src/components/workspace-pr-tab.tsx
@@ -801,7 +801,7 @@ export function WorkspacePrTab({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground",
+                    "h-7 gap-1 px-2 text-xs text-muted-foreground hover:text-sidebar-foreground",
                     instantHoverMotionClass,
                   )}
                   onClick={handleBackToList}

--- a/apps/desktop/src/components/workspace-tools-panel.tsx
+++ b/apps/desktop/src/components/workspace-tools-panel.tsx
@@ -820,8 +820,8 @@ const WorkspaceToolsDockContent = memo(function WorkspaceToolsDockContent({
                       data-workspace-new-tool-tab=""
                       aria-label={t('workspace.newToolTab')}
                       className={cn(
-                        'mb-1 size-7 shrink-0 rounded-full p-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground',
-                        'aria-expanded:bg-muted/35 aria-expanded:text-foreground aria-expanded:hover:bg-muted/50',
+                        'mb-1 size-7 shrink-0 rounded-full p-0 text-muted-foreground shadow-none hover:bg-muted/50 hover:text-sidebar-foreground',
+                        'aria-expanded:bg-muted/35 aria-expanded:text-sidebar-foreground aria-expanded:hover:bg-muted/50',
                         instantHoverMotionClass,
                       )}
                     >

--- a/apps/desktop/src/lib/desktop-chrome.ts
+++ b/apps/desktop/src/lib/desktop-chrome.ts
@@ -32,14 +32,14 @@ export const DESKTOP_INSTANT_HOVER_GHOST_BTN = cn(
 export const DESKTOP_SHELL_LAYOUT_TRANSITION =
   "transition-[width,margin,opacity] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none motion-reduce:duration-0";
 
-/** 默认正文 / chrome 默认字色（非强调态），与 `--foreground` 对齐 */
-export const DESKTOP_CONTENT_TEXT = "text-foreground";
+/** 顶栏默认字色/图标色，与侧栏 `sidebarItemDefaultTextClass` 对齐 */
+export const DESKTOP_CHROME_MUTED_TEXT = "text-sidebar-action-foreground";
 
 /** 会话标题内联重命名 input：ghost、无边框，字色与侧栏/顶栏会话名一致 */
 export const SESSION_TITLE_RENAME_INPUT_CLASS = cn(
   "min-w-0 rounded-none border-0 bg-transparent p-0 shadow-none outline-none ring-0 focus-visible:ring-0",
   DESKTOP_SIDEBAR_TEXT_CLASS,
-  DESKTOP_CONTENT_TEXT,
+  DESKTOP_CHROME_MUTED_TEXT,
 );
 
 /** 顶栏会话标题 hover：仅字色变亮，无半透明铺底 */
@@ -54,10 +54,10 @@ export const DESKTOP_CHROME_ACTIVE_TEXT = "text-sidebar-foreground";
 /** ghost 在 aria-expanded 时默认带 bg-muted，顶栏图标按钮需全透明底 */
 export const DESKTOP_CHROME_TOGGLE_ICON_BTN = cn(
   "electron-no-drag size-7 shrink-0 bg-transparent",
-  DESKTOP_CONTENT_TEXT,
+  DESKTOP_CHROME_MUTED_TEXT,
   "hover:bg-foreground/[0.06] hover:text-sidebar-foreground focus-visible:bg-foreground/[0.06] focus-visible:text-sidebar-foreground",
   "dark:hover:bg-white/[0.06] dark:focus-visible:bg-white/[0.06]",
-  "aria-expanded:bg-transparent dark:aria-expanded:bg-transparent aria-expanded:text-foreground",
+  "aria-expanded:bg-transparent dark:aria-expanded:bg-transparent aria-expanded:text-sidebar-action-foreground",
   "aria-expanded:hover:bg-foreground/[0.06] aria-expanded:hover:text-sidebar-foreground dark:aria-expanded:hover:bg-white/[0.06]",
   "[&_svg]:size-3.5",
   instantHoverMotionClass,

--- a/apps/desktop/src/lib/desktop-chrome.ts
+++ b/apps/desktop/src/lib/desktop-chrome.ts
@@ -25,21 +25,21 @@ export const DESKTOP_INSTANT_HOVER_OVERLAY = cn(
 /** ghost 图标/紧凑按钮：侧栏同源半透明 hover + 字色变亮 */
 export const DESKTOP_INSTANT_HOVER_GHOST_BTN = cn(
   DESKTOP_INSTANT_HOVER_OVERLAY,
-  "hover:!text-foreground focus-visible:!text-foreground aria-expanded:!text-foreground",
+  "hover:!text-sidebar-foreground focus-visible:!text-sidebar-foreground aria-expanded:!text-sidebar-foreground",
 );
 
 /** 侧栏壳层 / 顶栏槽位宽度过渡，与 SessionSidebarShell 一致 */
 export const DESKTOP_SHELL_LAYOUT_TRANSITION =
   "transition-[width,margin,opacity] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none motion-reduce:duration-0";
 
-/** 顶栏默认字色/图标色，与侧栏 `sidebarItemDefaultTextClass` 对齐 */
-export const DESKTOP_CHROME_MUTED_TEXT = "text-sidebar-action-foreground";
+/** 默认正文 / chrome 默认字色（非强调态），与 `--foreground` 对齐 */
+export const DESKTOP_CONTENT_TEXT = "text-foreground";
 
 /** 会话标题内联重命名 input：ghost、无边框，字色与侧栏/顶栏会话名一致 */
 export const SESSION_TITLE_RENAME_INPUT_CLASS = cn(
   "min-w-0 rounded-none border-0 bg-transparent p-0 shadow-none outline-none ring-0 focus-visible:ring-0",
   DESKTOP_SIDEBAR_TEXT_CLASS,
-  DESKTOP_CHROME_MUTED_TEXT,
+  DESKTOP_CONTENT_TEXT,
 );
 
 /** 顶栏会话标题 hover：仅字色变亮，无半透明铺底 */
@@ -54,10 +54,10 @@ export const DESKTOP_CHROME_ACTIVE_TEXT = "text-sidebar-foreground";
 /** ghost 在 aria-expanded 时默认带 bg-muted，顶栏图标按钮需全透明底 */
 export const DESKTOP_CHROME_TOGGLE_ICON_BTN = cn(
   "electron-no-drag size-7 shrink-0 bg-transparent",
-  DESKTOP_CHROME_MUTED_TEXT,
+  DESKTOP_CONTENT_TEXT,
   "hover:bg-foreground/[0.06] hover:text-sidebar-foreground focus-visible:bg-foreground/[0.06] focus-visible:text-sidebar-foreground",
   "dark:hover:bg-white/[0.06] dark:focus-visible:bg-white/[0.06]",
-  "aria-expanded:bg-transparent dark:aria-expanded:bg-transparent aria-expanded:text-sidebar-action-foreground",
+  "aria-expanded:bg-transparent dark:aria-expanded:bg-transparent aria-expanded:text-foreground",
   "aria-expanded:hover:bg-foreground/[0.06] aria-expanded:hover:text-sidebar-foreground dark:aria-expanded:hover:bg-white/[0.06]",
   "[&_svg]:size-3.5",
   instantHoverMotionClass,
@@ -70,7 +70,7 @@ export const DESKTOP_FILES_EXPLORER_TOOLBAR_ICON_BTN = cn(
 );
 
 export const DESKTOP_CHROME_COMMIT_BTN = cn(
-  "h-7 rounded-md px-2 text-xs text-foreground/90 hover:bg-foreground/[0.06] hover:text-foreground dark:hover:bg-foreground/10",
+  "h-7 rounded-md px-2 text-xs text-foreground/90 hover:bg-foreground/[0.06] hover:text-sidebar-foreground dark:hover:bg-foreground/10",
   FONT_WEIGHT_NORMAL,
   instantHoverMotionClass,
 );

--- a/apps/desktop/src/lib/markdown-message-components.tsx
+++ b/apps/desktop/src/lib/markdown-message-components.tsx
@@ -17,7 +17,6 @@ import {
   isMarkdownFragmentHref,
   scrollMarkdownFragmentIntoView,
 } from "@/lib/markdown-fragment-link";
-import { DESKTOP_CONTENT_TEXT } from "@/lib/desktop-chrome";
 import { slugifyMarkdownHeadingChildren } from "@/lib/markdown-heading-slug";
 import { FONT_WEIGHT_MEDIUM, FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
@@ -39,15 +38,14 @@ export function createMarkdownMessageComponents(
 ): Record<string, ComponentType<Record<string, unknown>>> {
   const compact = size === "compact";
   const muted = tone === "muted";
-  // 默认正文/标题与 chrome 默认字色一致（text-foreground）
-  const defaultText = DESKTOP_CONTENT_TEXT;
+  const defaultText = "text-foreground";
   const bodyText = muted
     ? compact
       ? "text-xs leading-relaxed text-foreground/80"
       : "text-sm leading-relaxed text-muted-foreground"
     : compact
-      ? cn("text-xs leading-relaxed", defaultText)
-      : cn("text-sm leading-relaxed", defaultText);
+      ? "text-xs leading-relaxed text-foreground"
+      : "text-sm leading-relaxed text-foreground";
   const headingText = muted ? (compact ? "text-foreground/85" : "text-muted-foreground") : defaultText;
   const inlineCodeText = muted ? (compact ? "text-foreground/80" : "text-muted-foreground") : defaultText;
   const blockCodeText = inlineCodeText;
@@ -160,10 +158,7 @@ export function createMarkdownMessageComponents(
         className={cn(
           muted
             ? "break-words text-muted-foreground underline underline-offset-2 hover:text-sidebar-foreground/80"
-            : cn(
-                "break-words underline underline-offset-2 hover:text-sidebar-foreground",
-                defaultText,
-              ),
+            : "break-words text-foreground underline underline-offset-2 hover:text-sidebar-foreground",
           className,
         )}
         href={href}
@@ -321,10 +316,10 @@ export function markdownMessageRootClassName(
     compact
       ? tone === "muted"
         ? "text-xs leading-relaxed text-foreground/80"
-        : cn("text-xs leading-relaxed", DESKTOP_CONTENT_TEXT)
+        : "text-xs leading-relaxed text-foreground"
       : tone === "muted"
         ? "font-sans text-sm leading-relaxed text-muted-foreground"
-        : DESKTOP_CONTENT_TEXT,
+        : "text-foreground",
     className,
   );
 }

--- a/apps/desktop/src/lib/markdown-message-components.tsx
+++ b/apps/desktop/src/lib/markdown-message-components.tsx
@@ -62,10 +62,10 @@ export function createMarkdownMessageComponents(
         id={slugifyMarkdownHeadingChildren(children)}
         className={cn(
           compact
-            ? cn("mt-2 mb-1.5 text-sm tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
+            ? cn("mt-2.5 mb-1.5 text-base tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
             : muted
-              ? cn("mt-2 mb-1.5 text-sm tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
-              : cn("mt-3 mb-2 text-lg tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM),
+              ? cn("mt-3 mb-2 text-xl tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
+              : cn("mt-4 mb-2 text-2xl tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM),
           headingText,
           className,
         )}
@@ -79,10 +79,10 @@ export function createMarkdownMessageComponents(
         id={slugifyMarkdownHeadingChildren(children)}
         className={cn(
           compact
-            ? cn("mt-2 mb-1 text-xs tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
+            ? cn("mt-2 mb-1 text-sm tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
             : muted
-              ? cn("mt-2 mb-1 text-sm tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
-              : cn("mt-3 mb-1.5 text-base tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM),
+              ? cn("mt-3 mb-1.5 text-lg tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM)
+              : cn("mt-3.5 mb-1.5 text-xl tracking-tight first:mt-0", FONT_WEIGHT_MEDIUM),
           headingText,
           className,
         )}
@@ -94,7 +94,15 @@ export function createMarkdownMessageComponents(
     h3: ({ className, children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
       <h3
         id={slugifyMarkdownHeadingChildren(children)}
-        className={cn("mt-2 mb-1 text-sm first:mt-0", FONT_WEIGHT_MEDIUM, headingText, className)}
+        className={cn(
+          compact
+            ? cn("mt-2 mb-1 text-sm first:mt-0", FONT_WEIGHT_MEDIUM)
+            : muted
+              ? cn("mt-2.5 mb-1 text-base first:mt-0", FONT_WEIGHT_MEDIUM)
+              : cn("mt-3 mb-1 text-lg first:mt-0", FONT_WEIGHT_MEDIUM),
+          headingText,
+          className,
+        )}
         {...props}
       >
         {children}
@@ -103,7 +111,15 @@ export function createMarkdownMessageComponents(
     h4: ({ className, children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
       <h4
         id={slugifyMarkdownHeadingChildren(children)}
-        className={cn("mt-2 mb-1 text-sm first:mt-0", FONT_WEIGHT_NORMAL, headingText, className)}
+        className={cn(
+          compact
+            ? cn("mt-2 mb-1 text-xs first:mt-0", FONT_WEIGHT_MEDIUM)
+            : muted
+              ? cn("mt-2 mb-1 text-sm first:mt-0", FONT_WEIGHT_MEDIUM)
+              : cn("mt-2.5 mb-1 text-base first:mt-0", FONT_WEIGHT_MEDIUM),
+          headingText,
+          className,
+        )}
         {...props}
       >
         {children}

--- a/apps/desktop/src/lib/markdown-message-components.tsx
+++ b/apps/desktop/src/lib/markdown-message-components.tsx
@@ -159,7 +159,7 @@ export function createMarkdownMessageComponents(
       <a
         className={cn(
           muted
-            ? "break-words text-muted-foreground underline underline-offset-2 hover:text-foreground/80"
+            ? "break-words text-muted-foreground underline underline-offset-2 hover:text-sidebar-foreground/80"
             : cn(
                 "break-words underline underline-offset-2 hover:text-sidebar-foreground",
                 defaultText,

--- a/apps/desktop/src/lib/markdown-message-components.tsx
+++ b/apps/desktop/src/lib/markdown-message-components.tsx
@@ -17,6 +17,7 @@ import {
   isMarkdownFragmentHref,
   scrollMarkdownFragmentIntoView,
 } from "@/lib/markdown-fragment-link";
+import { DESKTOP_CONTENT_TEXT } from "@/lib/desktop-chrome";
 import { slugifyMarkdownHeadingChildren } from "@/lib/markdown-heading-slug";
 import { FONT_WEIGHT_MEDIUM, FONT_WEIGHT_NORMAL } from "@/lib/desktop-typography";
 import { cn } from "@/lib/utils";
@@ -38,24 +39,23 @@ export function createMarkdownMessageComponents(
 ): Record<string, ComponentType<Record<string, unknown>>> {
   const compact = size === "compact";
   const muted = tone === "muted";
+  // 默认正文/标题与 chrome 默认字色一致（text-foreground）
+  const defaultText = DESKTOP_CONTENT_TEXT;
   const bodyText = muted
     ? compact
       ? "text-xs leading-relaxed text-foreground/80"
       : "text-sm leading-relaxed text-muted-foreground"
     : compact
-      ? "text-xs leading-relaxed text-foreground/90"
-      : "text-sm leading-relaxed text-foreground/95";
-  const headingText = muted ? (compact ? "text-foreground/85" : "text-muted-foreground") : "text-foreground";
-  const inlineCodeText = muted ? (compact ? "text-foreground/80" : "text-muted-foreground") : "text-foreground";
+      ? cn("text-xs leading-relaxed", defaultText)
+      : cn("text-sm leading-relaxed", defaultText);
+  const headingText = muted ? (compact ? "text-foreground/85" : "text-muted-foreground") : defaultText;
+  const inlineCodeText = muted ? (compact ? "text-foreground/80" : "text-muted-foreground") : defaultText;
   const blockCodeText = inlineCodeText;
   const tableCellText = muted
     ? compact
       ? "text-foreground/80"
       : "text-muted-foreground"
-    : compact
-      ? "text-foreground/90"
-      : "text-foreground/95";
-
+    : defaultText;
   return {
     h1: ({ className, children, ...props }: HTMLAttributes<HTMLHeadingElement>) => (
       <h1
@@ -160,7 +160,10 @@ export function createMarkdownMessageComponents(
         className={cn(
           muted
             ? "break-words text-muted-foreground underline underline-offset-2 hover:text-foreground/80"
-            : "break-words text-primary underline underline-offset-2 hover:opacity-90",
+            : cn(
+                "break-words underline underline-offset-2 hover:text-sidebar-foreground",
+                defaultText,
+              ),
           className,
         )}
         href={href}
@@ -185,7 +188,7 @@ export function createMarkdownMessageComponents(
     },
     strong: ({ className, ...props }: HTMLAttributes<HTMLElement>) => (
       <strong
-        className={cn(FONT_WEIGHT_MEDIUM, muted ? "text-muted-foreground" : "text-foreground", className)}
+        className={cn(FONT_WEIGHT_MEDIUM, muted ? "text-muted-foreground" : defaultText, className)}
         {...props}
       />
     ),
@@ -248,7 +251,7 @@ export function createMarkdownMessageComponents(
         className={cn(
           "border border-border/50 px-2 py-1.5 text-left",
           FONT_WEIGHT_NORMAL,
-          muted ? "text-muted-foreground" : "text-foreground",
+          muted ? "text-muted-foreground" : defaultText,
           className,
         )}
         {...props}
@@ -318,10 +321,10 @@ export function markdownMessageRootClassName(
     compact
       ? tone === "muted"
         ? "text-xs leading-relaxed text-foreground/80"
-        : "text-xs leading-relaxed text-foreground/90"
+        : cn("text-xs leading-relaxed", DESKTOP_CONTENT_TEXT)
       : tone === "muted"
         ? "font-sans text-sm leading-relaxed text-muted-foreground"
-        : "text-foreground/95",
+        : DESKTOP_CONTENT_TEXT,
     className,
   );
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -25,7 +25,8 @@
 
 :root {
   --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  /* 默认正文 / chrome 默认字色（非强调态） */
+  --foreground: #2b2b2b;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -56,8 +57,7 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  /* 侧栏内分级：交互按钮默认 / 交互项默认 / 列表正文 / 极淡说明（分区小标题等） */
-  --sidebar-action-foreground: #2b2b2b;
+  /* 侧栏内分级：交互项默认 / 列表正文 / 极淡说明（分区小标题等）；默认正文用 --foreground */
   --sidebar-item-foreground: oklch(0.42 0 0);
   --sidebar-list-foreground: oklch(0.4 0 0);
   --sidebar-faint-foreground: oklch(0.5 0 0);
@@ -96,7 +96,7 @@ html.dark,
 .dark,
 [data-spirit-theme="dark"] {
   --background: #000000;
-  --foreground: #ffffff;
+  --foreground: #d4d4d4;
   --card: #090909;
   --card-foreground: #d4d4d4;
   --popover: #090909;
@@ -128,7 +128,6 @@ html.dark,
   --sidebar-accent-foreground: #d4d4d4;
   --sidebar-border: #272727;
   --sidebar-ring: #3f3f3f;
-  --sidebar-action-foreground: #d4d4d4;
   --sidebar-item-foreground: #a3a3a3;
   --sidebar-list-foreground: #717171;
   --sidebar-faint-foreground: #525252;
@@ -378,7 +377,6 @@ html.spirit-desktop-native.spirit-desktop-mica.spirit-launch-splash-exiting
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar-action-foreground: var(--sidebar-action-foreground);
   --color-sidebar-item-foreground: var(--sidebar-item-foreground);
   --color-sidebar-list-foreground: var(--sidebar-list-foreground);
   --color-sidebar-faint-foreground: var(--sidebar-faint-foreground);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -50,7 +50,8 @@
   --chart-5: oklch(0.269 0 0);
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
+  /* 与 --foreground 同级，避免主区 hover:text-sidebar-foreground 比选中 text-foreground 更暗 */
+  --sidebar-foreground: #2b2b2b;
   --sidebar-primary: oklch(0.205 0 0);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -25,7 +25,7 @@
 
 :root {
   --background: oklch(1 0 0);
-  /* 默认正文 / chrome 默认字色（非强调态） */
+  /* 默认正文色（非强调态）；侧栏交互默认另见 --sidebar-action-foreground */
   --foreground: #2b2b2b;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -57,7 +57,8 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
-  /* 侧栏内分级：交互项默认 / 列表正文 / 极淡说明（分区小标题等）；默认正文用 --foreground */
+  /* 侧栏内分级：交互按钮默认 / 交互项默认 / 列表正文 / 极淡说明（分区小标题等） */
+  --sidebar-action-foreground: #2b2b2b;
   --sidebar-item-foreground: oklch(0.42 0 0);
   --sidebar-list-foreground: oklch(0.4 0 0);
   --sidebar-faint-foreground: oklch(0.5 0 0);
@@ -96,7 +97,7 @@ html.dark,
 .dark,
 [data-spirit-theme="dark"] {
   --background: #000000;
-  --foreground: #d4d4d4;
+  --foreground: #e4e4e4;
   --card: #090909;
   --card-foreground: #d4d4d4;
   --popover: #090909;
@@ -128,6 +129,7 @@ html.dark,
   --sidebar-accent-foreground: #d4d4d4;
   --sidebar-border: #272727;
   --sidebar-ring: #3f3f3f;
+  --sidebar-action-foreground: #d4d4d4;
   --sidebar-item-foreground: #a3a3a3;
   --sidebar-list-foreground: #717171;
   --sidebar-faint-foreground: #525252;
@@ -377,6 +379,7 @@ html.spirit-desktop-native.spirit-desktop-mica.spirit-launch-splash-exiting
   --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
   --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-action-foreground: var(--sidebar-action-foreground);
   --color-sidebar-item-foreground: var(--sidebar-item-foreground);
   --color-sidebar-list-foreground: var(--sidebar-list-foreground);
   --color-sidebar-faint-foreground: var(--sidebar-faint-foreground);


### PR DESCRIPTION
## Summary
- 暗色主区 `--foreground` 定为适中的 `#e4e4e4`（浅色仍为 `#2b2b2b`），避免纯白过亮
- 恢复独立 `--sidebar-action-foreground`（`#d4d4d4`），侧栏与顶栏 chrome 继续走侧栏 Token；hover/选中仍用 `sidebar-foreground` 提亮
- `text-primary` 文本用法柔化（保留 `bg-primary`）；浮层继续 `popover-foreground`
- Markdown 标题字号上调，默认正文直接使用 `text-foreground`

## Test plan
- [x] 暗色主题：Agent 回复 / 设置主文为 `#e4e4e4` 量级，不过白也不发灰
- [x] 侧栏默认字色仍为独立 `#d4d4d4`，与主区可区分
- [x] 侧栏与顶栏交互项 hover/选中仍明显更亮（`sidebar-foreground`）
- [x] 实心 primary 按钮（`bg-primary`）外观正常
- [x] 浮层菜单字色无明显回归（仍为 `popover-foreground`）
- [x] Markdown `#` / `##` 标题层级比正文更清晰
- [x] 浅色模式正文仍为 `#2b2b2b`