### PR TITLE
ci(release): macOS 产物接入 Developer ID 签名与公证

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 # Manual release pipeline: build HEAD → prepare report → single environment:release publish → tag X.Y.Z.
 # Configure GitHub Environment "release" with Required reviewers (and Cloudflare secrets) before publishing.
+# Configure GitHub Environment "signing" WITHOUT reviewers (build jobs must not sit behind the approval gate):
+#   APPLE_CSC_LINK / APPLE_CSC_KEY_PASSWORD  base64 Developer ID .p12 and its password
+#   APPLE_TEAM_ID                            expected TeamIdentifier, asserted by the signature checks
+#   APPLE_API_KEY_P8 / APPLE_API_KEY_ID / APPLE_API_ISSUER  App Store Connect key used to notarize Desktop
 name: Release
 
 on:
@@ -16,7 +20,6 @@ env:
   RELEASE_VERSION: ${{ inputs.version }}
   NODE_VERSION: '22'
   SPIRIT_RELEASE_NODE_MAJOR: '22'
-  CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
 jobs:
   verify:
@@ -126,8 +129,14 @@ jobs:
     name: Desktop ${{ matrix.package_target }}
     needs: verify
     runs-on: ${{ matrix.os }}
+    environment: signing
     env:
       SPIRIT_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.SPIRIT_GITHUB_OAUTH_CLIENT_ID }}
+      npm_config_registry: https://registry.npmjs.org/
+      npm_config_electron_mirror: https://github.com/electron/electron/releases/download/
+      npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+      ELECTRON_MIRROR: https://github.com/electron/electron/releases/download/
+      ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
     strategy:
       fail-fast: false
       matrix:
@@ -186,15 +195,72 @@ jobs:
         working-directory: apps/desktop
         run: npm run gen:icons
 
-      - name: Package Desktop
+      # notarytool takes --key as a file path, so the base64 secret has to be materialized on disk.
+      - name: Write notarization API key
+        if: matrix.platform == 'mac'
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          if [ -z "$APPLE_API_KEY_P8" ]; then
+            echo "::error::Environment secret APPLE_API_KEY_P8 is missing; the macOS build cannot be notarized."
+            exit 1
+          fi
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/AuthKey.p8"
+
+      # Signing env vars must stay off the Windows and Linux legs: electron-builder treats an empty
+      # CSC_LINK as a real value, so the two package steps are mutually exclusive rather than merged.
+      - name: Package Desktop (signed and notarized)
+        if: matrix.platform == 'mac'
         working-directory: apps/desktop
         env:
-          npm_config_registry: https://registry.npmjs.org/
-          npm_config_electron_mirror: https://github.com/electron/electron/releases/download/
-          npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
-          ELECTRON_MIRROR: https://github.com/electron/electron/releases/download/
-          ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
+          CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: npx electron-builder --config electron-builder.yml --${{ matrix.platform }} --${{ matrix.arch }} --publish never
+
+      - name: Package Desktop
+        if: matrix.platform != 'mac'
+        working-directory: apps/desktop
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: npx electron-builder --config electron-builder.yml --${{ matrix.platform }} --${{ matrix.arch }} --publish never
+
+      # electron-builder only warns when it silently skips signing, so this is the gate that turns
+      # an unsigned or unnotarized macOS build into a failed job.
+      - name: Verify Desktop signature
+        if: matrix.platform == 'mac'
+        working-directory: apps/desktop
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          app="$(find release -maxdepth 2 -name '*.app' -type d -print -quit)"
+          if [ -z "$app" ]; then
+            echo "::error::No .app bundle found under apps/desktop/release."
+            exit 1
+          fi
+          echo "Verifying $app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          details="$(codesign --display --verbose=4 "$app" 2>&1)"
+          echo "$details"
+          if ! grep -q "^TeamIdentifier=$APPLE_TEAM_ID$" <<<"$details"; then
+            echo "::error::Signed by an unexpected team; expected TeamIdentifier=$APPLE_TEAM_ID."
+            exit 1
+          fi
+          if ! grep -qE '^CodeDirectory .*flags=.*runtime' <<<"$details"; then
+            echo "::error::Hardened Runtime flag is missing from the signature."
+            exit 1
+          fi
+          xcrun stapler validate "$app"
+          spctl --assess --verbose=4 --type exec "$app"
+
+      - name: Remove notarization API key
+        if: always() && matrix.platform == 'mac'
+        run: rm -f "$RUNNER_TEMP/AuthKey.p8"
 
       - name: Upload Desktop artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,9 @@ jobs:
     name: CLI ${{ matrix.package_target }}
     needs: verify
     runs-on: ${{ matrix.os }}
-    environment: signing
+    # Only the macOS legs sign, so only they get the signing secrets; an empty name means no
+    # environment at all, which also keeps the Windows and Linux legs out of the deployment log.
+    environment: ${{ matrix.apple && 'signing' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -208,7 +210,9 @@ jobs:
     name: Desktop ${{ matrix.package_target }}
     needs: verify
     runs-on: ${{ matrix.os }}
-    environment: signing
+    # Same as the CLI job: the signing secrets are scoped to the macOS legs. The OAuth client id
+    # below is a repository secret, so the other legs still resolve it without any environment.
+    environment: ${{ matrix.platform == 'mac' && 'signing' || '' }}
     env:
       SPIRIT_GITHUB_OAUTH_CLIENT_ID: ${{ secrets.SPIRIT_GITHUB_OAUTH_CLIENT_ID }}
       npm_config_registry: https://registry.npmjs.org/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
     name: CLI ${{ matrix.package_target }}
     needs: verify
     runs-on: ${{ matrix.os }}
+    environment: signing
     strategy:
       fail-fast: false
       matrix:
@@ -77,10 +78,12 @@ jobs:
             rust_target: x86_64-apple-darwin
             package_target: darwin-x64
             builder: cargo
+            apple: true
           - os: macos-14
             rust_target: aarch64-apple-darwin
             package_target: darwin-arm64
             builder: cargo
+            apple: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -114,9 +117,81 @@ jobs:
         if: matrix.builder == 'cross'
         run: cross build -p spirit-agent --release --target ${{ matrix.rust_target }}
 
+      # Bundle CLI signs the embedded Mach-O binaries when it sees these two vars, so the identity
+      # has to be in place before bundling rather than after the archive exists.
+      - name: Import signing certificate
+        if: matrix.apple
+        env:
+          APPLE_CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
+          APPLE_CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/spirit-signing.keychain-db"
+          certificate="$RUNNER_TEMP/certificate.p12"
+          keychain_password="$(uuidgen)"
+          printf '%s' "$APPLE_CSC_LINK" | base64 --decode > "$certificate"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$certificate" -k "$keychain" -P "$APPLE_CSC_KEY_PASSWORD" -T /usr/bin/codesign -x
+          rm -f "$certificate"
+          security set-key-partition-list -S apple-tool:,apple: -k "$keychain_password" "$keychain" > /dev/null
+          # codesign resolves the certificate chain through the search list, not through --keychain.
+          security list-keychains -d user -s "$keychain" $(security list-keychains -d user | tr -d '"')
+          identity="$(security find-identity -v -p codesigning "$keychain" | awk -F'"' '/Developer ID Application/ { print $2; exit }')"
+          if [ -z "$identity" ]; then
+            echo "::error::The imported keychain holds no Developer ID Application identity."
+            exit 1
+          fi
+          echo "SPIRIT_MACOS_SIGN_IDENTITY=$identity" >> "$GITHUB_ENV"
+          echo "SPIRIT_MACOS_KEYCHAIN=$keychain" >> "$GITHUB_ENV"
+
       - name: Bundle CLI
         run: npm run release:cli:bundle -- --target ${{ matrix.rust_target }} --version "$RELEASE_VERSION"
         shell: bash
+
+      # The bundler only warns when no identity is configured, so this is the gate that turns an
+      # unsigned macOS archive into a failed job. It inspects the archive, not the staging directory.
+      - name: Verify CLI signature
+        if: matrix.apple
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          archive="dist/release/SpiritAgent-CLI-$RELEASE_VERSION-${{ matrix.package_target }}.tar.gz"
+          workdir="$RUNNER_TEMP/cli-verify"
+          rm -rf "$workdir"
+          mkdir -p "$workdir"
+          tar -xzf "$archive" -C "$workdir"
+          root="$workdir/SpiritAgent-CLI-$RELEASE_VERSION-${{ matrix.package_target }}"
+          for relative in bin/spirit node/bin/node packages/host-internal/node_modules/@vscode/ripgrep/bin/rg; do
+            binary="$root/$relative"
+            if [ ! -f "$binary" ]; then
+              echo "::error::$relative is missing from $archive."
+              exit 1
+            fi
+            codesign --verify --strict "$binary"
+            details="$(codesign --display --verbose=4 "$binary" 2>&1)"
+            if ! grep -q "^TeamIdentifier=$APPLE_TEAM_ID$" <<<"$details"; then
+              echo "::error::$relative is not signed by team $APPLE_TEAM_ID."
+              exit 1
+            fi
+            if ! grep -qE '^CodeDirectory .*flags=.*runtime' <<<"$details"; then
+              echo "::error::$relative is missing the Hardened Runtime flag."
+              exit 1
+            fi
+            echo "verified $relative"
+          done
+
+      - name: Remove signing keychain
+        if: always() && matrix.apple
+        run: |
+          set -euo pipefail
+          keychain="$RUNNER_TEMP/spirit-signing.keychain-db"
+          if [ -f "$keychain" ]; then
+            security delete-keychain "$keychain"
+          fi
+          rm -f "$RUNNER_TEMP/certificate.p12"
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,7 +406,7 @@ jobs:
           echo "SPIRIT_NOTARIZATION_ID=$id" >> "$GITHUB_ENV"
 
           status=""
-          for attempt in $(seq 1 120); do
+          for attempt in $(seq 1 240); do
             if info="$(xcrun notarytool info "$id" \
                 --key "$key" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
                 --output-format json 2>&1)"; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
           mkdir -p "$workdir"
           tar -xzf "$archive" -C "$workdir"
           root="$workdir/SpiritAgent-CLI-$RELEASE_VERSION-${{ matrix.package_target }}"
-          for relative in bin/spirit node/bin/node packages/host-internal/node_modules/@vscode/ripgrep/bin/rg; do
+          for relative in bin/spirit node/bin/node; do
             binary="$root/$relative"
             if [ ! -f "$binary" ]; then
               echo "::error::$relative is missing from $archive."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # Manual release pipeline: build HEAD → prepare report → single environment:release publish → tag X.Y.Z.
 # Configure GitHub Environment "release" with Required reviewers (and Cloudflare secrets) before publishing.
 # Configure GitHub Environment "signing" WITHOUT reviewers (build jobs must not sit behind the approval gate):
-#   APPLE_CSC_LINK / APPLE_CSC_KEY_PASSWORD  base64 Developer ID .p12 and its password
+#   APPLE_CSC_LINK / APPLE_CSC_PASSWORD      base64 Developer ID .p12 and its password
 #   APPLE_TEAM_ID                            expected TeamIdentifier, asserted by the signature checks
 #   APPLE_API_KEY_P8 / APPLE_API_KEY_ID / APPLE_API_ISSUER  App Store Connect key used to notarize Desktop
 name: Release
@@ -123,7 +123,7 @@ jobs:
         if: matrix.apple
         env:
           APPLE_CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
-          APPLE_CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+          APPLE_CSC_PASSWORD: ${{ secrets.APPLE_CSC_PASSWORD }}
         run: |
           set -euo pipefail
           keychain="$RUNNER_TEMP/spirit-signing.keychain-db"
@@ -133,7 +133,7 @@ jobs:
           security create-keychain -p "$keychain_password" "$keychain"
           security set-keychain-settings -lut 21600 "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
-          security import "$certificate" -k "$keychain" -P "$APPLE_CSC_KEY_PASSWORD" -T /usr/bin/codesign -x
+          security import "$certificate" -k "$keychain" -P "$APPLE_CSC_PASSWORD" -T /usr/bin/codesign -x
           rm -f "$certificate"
           security set-key-partition-list -S apple-tool:,apple: -k "$keychain_password" "$keychain" > /dev/null
           # codesign resolves the certificate chain through the search list, not through --keychain.
@@ -295,7 +295,7 @@ jobs:
         working-directory: apps/desktop
         env:
           CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_PASSWORD }}
           APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@
 # Configure GitHub Environment "signing" WITHOUT reviewers (build jobs must not sit behind the approval gate):
 #   APPLE_CSC_LINK / APPLE_CSC_PASSWORD      base64 Developer ID .p12 and its password
 #   APPLE_TEAM_ID                            expected TeamIdentifier, asserted by the signature checks
-#   APPLE_API_KEY_P8 / APPLE_API_KEY_ID / APPLE_API_ISSUER  App Store Connect key used to notarize Desktop
+#   APPLE_API_KEY_P8 / APPLE_API_KEY_ID / APPLE_API_ISSUER  App Store Connect key used by the notarize job
 name: Release
 
 on:
@@ -274,31 +274,14 @@ jobs:
         working-directory: apps/desktop
         run: npm run gen:icons
 
-      # notarytool takes --key as a file path, so the base64 secret has to be materialized on disk.
-      - name: Write notarization API key
-        if: matrix.platform == 'mac'
-        env:
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
-        run: |
-          set -euo pipefail
-          if [ -z "$APPLE_API_KEY_P8" ]; then
-            echo "::error::Environment secret APPLE_API_KEY_P8 is missing; the macOS build cannot be notarized."
-            exit 1
-          fi
-          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
-          chmod 600 "$RUNNER_TEMP/AuthKey.p8"
-
       # Signing env vars must stay off the Windows and Linux legs: electron-builder treats an empty
       # CSC_LINK as a real value, so the two package steps are mutually exclusive rather than merged.
-      - name: Package Desktop (signed and notarized)
+      - name: Package Desktop (signed)
         if: matrix.platform == 'mac'
         working-directory: apps/desktop
         env:
           CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_PASSWORD }}
-          APPLE_API_KEY: ${{ runner.temp }}/AuthKey.p8
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: npx electron-builder --config electron-builder.yml --${{ matrix.platform }} --${{ matrix.arch }} --publish never
 
       - name: Package Desktop
@@ -309,7 +292,7 @@ jobs:
         run: npx electron-builder --config electron-builder.yml --${{ matrix.platform }} --${{ matrix.arch }} --publish never
 
       # electron-builder only warns when it silently skips signing, so this is the gate that turns
-      # an unsigned or unnotarized macOS build into a failed job.
+      # an unsigned macOS build into a failed job. Notarization is asserted by the notarize job.
       - name: Verify Desktop signature
         if: matrix.platform == 'mac'
         working-directory: apps/desktop
@@ -334,14 +317,20 @@ jobs:
             echo "::error::Hardened Runtime flag is missing from the signature."
             exit 1
           fi
-          xcrun stapler validate "$app"
-          spctl --assess --verbose=4 --type exec "$app"
 
-      - name: Remove notarization API key
-        if: always() && matrix.platform == 'mac'
-        run: rm -f "$RUNNER_TEMP/AuthKey.p8"
+      # macOS output is not releasable yet, so it is staged under a name the release jobs ignore.
+      - name: Upload Desktop artifact (awaiting notarization)
+        if: matrix.platform == 'mac'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unnotarized-${{ matrix.package_target }}
+          path: |
+            apps/desktop/release/*.dmg
+            apps/desktop/release/*.zip
+          if-no-files-found: error
 
       - name: Upload Desktop artifact
+        if: matrix.platform != 'mac'
         uses: actions/upload-artifact@v4
         with:
           name: desktop-${{ matrix.package_target }}
@@ -349,9 +338,151 @@ jobs:
           path: |
             apps/desktop/release/*.AppImage
             apps/desktop/release/*.deb
-            apps/desktop/release/*.dmg
             apps/desktop/release/*.exe
             apps/desktop/release/*.zip
+          if-no-files-found: error
+
+  # Notarization is its own job so a failed Apple round trip can be re-run without rebuilding and
+  # re-signing. Each leg stays on its target architecture because the final spctl assessment is
+  # only meaningful on a machine that could actually launch the app.
+  notarize:
+    name: Notarize Desktop ${{ matrix.package_target }}
+    needs: desktop
+    runs-on: ${{ matrix.os }}
+    environment: signing
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15-intel
+            package_target: darwin-x64
+          - os: macos-14
+            package_target: darwin-arm64
+    steps:
+      - name: Download signed Desktop artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: unnotarized-${{ matrix.package_target }}
+          path: staging
+
+      # notarytool takes --key as a file path, so the base64 secret has to be materialized on disk.
+      - name: Write notarization API key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          set -euo pipefail
+          if [ -z "$APPLE_API_KEY_P8" ]; then
+            echo "::error::Environment secret APPLE_API_KEY_P8 is missing; the macOS build cannot be notarized."
+            exit 1
+          fi
+          printf '%s' "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/AuthKey.p8"
+
+      # `notarytool submit --wait` hides both progress and transient failures inside one silent
+      # process, and a dropped connection there discards a completed upload. Uploading once and
+      # polling here keeps the submission id, so a network blip costs one retry instead of the run.
+      - name: Notarize disk image
+        env:
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          key="$RUNNER_TEMP/AuthKey.p8"
+          dmg="$(find staging -maxdepth 1 -name '*.dmg' -print -quit)"
+          if [ -z "$dmg" ]; then
+            echo "::error::No .dmg found in the staged artifact."
+            exit 1
+          fi
+          echo "Submitting $dmg ($(du -h "$dmg" | cut -f1))"
+          submission="$(xcrun notarytool submit "$dmg" \
+            --key "$key" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
+            --no-wait --output-format json)"
+          id="$(jq -r '.id' <<<"$submission")"
+          if [ -z "$id" ] || [ "$id" = "null" ]; then
+            echo "::error::notarytool did not return a submission id: $submission"
+            exit 1
+          fi
+          echo "submission id: $id"
+          echo "SPIRIT_NOTARIZATION_ID=$id" >> "$GITHUB_ENV"
+
+          status=""
+          for attempt in $(seq 1 120); do
+            if info="$(xcrun notarytool info "$id" \
+                --key "$key" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" \
+                --output-format json 2>&1)"; then
+              status="$(jq -r '.status // "unknown"' <<<"$info")"
+              echo "[$attempt] $(date -u +%H:%M:%S) status=$status"
+              case "$status" in
+                Accepted) break ;;
+                Invalid|Rejected)
+                  echo "::error::Apple rejected the submission."
+                  xcrun notarytool log "$id" \
+                    --key "$key" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" || true
+                  exit 1
+                  ;;
+              esac
+            else
+              echo "[$attempt] $(date -u +%H:%M:%S) status query failed, retrying"
+            fi
+            sleep 30
+          done
+          if [ "$status" != "Accepted" ]; then
+            echo "::error::Notarization did not reach Accepted within the polling window (last status: ${status:-none})."
+            exit 1
+          fi
+
+      # Stapling embeds the ticket so Gatekeeper clears the app without contacting Apple. The zip
+      # holds a second copy of the same .app, which needs its own stapled ticket before rezipping.
+      - name: Staple tickets
+        run: |
+          set -euo pipefail
+          dmg="$(find staging -maxdepth 1 -name '*.dmg' -print -quit)"
+          zip="$(find staging -maxdepth 1 -name '*.zip' -print -quit)"
+          xcrun stapler staple "$dmg"
+
+          workdir="$RUNNER_TEMP/zip-restaple"
+          rm -rf "$workdir"
+          mkdir -p "$workdir"
+          ditto -x -k "$zip" "$workdir"
+          app="$(find "$workdir" -maxdepth 1 -name '*.app' -print -quit)"
+          if [ -z "$app" ]; then
+            echo "::error::No .app found inside $zip."
+            exit 1
+          fi
+          xcrun stapler staple "$app"
+          rm -f "$zip"
+          ditto -c -k --sequesterRsrc --keepParent "$app" "$zip"
+          echo "SPIRIT_STAPLED_APP=$app" >> "$GITHUB_ENV"
+
+      - name: Verify notarized artifacts
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          dmg="$(find staging -maxdepth 1 -name '*.dmg' -print -quit)"
+          app="$SPIRIT_STAPLED_APP"
+          xcrun stapler validate "$dmg"
+          xcrun stapler validate "$app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          details="$(codesign --display --verbose=4 "$app" 2>&1)"
+          if ! grep -q "^TeamIdentifier=$APPLE_TEAM_ID$" <<<"$details"; then
+            echo "::error::Signed by an unexpected team; expected TeamIdentifier=$APPLE_TEAM_ID."
+            exit 1
+          fi
+          # The only check that answers "will this launch on a clean Mac".
+          spctl --assess --verbose=4 --type exec "$app"
+
+      - name: Remove notarization API key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/AuthKey.p8"
+
+      - name: Upload Desktop artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.package_target }}
+          path: |
+            staging/*.dmg
+            staging/*.zip
           if-no-files-found: error
 
   # prepare builds the English approval summary (changelog + per-channel asset tables).
@@ -360,6 +491,7 @@ jobs:
     needs:
       - cli
       - desktop
+      - notarize
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -372,9 +504,19 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Download build artifacts
+      # Two scoped downloads rather than one bulk fetch: the unnotarized-* staging artifacts carry
+      # the same filenames as their notarized replacements and must not reach the release.
+      - name: Download CLI artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: cli-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Download Desktop artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: desktop-*
           path: release-assets
           merge-multiple: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,10 @@ jobs:
             fi
             echo "verified $relative"
           done
+          # A valid signature does not prove the binary still runs: re-signing stock Node with our
+          # own entitlements is the one change here that can kill V8 at startup.
+          "$root/node/bin/node" --version
+          "$root/bin/spirit" --version
 
       - name: Remove signing keychain
         if: always() && matrix.apple

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- V8 compiles to executable memory at runtime; both keys are required under Hardened Runtime. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- node-pty, koffi, @napi-rs/keyring and ripgrep load from app.asar.unpacked outside the bundle's sealed resources. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -2,12 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <!-- V8 compiles to executable memory at runtime; both keys are required under Hardened Runtime. -->
+    <!-- Same set electron-builder ships as its default: V8 needs writable executable memory. -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
-    <!-- node-pty, koffi, @napi-rs/keyring and ripgrep load from app.asar.unpacked outside the bundle's sealed resources. -->
+    <!-- Prebuilt .node addons load from app.asar.unpacked; see electron-builder#3940. -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
   </dict>

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -49,9 +49,13 @@ mac:
   target:
     - dmg
     - zip
-  hardenedRuntime: false
+  hardenedRuntime: true
   gatekeeperAssess: false
-  identity: null
+  # Helper processes need the same JIT entitlements as the main app; one plist covers both.
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
+  # Activated by APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER; skipped when they are absent.
+  notarize: true
 linux:
   maintainer: Spirit Agent contributors <121384036+N123999@users.noreply.github.com>
   target:

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -54,8 +54,9 @@ mac:
   # Helper processes need the same JIT entitlements as the main app; one plist covers both.
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
-  # Activated by APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER; skipped when they are absent.
-  notarize: true
+  # Notarization runs as its own CI job against the finished dmg/zip: bundling it here ties a
+  # 35-minute Apple round trip to the build, so one network blip discards the signed output too.
+  notarize: false
 linux:
   maintainer: Spirit Agent contributors <121384036+N123999@users.noreply.github.com>
   target:

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -22,7 +22,6 @@
         "@shikijs/monaco": "^3.23.0",
         "@shikijs/themes": "^3.23.0",
         "@spiritagent/agent-core": "file:../../packages/agent-core",
-        "@spiritagent/dev-root": "file:../..",
         "@spiritagent/host-internal": "file:../../packages/host-internal",
         "@streamdown/code": "^1.1.1",
         "@streamdown/math": "^1.0.2",
@@ -91,6 +90,9 @@
     },
     "../..": {
       "name": "@spiritagent/dev-root",
+      "dev": true,
+      "optional": true,
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -5397,10 +5399,6 @@
     },
     "node_modules/@spiritagent/agent-core": {
       "resolved": "../../packages/agent-core",
-      "link": true
-    },
-    "node_modules/@spiritagent/dev-root": {
-      "resolved": "../..",
       "link": true
     },
     "node_modules/@spiritagent/host-internal": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -54,7 +54,6 @@
     "@shikijs/monaco": "^3.23.0",
     "@shikijs/themes": "^3.23.0",
     "@spiritagent/agent-core": "file:../../packages/agent-core",
-    "@spiritagent/dev-root": "file:../..",
     "@spiritagent/host-internal": "file:../../packages/host-internal",
     "@streamdown/code": "^1.1.1",
     "@streamdown/math": "^1.0.2",

--- a/scripts/release/bundle-cli.mjs
+++ b/scripts/release/bundle-cli.mjs
@@ -3,6 +3,7 @@ import { cp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { signCliBundle } from './sign-macos.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const releaseRoot = path.join(repoRoot, 'dist', 'release');
@@ -267,6 +268,11 @@ async function main() {
       2,
     )}\n`,
   );
+
+  // 必须早于 createArchive：归档一旦生成，再签名也只是改了归档外的副本。
+  if (targetInfo.nodePlatform === 'darwin') {
+    await signCliBundle(bundleRoot);
+  }
 
   const archivePath = path.join(releaseRoot, `${bundleName}.${targetInfo.archiveExt}`);
   await rm(archivePath, { force: true });

--- a/scripts/release/entitlements/macos-node.plist
+++ b/scripts/release/entitlements/macos-node.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- 取自 nodejs/node 的 tools/osx-entitlements.plist：上游按这套权限分发 node，重签会覆盖它，缺项会让 V8 在运行期崩。 -->
+    <!-- 有意剔除上游的 com.apple.security.get-task-allow：那是调试权限，会允许任意进程附加调试器。 -->
+    <!-- 仅用于发布包的 node/ 子树；spirit 与 rg 是纯 Rust 二进制，不需要任何豁免。 -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/scripts/release/sign-macos.mjs
+++ b/scripts/release/sign-macos.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+import { open, readdir } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const nodeEntitlements = path.join(scriptDir, 'entitlements', 'macos-node.plist');
+
+// 大小端两种写法的魔数都各自唯一，因此统一按大端读一次即可，不必先判断字节序。
+const THIN_MAGICS = new Set([0xfeedface, 0xcefaedfe, 0xfeedfacf, 0xcffaedfe]);
+const FAT_MAGIC_BE = 0xcafebabe;
+const FAT_MAGIC_LE = 0xbebafeca;
+
+// Java class 文件与 fat Mach-O 共用 0xcafebabe，但紧随其后的字段是 class 版本号（≥45），
+// 远超任何真实的架构数量，用它把两者区分开。
+const MAX_FAT_ARCH_COUNT = 32;
+
+/**
+ * @param {string} filePath
+ */
+async function isMachO(filePath) {
+  const handle = await open(filePath, 'r');
+  try {
+    const buffer = Buffer.alloc(8);
+    const { bytesRead } = await handle.read(buffer, 0, 8, 0);
+    if (bytesRead < 4) {
+      return false;
+    }
+    const magic = buffer.readUInt32BE(0);
+    if (THIN_MAGICS.has(magic)) {
+      return true;
+    }
+    if (bytesRead < 8 || (magic !== FAT_MAGIC_BE && magic !== FAT_MAGIC_LE)) {
+      return false;
+    }
+    const archCount = magic === FAT_MAGIC_BE ? buffer.readUInt32BE(4) : buffer.readUInt32LE(4);
+    return archCount >= 1 && archCount <= MAX_FAT_ARCH_COUNT;
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * @param {string} root
+ * @param {string[]} skip 相对 root 的路径，命中后不再向下遍历
+ */
+async function collectMachO(root, skip = []) {
+  const skipSet = new Set(skip);
+  /** @type {string[]} */
+  const found = [];
+
+  /** @param {string} dir */
+  async function walk(dir) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const entryPath = path.join(dir, entry.name);
+      if (skipSet.has(path.relative(root, entryPath))) {
+        continue;
+      }
+      // node/bin 下有多个指向同一文件的符号链接，跟进去会把同一个二进制重复签几遍。
+      if (entry.isSymbolicLink()) {
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+      } else if (entry.isFile() && (await isMachO(entryPath))) {
+        found.push(entryPath);
+      }
+    }
+  }
+
+  await walk(root);
+  return found;
+}
+
+/**
+ * @param {string} filePath
+ * @param {{ identity: string, keychain?: string, entitlements?: string }} options
+ */
+function signFile(filePath, { identity, keychain, entitlements }) {
+  const args = ['--force', '--options', 'runtime', '--timestamp', '--sign', identity];
+  if (keychain) {
+    args.push('--keychain', keychain);
+  }
+  if (entitlements) {
+    args.push('--entitlements', entitlements);
+  }
+  args.push(filePath);
+  const result = spawnSync('codesign', args, { stdio: 'inherit' });
+  if (result.status !== 0) {
+    throw new Error(`codesign 失败: ${filePath}`);
+  }
+}
+
+/**
+ * 读取签名身份；未配置时返回 null，调用方据此整体跳过签名。
+ */
+function resolveSigningIdentity() {
+  const identity = process.env.SPIRIT_MACOS_SIGN_IDENTITY?.trim();
+  if (!identity) {
+    return null;
+  }
+  return { identity, keychain: process.env.SPIRIT_MACOS_KEYCHAIN?.trim() || undefined };
+}
+
+/**
+ * 对 CLI 发布包内全部 Mach-O 做 Developer ID 签名。必须在打包成归档之前调用，
+ * 否则归档里装的是未签名副本。
+ *
+ * @param {string} bundleRoot
+ */
+export async function signCliBundle(bundleRoot) {
+  if (process.platform !== 'darwin') {
+    console.log(`Skipping macOS signing: codesign is macOS-only, host is ${process.platform}`);
+    return;
+  }
+
+  const signing = resolveSigningIdentity();
+  if (!signing) {
+    console.log('Skipping macOS signing: SPIRIT_MACOS_SIGN_IDENTITY is not set');
+    return;
+  }
+
+  // node/ 子树用上游 Node 的 entitlements，其余二进制只启用 hardened runtime。
+  const nodeRoot = path.join(bundleRoot, 'node');
+  const groups = [
+    { files: await collectMachO(nodeRoot), entitlements: nodeEntitlements },
+    { files: await collectMachO(bundleRoot, ['node']), entitlements: undefined },
+  ];
+
+  let signed = 0;
+  for (const group of groups) {
+    for (const filePath of group.files) {
+      console.log(`Signing ${path.relative(bundleRoot, filePath)}`);
+      signFile(filePath, { ...signing, entitlements: group.entitlements });
+      signed += 1;
+    }
+  }
+
+  console.log(`Signed ${signed} Mach-O binaries with ${signing.identity}`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url))) {
+  const bundleRoot = process.argv[2];
+  if (!bundleRoot) {
+    console.error('Usage: node scripts/release/sign-macos.mjs <bundle root>');
+    process.exit(1);
+  }
+  signCliBundle(path.resolve(bundleRoot)).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- CLI macOS 包对内嵌 `bin/spirit` 与 `node/bin/node` 做 Developer ID 签名（Hardened Runtime + 定制 entitlements），CI 内解压验签并实际运行一次，避免重签 Node 后 V8 起不来却验签通过
- Desktop macOS 打包启用 Developer ID 签名；公证拆为独立 `notarize` job，用 `notarytool submit --no-wait` 取回 submission id 后自建 30 秒轮询，网络抖动只重试查询而不作废已完成的上传，失败可单独重试而无需重新构建与签名
- 公证通过后 staple dmg，并对 zip 内的 app 单独 staple 后重新打包；`stapler validate` 与 `spctl` 各自留在目标架构的 runner 上校验
- `signing` 环境只绑定到 macOS 构建 leg，Windows 与 Linux 不再可访问 Developer ID 证书与公证密钥

## Test plan
- [ ] 手动触发一次 Release，确认 CLI 两个 macOS 架构验签与冒烟步骤通过
- [ ] 确认 Desktop 两个架构的 `notarize` job 拿到 `Accepted`，`stapler validate` 与 `spctl` 通过
- [ ] 确认 Windows / Linux leg 在无 `signing` 环境下仍能取到 `SPIRIT_GITHUB_OAUTH_CLIENT_ID` 并正常出包
- [ ] 确认 `prepare` 只收到公证后的 `desktop-*`，`unnotarized-*` 暂存产物未混入发布