### PR TITLE
fix(desktop): 本地打包不再清空 .env 中的 OAuth client id

### DIFF
--- a/apps/desktop/scripts/materialize-oauth-env.mjs
+++ b/apps/desktop/scripts/materialize-oauth-env.mjs
@@ -18,12 +18,14 @@ if (clientId) {
   process.exit(0);
 }
 
-if (ensureForPackaging) {
-  writeEnvFile('');
+// electron-builder bundles .env, so packaging needs the file to exist — but only create it when
+// it is missing. Overwriting here would wipe the client id a developer keeps in their local .env.
+if (existsSync(envPath)) {
   process.exit(0);
 }
 
-if (existsSync(envPath)) {
+if (ensureForPackaging) {
+  writeEnvFile('');
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- `materialize-oauth-env.mjs` 把「`.env` 已存在则跳过」的判断提到 `--ensure-for-packaging` 之前，该标志此后只在文件缺失时创建空文件
- 此前未导出 `SPIRIT_GITHUB_OAUTH_CLIENT_ID` 时执行 `npm run dist` / `dist:dir`，会无条件把本地 `.env` 重写为空值，开发者填入的 client id 被静默清空
- `electron-builder.yml` 仍把 `.env` 列入打包内容，所以「文件必须存在」这个前提没有放弃，只是不再覆盖已有文件

## 背景
本次发版分支调试期间连跑了四次 `npm run dist:dir`，每次都触发这条路径，本地 `.env` 里的 client id 因此丢失，dev 模式下 vite 还会跟着报 `.env changed, restarting server`。

## Test plan
- [x] env var 已设置：按值写入（覆盖旧文件，CI 正常路径）
- [x] 无 env var 且 `.env` 已存在：内容原样保留（本次修复点）
- [x] 无 env var 且 `.env` 缺失 + `--ensure-for-packaging`：创建空文件，打包可继续
- [x] 无 env var 且 `.env` 缺失 + `GITHUB_ACTIONS=true` 非打包：报错并退出 1
- [x] 无 env var 且 `.env` 缺失、本地无标志：静默通过且不创建文件