### PR TITLE
fix(agent-core): 升级 MCP SDK 以修复 hono 路径穿越

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4027,7 +4027,7 @@
         "@ai-sdk/openai-compatible": "^3.0.0",
         "@ai-sdk/xai": "^4.0.1",
         "@aws/bedrock-token-generator": "^1.1.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "ai": "^7.0.3",
         "undici": "^7.27.2"
       },
@@ -4129,20 +4129,20 @@
       }
     },
     "packages/agent-core/node_modules/@hono/node-server": {
-      "version": "1.19.14",
+      "version": "2.0.12",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "packages/agent-core/node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
+      "version": "1.30.0",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -112,7 +112,7 @@
     "@ai-sdk/openai-compatible": "^3.0.0",
     "@ai-sdk/xai": "^4.0.1",
     "@aws/bedrock-token-generator": "^1.1.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "ai": "^7.0.3",
     "undici": "^7.27.2"
   }


### PR DESCRIPTION
## Summary
- 将 `@modelcontextprotocol/sdk` 从 `^1.29.0` 升至 `^1.30.0`
- 传递依赖 `@hono/node-server` 解析到 `2.0.12`，消除 Windows `serve-static` 经编码反斜杠 `%5C` 的路径穿越告警（GHSA-frvp-7c67-39w9）

## Test plan
- [x] `npm ls @modelcontextprotocol/sdk @hono/node-server -w @spiritagent/agent-core` 显示 sdk `1.30.0`、`@hono/node-server` `2.0.12`
- [x] `npm audit` 不再报告 `@hono/node-server` 路径穿越
- [x] `package-lock.json` diff 仅含 SDK / hono 相关条目，无整文件 CRLF 重写